### PR TITLE
feat: 增加 STM32 Cache 支持、修正原子 shim 类型、完善 I2C 注释等多项修复

### DIFF
--- a/doc/support.md
+++ b/doc/support.md
@@ -32,7 +32,7 @@
 
 ## STM32 Support
 
-| `Peripheral` | STM32F0/F1/F4/G0/G4 | STM32H7/L0/L1/L4 |
+| `Peripheral` | STM32F0/F1/F4/G0/G4/H7 | STM32L0/L1/L4 |
 | ------------ | ------------------- | ---------------- |
 | POWER        | ✅                   | ⚙️                |
 | GPIO         | ✅                   | ⚙️                |

--- a/driver/st/stm32_adc.hpp
+++ b/driver/st/stm32_adc.hpp
@@ -174,6 +174,9 @@ class STM32ADC
     uint16_t* buffer = reinterpret_cast<uint16_t*>(dma_buffer_.addr_);
     if (use_dma_)
     {
+#if __DCACHE_PRESENT
+      SCB_InvalidateDCache_by_Addr(buffer, filter_size_ * NUM_CHANNELS * 2);
+#endif
       uint32_t sum = 0;
       for (uint8_t i = 0; i < filter_size_; ++i)
       {

--- a/driver/st/stm32_atomic_shim.c
+++ b/driver/st/stm32_atomic_shim.c
@@ -1,6 +1,3 @@
-#include <stdbool.h>
-#include <stdint.h>
-
 #include "main.h"
 
 #if defined(STM32F0) || defined(STM32G0) || defined(STM32L0)
@@ -19,18 +16,16 @@
  * (ignored)
  * @retval 返回 1 表示成功，0 表示失败 / Returns 1 on success, 0 on failure
  */
-__attribute__((weak, used)) int __atomic_compare_exchange_4(volatile void *ptr,
-                                                            void *expected,
-                                                            uint32_t desired, bool weak,
-                                                            int success_memorder,
-                                                            int failure_memorder)
+__attribute__((weak, used)) _Bool
+__atomic_compare_exchange_4(volatile void *ptr, void *expected, unsigned int desired,
+                            _Bool weak, int success_memorder, int failure_memorder)
 {
   UNUSED(weak);
   UNUSED(success_memorder);
   UNUSED(failure_memorder);
 
-  volatile uint32_t *addr = (volatile uint32_t *)ptr;
-  uint32_t expected_val = *(uint32_t *)expected;
+  volatile unsigned int *addr = (volatile unsigned int *)ptr;
+  unsigned int expected_val = *(unsigned int *)expected;
   int result;
 
   __disable_irq();
@@ -41,7 +36,7 @@ __attribute__((weak, used)) int __atomic_compare_exchange_4(volatile void *ptr,
   }
   else
   {
-    *(uint32_t *)expected = *addr;
+    *(unsigned int *)expected = *addr;
     result = 0;
   }
   __enable_irq();
@@ -55,12 +50,12 @@ __attribute__((weak, used)) int __atomic_compare_exchange_4(volatile void *ptr,
  * @param  memorder 内存顺序标志 / Memory order (ignored)
  * @retval 无返回值 / None
  */
-__attribute__((weak, used)) void __atomic_store_4(volatile void *ptr, uint32_t val,
+__attribute__((weak, used)) void __atomic_store_4(volatile void *ptr, unsigned int val,
                                                   int memorder)
 {
   UNUSED(memorder);
 
-  volatile uint32_t *addr = (volatile uint32_t *)ptr;
+  volatile unsigned int *addr = (volatile unsigned int *)ptr;
   __disable_irq();
   *addr = val;
   __enable_irq();
@@ -72,12 +67,13 @@ __attribute__((weak, used)) void __atomic_store_4(volatile void *ptr, uint32_t v
  * @param  memorder 内存顺序标志 / Memory order (ignored)
  * @retval 当前值 / Returns the current value
  */
-__attribute__((weak, used)) uint32_t __atomic_load_4(volatile void *ptr, int memorder)
+__attribute__((weak, used)) unsigned int __atomic_load_4(const volatile void *ptr,
+                                                         int memorder)
 {
   UNUSED(memorder);
 
-  volatile uint32_t *addr = (volatile uint32_t *)ptr;
-  uint32_t val;
+  volatile unsigned int *addr = (volatile unsigned int *)ptr;
+  unsigned int val;
   __disable_irq();
   val = *addr;
   __enable_irq();
@@ -91,13 +87,14 @@ __attribute__((weak, used)) uint32_t __atomic_load_4(volatile void *ptr, int mem
  * @param  memorder 内存顺序标志 / Memory order (ignored)
  * @retval 交换前的旧值 / Returns the old value before exchange
  */
-__attribute__((weak, used)) uint32_t __atomic_exchange_4(volatile void *ptr, uint32_t val,
-                                                         int memorder)
+__attribute__((weak, used)) unsigned int __atomic_exchange_4(volatile void *ptr,
+                                                             unsigned int val,
+                                                             int memorder)
 {
   UNUSED(memorder);
 
-  volatile uint32_t *addr = (volatile uint32_t *)ptr;
-  uint32_t old_val;
+  volatile unsigned int *addr = (volatile unsigned int *)ptr;
+  unsigned int old_val;
   __disable_irq();
   old_val = *addr;
   *addr = val;
@@ -112,13 +109,14 @@ __attribute__((weak, used)) uint32_t __atomic_exchange_4(volatile void *ptr, uin
  * @param  memorder 内存顺序标志 / Memory order (ignored)
  * @retval 加法前的旧值 / Returns the old value before addition
  */
-__attribute__((weak, used)) uint32_t __atomic_fetch_add_4(volatile void *ptr,
-                                                          uint32_t val, int memorder)
+__attribute__((weak, used)) unsigned int __atomic_fetch_add_4(volatile void *ptr,
+                                                              unsigned int val,
+                                                              int memorder)
 {
   UNUSED(memorder);
 
-  volatile uint32_t *addr = (volatile uint32_t *)ptr;
-  uint32_t old_val;
+  volatile unsigned int *addr = (volatile unsigned int *)ptr;
+  unsigned int old_val;
   __disable_irq();
   old_val = *addr;
   *addr = old_val + val;
@@ -133,13 +131,14 @@ __attribute__((weak, used)) uint32_t __atomic_fetch_add_4(volatile void *ptr,
  * @param  memorder 内存顺序标志 / Memory order (ignored)
  * @retval 减法前的旧值 / Returns the old value before subtraction
  */
-__attribute__((weak, used)) uint32_t __atomic_fetch_sub_4(volatile void *ptr,
-                                                          uint32_t val, int memorder)
+__attribute__((weak, used)) unsigned int __atomic_fetch_sub_4(volatile void *ptr,
+                                                              unsigned int val,
+                                                              int memorder)
 {
   UNUSED(memorder);
 
-  volatile uint32_t *addr = (volatile uint32_t *)ptr;
-  uint32_t old_val;
+  volatile unsigned int *addr = (volatile unsigned int *)ptr;
+  unsigned int old_val;
   __disable_irq();
   old_val = *addr;
   *addr = old_val - val;
@@ -154,13 +153,14 @@ __attribute__((weak, used)) uint32_t __atomic_fetch_sub_4(volatile void *ptr,
  * @param  memorder 内存顺序标志（忽略） / Memory order (ignored)
  * @retval 交换前的旧值 / Returns the old value before exchange
  */
-__attribute__((weak, used)) uint8_t __atomic_exchange_1(volatile void *ptr, uint8_t val,
-                                                        int memorder)
+__attribute__((weak, used)) unsigned char __atomic_exchange_1(volatile void *ptr,
+                                                              unsigned char val,
+                                                              int memorder)
 {
   UNUSED(memorder);
 
-  volatile uint8_t *addr = (volatile uint8_t *)ptr;
-  uint8_t old_val;
+  volatile unsigned char *addr = (volatile unsigned char *)ptr;
+  unsigned char old_val;
   __disable_irq();
   old_val = *addr;
   *addr = val;
@@ -175,12 +175,12 @@ __attribute__((weak, used)) uint8_t __atomic_exchange_1(volatile void *ptr, uint
  * @param  memorder 内存顺序标志（忽略） / Memory order (ignored)
  * @retval 无返回值 / None
  */
-__attribute__((weak, used)) void __atomic_store_1(volatile void *ptr, uint8_t val,
+__attribute__((weak, used)) void __atomic_store_1(volatile void *ptr, unsigned char val,
                                                   int memorder)
 {
   UNUSED(memorder);
 
-  volatile uint8_t *addr = (volatile uint8_t *)ptr;
+  volatile unsigned char *addr = (volatile unsigned char *)ptr;
   __disable_irq();
   *addr = val;
   __enable_irq();
@@ -194,12 +194,12 @@ __attribute__((weak, used)) void __atomic_store_1(volatile void *ptr, uint8_t va
  * @retval 返回之前的值 / Returns the previous value (0 or 1)
  */
 #if !defined(__clang__)
-__attribute__((weak, used)) bool __atomic_test_and_set(volatile void *ptr, int memorder)
+__attribute__((weak, used)) _Bool __atomic_test_and_set(volatile void *ptr, int memorder)
 {
   UNUSED(memorder);
 
-  volatile uint8_t *addr = (volatile uint8_t *)ptr;
-  bool old_val;
+  volatile unsigned char *addr = (volatile unsigned char *)ptr;
+  _Bool old_val;
 
   __disable_irq();
   old_val = *addr;

--- a/driver/st/stm32_i2c.cpp
+++ b/driver/st/stm32_i2c.cpp
@@ -68,6 +68,9 @@ extern "C" void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef *hi2c)
   STM32I2C *i2c = STM32I2C::map[STM32_I2C_GetID(hi2c->Instance)];
   if (i2c)
   {
+#if __DCACHE_PRESENT
+    SCB_InvalidateDCache_by_Addr(i2c->dma_buff_.addr_, i2c->read_buff_.size_);
+#endif
     memcpy(i2c->read_buff_.addr_, i2c->dma_buff_.addr_, i2c->read_buff_.size_);
     i2c->read_op_.UpdateStatus(true, ErrorCode::OK);
   }
@@ -96,6 +99,9 @@ extern "C" void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef *hi2c)
   STM32I2C *i2c = STM32I2C::map[STM32_I2C_GetID(hi2c->Instance)];
   if (i2c)
   {
+#if __DCACHE_PRESENT
+    SCB_InvalidateDCache_by_Addr(i2c->dma_buff_.addr_, i2c->read_buff_.size_);
+#endif
     memcpy(i2c->read_buff_.addr_, i2c->dma_buff_.addr_, i2c->read_buff_.size_);
     i2c->read_op_.UpdateStatus(true, ErrorCode::OK);
   }

--- a/driver/st/stm32_i2c.hpp
+++ b/driver/st/stm32_i2c.hpp
@@ -112,6 +112,9 @@ class STM32I2C : public I2C
     if (write_data.size_ > dma_enable_min_size_)
     {
       write_op_ = op;
+#if __DCACHE_PRESENT
+      SCB_CleanDCache_by_Addr(reinterpret_cast<uint32_t *>(dma_buff_.addr_), write_data.size_);
+#endif
       HAL_I2C_Master_Transmit_DMA(i2c_handle_, slave_addr,
                                   reinterpret_cast<uint8_t *>(dma_buff_.addr_),
                                   write_data.size_);
@@ -202,6 +205,9 @@ class STM32I2C : public I2C
     if (write_data.size_ > dma_enable_min_size_)
     {
       write_op_ = op;
+#if __DCACHE_PRESENT
+      SCB_CleanDCache_by_Addr(reinterpret_cast<uint32_t *>(dma_buff_.addr_), write_data.size_);
+#endif
       HAL_I2C_Mem_Write_DMA(
           i2c_handle_, slave_addr, mem_addr,
           mem_addr_size == MemAddrLength::BYTE_8 ? I2C_MEMADD_SIZE_8BIT

--- a/driver/st/stm32_spi.hpp
+++ b/driver/st/stm32_spi.hpp
@@ -83,6 +83,14 @@ class STM32SPI : public SPI
       rw_op_ = op;
       read_buff_ = read_data;
 
+#if __DCACHE_PRESENT
+      if (write_data.size_ > 0)
+      {
+        SCB_CleanDCache_by_Addr(static_cast<uint32_t *>(dma_buff_tx_.addr_),
+                                write_data.size_);
+      }
+#endif
+
       HAL_SPI_TransmitReceive_DMA(spi_handle_, static_cast<uint8_t *>(dma_buff_tx_.addr_),
                                   static_cast<uint8_t *>(dma_buff_rx_.addr_), need_write);
 

--- a/driver/st/stm32_uart.hpp
+++ b/driver/st/stm32_uart.hpp
@@ -159,6 +159,11 @@ class STM32UART : public UART
 
       port.queue_info_->Pop(uart->write_info_active_);
 
+#if __DCACHE_PRESENT
+      SCB_CleanDCache_by_Addr(reinterpret_cast<uint32_t *>(uart->dma_buff_tx_.ActiveBuffer()),
+                              info.data.size_);
+#endif
+
       auto ans = HAL_UART_Transmit_DMA(
           uart->uart_handle_, static_cast<uint8_t *>(uart->dma_buff_tx_.ActiveBuffer()),
           info.data.size_);

--- a/driver/st/stm32_usb.cpp
+++ b/driver/st/stm32_usb.cpp
@@ -30,6 +30,10 @@ int8_t libxr_stm32_virtual_uart_receive(uint8_t *pbuf, uint32_t *Len)
 {
   STM32VirtualUART *uart = STM32VirtualUART::map[0];
 
+#if __DCACHE_PRESENT
+  SCB_InvalidateDCache_by_Addr(pbuf, *Len);
+#endif
+
   uart->read_port_->queue_data_->PushBatch(pbuf, *Len);
   uart->read_port_->ProcessPendingReads(true);
 
@@ -69,6 +73,9 @@ int8_t libxr_stm32_virtual_uart_transmit(uint8_t *pbuf, uint32_t *Len, uint8_t e
 
   USBD_CDC_SetTxBuffer(uart->usb_handle_, uart->tx_buffer_.ActiveBuffer(),
                        current_info.data.size_);
+#if __DCACHE_PRESENT
+  SCB_CleanDCache_by_Addr(reinterpret_cast<uint32_t *>(uart->tx_buffer_.ActiveBuffer()), *Len);
+#endif
   USBD_CDC_TransmitPacket(uart->usb_handle_);
 
   current_info.op.MarkAsRunning();

--- a/driver/st/stm32_usb.hpp
+++ b/driver/st/stm32_usb.hpp
@@ -115,6 +115,10 @@ class STM32VirtualUART : public UART
 
       USBD_CDC_SetTxBuffer(uart->usb_handle_, uart->tx_buffer_.ActiveBuffer(),
                            info.data.size_);
+#if __DCACHE_PRESENT
+      SCB_CleanDCache_by_Addr(
+          reinterpret_cast<uint32_t *>(uart->tx_buffer_.ActiveBuffer()), info.data.size_);
+#endif
       USBD_CDC_TransmitPacket(uart->usb_handle_);
 
       info.op.MarkAsRunning();

--- a/src/core/libxr_rw.hpp
+++ b/src/core/libxr_rw.hpp
@@ -51,7 +51,9 @@ class Operation
 
   /// @brief Default constructor, initializes with NONE type.
   /// @brief 默认构造函数，初始化为NONE类型。
-  Operation() : type(OperationType::NONE) {}
+  Operation() : type(OperationType::NONE) {
+    memset(&data, 0, sizeof(data));
+  }
 
   /**
    * @brief Constructs a blocking operation with a semaphore and timeout.

--- a/src/driver/i2c.hpp
+++ b/src/driver/i2c.hpp
@@ -46,8 +46,8 @@ class I2C
    * This function reads data from the specified I2C slave address
    * and stores it in `read_data`.
    *
-   * @param slave_addr 目标 I2C 从设备的地址。
-   *                   The address of the target I2C slave device.
+   * @param slave_addr 目标 I2C 从设备的八位地址。
+   *                   The eight-bit address of the target I2C slave device.
    * @param read_data 存储读取数据的 `RawData` 对象。
    *                  A `RawData` object to store the read data.
    * @param op 读取操作对象，包含同步或异步操作模式。
@@ -65,8 +65,8 @@ class I2C
    * 该函数将 `write_data` 写入指定的 I2C 从设备地址。
    * This function writes `write_data` to the specified I2C slave address.
    *
-   * @param slave_addr 目标 I2C 从设备的地址。
-   *                   The address of the target I2C slave device.
+   * @param slave_addr 目标 I2C 从设备的八位地址。
+   *                   The eight-bit address of the target I2C slave device.
    * @param write_data 需要写入的数据，`ConstRawData` 类型。
    *                   The data to be written, of type `ConstRawData`.
    * @param op 写入操作对象，包含同步或异步操作模式。
@@ -100,8 +100,8 @@ class I2C
    * This function reads data from the specified register of the I2C slave
    * and stores it in `read_data`.
    *
-   * @param slave_addr I2C 从设备地址。
-   *                   I2C slave address.
+   * @param slave_addr I2C 从设备的八位地址。
+   *                   The eight-bit address of the I2C slave device.
    * @param mem_addr 寄存器地址（通常为 8 位或 16 位）。
    *                 Register address (typically 8-bit or 16-bit).
    * @param read_data 用于存储读取数据的 `RawData` 对象。
@@ -124,8 +124,8 @@ class I2C
    * 该函数将 `write_data` 写入指定 I2C 从设备的寄存器地址。
    * This function writes `write_data` to the specified register of the I2C slave.
    *
-   * @param slave_addr I2C 从设备地址。
-   *                   I2C slave address.
+   * @param slave_addr I2C 从设备的八位地址。
+   *                   The eight-bit address of the I2C slave device.
    * @param mem_addr 寄存器地址（通常为 8 位或 16 位）。
    *                 Register address (typically 8-bit or 16-bit).
    * @param write_data 要写入的数据，`ConstRawData` 类型。

--- a/system/None/semaphore.cpp
+++ b/system/None/semaphore.cpp
@@ -22,7 +22,7 @@ ErrorCode Semaphore::Wait(uint32_t timeout) {
 
   uint32_t now = Timebase::GetMilliseconds();
 
-  while (Timebase::GetMilliseconds() - now < timeout) {
+  while (uint32_t(Timebase::GetMilliseconds()) - now < timeout) {
     if (semaphore_handle_ > 0) {
       semaphore_handle_--;
       return ErrorCode::OK;

--- a/system/None/thread.cpp
+++ b/system/None/thread.cpp
@@ -10,7 +10,7 @@ Thread Thread::Current(void) { return Thread(); }
 void Thread::Sleep(uint32_t milliseconds)
 {
   uint32_t now = Timebase::GetMilliseconds();
-  while (Timebase::GetMilliseconds() - now < milliseconds)
+  while (uint32_t(Timebase::GetMilliseconds()) - now < milliseconds)
   {
     Timer::RefreshTimerInIdle();
   }
@@ -18,7 +18,7 @@ void Thread::Sleep(uint32_t milliseconds)
 
 void Thread::SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep)
 {
-  while (Timebase::GetMilliseconds() - last_waskup_time < time_to_sleep)
+  while (uint32_t(Timebase::GetMilliseconds()) - last_waskup_time < time_to_sleep)
   {
     Timer::RefreshTimerInIdle();
   }

--- a/system/ThreadX/thread.cpp
+++ b/system/ThreadX/thread.cpp
@@ -13,7 +13,7 @@ void Thread::Sleep(uint32_t milliseconds)
 
 void Thread::SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep)
 {
-  TimestampMS target = last_waskup_time + time_to_sleep;
+  uint32_t target = last_waskup_time + time_to_sleep;
   uint32_t now = Timebase::GetMilliseconds();
   if (target > now)
   {


### PR DESCRIPTION
# 主要变更内容

- **DMA D-Cache 支持**  
  - 为 ADC、I2C、SPI、UART、USB 等驱动的 DMA 缓冲区增加 `SCB_CleanDCache_by_Addr` 和 `SCB_InvalidateDCache_by_Addr` 操作，提升 STM32 H7/G4 等带 D-Cache 平台的数据一致性，优化高性能设备兼容性。

- **原子操作 shim 类型对齐**  
  - `__atomic_*` weak shim 的参数与返回值完全对齐 GCC/Clang 内置声明，消除类型不匹配的编译警告，提升 GCC/Clang 下的可移植性。

- **I2C 接口注释完善**  
  - 明确 slave_addr 为 8 位 I2C 地址，提升 API 文档准确性和用户理解。

- **结构体默认初始化**  
  - `Operation` 默认构造函数增加 `memset`，避免 union data 未初始化引发的警告。

- **时间比较类型一致性**  
  - 所有与时间基相关的比较均统一使用 `uint32_t`，避免类型不匹配导致的编译错误。

- **文档支持表更新**  
  - `support.md` 添加 STM32H7 到支持平台列表，保持文档与实际功能同步。