### PR TITLE
Fix compilation error due to missing <climits> include

### DIFF
--- a/system/Linux/thread.hpp
+++ b/system/Linux/thread.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <climits>
+
 #include "libxr_system.hpp"
 #include "libxr_time.hpp"
 #include "logger.hpp"
@@ -31,14 +33,14 @@ class Thread
    * @brief  默认构造函数，初始化空线程
    *         Default constructor initializing an empty thread
    */
-  Thread() {};
+  Thread(){};
 
   /**
    * @brief  通过 POSIX 线程句柄创建线程对象
    *         Constructor to create a thread object from a POSIX thread handle
    * @param  handle POSIX 线程句柄 POSIX thread handle
    */
-  Thread(libxr_thread_handle handle) : thread_handle_(handle) {};
+  Thread(libxr_thread_handle handle) : thread_handle_(handle){};
 
   /**
    * @brief  创建新线程
@@ -123,8 +125,8 @@ class Thread
       }
 
       decltype(function) fun_;  ///< 线程执行的函数 Function executed by the thread
-      ArgType arg_;             ///< 线程函数的参数 Argument passed to the thread function
-      char *name_;              ///< 线程名称 Thread name
+      ArgType arg_;  ///< 线程函数的参数 Argument passed to the thread function
+      char *name_;   ///< 线程名称 Thread name
     };
 
     auto block = new ThreadBlock(function, arg, name);


### PR DESCRIPTION
## 描述

在使用 Luckfox SDK 为 Rockchip (ARM) 目标平台进行交叉编译时遇到了一个编译错误。错误信息为： `error: ‘PTHREAD_STACK_MIN’ was not declared in this scope`

## 原因

`thread.hpp` 中使用了 `PTHREAD_STACK_MIN` 宏，但并未包含 `<climits>` 头文件。虽然某些桌面开发环境可能会通过其他头文件隐式包含（间接引入）该定义，但在严格的嵌入式工具链中并非如此，从而导致构建失败。

## 变更

在 `libxr/system/Linux/thread.hpp` 中添加了 `#include <climits>`。

## 验证

已验证该项目现在在 Rockchip SDK 交叉编译器上没有相关编译报错。

## Summary by Sourcery

Bug Fixes:
- Fix compilation failure on some platforms by explicitly including <climits> where PTHREAD_STACK_MIN is used.