### PR TITLE
Add TI MSPM0 platform support and timebase peripheral

### DIFF
--- a/driver/mspm0/mspm0_atomic_shim.c
+++ b/driver/mspm0/mspm0_atomic_shim.c
@@ -1,0 +1,222 @@
+#include "msp.h" 
+
+static inline uint32_t atomic_enter(void) {
+    uint32_t primask_state = __get_PRIMASK();
+    __disable_irq();
+    return primask_state;
+}
+
+static inline void atomic_exit(uint32_t primask_state) {
+    if (!primask_state) {
+        __enable_irq();
+    }
+}
+
+#define UNUSED(x) (void)(x)
+
+/**
+ * @brief  模拟实现 __atomic_compare_exchange_4 函数 / Simulate the
+ * __atomic_compare_exchange_4 function
+ * @param  ptr 指向原子变量的指针 / Pointer to the atomic variable
+ * @param  expected 预期值的指针，如果比较失败会更新为实际值 / Pointer to the expected
+ * value, updated with actual value if comparison fails
+ * @param  desired 需要交换的新值 / The new value to be stored if the comparison succeeds
+ * @param  weak 忽略参数，保留以兼容 / Ignored parameter, kept for compatibility
+ * @param  success_memorder 成功时的内存顺序标志（忽略） / Memory order on success
+ * (ignored)
+ * @param  failure_memorder 失败时的内存顺序标志（忽略） / Memory order on failure
+ * (ignored)
+ * @retval 返回 1 表示成功，0 表示失败 / Returns 1 on success, 0 on failure
+ */
+__attribute__((weak)) _Bool
+__atomic_compare_exchange_4(volatile void *ptr, void *expected, unsigned int desired, // NOLINT
+                            _Bool weak, int success_memorder, int failure_memorder)
+{
+  UNUSED(weak);
+  UNUSED(success_memorder);
+  UNUSED(failure_memorder);
+
+  volatile unsigned int *addr = (volatile unsigned int *)ptr;
+  unsigned int expected_val = *(unsigned int *)expected;
+  _Bool result = false;
+
+  // 2. 使用安全的方式开关中断
+  uint32_t primask = atomic_enter(); 
+  
+  if (*addr == expected_val)
+  {
+    *addr = desired;
+    result = true;
+  }
+  else
+  {
+    *(unsigned int *)expected = *addr;
+    result = false;
+  }
+  
+  atomic_exit(primask); // 恢复状态
+  return result;
+}
+
+/**
+ * @brief  模拟实现 __atomic_store_4 函数 / Simulate the __atomic_store_4 function
+ * @param  ptr 指向原子变量的指针 / Pointer to the atomic variable
+ * @param  val 需要存储的新值 / The new value to be stored
+ * @param  memorder 内存顺序标志 / Memory order (ignored)
+ * @retval 无返回值 / None
+ */
+__attribute__((weak)) void 
+__atomic_store_4(volatile void *ptr, unsigned int val, int memorder) // NOLINT
+{
+  UNUSED(memorder);
+  volatile unsigned int *addr = (volatile unsigned int *)ptr;
+
+  uint32_t primask = atomic_enter();
+  *addr = val;
+  atomic_exit(primask);
+}
+
+/**
+ * @brief  模拟实现 __atomic_load_4 函数 / Simulate the __atomic_load_4 function
+ * @param  ptr 指向原子变量的指针 / Pointer to the atomic variable
+ * @param  memorder 内存顺序标志 / Memory order (ignored)
+ * @retval 当前值 / Returns the current value
+ */
+__attribute__((weak)) unsigned int 
+__atomic_load_4(const volatile void *ptr, int memorder) // NOLINT
+{
+  UNUSED(memorder);
+  volatile unsigned int *addr = (volatile unsigned int *)ptr;
+  unsigned int val = 0;
+
+  uint32_t primask = atomic_enter();
+  val = *addr;
+  atomic_exit(primask);
+  return val;
+}
+
+/**
+ * @brief  模拟实现 __atomic_exchange_4 函数 / Simulate the __atomic_exchange_4 function
+ * @param  ptr 指向原子变量的指针 / Pointer to the atomic variable
+ * @param  val 需要存储的新值 / The new value to be stored
+ * @param  memorder 内存顺序标志 / Memory order (ignored)
+ * @retval 交换前的旧值 / Returns the old value before exchange
+ */
+__attribute__((weak)) unsigned int 
+__atomic_exchange_4(volatile void *ptr, unsigned int val, int memorder) // NOLINT
+{
+  UNUSED(memorder);
+  volatile unsigned int *addr = (volatile unsigned int *)ptr;
+  unsigned int old_val = 0;
+
+  uint32_t primask = atomic_enter();
+  old_val = *addr;
+  *addr = val;
+  atomic_exit(primask);
+  return old_val;
+}
+
+/**
+ * @brief  模拟实现 __atomic_fetch_add_4 函数 / Simulate the __atomic_fetch_add_4 function
+ * @param  ptr 指向原子变量的指针 / Pointer to the atomic variable
+ * @param  val 需要相加的值 / The value to add
+ * @param  memorder 内存顺序标志 / Memory order (ignored)
+ * @retval 加法前的旧值 / Returns the old value before addition
+ */
+__attribute__((weak)) unsigned int 
+__atomic_fetch_add_4(volatile void *ptr, unsigned int val, int memorder) // NOLINT
+{
+  UNUSED(memorder);
+  volatile unsigned int *addr = (volatile unsigned int *)ptr;
+  unsigned int old_val = 0;
+
+  uint32_t primask = atomic_enter();
+  old_val = *addr;
+  *addr = old_val + val;
+  atomic_exit(primask);
+  return old_val;
+}
+
+/**
+ * @brief  模拟实现 __atomic_fetch_sub_4 函数 / Simulate the __atomic_fetch_sub_4 function
+ * @param  ptr 指向原子变量的指针 / Pointer to the atomic variable
+ * @param  val 需要相减的值 / The value to subtract
+ * @param  memorder 内存顺序标志 / Memory order (ignored)
+ * @retval 减法前的旧值 / Returns the old value before subtraction
+ */
+__attribute__((weak)) unsigned int 
+__atomic_fetch_sub_4(volatile void *ptr, unsigned int val, int memorder) // NOLINT
+{
+  UNUSED(memorder);
+  volatile unsigned int *addr = (volatile unsigned int *)ptr;
+  unsigned int old_val = 0;
+
+  uint32_t primask = atomic_enter();
+  old_val = *addr;
+  *addr = old_val - val;
+  atomic_exit(primask);
+  return old_val;
+}
+
+/**
+ * @brief  模拟实现 __atomic_exchange_1 函数 / Simulate the __atomic_exchange_1 function
+ * @param  ptr 指向原子变量（1字节大小）的指针 / Pointer to the 1-byte atomic variable
+ * @param  val 需要存储的新值 / The new value to be stored
+ * @param  memorder 内存顺序标志（忽略） / Memory order (ignored)
+ * @retval 交换前的旧值 / Returns the old value before exchange
+ */
+__attribute__((weak)) unsigned char 
+__atomic_exchange_1(volatile void *ptr, unsigned char val, int memorder) // NOLINT
+{
+  UNUSED(memorder);
+  volatile unsigned char *addr = (volatile unsigned char *)ptr;
+  unsigned char old_val = 0;
+
+  uint32_t primask = atomic_enter();
+  old_val = *addr;
+  *addr = val;
+  atomic_exit(primask);
+  return old_val;
+}
+
+/**
+ * @brief  模拟实现 __atomic_store_1 函数 / Simulate the __atomic_store_1 function
+ * @param  ptr 指向原子变量（1字节大小）的指针 / Pointer to the 1-byte atomic variable
+ * @param  val 需要存储的新值 / The new value to be stored
+ * @param  memorder 内存顺序标志（忽略） / Memory order (ignored)
+ * @retval 无返回值 / None
+ */
+__attribute__((weak)) void 
+__atomic_store_1(volatile void *ptr, unsigned char val, int memorder) // NOLINT
+{
+  UNUSED(memorder);
+  volatile unsigned char *addr = (volatile unsigned char *)ptr;
+
+  uint32_t primask = atomic_enter();
+  *addr = val;
+  atomic_exit(primask);
+}
+
+/**
+ * @brief  模拟实现 __atomic_test_and_set 函数 / Simulate the __atomic_test_and_set
+ * function
+ * @param  ptr 指向原子标志位的指针 / Pointer to the atomic flag variable
+ * @param  memorder 内存顺序标志（忽略） / Memory order (ignored)
+ * @retval 返回之前的值 / Returns the previous value (0 or 1)
+ */
+#if !defined(__clang__)
+__attribute__((weak)) _Bool
+__atomic_test_and_set(volatile void *ptr, int memorder)
+{
+  UNUSED(memorder);
+  volatile unsigned char *addr = (volatile unsigned char *)ptr;
+  _Bool old_val = false;
+
+  uint32_t primask = atomic_enter();
+  old_val = *addr;
+  *addr = 1; 
+  atomic_exit(primask);
+  
+  return old_val;
+}
+#endif

--- a/driver/mspm0/mspm0_timebase.cpp
+++ b/driver/mspm0/mspm0_timebase.cpp
@@ -1,0 +1,51 @@
+#include "mspm0_timebase.hpp"
+
+using namespace LibXR;
+
+MSPM0Timebase::MSPM0Timebase()
+    : Timebase(static_cast<uint64_t>(UINT32_MAX) * 1000 + 999, UINT32_MAX)
+{
+}
+
+MicrosecondTimestamp MSPM0Timebase::_get_microseconds()
+{
+  do
+  {
+    uint32_t tick_old = sys_tick_ms;
+    uint32_t val_old = DL_SYSTICK_getValue();
+    uint32_t tick_new = sys_tick_ms;
+    uint32_t val_new = DL_SYSTICK_getValue();
+
+    auto tick_diff = tick_new - tick_old;
+
+    uint32_t cycles_per_ms = DL_SYSTICK_getPeriod() + 1;
+
+    switch (tick_diff)
+    {
+      case 0:
+        return MicrosecondTimestamp(
+            static_cast<uint64_t>(tick_new) * 1000 +
+            static_cast<uint64_t>(DL_SYSTICK_getPeriod() - val_old) * 1000 /
+                cycles_per_ms);
+      case 1:
+        /* 中断发生在两次读取之间 / Interrupt happened between two reads */
+        return MicrosecondTimestamp(
+            static_cast<uint64_t>(tick_new) * 1000 +
+            static_cast<uint64_t>(DL_SYSTICK_getPeriod() - val_new) * 1000 /
+                cycles_per_ms);
+      default:
+        /* 中断耗时过长（超过1ms），程序异常 / Indicates that interrupt took more than
+         * 1ms, an error case */
+        continue;
+    }
+  } while (true);
+}
+
+MillisecondTimestamp MSPM0Timebase::_get_milliseconds() { return sys_tick_ms; }
+void MSPM0Timebase::OnSysTickInterrupt() { sys_tick_ms++; }
+void MSPM0Timebase::Sync(uint32_t ticks) { sys_tick_ms = ticks; }
+
+extern "C" void SysTick_Handler(void)  // NOLINT
+{
+  LibXR::MSPM0Timebase::OnSysTickInterrupt();
+}

--- a/driver/mspm0/mspm0_timebase.hpp
+++ b/driver/mspm0/mspm0_timebase.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "dl_systick.h"
+#include "timebase.hpp"
+
+namespace LibXR
+{
+
+class MSPM0Timebase : public Timebase
+{
+ public:
+  MSPM0Timebase();
+
+  static void OnSysTickInterrupt();
+
+  static void Sync(uint32_t ticks);
+
+  MicrosecondTimestamp _get_microseconds() override;
+
+  MillisecondTimestamp _get_milliseconds() override;
+
+  inline static volatile uint32_t sys_tick_ms;  // NOLINT
+};
+
+}  // namespace LibXR


### PR DESCRIPTION
## 摘要

本 PR 为 LibXR 引入了 **TI MSPM0 (Cortex-M0+)** 系列微控制器的初始支持。

主要实现了基于硬件 SysTick 的 `mspm0_timebase` 抽象层，为框架提供微秒级时间戳和任务调度能力。

## 主要变更

- **平台支持**：添加了与 STM32/CH32 风格对齐的 `MSPM0Timebase` 实现。
- **Cortex-M0+ 兼容性适配**：
    - **增加 Atomic Shim**：针对 Cortex-M0+ 缺失 `LDREX`/`STREX` 独占指令的问题，提供了基于关中断的软件原子操作实现。
    - 修复了在 M0+ 架构下链接 `std::atomic` 符号缺失的问题，确保框架的并发原语可用。
- **实现逻辑**：
    - 使用 TI DriverLib 的 `DL_SYSTICK` API 实现了 `_get_microseconds()`。
    - 完成了 `SysTick_Handler` 的中断挂接。
    - **代码风格与逻辑结构严格对齐现有的 STM32 和 CH32 实现**，以保证 HAL 层的一致性。
- **依赖**：依赖 TI MSPM0 SDK (DriverLib)。

## 验证

### 测试应用 (`app_main.cpp`)

编写了一个简单的 LED 闪烁程序，用于验证系统滴答（SysTick）和 `Thread::Sleep` 功能。

### 硬件环境

- **开发板**: 立创天猛星 MSPM0G3507 开发板
- **引脚**: GPIO PB22 (板载 LED)

### 测试逻辑

1. 初始化 `MSPM0Timebase` 及平台底层。
2. 配置 PB22 为推挽输出。
3. 在死循环中通过 `LibXR::Thread::Sleep(1000)` 切换 LED 状态。

### 观察结果
- PB22 连接的 LED 每隔 **1000 ms** 翻转一次状态。
- 验证结论：
    1. `SysTick_Handler` 中断触发正常。
    2. `MSPM0Timebase` 能为调度器提供准确的毫秒级时间戳。
    3. 基础的原子操作功能正常。

### 使用的验证代码片段

```c
// main.c

#include "app_main.h"
#include "ti_msp_dl_config.h"

int main(void) {
    SYSCFG_DL_init(); // Generated by TI's DriverLib configuration tool
    app_main();
}
```

```cpp
// app_main.cpp

#include "libxr_system.hpp"
#include "mspm0_gpio.hpp"  // Partially implemented yet
#include "mspm0_timebase.hpp"
#include "thread.hpp"

extern "C" void app_main(void)
{
  LibXR::MSPM0Timebase timebase;
  LibXR::PlatformInit();

  LibXR::MSPM0GPIO led_gpio(GPIOB, 22);

  LibXR::GPIO::Configuration config;
  config.direction = LibXR::GPIO::Direction::OUTPUT_PUSH_PULL;
  config.pull = LibXR::GPIO::Pull::NONE;

  led_gpio.SetConfig(config);

  led_gpio.Write(false);

  while (1)
  {
    LibXR::Thread::Sleep(1000);
    led_gpio.Write(true);
    LibXR::Thread::Sleep(1000);
    led_gpio.Write(false);
  }
}
```

## Summary by Sourcery

Add initial TI MSPM0 timebase support and provide atomic operation shims for Cortex-M0+ platforms.

New Features:
- Introduce MSPM0Timebase implementation using SysTick to provide microsecond and millisecond timestamps.
- Hook the SysTick interrupt to feed the MSPM0 timebase counter for scheduling and timing.

Enhancements:
- Provide software-based atomic operation shims for GCC atomic builtins on Cortex-M0+ using interrupt masking to enable use of std::atomic and related primitives.