### PR TITLE
refactor: 统一时间戳类型，重构Flash/Database接口，清理命名和宏定义

### DIFF
--- a/driver/Linux/linux_flash.hpp
+++ b/driver/Linux/linux_flash.hpp
@@ -59,8 +59,8 @@ class LinuxBinaryFileFlash : public Flash
    */
   ErrorCode Erase(size_t offset, size_t size) override
   {
-    ASSERT(offset % min_erase_size_ == 0);
-    ASSERT(size % min_erase_size_ == 0);
+    ASSERT(offset % MinEraseSize() == 0);
+    ASSERT(size % MinEraseSize() == 0);
 
     if ((offset + size) > flash_area_.size())
     {
@@ -86,7 +86,7 @@ class LinuxBinaryFileFlash : public Flash
       return ErrorCode::OUT_OF_RANGE;
     }
 
-    if (offset % min_write_size_ != 0 || data.size_ % min_write_size_ != 0)
+    if (offset % MinWriteSize() != 0 || data.size_ % MinWriteSize() != 0)
     {
       ASSERT(false);
       return ErrorCode::FAILED;
@@ -94,7 +94,7 @@ class LinuxBinaryFileFlash : public Flash
 
     if (write_order_check_)
     {
-      ASSERT(offset % min_erase_size_ == 0);
+      ASSERT(offset % MinEraseSize() == 0);
     }
 
     uint8_t* dst = flash_area_.data() + offset;

--- a/driver/Linux/linux_timebase.hpp
+++ b/driver/Linux/linux_timebase.hpp
@@ -17,9 +17,9 @@ class LinuxTimebase : public Timebase
   /**
    * @brief 获取当前时间戳（微秒级）。Returns the current timestamp in microseconds.
    *
-   * @return TimestampUS
+   * @return MicrosecondTimestamp
    */
-  TimestampUS _get_microseconds()
+  MicrosecondTimestamp _get_microseconds()
   {
     struct timeval tv;
     gettimeofday(&tv, nullptr);
@@ -31,9 +31,9 @@ class LinuxTimebase : public Timebase
   /**
    * @brief 获取当前时间戳（毫秒级）
    *
-   * @return TimestampMS
+   * @return MillisecondTimestamp
    */
-  TimestampMS _get_milliseconds()
+  MillisecondTimestamp _get_milliseconds()
   {
     struct timeval tv;
     gettimeofday(&tv, nullptr);

--- a/driver/WebAsm/webasm_timebase.hpp
+++ b/driver/WebAsm/webasm_timebase.hpp
@@ -22,26 +22,26 @@ class WebAsmTimebase : public Timebase
 
   /**
    * @brief 获取当前时间戳（微秒级）
-   * @return TimestampUS
+   * @return MicrosecondTimestamp
    */
-  TimestampUS _get_microseconds() override
+  MicrosecondTimestamp _get_microseconds() override
   {
     auto now = std::chrono::system_clock::now();
     auto us =
         std::chrono::duration_cast<std::chrono::microseconds>(now - start_time_).count();
-    return static_cast<TimestampUS>(us % UINT32_MAX);
+    return static_cast<MicrosecondTimestamp>(us % UINT32_MAX);
   }
 
   /**
    * @brief 获取当前时间戳（毫秒级）
-   * @return TimestampMS
+   * @return MillisecondTimestamp
    */
-  TimestampMS _get_milliseconds() override
+  MillisecondTimestamp _get_milliseconds() override
   {
     auto now = std::chrono::system_clock::now();
     auto ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time_).count();
-    return static_cast<TimestampMS>(ms % UINT32_MAX);
+    return static_cast<MillisecondTimestamp>(ms % UINT32_MAX);
   }
 
  private:

--- a/driver/ch/ch32_timebase.hpp
+++ b/driver/ch/ch32_timebase.hpp
@@ -15,13 +15,13 @@ class CH32Timebase : public Timebase
     cnt_per_microsec_ = SystemCoreClock / 1000000;
   }
 
-  TimestampUS _get_microseconds() override
+  MicrosecondTimestamp _get_microseconds() override
   {
     uint64_t cnt = SysTick->CNT;
-    return TimestampUS(cnt / cnt_per_microsec_);
+    return MicrosecondTimestamp(cnt / cnt_per_microsec_);
   }
 
-  TimestampMS _get_milliseconds() override { return cnt_per_microsec_ / 1000; }
+  MillisecondTimestamp _get_milliseconds() override { return cnt_per_microsec_ / 1000; }
 
   static inline uint32_t cnt_per_microsec_;
 };

--- a/driver/esp/esp_timebase.hpp
+++ b/driver/esp/esp_timebase.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "timebase.hpp"
 #include "esp_timer.h"
+#include "timebase.hpp"
 
 namespace LibXR
 {
@@ -24,20 +24,20 @@ class ESP32Timebase : public Timebase
 
   /**
    * @brief 获取当前时间（微秒）
-   * @return TimestampUS 当前时间（微秒）
+   * @return MicrosecondTimestamp 当前时间（微秒）
    */
-  TimestampUS _get_microseconds() override
+  MicrosecondTimestamp _get_microseconds() override
   {
     return esp_timer_get_time();  // 返回自启动以来的微秒数
   }
 
   /**
    * @brief 获取当前时间（毫秒）
-   * @return TimestampMS 当前时间（毫秒）
+   * @return MillisecondTimestamp 当前时间（毫秒）
    */
-  TimestampMS _get_milliseconds() override
+  MillisecondTimestamp _get_milliseconds() override
   {
-    return static_cast<TimestampMS>(esp_timer_get_time() / 1000) % UINT32_MAX;
+    return static_cast<MillisecondTimestamp>(esp_timer_get_time() / 1000) % UINT32_MAX;
   }
 };
 

--- a/driver/st/stm32_flash.hpp
+++ b/driver/st/stm32_flash.hpp
@@ -179,7 +179,7 @@ class STM32Flash : public Flash
                                                  0xFFFFFFFFu, 0xFFFFFFFFu};
     while (written < data.size_)
     {
-      size_t chunk_size = LibXR::min<size_t>(min_write_size_, data.size_ - written);
+      size_t chunk_size = LibXR::min<size_t>(MinWriteSize(), data.size_ - written);
 
       std::memcpy(flash_word_buffer, src + written, chunk_size);
 
@@ -203,7 +203,7 @@ class STM32Flash : public Flash
 #else
     while (written < data.size_)
     {
-      size_t chunk_size = LibXR::min<size_t>(min_write_size_, data.size_ - written);
+      size_t chunk_size = LibXR::min<size_t>(MinWriteSize(), data.size_ - written);
 
       if (memcmp(reinterpret_cast<const uint8_t*>(addr + written), src + written,
                  chunk_size) == 0)

--- a/driver/st/stm32_timebase.hpp
+++ b/driver/st/stm32_timebase.hpp
@@ -27,9 +27,9 @@ class STM32Timebase : public Timebase
    * It calculates current microsecond timestamp based on SysTick counter and system tick
    * value.
    *
-   * @return TimestampUS 当前时间（微秒） / Current timestamp in microseconds
+   * @return MicrosecondTimestamp 当前时间（微秒） / Current timestamp in microseconds
    */
-  TimestampUS _get_microseconds()
+  MicrosecondTimestamp _get_microseconds()
   {
     uint32_t ms_old = HAL_GetTick();
     uint32_t tick_value_old = SysTick->VAL;
@@ -41,12 +41,14 @@ class STM32Timebase : public Timebase
     switch (time_diff)
     {
       case 0:
-        return TimestampUS(static_cast<uint64_t>(ms_new) * 1000 + 1000 -
-                           static_cast<uint64_t>(tick_value_old) * 1000 / tick_load);
+        return MicrosecondTimestamp(static_cast<uint64_t>(ms_new) * 1000 + 1000 -
+                                    static_cast<uint64_t>(tick_value_old) * 1000 /
+                                        tick_load);
       case 1:
         /* 中断发生在两次读取之间 / Interrupt happened between two reads */
-        return TimestampUS(static_cast<uint64_t>(ms_new) * 1000 + 1000 -
-                           static_cast<uint64_t>(tick_value_new) * 1000 / tick_load);
+        return MicrosecondTimestamp(static_cast<uint64_t>(ms_new) * 1000 + 1000 -
+                                    static_cast<uint64_t>(tick_value_new) * 1000 /
+                                        tick_load);
       default:
         /* 中断耗时过长（超过1ms），程序异常 / Indicates that interrupt took more than
          * 1ms, an error case */
@@ -59,9 +61,9 @@ class STM32Timebase : public Timebase
   /**
    * @brief 获取当前时间（毫秒级） / Get current time in milliseconds
    *
-   * @return TimestampMS 当前时间（毫秒） / Current timestamp in milliseconds
+   * @return MillisecondTimestamp 当前时间（毫秒） / Current timestamp in milliseconds
    */
-  TimestampMS _get_milliseconds() { return HAL_GetTick(); }
+  MillisecondTimestamp _get_milliseconds() { return HAL_GetTick(); }
 };
 
 #ifdef HAL_TIM_MODULE_ENABLED
@@ -90,9 +92,9 @@ class STM32TimerTimebase : public Timebase
    * It calculates current microsecond timestamp based on hardware timer counter and
    * system tick value.
    *
-   * @return TimestampUS 当前时间（微秒） / Current timestamp in microseconds
+   * @return MicrosecondTimestamp 当前时间（微秒） / Current timestamp in microseconds
    */
-  TimestampUS _get_microseconds()
+  MicrosecondTimestamp _get_microseconds()
   {
     uint32_t ms_old = HAL_GetTick();
     uint32_t tick_value_old = __HAL_TIM_GET_COUNTER(htim);
@@ -105,12 +107,14 @@ class STM32TimerTimebase : public Timebase
     switch (delta_ms)
     {
       case 0:
-        return TimestampUS(static_cast<uint64_t>(ms_new) * 1000 +
-                           static_cast<uint64_t>(tick_value_old) * 1000 / autoreload);
+        return MicrosecondTimestamp(static_cast<uint64_t>(ms_new) * 1000 +
+                                    static_cast<uint64_t>(tick_value_old) * 1000 /
+                                        autoreload);
       case 1:
         /* 中断发生在两次读取之间 / Interrupt happened between two reads */
-        return TimestampUS(static_cast<uint64_t>(ms_new) * 1000 +
-                           static_cast<uint64_t>(tick_value_new) * 1000 / autoreload);
+        return MicrosecondTimestamp(static_cast<uint64_t>(ms_new) * 1000 +
+                                    static_cast<uint64_t>(tick_value_new) * 1000 /
+                                        autoreload);
       default:
         /* 中断耗时过长（超过1ms），程序异常 / Indicates that interrupt took more than
          * 1ms, an error case */
@@ -123,9 +127,9 @@ class STM32TimerTimebase : public Timebase
   /**
    * @brief 获取当前时间（毫秒级） / Get current time in milliseconds
    *
-   * @return TimestampMS 当前时间（毫秒） / Current timestamp in milliseconds
+   * @return MillisecondTimestamp 当前时间（毫秒） / Current timestamp in milliseconds
    */
-  TimestampMS _get_milliseconds() { return HAL_GetTick(); }
+  MillisecondTimestamp _get_milliseconds() { return HAL_GetTick(); }
 
   /**
    * @brief 硬件定时器句柄指针 / Static pointer to hardware timer handle

--- a/driver/st/stm32_watchdog.hpp
+++ b/driver/st/stm32_watchdog.hpp
@@ -70,7 +70,7 @@ class STM32Watchdog : public Watchdog
     }
 
     timeout_ms_ = config.timeout_ms;
-    feed_ms_ = config.feed_ms;
+    auto_feed_interval_ms = config.feed_ms;
 
     hiwdg_->Init.Prescaler = best_pr;
     hiwdg_->Init.Reload = best_rlr;

--- a/src/core/libxr_assert.hpp
+++ b/src/core/libxr_assert.hpp
@@ -3,7 +3,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
-#include <optional>
 
 #include "libxr_cb.hpp"
 #include "libxr_def.hpp"
@@ -40,19 +39,6 @@ class Assert
 {
  public:
   using Callback = LibXR::Callback<const char *, uint32_t>;
-  /**
-   * @brief 注册致命错误的回调函数。
-   *        Registers a fatal error callback.
-   *
-   * 该回调函数会在发生致命错误时被触发，用于执行相应的错误处理逻辑。
-   * This callback will be triggered when a fatal error occurs.
-   *
-   * @param cb 要注册的回调函数。 The callback function to be registered.
-   */
-  static void RegisterFatalErrorCB(const Callback &cb)
-  {
-    libxr_fatal_error_callback_ = cb;
-  }
 
   /**
    * @brief 注册致命错误的回调函数。
@@ -63,7 +49,7 @@ class Assert
    * registered.
    */
   template <typename T>
-  static void RegisterFatalErrorCB(T &&cb)
+  static void RegisterFatalErrorCallback(T &&cb)
   {
     libxr_fatal_error_callback_ = std::forward<T>(cb);
   }
@@ -128,6 +114,6 @@ class Assert
    *        Registered fatal error callback.
    *
    */
-  static inline Callback libxr_fatal_error_callback_;
+  static inline Callback libxr_fatal_error_callback_;  // NOLINT
 };
 }  // namespace LibXR

--- a/src/core/libxr_cb.hpp
+++ b/src/core/libxr_cb.hpp
@@ -99,7 +99,6 @@ class CallbackBlock
     {
       fun_ = std::exchange(other.fun_, nullptr);
       arg_ = std::move(other.arg_);
-      in_isr_ = other.in_isr_;
     }
     return *this;
   }

--- a/src/core/libxr_def.hpp
+++ b/src/core/libxr_def.hpp
@@ -32,7 +32,7 @@ constexpr double M_1G = 9.80665;
 #ifndef OFFSET_OF
 /// \brief 计算结构体成员在结构体中的偏移量
 /// \brief Computes the offset of a member within a struct
-#define OFFSET_OF(type, member) ((size_t) & ((type *)0)->member)
+#define OFFSET_OF(type, member) ((size_t)&((type *)0)->member)
 #endif
 
 #ifndef MEMBER_SIZE_OF
@@ -41,10 +41,12 @@ constexpr double M_1G = 9.80665;
 #define MEMBER_SIZE_OF(type, member) (sizeof(decltype(((type *)0)->member)))
 #endif
 
+#ifndef CONTAINER_OF
 /// \brief 通过成员指针获取包含该成员的结构体指针
 /// \brief Retrieve the pointer to the containing structure from a member pointer
 #define CONTAINER_OF(ptr, type, member) \
   ((type *)((char *)(ptr) - OFFSET_OF(type, member)))  // NOLINT
+#endif
 
 /// \brief 缓存行大小
 static constexpr size_t LIBXR_CACHE_LINE_SIZE = (sizeof(void *) == 8) ? 64 : 32;
@@ -65,7 +67,7 @@ enum class ErrorCode : int8_t
   CHECK_ERR = -6,     ///< 校验错误 | Check error
   NOT_SUPPORT = -7,   ///< 不支持 | Not supported
   NOT_FOUND = -8,     ///< 未找到 | Not found
-  NO_REPONSE = -9,    ///< 无响应 | No response
+  NO_RESPONSE = -9,   ///< 无响应 | No response
   NO_MEM = -10,       ///< 内存不足 | Insufficient memory
   NO_BUFF = -11,      ///< 缓冲区不足 | Insufficient buffer
   TIMEOUT = -12,      ///< 超时 | Timeout
@@ -137,6 +139,9 @@ extern void libxr_fatal_error(const char *file, uint32_t line, bool in_isr);
 
 namespace LibXR
 {
+using ErrorCode = ErrorCode;
+using SizeLimitMode = SizeLimitMode;
+
 /**
  * @brief 计算两个数的最大值
  * @brief Computes the maximum of two numbers

--- a/src/core/libxr_time.hpp
+++ b/src/core/libxr_time.hpp
@@ -12,24 +12,24 @@ namespace LibXR
 {
 
 /**
- * @class TimestampUS
+ * @class MicrosecondTimestamp
  * @brief 表示微秒级时间戳的类。Class representing a timestamp in microseconds.
  */
-class TimestampUS
+class MicrosecondTimestamp
 {
  public:
   /**
    * @brief 默认构造函数，初始化时间戳为 0。
    * Default constructor initializing the timestamp to 0.
    */
-  TimestampUS() : microsecond_(0) {}
+  MicrosecondTimestamp() : microsecond_(0) {}
 
   /**
    * @brief 以给定的微秒值构造时间戳。
    * Constructor initializing the timestamp with a given microsecond value.
    * @param microsecond 以微秒表示的时间值。Time value in microseconds.
    */
-  TimestampUS(uint64_t microsecond) : microsecond_(microsecond) {}
+  MicrosecondTimestamp(uint64_t microsecond) : microsecond_(microsecond) {}
 
   /**
    * @brief 转换运算符，将时间戳转换为 uint64_t。
@@ -38,10 +38,10 @@ class TimestampUS
   operator uint64_t() const { return microsecond_; }
 
   /**
-   * @class TimeDiffUS
+   * @class Duration
    * @brief 表示微秒级时间差的类。Class representing a time difference in microseconds.
    */
-  class TimeDiffUS
+  class Duration
   {
    public:
     /**
@@ -49,7 +49,7 @@ class TimestampUS
      * Constructor initializing the time difference.
      * @param diff 以微秒表示的时间差。Time difference in microseconds.
      */
-    TimeDiffUS(uint64_t diff) : diff_(diff) {}
+    Duration(uint64_t diff) : diff_(diff) {}
 
     /**
      * @brief 转换运算符，将时间差转换为 uint64_t。
@@ -95,9 +95,9 @@ class TimestampUS
    * @brief 计算两个时间戳之间的时间差。
    * Computes the time difference between two timestamps.
    * @param old_microsecond 旧的时间戳。The older timestamp.
-   * @return TimeDiffUS 计算得到的时间差。Computed time difference.
+   * @return Duration 计算得到的时间差。Computed time difference.
    */
-  TimeDiffUS operator-(const TimestampUS &old_microsecond) const
+  Duration operator-(const MicrosecondTimestamp &old_microsecond) const
   {
     uint64_t diff;  // NOLINT
 
@@ -112,16 +112,16 @@ class TimestampUS
 
     ASSERT(diff <= libxr_timebase_max_valid_us);
 
-    return TimeDiffUS(diff);
+    return Duration(diff);
   }
 
   /**
    * @brief 赋值运算符重载。
    * Assignment operator overload.
-   * @param other 另一个 TimestampUS 对象。Another TimestampUS object.
+   * @param other 另一个 MicrosecondTimestamp 对象。Another MicrosecondTimestamp object.
    * @return 返回当前对象的引用。Returns a reference to the current object.
    */
-  TimestampUS &operator=(const TimestampUS &other)
+  MicrosecondTimestamp &operator=(const MicrosecondTimestamp &other)
   {
     if (this != &other)
     {
@@ -135,21 +135,21 @@ class TimestampUS
 };
 
 /**
- * @class TimestampMS
+ * @class MillisecondTimestamp
  * @brief 表示毫秒级时间戳的类。Class representing a timestamp in milliseconds.
  */
-class TimestampMS
+class MillisecondTimestamp
 {
  public:
-  TimestampMS() : millisecond_(0) {}
-  TimestampMS(uint32_t millisecond) : millisecond_(millisecond) {}
+  MillisecondTimestamp() : millisecond_(0) {}
+  MillisecondTimestamp(uint32_t millisecond) : millisecond_(millisecond) {}
   operator uint32_t() const { return millisecond_; }
 
   /**
-   * @class TimeDiffMS
+   * @class Duration
    * @brief 表示毫秒级时间差的类。Class representing a time difference in milliseconds.
    */
-  class TimeDiffMS
+  class Duration
   {
    public:
     /**
@@ -157,7 +157,7 @@ class TimestampMS
      * Constructor initializing the time difference.
      * @param diff 以毫秒表示的时间差。Time difference in milliseconds.
      */
-    TimeDiffMS(uint32_t diff) : diff_(diff) {}
+    Duration(uint32_t diff) : diff_(diff) {}
 
     /**
      * @brief 转换运算符，将时间差转换为 uint32_t。
@@ -200,9 +200,9 @@ class TimestampMS
    * @brief 计算两个时间戳之间的时间差。
    * Computes the time difference between two timestamps.
    * @param old_millisecond 旧的时间戳。The older timestamp.
-   * @return TimeDiffMS 计算得到的时间差。Computed time difference.
+   * @return Duration 计算得到的时间差。Computed time difference.
    */
-  [[nodiscard]] TimeDiffMS operator-(const TimestampMS &old_millisecond) const
+  [[nodiscard]] Duration operator-(const MillisecondTimestamp &old_millisecond) const
   {
     uint32_t diff;  // NOLINT
 
@@ -217,7 +217,7 @@ class TimestampMS
 
     ASSERT(diff <= libxr_timebase_max_valid_ms);
 
-    return TimeDiffMS(diff);
+    return Duration(diff);
   }
 
  private:

--- a/src/core/libxr_type.hpp
+++ b/src/core/libxr_type.hpp
@@ -83,7 +83,7 @@ class RawData
    *             The character array to be stored.
    */
   template <size_t N>
-  RawData(const char (&data)[N]) : addr_(&data), size_(N - 1)
+  RawData(const char (&data)[N]) : addr_(reinterpret_cast<void *>(data)), size_(N - 1)
   {
   }
 
@@ -95,7 +95,7 @@ class RawData
    * @param data `std::string` 类型数据。
    *             A `std::string` object.
    */
-  RawData(const std::string &data)
+  explicit RawData(const std::string &data)
       : addr_(const_cast<char *>(data.data())), size_(data.size())
   {
   }
@@ -157,7 +157,7 @@ class ConstRawData
    */
   template <typename DataType>
   ConstRawData(const DataType &data)
-      : addr_(const_cast<DataType *>(&data)), size_(sizeof(DataType))
+      : addr_(reinterpret_cast<const DataType *>(&data)), size_(sizeof(DataType))
   {
   }
 
@@ -198,6 +198,22 @@ class ConstRawData
    *             A C-style string pointer.
    */
   ConstRawData(const char *data) : addr_(data), size_(data ? strlen(data) : 0) {}
+
+  /**
+   * @brief 从字符数组构造 `ConstRawData`，数据大小为数组长度减 1（不含 `\0`）。
+   *        Constructs `ConstRawData` from a character array,
+   *        with size set to array length minus 1 (excluding `\0`).
+   *
+   * @tparam N 数组大小。
+   *           The array size.
+   * @param data 需要存储的字符数组。
+   *             The character array to be stored.
+   */
+  template <size_t N>
+  ConstRawData(const char (&data)[N])
+      : addr_(reinterpret_cast<const void *>(data)), size_(N - 1)
+  {
+  }
 
   /**
    * @brief 赋值运算符重载。

--- a/src/driver/flash.hpp
+++ b/src/driver/flash.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 
+#include "libxr_def.hpp"
+#include "libxr_rw.hpp"
 #include "libxr_type.hpp"
 
 namespace LibXR
@@ -31,13 +34,6 @@ class Flash
   {
   }
 
-  size_t min_erase_size_ =
-      0;  ///< Minimum erasable block size in bytes. 最小可擦除块大小（字节）。
-  size_t min_write_size_ =
-      0;  ///< Minimum writable block size in bytes. 最小可写块大小（字节）。
-  RawData flash_area_;  ///< Memory area allocated for flash operations.
-                        ///< 用于闪存操作的存储区域。
-
   /**
    * @brief Erases a section of the flash memory. 擦除闪存的指定区域。
    * @param offset The starting offset of the section to erase. 要擦除的起始偏移地址。
@@ -53,6 +49,50 @@ class Flash
    * @return ErrorCode indicating success or failure. 返回操作结果的错误码。
    */
   virtual ErrorCode Write(size_t offset, ConstRawData data) = 0;
+
+  virtual ErrorCode Read(size_t offset, RawData data)
+  {
+    ASSERT(offset + data.size_ <= flash_area_.size_);
+    memcpy(data.addr_, reinterpret_cast<const uint8_t*>(flash_area_.addr_) + offset,
+           data.size_);
+
+    return ErrorCode::OK;
+  }
+
+  /**
+   * @brief Returns the minimum erasable block size in bytes.
+   * 获取最小可擦除块大小（字节）。
+   *
+   * @return size_t Minimum erasable block size in bytes.
+   * 最小可擦除块大小（字节）。
+   */
+  size_t MinEraseSize() const { return min_erase_size_; }
+
+  /**
+   * @brief Returns the minimum writable block size in bytes.
+   * 获取最小可写块大小（字节）。
+   *
+   * @return size_t Minimum writable block size in bytes.
+   * 最小可写块大小（字节）。
+   */
+  size_t MinWriteSize() const { return min_write_size_; }
+
+  /**
+   * @brief Returns the memory area allocated for flash operations.
+   * 获取用于闪存操作的存储区域。
+   *
+   * @return const RawData& The memory area allocated for flash operations.
+   * 用于闪存操作的存储区域。
+   */
+  size_t Size() const { return flash_area_.size_; }
+
+ private:
+  size_t min_erase_size_ =
+      0;  ///< Minimum erasable block size in bytes. 最小可擦除块大小（字节）。
+  size_t min_write_size_ =
+      0;  ///< Minimum writable block size in bytes. 最小可写块大小（字节）。
+  RawData flash_area_;  ///< Memory area allocated for flash operations.
+                        ///< 用于闪存操作的存储区域。
 };
 
 }  // namespace LibXR

--- a/src/driver/power.hpp
+++ b/src/driver/power.hpp
@@ -44,6 +44,13 @@ class PowerManager
    * operations, such as cutting off power or entering a low-power mode.
    */
   virtual void Shutdown() = 0;
+
+  /**
+   * @brief 跳转到启动加载器 / Jumps to the bootloader
+   *
+   *
+   */
+  virtual void JumpToBootloader() { Reset(); }
 };
 
 }  // namespace LibXR

--- a/src/driver/timebase.hpp
+++ b/src/driver/timebase.hpp
@@ -46,7 +46,7 @@ class Timebase
    * @return 返回当前的时间戳（单位：微秒）。
    *         Returns the current timestamp (in microseconds).
    */
-  static TimestampUS GetMicroseconds() { return timebase->_get_microseconds(); }
+  static MicrosecondTimestamp GetMicroseconds() { return timebase->_get_microseconds(); }
 
   /**
    * @brief 获取当前时间的毫秒级时间戳。
@@ -60,7 +60,7 @@ class Timebase
    * @return 返回当前的时间戳（单位：毫秒）。
    *         Returns the current timestamp (in milliseconds).
    */
-  static TimestampMS GetMilliseconds() { return timebase->_get_milliseconds(); }
+  static MillisecondTimestamp GetMilliseconds() { return timebase->_get_milliseconds(); }
 
   /**
    * @brief 纯虚函数，获取当前时间的微秒级时间戳（由派生类实现）。
@@ -74,7 +74,7 @@ class Timebase
    * @return 返回当前的时间戳（单位：微秒）。
    *         Returns the current timestamp (in microseconds).
    */
-  virtual TimestampUS _get_microseconds() = 0;  // NOLINT
+  virtual MicrosecondTimestamp _get_microseconds() = 0;  // NOLINT
 
   /**
    * @brief 纯虚函数，获取当前时间的毫秒级时间戳（由派生类实现）。
@@ -88,7 +88,7 @@ class Timebase
    * @return 返回当前的时间戳（单位：毫秒）。
    *         Returns the current timestamp (in milliseconds).
    */
-  virtual TimestampMS _get_milliseconds() = 0;  // NOLINT
+  virtual MillisecondTimestamp _get_milliseconds() = 0;  // NOLINT
 
   /**
    * @brief 静态指针，用于存储全局时间基对象。

--- a/src/driver/watchdog.hpp
+++ b/src/driver/watchdog.hpp
@@ -83,7 +83,7 @@ class Watchdog
       {
         wdg->Feed();
       }
-      LibXR::Thread::Sleep(wdg->feed_ms_);
+      LibXR::Thread::Sleep(wdg->auto_feed_interval_ms);
     }
   }
 
@@ -106,9 +106,9 @@ class Watchdog
     }
   }
 
-  uint32_t timeout_ms_ = 3000;  ///< 溢出时间
-  uint32_t feed_ms_ = 1000;     ///< 自动喂狗间隔
-  bool auto_feed_ = false;      ///< 是否自动喂狗
+  uint32_t timeout_ms_ = 3000;            ///< 溢出时间
+  uint32_t auto_feed_interval_ms = 1000;  ///< 自动喂狗间隔
+  bool auto_feed_ = false;                ///< 是否自动喂狗
 };
 
 }  // namespace LibXR

--- a/src/middleware/database.cpp
+++ b/src/middleware/database.cpp
@@ -7,100 +7,109 @@
 
 using namespace LibXR;
 
-/**
- * @brief 构造函数，初始化数据库存储，并设置缓冲区 (Constructor to initialize database
- * storage and set buffer).
- * @param flash 闪存对象 (Flash object).
- * @param max_buffer_size 最大缓冲区大小 (Maximum buffer size).
- */
 DatabaseRawSequential::DatabaseRawSequential(Flash& flash, size_t max_buffer_size)
     : flash_(flash), max_buffer_size_(max_buffer_size)
 {
-  ASSERT(flash.min_erase_size_ * 2 <= flash.flash_area_.size_);
-  if (max_buffer_size * 2 > flash.flash_area_.size_)
+  ASSERT(flash.MinEraseSize() * 2 <= flash.Size());
+  if (max_buffer_size * 2 > flash.Size())
   {
-    max_buffer_size = flash.flash_area_.size_ / 2;
+    max_buffer_size = flash.Size() / 2;
   }
-  auto block_num = static_cast<size_t>(flash.flash_area_.size_ / flash.min_erase_size_);
-  block_size_ = block_num / 2 * flash.min_erase_size_;
-  data_buffer_ = new uint8_t[max_buffer_size];
-  flash_data_ = reinterpret_cast<FlashInfo*>(data_buffer_);
-  info_main_ = reinterpret_cast<FlashInfo*>(flash.flash_area_.addr_);
-  info_backup_ = reinterpret_cast<FlashInfo*>(
-      reinterpret_cast<uint8_t*>(flash.flash_area_.addr_) + block_size_);
+  auto block_num = static_cast<size_t>(flash.Size() / flash.MinEraseSize());
+  block_size_ = block_num / 2 * flash.MinEraseSize();
+  buffer_ = new uint8_t[max_buffer_size];
+
   Init();
 }
 
-/**
- * @brief 初始化数据库存储，确保主备块正确 (Initialize database storage, ensuring main and
- * backup blocks are valid).
- */
 void DatabaseRawSequential::Init()
 {
-  memset(data_buffer_, 0xFF, max_buffer_size_);
+  memset(buffer_, 0xFF, max_buffer_size_);
+  FlashInfo* flash_data_ = reinterpret_cast<FlashInfo*>(buffer_);
   flash_data_->header = FLASH_HEADER;
   flash_data_->key = {0, 0, 0};
-  data_buffer_[max_buffer_size_ - 1] = CHECKSUM_BYTE;
+  buffer_[max_buffer_size_ - 1] = CHECKSUM_BYTE;
 
-  if (!IsBlockInited(info_backup_) || IsBlockError(info_backup_))
+  if (!IsBlockInited(BlockType::BACKUP) || IsBlockError(BlockType::BACKUP))
   {
-    InitBlock(info_backup_);
+    InitBlock(BlockType::BACKUP);
   }
 
-  if (IsBlockError(info_main_))
+  if (IsBlockError(BlockType::MAIN))
   {
-    if (IsBlockEmpty(info_backup_))
+    if (IsBlockEmpty(BlockType::BACKUP))
     {
-      InitBlock(info_main_);
+      InitBlock(BlockType::MAIN);
     }
     else
     {
+      flash_.Read(block_size_, {buffer_, max_buffer_size_});
       flash_.Erase(0, block_size_);
-      flash_.Write(0, {reinterpret_cast<uint8_t*>(info_backup_), max_buffer_size_});
+      flash_.Write(0, {buffer_, max_buffer_size_});
     }
   }
 
-  memcpy(data_buffer_, info_main_, max_buffer_size_);
+  if (!IsBlockEmpty(BlockType::BACKUP))
+  {
+    InitBlock(BlockType::MAIN);
+  }
+
+  Load();
 }
 
-/**
- * @brief 保存数据到存储器 (Save data to storage).
- */
 void DatabaseRawSequential::Save()
 {
   flash_.Erase(block_size_, block_size_);
-  flash_.Write(block_size_, {reinterpret_cast<uint8_t*>(info_main_), max_buffer_size_});
+  flash_.Write(block_size_, {buffer_, max_buffer_size_});
 
   flash_.Erase(0, block_size_);
-  flash_.Write(0, {data_buffer_, max_buffer_size_});
+  flash_.Write(0, {buffer_, max_buffer_size_});
 }
 
-/**
- * @brief 加载数据到缓冲区 (Load data into buffer).
- */
-void DatabaseRawSequential::Load() { memcpy(data_buffer_, info_main_, max_buffer_size_); }
+void DatabaseRawSequential::Load() { flash_.Read(0, {buffer_, max_buffer_size_}); }
 
-/**
- * @brief 还原存储数据 (Restore storage data).
- */
 void DatabaseRawSequential::Restore()
 {
-  flash_.Erase(0, max_buffer_size_);
-  flash_.Erase(block_size_, max_buffer_size_);
+  memset(buffer_, 0xFF, max_buffer_size_);
+  FlashInfo* flash_data_ = reinterpret_cast<FlashInfo*>(buffer_);
+  flash_data_->header = FLASH_HEADER;
+  flash_data_->key = {0, 0, 0};
+  buffer_[max_buffer_size_ - 1] = CHECKSUM_BYTE;
+  flash_.Write(0, {buffer_, max_buffer_size_});
+  flash_.Write(block_size_, {buffer_, max_buffer_size_});
 }
 
-/**
- * @brief 初始化块数据 (Initialize block data).
- * @param block 需要初始化的块 (Block to initialize).
- */
-void DatabaseRawSequential::InitBlock(FlashInfo* block)
+ErrorCode DatabaseRawSequential::Get(Database::KeyBase& key)
 {
-  flash_.Erase(reinterpret_cast<size_t>(block) -
-                   reinterpret_cast<size_t>(flash_.flash_area_.addr_),
-               block_size_);
-  flash_.Write(reinterpret_cast<size_t>(block) -
-                   reinterpret_cast<size_t>(flash_.flash_area_.addr_),
-               {data_buffer_, block_size_});
+  auto ans = SearchKey(key.name_);
+  if (!ans)
+  {
+    return ErrorCode::NOT_FOUND;
+  }
+
+  KeyInfo key_buffer;
+  flash_.Read(ans, key_buffer);
+
+  if (key.raw_data_.size_ != key_buffer.GetDataSize())
+  {
+    return ErrorCode::FAILED;
+  }
+
+  GetKeyData(ans, key.raw_data_);
+
+  return ErrorCode::OK;
+}
+
+void DatabaseRawSequential::InitBlock(BlockType block)
+{
+  size_t offset = 0;
+  if (block == BlockType::BACKUP)
+  {
+    offset = block_size_;
+  }
+
+  flash_.Erase(offset, block_size_);
+  flash_.Write(offset, {buffer_, max_buffer_size_});
 }
 
 /**
@@ -109,9 +118,16 @@ void DatabaseRawSequential::InitBlock(FlashInfo* block)
  * @return 如果已初始化返回 true，否则返回 false (Returns true if initialized, false
  * otherwise).
  */
-bool DatabaseRawSequential::IsBlockInited(FlashInfo* block)
+bool DatabaseRawSequential::IsBlockInited(BlockType block)
 {
-  return block->header == FLASH_HEADER;
+  size_t offset = 0;
+  if (block == BlockType::BACKUP)
+  {
+    offset = block_size_;
+  }
+  FlashInfo flash_data_;
+  flash_.Read(offset, flash_data_);
+  return flash_data_.header == FLASH_HEADER;
 }
 
 /**
@@ -119,9 +135,16 @@ bool DatabaseRawSequential::IsBlockInited(FlashInfo* block)
  * @param block 需要检查的块 (Block to check).
  * @return 如果为空返回 true，否则返回 false (Returns true if empty, false otherwise).
  */
-bool DatabaseRawSequential::IsBlockEmpty(FlashInfo* block)
+bool DatabaseRawSequential::IsBlockEmpty(BlockType block)
 {
-  return block->key.GetNameLength() == 0;
+  size_t offset = 0;
+  if (block == BlockType::BACKUP)
+  {
+    offset = block_size_;
+  }
+  FlashInfo flash_data_;
+  flash_.Read(offset, flash_data_);
+  return flash_data_.key.GetNameLength() == 0;
 }
 
 /**
@@ -129,60 +152,93 @@ bool DatabaseRawSequential::IsBlockEmpty(FlashInfo* block)
  * @param block 需要检查的块 (Block to check).
  * @return 如果损坏返回 true，否则返回 false (Returns true if corrupted, false otherwise).
  */
-bool DatabaseRawSequential::IsBlockError(FlashInfo* block)
+bool DatabaseRawSequential::IsBlockError(BlockType block)
 {
-  return reinterpret_cast<uint8_t*>(
-             block)[max_buffer_size_ / sizeof(CHECKSUM_BYTE) - 1] != CHECKSUM_BYTE;
+  size_t offset = 0;
+  if (block == BlockType::BACKUP)
+  {
+    offset = block_size_;
+  }
+  uint8_t checksum_byte = 0;
+  flash_.Read(offset + max_buffer_size_ / sizeof(CHECKSUM_BYTE) - 1, checksum_byte);
+  return checksum_byte != CHECKSUM_BYTE;
 }
 
-/**
- * @brief 计算键的总大小 (Calculate total size of a key).
- * @param key 键信息 (Key information).
- * @return 键的大小 (Size of the key).
- */
-size_t DatabaseRawSequential::GetKeySize(KeyInfo* key)
+bool DatabaseRawSequential::HasLastKey(size_t offset)
 {
-  return sizeof(KeyInfo) + key->GetNameLength() + key->GetDataSize();
+  KeyInfo key;
+  flash_.Read(offset, key);
+  return key.GetNextKeyExist();
 }
 
-/**
- * @brief 获取下一个键 (Get next key).
- * @param key 当前键 (Current key).
- * @return 下一个键 (Next key).
- */
-DatabaseRawSequential::KeyInfo* DatabaseRawSequential::GetNextKey(KeyInfo* key)
+size_t DatabaseRawSequential::GetKeySize(size_t offset)
 {
-  return reinterpret_cast<KeyInfo*>(reinterpret_cast<uint8_t*>(key) + GetKeySize(key));
+  KeyInfo key;
+  flash_.Read(offset, key);
+  return sizeof(KeyInfo) + key.GetNameLength() + key.GetDataSize();
 }
 
-/**
- * @brief 获取块中的最后一个键 (Get last key in block).
- * @param block 目标块 (Block to check).
- * @return 最后一个键的指针，如果块为空返回 nullptr (Pointer to last key, or nullptr if
- * block is empty).
- */
-DatabaseRawSequential::KeyInfo* DatabaseRawSequential::GetLastKey(FlashInfo* block)
+size_t DatabaseRawSequential::GetNextKey(size_t offset)
+{
+  return offset + GetKeySize(offset);
+}
+
+size_t DatabaseRawSequential::GetLastKey(BlockType block)
 {
   if (IsBlockEmpty(block))
   {
-    return nullptr;
+    return 0;
   }
 
-  KeyInfo* key = &block->key;
-  while (key->GetNextKeyExist())
+  size_t offset = OFFSET_OF(FlashInfo, key);
+  while (HasLastKey(offset))
   {
-    key = GetNextKey(key);
+    offset = GetNextKey(offset);
   }
-  return key;
+  return offset;
 }
 
-/**
- * @brief 添加键值对到数据库 (Add key-value pair to database).
- * @param name 键名 (Key name).
- * @param data 数据 (Data value).
- * @param size 数据大小 (Size of data).
- * @return 操作结果 (Operation result).
- */
+void DatabaseRawSequential::SetNestKeyExist(size_t offset, bool exist)
+{
+  KeyInfo key;
+  flash_.Read(offset, key);
+  key.SetNextKeyExist(exist);
+  memcpy(buffer_ + offset, &key, sizeof(KeyInfo));
+}
+
+bool DatabaseRawSequential::KeyDataCompare(size_t offset, const void* data, size_t size)
+{
+  KeyInfo key;
+  flash_.Read(offset, key);
+  size_t key_data_offset = offset + sizeof(KeyInfo) + key.GetNameLength();
+  uint8_t data_buffer;
+  for (size_t i = 0; i < size; i++)
+  {
+    flash_.Read(key_data_offset + i, data_buffer);
+    if (data_buffer != ((uint8_t*)data)[i])
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool DatabaseRawSequential::KeyNameCompare(size_t offset, const char* name)
+{
+  KeyInfo key;
+  flash_.Read(offset, key);
+  for (size_t i = 0; i < key.GetNameLength(); i++)
+  {
+    uint8_t data_buffer;
+    flash_.Read(offset + sizeof(KeyInfo) + i, data_buffer);
+    if (data_buffer != name[i])
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
 ErrorCode DatabaseRawSequential::AddKey(const char* name, const void* data, size_t size)
 {
   if (auto ans = SearchKey(name))
@@ -191,69 +247,52 @@ ErrorCode DatabaseRawSequential::AddKey(const char* name, const void* data, size
   }
 
   const uint32_t NAME_LEN = strlen(name) + 1;
-  KeyInfo* last_key = GetLastKey(flash_data_);
-  KeyInfo* key_buf = last_key ? GetNextKey(last_key) : &flash_data_->key;
+  size_t last_key_offset = GetLastKey(BlockType::MAIN);
+  size_t key_buf_offset =
+      last_key_offset ? GetNextKey(last_key_offset) : OFFSET_OF(FlashInfo, key);
 
-  const uint8_t* end_pos =
-      reinterpret_cast<uint8_t*>(key_buf) + sizeof(KeyInfo) + NAME_LEN + size;
-  if (end_pos > data_buffer_ + max_buffer_size_ - 1)
+  size_t end_pos_offset = key_buf_offset + sizeof(KeyInfo) + NAME_LEN + size;
+  if (end_pos_offset > max_buffer_size_ - 1)
   {
     return ErrorCode::FULL;
   }
 
-  uint8_t* data_ptr = reinterpret_cast<uint8_t*>(key_buf) + sizeof(KeyInfo);
-  memcpy(data_ptr, name, NAME_LEN);
-  memcpy(data_ptr + NAME_LEN, data, size);
+  size_t data_ptr_offset = key_buf_offset + sizeof(KeyInfo);
+  memcpy(buffer_ + data_ptr_offset, name, NAME_LEN);
+  memcpy(buffer_ + data_ptr_offset + NAME_LEN, data, size);
 
-  *key_buf = KeyInfo{0, static_cast<uint8_t>(NAME_LEN), static_cast<uint32_t>(size)};
-  if (last_key)
+  KeyInfo key_buf = {0, static_cast<uint8_t>(NAME_LEN), static_cast<uint32_t>(size)};
+  memcpy(buffer_ + key_buf_offset, &key_buf, sizeof(KeyInfo));
+  if (last_key_offset)
   {
-    last_key->SetNextKeyExist(1);
+    SetNestKeyExist(last_key_offset, 1);
   }
 
   Save();
   return ErrorCode::OK;
 }
 
-/**
- * @brief 设置键值 (Set key value).
- * @param name 键名 (Key name).
- * @param data 数据 (Data value).
- * @param size 数据大小 (Size of data).
- * @return 操作结果 (Operation result).
- */
 ErrorCode DatabaseRawSequential::SetKey(const char* name, const void* data, size_t size)
 {
-  if (KeyInfo* key = SearchKey(name))
+  if (size_t key_offset = SearchKey(name))
   {
-    return SetKey(key, data, size);
+    return SetKey(key_offset, data, size);
   }
   return ErrorCode::FAILED;
 }
 
-/**
- * @brief 设置指定键的值 (Set the value of a specified key).
- *
- * This function updates the key's data if the new size matches the existing size.
- * If the data differs, it will be updated and saved.
- * 此函数在新数据大小与现有数据大小匹配时更新键的值。如果数据不同，则会进行更新并保存。
- *
- * @param key 指向要更新的键的指针 (Pointer to the key to update).
- * @param data 指向要写入的数据 (Pointer to the data to be written).
- * @param size 数据大小 (Size of the data).
- * @return 返回操作结果，成功返回 ErrorCode::OK，失败返回 ErrorCode::FAILED
- *         (Returns the operation result: ErrorCode::OK on success, ErrorCode::FAILED on
- * failure).
- */
-ErrorCode DatabaseRawSequential::SetKey(KeyInfo* key, const void* data, size_t size)
+ErrorCode DatabaseRawSequential::SetKey(size_t offset, const void* data, size_t size)
 {
-  ASSERT(key != nullptr);
+  ASSERT(offset != 0);
 
-  if (key->GetDataSize() == size)
+  KeyInfo key;
+  flash_.Read(offset, key);
+
+  if (key.GetDataSize() == size)
   {
-    if (memcmp(GetKeyData(key), data, size) != 0)
+    if (KeyDataCompare(offset, data, size))
     {
-      memcpy(GetKeyData(key), data, size);
+      memcpy(buffer_ + offset + sizeof(KeyInfo) + key.GetNameLength(), data, size);
       Save();
     }
     return ErrorCode::OK;
@@ -262,59 +301,38 @@ ErrorCode DatabaseRawSequential::SetKey(KeyInfo* key, const void* data, size_t s
   return ErrorCode::FAILED;
 }
 
-/**
- * @brief 获取键的数据信息 (Retrieve the data associated with a key).
- *
- * This function returns a pointer to the data section of the specified key.
- * 此函数返回指向指定键的数据部分的指针。
- *
- * @param key 指向目标键的指针 (Pointer to the key whose data is retrieved).
- * @return 返回数据的起始地址 (Returns a pointer to the start of the data).
- */
-uint8_t* DatabaseRawSequential::GetKeyData(KeyInfo* key)
+ErrorCode DatabaseRawSequential::GetKeyData(size_t offset, RawData data)
 {
-  return reinterpret_cast<uint8_t*>(key) + sizeof(KeyInfo) + key->GetNameLength();
-}
-
-/**
- * @brief 获取键的名称 (Retrieve the name of a key).
- *
- * This function returns a pointer to the name section of the specified key.
- * 此函数返回指向指定键名称部分的指针。
- *
- * @param key 指向目标键的指针 (Pointer to the key whose name is retrieved).
- * @return 返回键名的起始地址 (Returns a pointer to the start of the key name).
- */
-const char* DatabaseRawSequential::GetKeyName(KeyInfo* key)
-{
-  return reinterpret_cast<const char*>(key) + sizeof(KeyInfo);
-}
-
-/**
- * @brief 查找键 (Search for key).
- * @param name 需要查找的键名 (Key name to search).
- * @return 指向找到的键的指针，若不存在则返回 nullptr (Pointer to found key, or nullptr if
- * not found).
- */
-DatabaseRawSequential::KeyInfo* DatabaseRawSequential::SearchKey(const char* name)
-{
-  if (IsBlockEmpty(flash_data_))
+  KeyInfo key;
+  flash_.Read(offset, key);
+  if (key.GetDataSize() > data.size_)
   {
-    return nullptr;
+    return ErrorCode::FAILED;
+  }
+  auto data_offset = offset + sizeof(KeyInfo) + key.GetNameLength();
+  flash_.Read(data_offset, {data.addr_, key.GetDataSize()});
+  return ErrorCode::OK;
+}
+
+size_t DatabaseRawSequential::SearchKey(const char* name)
+{
+  if (IsBlockEmpty(BlockType::MAIN))
+  {
+    return 0;
   }
 
-  KeyInfo* key = &flash_data_->key;
+  size_t key_offset = OFFSET_OF(FlashInfo, key);
   while (true)
   {
-    if (strcmp(name, GetKeyName(key)) == 0)
+    if (KeyNameCompare(key_offset, name) == 0)
     {
-      return key;
+      return key_offset;
     }
-    if (!key->GetNextKeyExist())
+    if (!HasLastKey(key_offset))
     {
       break;
     }
-    key = GetNextKey(key);
+    key_offset = GetNextKey(key_offset);
   }
-  return nullptr;
+  return 0;
 }

--- a/src/middleware/database.hpp
+++ b/src/middleware/database.hpp
@@ -11,7 +11,7 @@
 namespace LibXR
 {
 
-static constexpr uint16_t LIBXR_DATABASE_VERSION = 2;
+static constexpr uint16_t LIBXR_DATABASE_VERSION = 3;
 
 /**
  * @brief 数据库接口，提供键值存储和管理功能 (Database interface providing key-value
@@ -192,7 +192,46 @@ class DatabaseRawSequential : public Database
    */
   void Restore();
 
+  /**
+   * @brief 获取数据库中的键值
+   *        (Retrieve the key's value from the database).
+   * @param key 需要获取的键 (Key to retrieve).
+   * @return 操作结果，如果找到则返回 `ErrorCode::OK`，否则返回 `ErrorCode::NOT_FOUND`
+   *         (Operation result, returns `ErrorCode::OK` if found, otherwise
+   * `ErrorCode::NOT_FOUND`).
+   */
+  ErrorCode Get(Database::KeyBase& key) override;
+
+  /**
+   * @brief 设置数据库中的键值
+   *        (Set the key's value in the database).
+   * @param key 目标键 (Target key).
+   * @param data 需要存储的新值 (New value to store).
+   * @return 操作结果 (Operation result).
+   */
+  ErrorCode Set(KeyBase& key, RawData data) override
+  {
+    return SetKey(key.name_, data.addr_, data.size_);
+  }
+
+  /**
+   * @brief 添加新键到数据库
+   *        (Add a new key to the database).
+   * @param key 需要添加的键 (Key to add).
+   * @return 操作结果 (Operation result).
+   */
+  ErrorCode Add(KeyBase& key) override
+  {
+    return AddKey(key.name_, key.raw_data_.addr_, key.raw_data_.size_);
+  }
+
  private:
+  enum class BlockType : uint8_t
+  {
+    MAIN = 0,   ///< 主块 (Main block).
+    BACKUP = 1  ///< 备份块 (Backup block).
+  };
+
 #pragma pack(push, 1)
   /**
    * @brief 键信息结构，存储键的元数据
@@ -204,9 +243,8 @@ class DatabaseRawSequential : public Database
 
     KeyInfo() : raw_data(0xFFFFFFFF) {}
 
-    KeyInfo(bool nextKey, uint8_t nameLength, uint32_t dataSize)
+    KeyInfo(bool nextKey, uint8_t nameLength, uint32_t dataSize) : raw_data(0)
     {
-      raw_data = 0;
       SetNextKeyExist(nextKey);
       SetNameLength(nameLength);
       SetDataSize(dataSize);
@@ -214,13 +252,13 @@ class DatabaseRawSequential : public Database
 
     void SetNextKeyExist(bool value)
     {
-      raw_data = (raw_data & 0x7FFFFFFF) | (uint32_t(value & 0x1) << 31);
+      raw_data = (raw_data & 0x7FFFFFFF) | (static_cast<uint32_t>(value & 0x1) << 31);
     }
     bool GetNextKeyExist() const { return (raw_data >> 31) & 0x1; }
 
     void SetNameLength(uint8_t len)
     {
-      raw_data = (raw_data & 0x80FFFFFF) | (uint32_t(len & 0x7F) << 24);
+      raw_data = (raw_data & 0x80FFFFFF) | (static_cast<uint32_t>(len & 0x7F) << 24);
     }
     uint8_t GetNameLength() const { return (raw_data >> 24) & 0x7F; }
 
@@ -246,94 +284,29 @@ class DatabaseRawSequential : public Database
 
   ErrorCode AddKey(const char* name, const void* data, size_t size);
   ErrorCode SetKey(const char* name, const void* data, size_t size);
-  ErrorCode SetKey(KeyInfo* key, const void* data, size_t size);
-
-  /**
-   * @brief 获取指定键的数据信息
-   *        (Retrieve the data associated with a key).
-   * @param key 目标键 (Key to retrieve data from).
-   * @return 指向数据的指针 (Pointer to the key's data).
-   */
-  uint8_t* GetKeyData(KeyInfo* key);
-
-  /**
-   * @brief 获取键的名称
-   *        (Retrieve the name of a key).
-   * @param key 目标键 (Key to retrieve the name from).
-   * @return 指向键名的指针 (Pointer to the key name).
-   */
-  const char* GetKeyName(KeyInfo* key);
+  ErrorCode SetKey(size_t offset, const void* data, size_t size);
+  ErrorCode GetKeyData(size_t offset, RawData data);
+  void InitBlock(BlockType block);
+  bool IsBlockInited(BlockType block);
+  bool IsBlockEmpty(BlockType block);
+  bool IsBlockError(BlockType block);
+  bool HasLastKey(size_t offset);
+  size_t GetKeySize(size_t offset);
+  size_t GetNextKey(size_t offset);
+  size_t GetLastKey(BlockType block);
+  void SetNestKeyExist(size_t offset, bool exist);
+  bool KeyDataCompare(size_t offset, const void* data, size_t size);
+  bool KeyNameCompare(size_t offset, const char* name);
+  size_t SearchKey(const char* name);
 
   static constexpr uint32_t FLASH_HEADER =
       0x12345678 + LIBXR_DATABASE_VERSION;  ///< Flash 头部标识 (Flash header identifier).
   static constexpr uint8_t CHECKSUM_BYTE = 0x56;  ///< 校验字节 (Checksum byte).
 
-  Flash& flash_;           ///< 目标 Flash 存储设备 (Target Flash storage device).
-  uint8_t* data_buffer_;   ///< 数据缓冲区 (Data buffer).
-  FlashInfo* flash_data_;  ///< Flash 数据存储区 (Pointer to the Flash data storage).
-  FlashInfo* info_main_;   ///< 主存储区信息 (Main storage block information).
-  FlashInfo* info_backup_;  ///< 备份存储区信息 (Backup storage block information).
-  uint32_t block_size_;     ///< Flash 块大小 (Flash block size).
+  Flash& flash_;              ///< 目标 Flash 存储设备 (Target Flash storage device).
+  uint8_t* buffer_;           ///< 数据缓冲区 (Data buffer).
+  uint32_t block_size_;       ///< Flash 块大小 (Flash block size).
   uint32_t max_buffer_size_;  ///< 最大缓冲区大小 (Maximum buffer size).
-
-  void InitBlock(FlashInfo* block);
-  bool IsBlockInited(FlashInfo* block);
-  bool IsBlockEmpty(FlashInfo* block);
-  bool IsBlockError(FlashInfo* block);
-  size_t GetKeySize(KeyInfo* key);
-  KeyInfo* GetNextKey(KeyInfo* key);
-  KeyInfo* GetLastKey(FlashInfo* block);
-  KeyInfo* SearchKey(const char* name);
-
-  /**
-   * @brief 添加新键到数据库
-   *        (Add a new key to the database).
-   * @param key 需要添加的键 (Key to add).
-   * @return 操作结果 (Operation result).
-   */
-  ErrorCode Add(KeyBase& key) override
-  {
-    return AddKey(key.name_, key.raw_data_.addr_, key.raw_data_.size_);
-  }
-
- public:
-  /**
-   * @brief 获取数据库中的键值
-   *        (Retrieve the key's value from the database).
-   * @param key 需要获取的键 (Key to retrieve).
-   * @return 操作结果，如果找到则返回 `ErrorCode::OK`，否则返回 `ErrorCode::NOT_FOUND`
-   *         (Operation result, returns `ErrorCode::OK` if found, otherwise
-   * `ErrorCode::NOT_FOUND`).
-   */
-  ErrorCode Get(Database::KeyBase& key) override
-  {
-    auto ans = SearchKey(key.name_);
-    if (!ans)
-    {
-      return ErrorCode::NOT_FOUND;
-    }
-
-    if (key.raw_data_.size_ != ans->GetDataSize())
-    {
-      return ErrorCode::FAILED;
-    }
-
-    memcpy(key.raw_data_.addr_, GetKeyData(ans), ans->GetDataSize());
-
-    return ErrorCode::OK;
-  }
-
-  /**
-   * @brief 设置数据库中的键值
-   *        (Set the key's value in the database).
-   * @param key 目标键 (Target key).
-   * @param data 需要存储的新值 (New value to store).
-   * @return 操作结果 (Operation result).
-   */
-  ErrorCode Set(KeyBase& key, RawData data) override
-  {
-    return SetKey(key.name_, data.addr_, data.size_);
-  }
 };
 
 /**
@@ -351,7 +324,17 @@ class DatabaseRawSequential : public Database
 template <size_t MinWriteSize>
 class DatabaseRaw : public Database
 {
- public:
+  static constexpr uint32_t FLASH_HEADER =
+      0x12345678 + LIBXR_DATABASE_VERSION;  ///< Flash 头部标识 (Flash header identifier).
+
+  static constexpr uint32_t CHECKSUM_BYTE = 0x9abcedf0;  ///< 校验字节 (Checksum byte).
+
+  enum class BlockType : uint8_t
+  {
+    MAIN = 0,   ///< 主块 (Main block).
+    BACKUP = 1  ///< 备份块 (Backup block).
+  };
+
 #pragma pack(push, 1)
   template <size_t BlockSize>
   struct BlockBoolData
@@ -410,132 +393,6 @@ class DatabaseRaw : public Database
     }
   };
 
-  /**
-   * @brief 构造函数，初始化 Flash 存储和缓冲区
-   *        (Constructor to initialize Flash storage and buffer).
-   *
-   * @param flash 目标 Flash 存储设备 (Target Flash storage device).
-   */
-  explicit DatabaseRaw(Flash& flash)
-      : flash_(flash), write_buffer_(new uint8_t[flash_.min_write_size_])
-  {
-    ASSERT(flash.min_erase_size_ * 2 <= flash.flash_area_.size_);
-    ASSERT(flash_.min_write_size_ <= MinWriteSize);
-    auto block_num = static_cast<size_t>(flash.flash_area_.size_ / flash.min_erase_size_);
-    block_size_ = block_num / 2 * flash.min_erase_size_;
-    info_main_ = reinterpret_cast<FlashInfo*>(flash.flash_area_.addr_);
-    info_backup_ = reinterpret_cast<FlashInfo*>(
-        reinterpret_cast<uint8_t*>(flash.flash_area_.addr_) + block_size_);
-    Init();
-  }
-
-  /**
-   * @brief 初始化数据库存储区，确保主备块正确
-   *        (Initialize database storage, ensuring main and backup blocks are valid).
-   */
-  void Init()
-  {
-    if (!IsBlockInited(info_backup_) || IsBlockError(info_backup_))
-    {
-      InitBlock(info_backup_);
-    }
-
-    if (!IsBlockInited(info_main_) || IsBlockError(info_main_))
-    {
-      if (IsBlockEmpty(info_backup_))
-      {
-        InitBlock(info_main_);
-      }
-      else
-      {
-        flash_.Erase(0, block_size_);
-        Write(0, {reinterpret_cast<uint8_t*>(info_backup_), block_size_});
-      }
-    }
-    else if (!IsBlockEmpty(info_backup_))
-    {
-      InitBlock(info_backup_);
-    }
-
-    KeyInfo* key = &info_main_->key;
-    while (!BlockBoolUtil<MinWriteSize>::ReadFlag(key->no_next_key))
-    {
-      key = GetNextKey(key);
-      if (BlockBoolUtil<MinWriteSize>::ReadFlag(key->uninit))
-      {
-        InitBlock(info_main_);
-        break;
-      }
-    }
-  }
-
-  /**
-   * @brief 还原存储数据，清空 Flash 区域
-   *        (Restore storage data, clearing Flash memory area).
-   */
-  void Restore() {}
-
-  /**
-   * @brief 回收 Flash 空间，整理数据
-   *        (Recycle Flash storage space and organize data).
-   *
-   * Moves valid keys from the main block to the backup block and erases the main block.
-   * 将主存储块中的有效键移动到备份块，并擦除主存储块。
-   *
-   * @return 操作结果 (Operation result).
-   */
-  ErrorCode Recycle()
-  {
-    if (IsBlockEmpty(info_main_))
-    {
-      return ErrorCode::OK;
-    }
-
-    KeyInfo* key = &info_main_->key;
-
-    if (!IsBlockEmpty(info_backup_))
-    {
-      ASSERT(false);
-      return ErrorCode::FAILED;
-    }
-
-    uint8_t* write_buff = reinterpret_cast<uint8_t*>(&info_backup_->key);
-
-    auto new_key = KeyInfo{};
-    BlockBoolUtil<MinWriteSize>::SetFlag(new_key.uninit, false);
-    BlockBoolUtil<MinWriteSize>::SetFlag(new_key.available_flag, false);
-    BlockBoolUtil<MinWriteSize>::SetFlag(new_key.no_next_key, false);
-    Write(write_buff - reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_), new_key);
-
-    write_buff += GetKeySize(&info_backup_->key);
-
-    do
-    {
-      key = GetNextKey(key);
-
-      if (!BlockBoolUtil<MinWriteSize>::ReadFlag(key->available_flag))
-      {
-        continue;
-      }
-
-      Write(write_buff - reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_), *key);
-      write_buff += AlignSize(sizeof(KeyInfo));
-      Write(write_buff - reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_),
-            {GetKeyName(key), key->GetNameLength()});
-      write_buff += AlignSize(key->GetNameLength());
-      Write(write_buff - reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_),
-            {GetKeyData(key), static_cast<size_t>(key->GetDataSize())});
-      write_buff += AlignSize(key->GetDataSize());
-    } while (!BlockBoolUtil<MinWriteSize>::ReadFlag(key->no_next_key));
-
-    flash_.Erase(0, block_size_);
-    Write(0, {reinterpret_cast<uint8_t*>(info_backup_), block_size_});
-    InitBlock(info_backup_);
-
-    return ErrorCode::OK;
-  }
-
- private:
 #pragma pack(push, 1)
   /**
    * @brief 键信息结构，存储键的元数据
@@ -547,10 +404,10 @@ class DatabaseRaw : public Database
     BlockBoolData<MinWriteSize> available_flag;  ///< 该键是否有效
     BlockBoolData<MinWriteSize> uninit;          ///< 该键是否未初始化
 
-    uint32_t raw_info;  ///< 高7位为 nameLength，低25位为 dataSize
+    uint32_t raw_info = 0;  ///< 高7位为 nameLength，低25位为 dataSize
 
     // 默认构造
-    KeyInfo() : raw_info(0)
+    KeyInfo()
     {
       BlockBoolUtil<MinWriteSize>::SetFlag(no_next_key, true);
       BlockBoolUtil<MinWriteSize>::SetFlag(available_flag, true);
@@ -595,6 +452,11 @@ class DatabaseRaw : public Database
   };
 #pragma pack(pop)
 
+  size_t recycle_threshold_ = 0;  ///< 回收阈值 (Recycle threshold).
+  Flash& flash_;                  ///< 目标 Flash 存储设备 (Target Flash storage device).
+  uint32_t block_size_;           ///< Flash 块大小 (Flash block size).
+  uint8_t* write_buffer_;         ///< 写入缓冲区 (Write buffer).
+
   /**
    * @brief 计算可用的存储空间大小
    *        (Calculate the available storage size).
@@ -602,28 +464,20 @@ class DatabaseRaw : public Database
    */
   size_t AvailableSize()
   {
-    return block_size_ - sizeof(CHECKSUM_BYTE) -
-           (reinterpret_cast<uint8_t*>(GetNextKey(GetLastKey(info_main_))) -
-            reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_));
+    auto offset = GetNextKey(GetLastKey(BlockType::MAIN));
+    return block_size_ - sizeof(CHECKSUM_BYTE) - offset;
   }
 
-  ErrorCode AddKey(const char* name, const void* data, size_t size)
+  ErrorCode AddKeyBody(size_t name_len, size_t size, size_t& key_buf_offset)
   {
-    if (auto ans = SearchKey(name))
-    {
-      return SetKey(name, data, size);
-    }
-
     bool recycle = false;
-
   add_again:
-    const uint32_t NAME_LEN = strlen(name) + 1;
-    KeyInfo* last_key = GetLastKey(info_main_);
-    KeyInfo* key_buf = nullptr;
+    size_t last_key_offset = GetLastKey(BlockType::MAIN);
+    key_buf_offset = 0;
 
-    if (!last_key)
+    if (last_key_offset == 0)
     {
-      FlashInfo flash_info;  // constructor fills padding with 0xFF
+      FlashInfo flash_info;
       flash_info.header = FLASH_HEADER;
       KeyInfo& tmp_key = flash_info.key;
       BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.no_next_key, false);
@@ -632,21 +486,22 @@ class DatabaseRaw : public Database
       tmp_key.SetNameLength(0);
       tmp_key.SetDataSize(0);
       Write(0, flash_info);
-      key_buf = GetNextKey(&info_main_->key);
+      key_buf_offset = GetNextKey(OFFSET_OF(FlashInfo, key));
     }
     else
     {
-      key_buf = GetNextKey(last_key);
+      key_buf_offset = GetNextKey(last_key_offset);
     }
 
     if (AvailableSize() <
-        AlignSize(sizeof(KeyInfo)) + AlignSize(NAME_LEN) + AlignSize(size))
+        AlignSize(sizeof(KeyInfo)) + AlignSize(name_len) + AlignSize(size))
     {
       if (!recycle)
       {
         Recycle();
         recycle = true;
-        goto add_again;  // NOLINT
+        // NOLINTNEXTLINE
+        goto add_again;
       }
       else
       {
@@ -655,57 +510,117 @@ class DatabaseRaw : public Database
       }
     }
 
-    if (last_key)
-    {
-      KeyInfo new_last_key = {};
-      BlockBoolUtil<MinWriteSize>::SetFlag(new_last_key.no_next_key, false);
-      BlockBoolUtil<MinWriteSize>::SetFlag(
-          new_last_key.available_flag,
-          BlockBoolUtil<MinWriteSize>::ReadFlag(last_key->available_flag));
-      BlockBoolUtil<MinWriteSize>::SetFlag(
-          new_last_key.uninit, BlockBoolUtil<MinWriteSize>::ReadFlag(last_key->uninit));
-      new_last_key.SetNameLength(last_key->GetNameLength());
-      new_last_key.SetDataSize(last_key->GetDataSize());
-
-      Write(reinterpret_cast<uint8_t*>(last_key) -
-                reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_),
-            new_last_key);
-    }
-
     KeyInfo new_key = {};
     BlockBoolUtil<MinWriteSize>::SetFlag(new_key.no_next_key, true);
     BlockBoolUtil<MinWriteSize>::SetFlag(new_key.available_flag, true);
     BlockBoolUtil<MinWriteSize>::SetFlag(new_key.uninit, true);
-    new_key.SetNameLength(NAME_LEN);
+    new_key.SetNameLength(name_len);
     new_key.SetDataSize(size);
 
-    Write(reinterpret_cast<uint8_t*>(key_buf) -
-              reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_),
-          new_key);
-    Write(reinterpret_cast<const uint8_t*>(GetKeyName(key_buf)) -
-              reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_),
-          {reinterpret_cast<const uint8_t*>(name), NAME_LEN});
-    Write(reinterpret_cast<uint8_t*>(GetKeyData(key_buf)) -
-              reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_),
-          {reinterpret_cast<const uint8_t*>(data), size});
+    Write(key_buf_offset, new_key);
     BlockBoolUtil<MinWriteSize>::SetFlag(new_key.uninit, false);
-    Write(reinterpret_cast<uint8_t*>(key_buf) -
-              reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_),
-          new_key);
+
+    if (last_key_offset != 0)
+    {
+      KeyInfo last_key;
+      flash_.Read(last_key_offset, last_key);
+      KeyInfo new_last_key = {};
+      BlockBoolUtil<MinWriteSize>::SetFlag(new_last_key.no_next_key, false);
+      BlockBoolUtil<MinWriteSize>::SetFlag(
+          new_last_key.available_flag,
+          BlockBoolUtil<MinWriteSize>::ReadFlag(last_key.available_flag));
+      BlockBoolUtil<MinWriteSize>::SetFlag(
+          new_last_key.uninit, BlockBoolUtil<MinWriteSize>::ReadFlag(last_key.uninit));
+      new_last_key.SetNameLength(last_key.GetNameLength());
+      new_last_key.SetDataSize(last_key.GetDataSize());
+
+      Write(last_key_offset, new_last_key);
+    }
+
+    Write(key_buf_offset, new_key);
 
     return ErrorCode::OK;
   }
 
+  ErrorCode AddKey(size_t name_offset, size_t name_len, const void* data, size_t size)
+  {
+    size_t key_buf_offset = 0;
+    ErrorCode ec = AddKeyBody(name_len, size, key_buf_offset);
+    if (ec != ErrorCode::OK)
+    {
+      return ec;
+    }
+    CopyFlashData(GetKeyName(key_buf_offset), name_offset, name_len);
+    Write(GetKeyData(key_buf_offset), {reinterpret_cast<const uint8_t*>(data), size});
+    return ErrorCode::OK;
+  }
+
+  ErrorCode AddKey(const char* name, const void* data, size_t size)
+  {
+    size_t name_len = strlen(name) + 1;
+    if (auto ans = SearchKey(name))
+    {
+      return SetKey(name, data, size);
+    }
+    size_t key_buf_offset = 0;
+    ErrorCode ec = AddKeyBody(name_len, size, key_buf_offset);
+    if (ec != ErrorCode::OK)
+    {
+      return ec;
+    }
+    Write(GetKeyName(key_buf_offset), {reinterpret_cast<const uint8_t*>(name), name_len});
+    Write(GetKeyData(key_buf_offset), {reinterpret_cast<const uint8_t*>(data), size});
+    return ErrorCode::OK;
+  }
+
+  ErrorCode SetKeyCommon(size_t key_offset, size_t name_len, const void* data,
+                         size_t size)
+  {
+    if (key_offset)
+    {
+      KeyInfo key;
+      flash_.Read(key_offset, key);
+      if (key.GetDataSize() == size)
+      {
+        if (KeyDataCompare(key_offset, data, size))
+        {
+          KeyInfo new_key = {};
+          BlockBoolUtil<MinWriteSize>::SetFlag(
+              new_key.no_next_key,
+              BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key));
+          BlockBoolUtil<MinWriteSize>::SetFlag(new_key.available_flag, false);
+          BlockBoolUtil<MinWriteSize>::SetFlag(
+              new_key.uninit, BlockBoolUtil<MinWriteSize>::ReadFlag(key.uninit));
+          new_key.SetNameLength(name_len);
+          new_key.SetDataSize(size);
+          Write(key_offset, new_key);
+          return AddKey(GetKeyName(key_offset), name_len, data, size);
+        }
+        return ErrorCode::OK;
+      }
+    }
+    return ErrorCode::FAILED;
+  }
+
+  ErrorCode SetKey(size_t name_offset, size_t name_length, const void* data, size_t size)
+  {
+    size_t key_offset = SearchKey(name_offset, name_length);
+    return SetKeyCommon(key_offset, name_length, data, size);
+  }
+
   ErrorCode SetKey(const char* name, const void* data, size_t size, bool recycle = true)
   {
-    if (KeyInfo* key = SearchKey(name))
+    size_t key_offset = SearchKey(name);
+    if (key_offset)
     {
-      if (key->GetDataSize() == size)
+      KeyInfo key;
+      flash_.Read(key_offset, key);
+      if (key.GetDataSize() == size)
       {
-        if (memcmp(GetKeyData(key), data, size) != 0)
+        if (KeyDataCompare(key_offset, data, size))
         {
           if (AvailableSize() < AlignSize(size) + AlignSize(sizeof(KeyInfo)) +
-                                    AlignSize(key->GetNameLength()))
+                                    AlignSize(key.GetNameLength()))
           {
             if (recycle)
             {
@@ -718,66 +633,41 @@ class DatabaseRaw : public Database
               return ErrorCode::FULL;
             }
           }
-
           KeyInfo new_key = {};
           BlockBoolUtil<MinWriteSize>::SetFlag(
               new_key.no_next_key,
-              BlockBoolUtil<MinWriteSize>::ReadFlag(key->no_next_key));
+              BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key));
           BlockBoolUtil<MinWriteSize>::SetFlag(new_key.available_flag, false);
           BlockBoolUtil<MinWriteSize>::SetFlag(
-              new_key.uninit, BlockBoolUtil<MinWriteSize>::ReadFlag(key->uninit));
-          new_key.SetNameLength(key->GetNameLength());
+              new_key.uninit, BlockBoolUtil<MinWriteSize>::ReadFlag(key.uninit));
+          new_key.SetNameLength(key.GetNameLength());
           new_key.SetDataSize(size);
-          Write(reinterpret_cast<uint8_t*>(key) -
-                    reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_),
-                new_key);
-          return AddKey(GetKeyName(key), data, size);
+          Write(key_offset, new_key);
+          return AddKey(GetKeyName(key_offset), key.GetNameLength(), data, size);
         }
         return ErrorCode::OK;
       }
     }
-
     return ErrorCode::FAILED;
   }
 
-  /**
-   * @brief 获取指定键的数据信息
-   *        (Retrieve the data associated with a key).
-   * @param key 目标键 (Key to retrieve data from).
-   * @return 指向数据的指针 (Pointer to the key's data).
-   */
-  uint8_t* GetKeyData(KeyInfo* key)
+  size_t GetKeyData(size_t offset)
   {
-    return reinterpret_cast<uint8_t*>(key) + AlignSize(sizeof(KeyInfo)) +
-           AlignSize(key->GetNameLength());
+    KeyInfo key;
+    flash_.Read(offset, key);
+    return offset + AlignSize(sizeof(KeyInfo)) + AlignSize(key.GetNameLength());
   }
 
-  /**
-   * @brief 获取键的名称
-   *        (Retrieve the name of a key).
-   * @param key 目标键 (Key to retrieve the name from).
-   * @return 指向键名的指针 (Pointer to the key name).
-   */
-  const char* GetKeyName(KeyInfo* key)
+  size_t GetKeyName(size_t offset) { return offset + AlignSize(sizeof(KeyInfo)); }
+
+  void InitBlock(BlockType block)
   {
-    return reinterpret_cast<const char*>(key) + AlignSize(sizeof(KeyInfo));
-  }
-
-  static constexpr uint32_t FLASH_HEADER =
-      0x12345678 + LIBXR_DATABASE_VERSION;  ///< Flash 头部标识 (Flash header identifier).
-  static constexpr uint32_t CHECKSUM_BYTE = 0x9abcedf0;  ///< 校验字节 (Checksum byte).
-
-  Flash& flash_;            ///< 目标 Flash 存储设备 (Target Flash storage device).
-  FlashInfo* info_main_;    ///< 主存储区信息 (Main storage block information).
-  FlashInfo* info_backup_;  ///< 备份存储区信息 (Backup storage block information).
-  uint32_t block_size_;     ///< Flash 块大小 (Flash block size).
-  uint8_t* write_buffer_;   ///< 写入缓冲区 (Write buffer).
-
-  void InitBlock(FlashInfo* block)
-  {
-    flash_.Erase(reinterpret_cast<uint8_t*>(block) -
-                     reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_),
-                 block_size_);
+    size_t offset = 0;
+    if (block == BlockType::BACKUP)
+    {
+      offset = block_size_;
+    }
+    flash_.Erase(offset, block_size_);
 
     FlashInfo info;  // padding filled with 0xFF by constructor
     info.header = FLASH_HEADER;
@@ -787,84 +677,193 @@ class DatabaseRaw : public Database
     BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.uninit, false);
     tmp_key.SetNameLength(0);
     tmp_key.SetDataSize(0);
-    Write(reinterpret_cast<uint8_t*>(block) -
-              reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_),
-          {reinterpret_cast<uint8_t*>(&info), sizeof(FlashInfo)});
-    Write(reinterpret_cast<uint8_t*>(block) -
-              reinterpret_cast<uint8_t*>(flash_.flash_area_.addr_) + block_size_ -
-              AlignSize(sizeof(CHECKSUM_BYTE)),
+    Write(offset, {reinterpret_cast<uint8_t*>(&info), sizeof(FlashInfo)});
+    Write(offset + block_size_ - AlignSize(sizeof(CHECKSUM_BYTE)),
           {&CHECKSUM_BYTE, sizeof(CHECKSUM_BYTE)});
   }
 
-  bool IsBlockInited(FlashInfo* block) { return block->header == FLASH_HEADER; }
-  bool IsBlockEmpty(FlashInfo* block)
+  bool IsBlockInited(BlockType block)
   {
-    return BlockBoolUtil<MinWriteSize>::ReadFlag(block->key.available_flag) == true;
+    size_t offset = 0;
+    if (block == BlockType::BACKUP)
+    {
+      offset = block_size_;
+    }
+    FlashInfo flash_data;
+    flash_.Read(offset, flash_data);
+    return flash_data.header == FLASH_HEADER;
   }
-  bool IsBlockError(FlashInfo* block)
+
+  bool IsBlockEmpty(BlockType block)
   {
-    auto checksum_byte_addr = reinterpret_cast<uint8_t*>(block) + block_size_ -
-                              AlignSize(sizeof(CHECKSUM_BYTE));
-    return *reinterpret_cast<uint32_t*>(checksum_byte_addr) != CHECKSUM_BYTE;
+    size_t offset = 0;
+    if (block == BlockType::BACKUP)
+    {
+      offset = block_size_;
+    }
+    FlashInfo flash_data;
+    flash_.Read(offset, flash_data);
+    return BlockBoolUtil<MinWriteSize>::ReadFlag(flash_data.key.available_flag) == true;
   }
-  size_t GetKeySize(KeyInfo* key)
+
+  bool IsBlockError(BlockType block)
   {
-    return AlignSize(sizeof(KeyInfo)) + AlignSize(key->GetNameLength()) +
-           AlignSize(key->GetDataSize());
+    size_t offset = 0;
+    if (block == BlockType::BACKUP)
+    {
+      offset = block_size_;
+    }
+    uint32_t checksum = 0;
+    flash_.Read(offset + block_size_ - AlignSize(sizeof(CHECKSUM_BYTE)), checksum);
+    return checksum != CHECKSUM_BYTE;
   }
-  KeyInfo* GetNextKey(KeyInfo* key)
+
+  size_t GetKeySize(size_t offset)
   {
-    return reinterpret_cast<KeyInfo*>(reinterpret_cast<uint8_t*>(key) + GetKeySize(key));
+    KeyInfo key;
+    flash_.Read(offset, key);
+    return AlignSize(sizeof(KeyInfo)) + AlignSize(key.GetNameLength()) +
+           AlignSize(key.GetDataSize());
   }
-  KeyInfo* GetLastKey(FlashInfo* block)
+
+  size_t GetNextKey(size_t offset)
+  {
+    KeyInfo key;
+    flash_.Read(offset, key);
+    return offset + GetKeySize(offset);
+  }
+
+  size_t GetLastKey(BlockType block)
   {
     if (IsBlockEmpty(block))
     {
-      return nullptr;
+      return 0;
     }
 
-    KeyInfo* key = &block->key;
-    while (!BlockBoolUtil<MinWriteSize>::ReadFlag(key->no_next_key))
+    KeyInfo key;
+    size_t key_offset = OFFSET_OF(FlashInfo, key);
+    if (block != BlockType::MAIN)
     {
-      key = GetNextKey(key);
+      key_offset += block_size_;
     }
-    return key;
+    flash_.Read(key_offset, key);
+    while (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key))
+    {
+      key_offset = GetNextKey(key_offset);
+      flash_.Read(key_offset, key);
+    }
+    return key_offset;
   }
-  KeyInfo* SearchKey(const char* name)
+
+  bool KeyDataCompare(size_t offset, const void* data, size_t size)
   {
-    if (IsBlockEmpty(info_main_))
+    KeyInfo key;
+    flash_.Read(offset, key);
+    size_t key_data_offset = GetKeyData(offset);
+    uint8_t data_buffer = 0;
+    for (size_t i = 0; i < size; i++)
     {
-      return nullptr;
+      flash_.Read(key_data_offset + i, data_buffer);
+      if (data_buffer != (reinterpret_cast<const uint8_t*>(data))[i])
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool KeyNameCompare(size_t offset, const char* name)
+  {
+    KeyInfo key;
+    flash_.Read(offset, key);
+    for (size_t i = 0; i < key.GetNameLength(); i++)
+    {
+      uint8_t data_buffer = 0;
+      flash_.Read(offset + AlignSize(sizeof(KeyInfo)) + i, data_buffer);
+      if (data_buffer != name[i])
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool KeyNameCompare(size_t offset_a, size_t offset_b)
+  {
+    KeyInfo key_a, key_b;
+    flash_.Read(offset_a, key_a);
+    flash_.Read(offset_b, key_b);
+    if (key_a.GetNameLength() != key_b.GetNameLength())
+    {
+      return true;
+    }
+    for (size_t i = 0; i < key_a.GetNameLength(); i++)
+    {
+      uint8_t data_buffer_a = 0, data_buffer_b = 0;
+      flash_.Read(offset_a + sizeof(KeyInfo) + i, data_buffer_a);
+      flash_.Read(offset_b + sizeof(KeyInfo) + i, data_buffer_b);
+      if (data_buffer_a != data_buffer_b)
+      {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  void CopyFlashData(size_t dst_offset, size_t src_offset, size_t size)
+  {
+    for (size_t i = 0; i < size; i += MinWriteSize)
+    {
+      flash_.Read(src_offset + i, {write_buffer_, MinWriteSize});
+      flash_.Write(dst_offset + i, {write_buffer_, MinWriteSize});
+    }
+  }
+
+  size_t SearchKey(const char* name)
+  {
+    if (IsBlockEmpty(BlockType::MAIN))
+    {
+      return 0;
     }
 
-    KeyInfo* key = &info_main_->key;
+    KeyInfo key;
+    size_t key_offset = OFFSET_OF(FlashInfo, key);
+    flash_.Read(key_offset, key);
+
+    size_t ans = 0, need_cycle = 0;
 
     while (true)
     {
-      if (!BlockBoolUtil<MinWriteSize>::ReadFlag(key->available_flag))
+      if (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.available_flag))
       {
-        key = GetNextKey(key);
+        key_offset = GetNextKey(key_offset);
+        flash_.Read(key_offset, key);
+        need_cycle++;
         continue;
       }
 
-      if (strcmp(name, GetKeyName(key)) == 0)
+      if (!KeyNameCompare(key_offset, name))
       {
-        return key;
+        ans = key_offset;
+        break;
       }
-      if (BlockBoolUtil<MinWriteSize>::ReadFlag(key->no_next_key))
+
+      if (BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key))
       {
         break;
       }
 
-      key = GetNextKey(key);
+      key_offset = GetNextKey(key_offset);
+      flash_.Read(key_offset, key);
     }
 
-    return nullptr;
-  }
+    if (need_cycle > recycle_threshold_)
+    {
+      Recycle();
+      return SearchKey(name);
+    }
 
-  ErrorCode Add(KeyBase& key) override
-  {
-    return AddKey(key.name_, key.raw_data_.addr_, key.raw_data_.size_);
+    return ans;
   }
 
   /**
@@ -928,12 +927,15 @@ class DatabaseRaw : public Database
       return ErrorCode::NOT_FOUND;
     }
 
-    if (key.raw_data_.size_ != ans->GetDataSize())
+    KeyInfo key_buffer;
+    flash_.Read(ans, key_buffer);
+
+    if (key.raw_data_.size_ < key_buffer.GetDataSize())
     {
       return ErrorCode::FAILED;
     }
 
-    memcpy(key.raw_data_.addr_, GetKeyData(ans), ans->GetDataSize());
+    flash_.Read(GetKeyData(ans), key.raw_data_);
 
     return ErrorCode::OK;
   }
@@ -949,6 +951,161 @@ class DatabaseRaw : public Database
   {
     memcpy(key.raw_data_.addr_, data.addr_, data.size_);
     return SetKey(key.name_, data.addr_, data.size_);
+  }
+
+  ErrorCode Add(KeyBase& key) override
+  {
+    return AddKey(key.name_, key.raw_data_.addr_, key.raw_data_.size_);
+  }
+
+  /**
+   * @brief 构造函数，初始化 Flash 存储和缓冲区
+   *        (Constructor to initialize Flash storage and buffer).
+   *
+   * @param flash 目标 Flash 存储设备 (Target Flash storage device).
+   */
+  explicit DatabaseRaw(Flash& flash, size_t recycle_threshold = 128)
+      : recycle_threshold_(recycle_threshold),
+        flash_(flash),
+        write_buffer_(new uint8_t[flash_.MinWriteSize()])
+  {
+    ASSERT(flash.MinEraseSize() * 2 <= flash_.Size());
+    ASSERT(flash_.MinWriteSize() <= MinWriteSize);
+    auto block_num = static_cast<size_t>(flash_.Size() / flash.MinEraseSize());
+    block_size_ = block_num / 2 * flash.MinEraseSize();
+    Init();
+  }
+
+  /**
+   * @brief 初始化数据库存储区，确保主备块正确
+   *        (Initialize database storage, ensuring main and backup blocks are valid).
+   */
+  void Init()
+  {
+    if (!IsBlockInited(BlockType::BACKUP) || IsBlockError(BlockType::BACKUP))
+    {
+      InitBlock(BlockType::BACKUP);
+    }
+
+    if (!IsBlockInited(BlockType::MAIN) || IsBlockError(BlockType::MAIN))
+    {
+      if (IsBlockEmpty(BlockType::BACKUP))
+      {
+        InitBlock(BlockType::MAIN);
+      }
+      else
+      {
+        flash_.Erase(0, block_size_);
+        for (uint32_t i = 0; i < block_size_; i += MinWriteSize)
+        {
+          flash_.Read(i + block_size_, {write_buffer_, MinWriteSize});
+          flash_.Write(i, {write_buffer_, MinWriteSize});
+        }
+      }
+    }
+
+    if (!IsBlockEmpty(BlockType::BACKUP))
+    {
+      InitBlock(BlockType::BACKUP);
+    }
+
+    KeyInfo key;
+    size_t key_offset = OFFSET_OF(FlashInfo, key);
+    flash_.Read(key_offset, key);
+    size_t need_cycle = 0;
+    while (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key))
+    {
+      key_offset = GetNextKey(key_offset);
+      flash_.Read(key_offset, key);
+      // TODO: 恢复损坏数据
+      if (BlockBoolUtil<MinWriteSize>::ReadFlag(key.uninit))
+      {
+        InitBlock(BlockType::MAIN);
+        break;
+      }
+      if (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.available_flag))
+      {
+        need_cycle += 1;
+      }
+    }
+
+    if (need_cycle > recycle_threshold_)
+    {
+      Recycle();
+    }
+  }
+
+  /**
+   * @brief 还原存储数据，清空 Flash 区域
+   *        (Restore storage data, clearing Flash memory area).
+   */
+  void Restore() {}
+
+  /**
+   * @brief 回收 Flash 空间，整理数据
+   *        (Recycle Flash storage space and organize data).
+   *
+   * Moves valid keys from the main block to the backup block and erases the main
+   block.
+   * 将主存储块中的有效键移动到备份块，并擦除主存储块。
+   *
+   * @return 操作结果 (Operation result).
+   */
+  ErrorCode Recycle()
+  {
+    if (IsBlockEmpty(BlockType::MAIN))
+    {
+      return ErrorCode::OK;
+    }
+
+    KeyInfo key;
+    size_t key_offset = OFFSET_OF(FlashInfo, key);
+    flash_.Read(key_offset, key);
+
+    if (!IsBlockEmpty(BlockType::BACKUP))
+    {
+      ASSERT(false);
+      return ErrorCode::FAILED;
+    }
+
+    size_t write_buff_offset = OFFSET_OF(FlashInfo, key) + block_size_;
+
+    auto new_key = KeyInfo{};
+    BlockBoolUtil<MinWriteSize>::SetFlag(new_key.uninit, false);
+    BlockBoolUtil<MinWriteSize>::SetFlag(new_key.available_flag, false);
+    BlockBoolUtil<MinWriteSize>::SetFlag(new_key.no_next_key, false);
+    Write(write_buff_offset, new_key);
+
+    write_buff_offset += GetKeySize(write_buff_offset);
+
+    do
+    {
+      key_offset = GetNextKey(key_offset);
+      flash_.Read(key_offset, key);
+
+      if (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.available_flag))
+      {
+        continue;
+      }
+
+      Write(write_buff_offset, key);
+      write_buff_offset += AlignSize(sizeof(KeyInfo));
+      CopyFlashData(write_buff_offset, GetKeyName(key_offset), key.GetNameLength());
+      write_buff_offset += AlignSize(key.GetNameLength());
+      CopyFlashData(write_buff_offset, GetKeyData(key_offset), key.GetDataSize());
+      write_buff_offset += AlignSize(key.GetDataSize());
+    } while (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key));
+
+    flash_.Erase(0, block_size_);
+    for (uint32_t i = 0; i < block_size_; i += MinWriteSize)
+    {
+      flash_.Read(i + block_size_, {write_buffer_, MinWriteSize});
+      flash_.Write(i, {write_buffer_, MinWriteSize});
+    }
+
+    InitBlock(BlockType::BACKUP);
+
+    return ErrorCode::OK;
   }
 };
 

--- a/src/middleware/logger.cpp
+++ b/src/middleware/logger.cpp
@@ -47,7 +47,7 @@ void Logger::Publish(LogLevel level, const char *file, uint32_t line, const char
     Init();
   }
   LogData data;
-  data.timestamp = TimestampMS(Thread::GetTime());
+  data.timestamp = MillisecondTimestamp(Thread::GetTime());
   data.level = level;
   data.file = file;
   data.line = line;

--- a/src/middleware/logger.hpp
+++ b/src/middleware/logger.hpp
@@ -30,7 +30,7 @@ enum class LogLevel : uint8_t
  */
 struct LogData
 {
-  TimestampMS timestamp;                 ///< 时间戳 / Timestamp
+  MillisecondTimestamp timestamp;        ///< 时间戳 / Timestamp
   LogLevel level;                        ///< 日志级别 / Log level
   const char* file;                      ///< 文件名指针 / Source file name pointer
   uint32_t line;                         ///< 行号 / Line number

--- a/src/system/timer.hpp
+++ b/src/system/timer.hpp
@@ -136,7 +136,7 @@ class Timer
    */
   static void RefreshThreadFunction(void *)
   {
-    TimestampMS time = Thread::GetTime();
+    MillisecondTimestamp time = Thread::GetTime();
     while (true)
     {
       Timer::Refresh();

--- a/system/FreeRTOS/thread.cpp
+++ b/system/FreeRTOS/thread.cpp
@@ -8,9 +8,9 @@ Thread Thread::Current(void) { return Thread(xTaskGetCurrentTaskHandle()); }
 
 void Thread::Sleep(uint32_t milliseconds) { vTaskDelay(milliseconds); }
 
-void Thread::SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep) {
-  vTaskDelayUntil(reinterpret_cast<uint32_t *>(&last_waskup_time),
-                  time_to_sleep);
+void Thread::SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep)
+{
+  vTaskDelayUntil(reinterpret_cast<uint32_t *>(&last_waskup_time), time_to_sleep);
 }
 
 uint32_t Thread::GetTime() { return xTaskGetTickCount(); }

--- a/system/FreeRTOS/thread.hpp
+++ b/system/FreeRTOS/thread.hpp
@@ -125,7 +125,7 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程

--- a/system/Linux/thread.cpp
+++ b/system/Linux/thread.cpp
@@ -13,14 +13,16 @@ extern struct timespec libxr_linux_start_time_spec;
 
 Thread Thread::Current(void) { return Thread(pthread_self()); }
 
-void Thread::Sleep(uint32_t milliseconds) {
+void Thread::Sleep(uint32_t milliseconds)
+{
   struct timespec ts;
   ts.tv_sec = milliseconds / 1000;
   ts.tv_nsec = static_cast<__syscall_slong_t>((milliseconds % 1000) * 1000000);
   UNUSED(clock_nanosleep(CLOCK_REALTIME, 0, &ts, nullptr));
 }
 
-void Thread::SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep) {
+void Thread::SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep)
+{
   last_waskup_time = last_waskup_time + time_to_sleep;
 
   struct timespec ts = libxr_linux_start_time_spec;
@@ -31,12 +33,13 @@ void Thread::SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep) {
   ts.tv_sec += (add + secs);
   ts.tv_nsec = raw_time % (static_cast<int64_t>(1000U * 1000U * 1000U));
 
-  while (clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &ts, &ts) &&
-         errno == EINTR) {
+  while (clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &ts, &ts) && errno == EINTR)
+  {
   }
 }
 
-uint32_t Thread::GetTime() {
+uint32_t Thread::GetTime()
+{
   struct timeval tv;
   gettimeofday(&tv, nullptr);
   return ((tv.tv_sec - libxr_linux_start_time.tv_sec) * 1000 +

--- a/system/Linux/thread.hpp
+++ b/system/Linux/thread.hpp
@@ -200,7 +200,7 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程

--- a/system/None/thread.cpp
+++ b/system/None/thread.cpp
@@ -16,7 +16,7 @@ void Thread::Sleep(uint32_t milliseconds)
   }
 }
 
-void Thread::SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep)
+void Thread::SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep)
 {
   while (uint32_t(Timebase::GetMilliseconds()) - last_waskup_time < time_to_sleep)
   {

--- a/system/None/thread.hpp
+++ b/system/None/thread.hpp
@@ -104,7 +104,7 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程

--- a/system/ThreadX/thread.cpp
+++ b/system/ThreadX/thread.cpp
@@ -11,7 +11,7 @@ void Thread::Sleep(uint32_t milliseconds)
   tx_thread_sleep(milliseconds * TX_TIMER_TICKS_PER_SECOND / 1000);
 }
 
-void Thread::SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep)
+void Thread::SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep)
 {
   uint32_t target = last_waskup_time + time_to_sleep;
   uint32_t now = Timebase::GetMilliseconds();
@@ -24,7 +24,4 @@ void Thread::SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep)
 
 uint32_t Thread::GetTime() { return Timebase::GetMilliseconds(); }
 
-void Thread::Yield()
-{
-  tx_thread_relinquish();
-}
+void Thread::Yield() { tx_thread_relinquish(); }

--- a/system/ThreadX/thread.hpp
+++ b/system/ThreadX/thread.hpp
@@ -117,7 +117,7 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程

--- a/system/WebAsm/thread.cpp
+++ b/system/WebAsm/thread.cpp
@@ -10,13 +10,13 @@ Thread Thread::Current(void) { return Thread(); }
 void Thread::Sleep(uint32_t milliseconds)
 {
   uint32_t now = Timebase::GetMilliseconds();
-  while (uint32_t(Timebase::GetMilliseconds() )- now < milliseconds)
+  while (uint32_t(Timebase::GetMilliseconds()) - now < milliseconds)
   {
     Timer::RefreshTimerInIdle();
   }
 }
 
-void Thread::SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep)
+void Thread::SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep)
 {
   while (uint32_t(Timebase::GetMilliseconds()) - last_waskup_time < time_to_sleep)
   {

--- a/system/WebAsm/thread.hpp
+++ b/system/WebAsm/thread.hpp
@@ -104,7 +104,7 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程

--- a/system/Webots/thread.cpp
+++ b/system/Webots/thread.cpp
@@ -49,7 +49,7 @@ void Thread::Sleep(uint32_t milliseconds)
   }
 }
 
-void Thread::SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep)
+void Thread::SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep)
 {
   last_waskup_time = last_waskup_time + time_to_sleep;
 

--- a/system/Webots/thread.hpp
+++ b/system/Webots/thread.hpp
@@ -201,7 +201,7 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(TimestampMS &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -100,8 +100,8 @@ static void run_libxr_tests()
     XR_LOG_INFO("Test Group [%s]\n", test_groups[g].name);
     for (size_t i = 0; i < group_sizes[g]; ++i)
     {
-      TEST_STEP(test_groups[g].tests[i].name);
       test_groups[g].tests[i].function();
+      TEST_STEP(test_groups[g].tests[i].name);
     }
   }
 
@@ -127,7 +127,7 @@ int main()
       },
       reinterpret_cast<void *>(0));
 
-  LibXR::Assert::RegisterFatalErrorCB(err_cb);
+  LibXR::Assert::RegisterFatalErrorCallback(err_cb);
 
   run_libxr_tests();
 

--- a/test/test_database.cpp
+++ b/test/test_database.cpp
@@ -13,91 +13,141 @@ using namespace LibXR;
 
 void test_database()
 {
-  constexpr size_t FLASH_SIZE = 2048;
-  LinuxBinaryFileFlash<FLASH_SIZE> flash("/tmp/flash_test.bin", 512, 8, true, true);
-  DatabaseRawSequential db(flash);
+  constexpr size_t FLASH_SIZE = 4096;
 
-  std::array<uint32_t, 1> key1_data = {1};
-  std::array<uint32_t, 2> key2_data = {11, 22};
-  std::array<uint32_t, 3> key3_data = {111, 222, 333};
-  std::array<uint32_t, 4> key4_data = {1111, 2222, 3333, 4444};
+  // 1. 初始化 Flash 和 DB
+  LinuxBinaryFileFlash<FLASH_SIZE> test_flash("/tmp/flash_test.bin", 512, 8, true, true);
+  DatabaseRawSequential test_db(test_flash);
 
-  DatabaseRawSequential::Key key1(db, "key1", key1_data);
-  DatabaseRawSequential::Key key2(db, "keasdasy2", key2_data);
-  DatabaseRawSequential::Key key3(db, "keaasdasdy3", key3_data);
-  DatabaseRawSequential::Key key4(db, "keyaskdhasjh4", key4_data);
+  // 2. 定义数据和 Key 对象
+  std::array<uint32_t, 1> data_k1 = {1};
+  std::array<uint32_t, 2> data_k2 = {11, 22};
+  std::array<uint32_t, 3> data_k3 = {111, 222, 333};
+  std::array<uint32_t, 4> data_k4 = {1111, 2222, 3333, 4444};
 
-  key4_data[1] = 123456;
+  DatabaseRawSequential::Key k1(test_db, "key1", data_k1);
+  DatabaseRawSequential::Key k2(test_db, "key2", data_k2);
+  DatabaseRawSequential::Key k3(test_db, "key3", data_k3);
+  DatabaseRawSequential::Key k4(test_db, "key4", data_k4);
 
-  key4 = key4_data;
+  for (int i = 0; i < 1000; i++)
+  {
+    k1 = data_k1;  // 写入
+    k2 = data_k2;  // 写入
+    k3 = data_k3;  // 写入
+    k4 = data_k4;  // 写入
 
-  db.Load();
+    k1.Load();  // 读取
+    k2.Load();  // 读取
+    k3.Load();  // 读取
+    k4.Load();  // 读取
 
-  key1.Load();
-  key2.Load();
-  key3.Load();
-  key4.Load();
+    ASSERT(memcmp(data_k1.data(), k1.data_.data(), sizeof(data_k1)) == 0);
+    ASSERT(memcmp(data_k2.data(), k2.data_.data(), sizeof(data_k2)) == 0);
+    ASSERT(memcmp(data_k3.data(), k3.data_.data(), sizeof(data_k3)) == 0);
+    ASSERT(memcmp(data_k4.data(), k4.data_.data(), sizeof(data_k4)) == 0);
 
-  ASSERT(memcmp(&key1_data[0], &key1.data_[0], sizeof(key1_data)) == 0);
-  ASSERT(memcmp(&key2_data[0], &key2.data_[0], sizeof(key2_data)) == 0);
-  ASSERT(memcmp(&key3_data[0], &key3.data_[0], sizeof(key3_data)) == 0);
-  ASSERT(memcmp(&key4_data[0], &key4.data_[0], sizeof(key4_data)) == 0);
+    for (int i = 0; i < Thread::GetTime() % 100; i++)
+    {  // 3. 覆盖 key4 并校验
+      data_k4[1] = Thread::GetTime() + i;
+      k4 = data_k4;  // 写入
+      k4.Load();     // 读取
+      ASSERT(memcmp(data_k4.data(), k4.data_.data(), sizeof(data_k4)) == 0);
+    }
+
+    for (int i = 0; i < Thread::GetTime() % 100; i++)
+    {  // 4. key1 覆盖-读取-校验
+      data_k1[0] = Thread::GetTime() + i;
+      k1 = data_k1;
+      k1.Load();
+      ASSERT(memcmp(data_k1.data(), k1.data_.data(), sizeof(data_k1)) == 0);
+    }
+
+    // 5. 多次循环 Load/校验
+    for (int i = 0; i < Thread::GetTime() % 100; ++i)
+    {
+      k1.Load();
+      k2.Load();
+      k3.Load();
+      k4.Load();
+      ASSERT(memcmp(data_k1.data(), k1.data_.data(), sizeof(data_k1)) == 0);
+      ASSERT(memcmp(data_k2.data(), k2.data_.data(), sizeof(data_k2)) == 0);
+      ASSERT(memcmp(data_k3.data(), k3.data_.data(), sizeof(data_k3)) == 0);
+      ASSERT(memcmp(data_k4.data(), k4.data_.data(), sizeof(data_k4)) == 0);
+    }
+
+    // 6. 更新 key2 数据，写入并校验
+    for (int i = 0; i < Thread::GetTime() % 100; i++)
+    {
+      data_k2[0] = LibXR::Timebase::GetMicroseconds();
+      data_k2[1] = LibXR::Timebase::GetMilliseconds();
+      k2 = data_k2;
+      k2.Load();
+      ASSERT(memcmp(data_k2.data(), k2.data_.data(), sizeof(data_k2)) == 0);
+    }
+
+    // 7. 最后统一校验
+    ASSERT(memcmp(data_k1.data(), k1.data_.data(), sizeof(data_k1)) == 0);
+    ASSERT(memcmp(data_k2.data(), k2.data_.data(), sizeof(data_k2)) == 0);
+    ASSERT(memcmp(data_k3.data(), k3.data_.data(), sizeof(data_k3)) == 0);
+    ASSERT(memcmp(data_k4.data(), k4.data_.data(), sizeof(data_k4)) == 0);
+  }
 
   LinuxBinaryFileFlash<FLASH_SIZE> flash_2("/tmp/flash_test_2.bin", 512, 16, false, true);
-  DatabaseRaw<16> db_2(flash_2);
+  DatabaseRaw<16> test_db_2(flash_2, 5);
 
-  DatabaseRaw<16>::Key key1_2(db_2, "key1", key1_data);
-  DatabaseRaw<16>::Key key2_2(db_2, "keasdasy2", key2_data);
-  DatabaseRaw<16>::Key key3_2(db_2, "keaasdasdy3", key3_data);
-  DatabaseRaw<16>::Key key4_2(db_2, "keyaskdhasjh4", key4_data);
+  DatabaseRaw<16>::Key k1_2(test_db_2, "key1", data_k1);
+  DatabaseRaw<16>::Key k2_2(test_db_2, "keasdasy2", data_k2);
+  DatabaseRaw<16>::Key k3_2(test_db_2, "keaasdasdy3", data_k3);
+  DatabaseRaw<16>::Key k4_2(test_db_2, "keyaskdhasjh4", data_k4);
 
-  key4_data[1] = 1234567;
+  data_k4[1] = 1234567;
 
-  key1_2 = key1_data;
-  key2_2 = key2_data;
-  key3_2 = key3_data;
-  key4_2 = key4_data;
+  k1_2 = data_k1;
+  k2_2 = data_k2;
+  k3_2 = data_k3;
+  k4_2 = data_k4;
 
-  key1_2.Load();
-  key2_2.Load();
-  key3_2.Load();
-  key4_2.Load();
+  k1_2.Load();
+  k2_2.Load();
+  k3_2.Load();
+  k4_2.Load();
 
-  ASSERT(memcmp(&key1_data[0], &key1_2.data_[0], sizeof(key1_data)) == 0);
-  ASSERT(memcmp(&key2_data[0], &key2_2.data_[0], sizeof(key2_data)) == 0);
-  ASSERT(memcmp(&key3_data[0], &key3_2.data_[0], sizeof(key3_data)) == 0);
-  ASSERT(memcmp(&key4_data[0], &key4_2.data_[0], sizeof(key4_data)) == 0);
+  ASSERT(memcmp(&data_k1[0], &k1_2.data_[0], sizeof(data_k1)) == 0);
+  ASSERT(memcmp(&data_k2[0], &k2_2.data_[0], sizeof(data_k2)) == 0);
+  ASSERT(memcmp(&data_k3[0], &k3_2.data_[0], sizeof(data_k3)) == 0);
+  ASSERT(memcmp(&data_k4[0], &k4_2.data_[0], sizeof(data_k4)) == 0);
 
-  for (size_t i = 0; i < FLASH_SIZE; i++)
+  for (size_t i = 0; i < 1000; i++)
   {
-    for (uint32_t j = 0; j < Thread::GetTime() % 3; j++)
+    for (uint32_t j = 0; j < Thread::GetTime() % 100; j++)
     {
-      key1_data[0] = j;
-      key1_2 = key1_data;
+      data_k1[0] = Thread::GetTime() + j;
+      k1_2 = data_k1;
     }
-    for (uint32_t j = 0; j < Thread::GetTime() % 3; j++)
+    for (uint32_t j = 0; j < Thread::GetTime() % 100; j++)
     {
-      key2_data[0] = j;
-      key2_2 = key2_data;
+      data_k2[0] = Thread::GetTime() + j;
+      k2_2 = data_k2;
     }
-    for (uint32_t j = 0; j < Thread::GetTime() % 3; j++)
+    for (uint32_t j = 0; j < Thread::GetTime() % 100; j++)
     {
-      key3_data[0] = j;
-      key3_2 = key3_data;
+      data_k3[0] = Thread::GetTime() + j;
+      k3_2 = data_k3;
     }
-    for (uint32_t j = 0; j < Thread::GetTime() % 3; j++)
+    for (uint32_t j = 0; j < Thread::GetTime() % 100; j++)
     {
-      key4_data[0] = j;
-      key4_2 = key4_data;
+      data_k4[0] = Thread::GetTime() + j;
+      k4_2 = data_k4;
     }
 
-    key1_2.Load();
-    key2_2.Load();
-    key3_2.Load();
-    key4_2.Load();
-    ASSERT(memcmp(&key1_data[0], &key1_2.data_[0], sizeof(key1_data)) == 0);
-    ASSERT(memcmp(&key2_data[0], &key2_2.data_[0], sizeof(key2_data)) == 0);
-    ASSERT(memcmp(&key3_data[0], &key3_2.data_[0], sizeof(key3_data)) == 0);
-    ASSERT(memcmp(&key4_data[0], &key4_2.data_[0], sizeof(key4_data)) == 0);
+    k1_2.Load();
+    k2_2.Load();
+    k3_2.Load();
+    k4_2.Load();
+    ASSERT(memcmp(&data_k1[0], &k1_2.data_[0], sizeof(data_k1)) == 0);
+    ASSERT(memcmp(&data_k2[0], &k2_2.data_[0], sizeof(data_k2)) == 0);
+    ASSERT(memcmp(&data_k3[0], &k3_2.data_[0], sizeof(data_k3)) == 0);
+    ASSERT(memcmp(&data_k4[0], &k4_2.data_[0], sizeof(data_k4)) == 0);
   }
 }

--- a/test/test_timebase.cpp
+++ b/test/test_timebase.cpp
@@ -4,9 +4,10 @@
 #include "libxr_def.hpp"
 #include "test.hpp"
 
-void test_timebase() {
-  LibXR::TimestampMS t1(1000), t2(2005);
-  LibXR::TimestampUS t3(1000), t4(2005);
+void test_timebase()
+{
+  LibXR::MillisecondTimestamp t1(1000), t2(2005);
+  LibXR::MicrosecondTimestamp t3(1000), t4(2005);
 
   t1 = LibXR::Timebase::GetMilliseconds();
   t3 = LibXR::Timebase::GetMicroseconds();
@@ -14,6 +15,6 @@ void test_timebase() {
   t4 = LibXR::Timebase::GetMicroseconds();
   t2 = LibXR::Timebase::GetMilliseconds();
 
-  ASSERT(std::fabs((t2 - t1).ToMillisecond()- 100.0f) < 2);
-  ASSERT(std::fabs((t4 - t3).ToMicrosecond() - 100000.0f) < 2000);
+  ASSERT(std::fabs((t2 - t1).ToMillisecond() - 100.0f) < 10);
+  ASSERT(std::fabs((t4 - t3).ToMicrosecond() - 100000.0f) < 10000);
 }


### PR DESCRIPTION
- 所有时间戳类型统一重命名（TimestampUS/MS → MicrosecondTimestamp/MillisecondTimestamp），相关API同步更新
- Flash/Database底层接口重构，统一访问方式，优化结构，Flash成员变量私有化并增加MinEraseSize/MinWriteSize接口
- 命名规范化，修正拼写错误（如NO_REPONSE→NO_RESPONSE），清理重复/无用宏定义，统一成员变量命名
- Watchdog、Thread、Timer相关接口和成员命名统一
- Logger等中间件适配新类型
- 批量修改所有受影响的驱动、测试代码
- 其它细节优化及小范围bug修正