### PR TITLE
Fix buffer indexing in PeekBatch

### DIFF
--- a/src/structure/queue.hpp
+++ b/src/structure/queue.hpp
@@ -257,7 +257,7 @@ class BaseQueue
 
     for (size_t i = 0; i < size; i++)
     {
-      memcpy(&tmp[index * ELEMENT_SIZE], &queue_array_[index * ELEMENT_SIZE],
+      memcpy(&tmp[i * ELEMENT_SIZE], &queue_array_[index * ELEMENT_SIZE],
              ELEMENT_SIZE);
       index = (index + 1) % length_;
     }


### PR DESCRIPTION
## Summary
- fix queue copy indexing bug in `PeekBatch`

## Testing
- `cmake -DLIBXR_TEST_BUILD=True ..`
- `make -j4`
- `./test`

------
https://chatgpt.com/codex/tasks/task_e_6859185ecb3483218b57b29dce46e5a8