### PR TITLE
Add ErrorCode assertions for queue popping tests

### DIFF
--- a/test/test_queue.cpp
+++ b/test/test_queue.cpp
@@ -35,7 +35,8 @@ void test_queue()
   lock_free_queue.Pop(tmp);
   ASSERT(tmp == 2.1f);
 
-  lock_free_queue.Pop(tmp);
+  auto ret = lock_free_queue.Pop(tmp);
+  ASSERT(ret == LibXR::ErrorCode::EMPTY);
   ASSERT(tmp == 2.1f);
 
   auto queue = LibXR::LockQueue<float>(3);
@@ -70,6 +71,7 @@ void test_queue()
   queue.Pop(tmp, 20);
   ASSERT(tmp == 2.1f);
 
-  queue.Pop(tmp, 20);
+  auto ret2 = queue.Pop(tmp, 20);
+  ASSERT(ret2 == LibXR::ErrorCode::EMPTY);
   ASSERT(tmp == 2.1f);
 }


### PR DESCRIPTION
## Summary
- test `LockFreeQueue::Pop` returns `EMPTY` when the queue is empty
- test `LockQueue::Pop` with timeout returns `EMPTY` once queue drained

## Testing
- `cmake -DLIBXR_SYSTEM=Linux -DLIBXR_TEST_BUILD=ON ..`
- `make -j$(nproc)` *(fails: linux_timebase.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68591b966d248321af052822e4d1312c