### PR TITLE
驱动：PWM 增加互补输出支持，SPI/DMA 逻辑安全性增强

### DIFF
--- a/driver/st/stm32_pwm.hpp
+++ b/driver/st/stm32_pwm.hpp
@@ -12,7 +12,10 @@ namespace LibXR
 class STM32PWM : public PWM
 {
  public:
-  STM32PWM(TIM_HandleTypeDef* htim, uint32_t channel) : htim_(htim), channel_(channel) {}
+  STM32PWM(TIM_HandleTypeDef* htim, uint32_t channel, bool complementary = false)
+      : htim_(htim), channel_(channel), complementary_(complementary)
+  {
+  }
 
   ErrorCode SetDutyCycle(float value) override
   {
@@ -167,18 +170,38 @@ class STM32PWM : public PWM
 
   ErrorCode Enable() override
   {
-    if (HAL_TIM_PWM_Start(htim_, channel_) != HAL_OK)
+    if (!complementary_)
     {
-      return ErrorCode::FAILED;
+      if (HAL_TIM_PWM_Start(htim_, channel_) != HAL_OK)
+      {
+        return ErrorCode::FAILED;
+      }
+    }
+    else
+    {
+      if (HAL_TIMEx_PWMN_Start(htim_, channel_) != HAL_OK)
+      {
+        return ErrorCode::FAILED;
+      }
     }
     return ErrorCode::OK;
   }
 
   ErrorCode Disable() override
   {
-    if (HAL_TIM_PWM_Stop(htim_, channel_) != HAL_OK)
+    if (!complementary_)
     {
-      return ErrorCode::FAILED;
+      if (HAL_TIM_PWM_Stop(htim_, channel_) != HAL_OK)
+      {
+        return ErrorCode::FAILED;
+      }
+    }
+    else
+    {
+      if (HAL_TIMEx_PWMN_Stop(htim_, channel_) != HAL_OK)
+      {
+        return ErrorCode::FAILED;
+      }
     }
     return ErrorCode::OK;
   }
@@ -186,6 +209,7 @@ class STM32PWM : public PWM
  private:
   TIM_HandleTypeDef* htim_;
   uint32_t channel_;
+  bool complementary_;
 };
 
 }  // namespace LibXR

--- a/driver/st/stm32_spi.cpp
+++ b/driver/st/stm32_spi.cpp
@@ -1,5 +1,8 @@
 #include "stm32_spi.hpp"
 
+#include "libxr_def.hpp"
+
+
 #ifdef HAL_SPI_MODULE_ENABLED
 
 using namespace LibXR;
@@ -66,7 +69,13 @@ stm32_spi_id_t STM32_SPI_GetID(SPI_TypeDef *addr)
   }
 }
 
-extern "C" void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
+extern "C" void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  STM32SPI *spi = STM32SPI::map[STM32_SPI_GetID(hspi->Instance)];
+  spi->rw_op_.UpdateStatus(true, ErrorCode::OK);
+}
+
+extern "C" void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi)
 {
   STM32SPI *spi = STM32SPI::map[STM32_SPI_GetID(hspi->Instance)];
 
@@ -87,6 +96,11 @@ extern "C" void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
   }
 
   spi->rw_op_.UpdateStatus(true, ErrorCode::OK);
+}
+
+extern "C" void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef *hspi)
+{
+  HAL_SPI_RxCpltCallback(hspi);
 }
 
 extern "C" void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)

--- a/src/middleware/app_framework.hpp
+++ b/src/middleware/app_framework.hpp
@@ -2,7 +2,6 @@
 
 #include <cstring>
 #include <initializer_list>
-#include <tuple>
 
 #include "libxr_def.hpp"
 #include "libxr_type.hpp"
@@ -90,7 +89,7 @@ class HardwareContainer
    *
    */
   template <typename T>
-  void Register(Entry<T>&& entry)
+  void Register(const Entry<T>& entry)
   {
     for (const auto& alias : entry.aliases)
     {
@@ -101,7 +100,7 @@ class HardwareContainer
     }
   }
 
- private:
+ protected:
   struct AliasEntry
   {
     const char* name;


### PR DESCRIPTION
- STM32PWM: 支持互补通道(如 TIMx_CH1N)启动/关闭
- STM32SPI: 读写/缓冲区判定更严格，DMA 判断更健壮
- 其它：参数、回调细节优化