### PR TITLE
Add TI MSPM0 PWM peripheral

### DIFF
--- a/driver/mspm0/mspm0_pwm.cpp
+++ b/driver/mspm0/mspm0_pwm.cpp
@@ -1,0 +1,103 @@
+#include "mspm0_pwm.hpp"
+
+using namespace LibXR;
+
+MSPM0PWM::MSPM0PWM(MSPM0PWM::Resources res)
+    : timer_(res.timer), channel_(res.channel), clock_freq_(res.clock_freq)
+{
+  ASSERT(timer_ != nullptr);
+  ASSERT(clock_freq_ > 0);
+}
+
+ErrorCode MSPM0PWM::SetDutyCycle(float value)
+{
+  if (value < 0.0f)
+  {
+    value = 0.0f;
+  }
+  if (value > 1.0f)
+  {
+    value = 1.0f;
+  }
+
+  uint32_t period = DL_Timer_getLoadValue(timer_);
+  uint32_t compare_value = 0;
+
+  if (value <= 0.0f)
+  {
+    compare_value = period;
+  }
+  else if (value >= 1.0f)
+  {
+    compare_value = period + 1;
+  }
+  else
+  {
+    compare_value = static_cast<uint32_t>(static_cast<float>(period) * (1.0f - value));
+  }
+
+  DL_Timer_setCaptureCompareValue(timer_, compare_value, channel_);
+
+  return ErrorCode::OK;
+}
+
+ErrorCode MSPM0PWM::SetConfig(Configuration config)
+{
+  const uint32_t SOURCE_CLOCK = clock_freq_;
+  if (config.frequency > SOURCE_CLOCK || config.frequency == 0)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  const uint32_t TOTAL_CYCLES_NEEDED = SOURCE_CLOCK / config.frequency;
+  uint32_t min_total_prescale = (TOTAL_CYCLES_NEEDED + 65535) >> 16;
+  if (min_total_prescale == 0)
+  {
+    min_total_prescale = 1;
+  }
+
+  uint32_t best_div = (min_total_prescale + 255) >> 8;
+  if (best_div > 8)
+  {
+    return ErrorCode::NOT_SUPPORT;  // Frequency too low
+  }
+  if (best_div == 0)
+  {
+    best_div = 1;
+  }
+
+  uint32_t best_prescaler = (min_total_prescale + best_div - 1) / best_div;
+  if (best_prescaler == 0)
+  {
+    best_prescaler = 1;
+  }
+
+  uint32_t best_load = (SOURCE_CLOCK / (best_div * best_prescaler * config.frequency));
+  if (best_load > 0)
+  {
+    best_load -= 1;
+  }
+
+  DL_Timer_ClockConfig clock_config;
+  DL_Timer_getClockConfig(timer_, &clock_config);
+
+  clock_config.divideRatio = static_cast<DL_TIMER_CLOCK_DIVIDE>(best_div - 1);
+  clock_config.prescale = static_cast<uint8_t>(best_prescaler - 1);
+
+  DL_Timer_setClockConfig(timer_, &clock_config);
+  DL_Timer_setLoadValue(timer_, best_load);
+
+  return ErrorCode::OK;
+}
+
+ErrorCode MSPM0PWM::Enable()
+{
+  DL_Timer_startCounter(timer_);
+  return ErrorCode::OK;
+}
+
+ErrorCode MSPM0PWM::Disable()
+{
+  DL_Timer_stopCounter(timer_);
+  return ErrorCode::OK;
+}

--- a/driver/mspm0/mspm0_pwm.cpp
+++ b/driver/mspm0/mspm0_pwm.cpp
@@ -22,18 +22,27 @@ ErrorCode MSPM0PWM::SetDutyCycle(float value)
 
   uint32_t period = DL_Timer_getLoadValue(timer_);
   uint32_t compare_value = 0;
+  DL_TIMER_COUNT_MODE count_mode = DL_Timer_getCounterMode(timer_);
 
-  if (value <= 0.0f)
+  switch (count_mode)
+  {
+    case DL_TIMER_COUNT_MODE_DOWN:
+      compare_value = static_cast<uint32_t>(static_cast<float>(period) * (1.0f - value));
+      break;
+
+    case DL_TIMER_COUNT_MODE_UP:
+    case DL_TIMER_COUNT_MODE_UP_DOWN:
+      compare_value = static_cast<uint32_t>(static_cast<float>(period) * value);
+      break;
+
+    default:
+      compare_value = static_cast<uint32_t>(static_cast<float>(period) * (1.0f - value));
+      break;
+  }
+
+  if (compare_value > period)
   {
     compare_value = period;
-  }
-  else if (value >= 1.0f)
-  {
-    compare_value = period + 1;
-  }
-  else
-  {
-    compare_value = static_cast<uint32_t>(static_cast<float>(period) * (1.0f - value));
   }
 
   DL_Timer_setCaptureCompareValue(timer_, compare_value, channel_);

--- a/driver/mspm0/mspm0_pwm.hpp
+++ b/driver/mspm0/mspm0_pwm.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "mspm0_conf.hpp"
+#include "pwm.hpp"
+#include "ti_msp_dl_config.h"
+
+namespace LibXR
+{
+
+class MSPM0PWM : public PWM
+{
+ public:
+  struct Resources
+  {
+    GPTIMER_Regs* timer;
+    DL_TIMER_CC_INDEX channel;
+    uint32_t clock_freq;
+  };
+
+  MSPM0PWM(Resources res);
+
+  ErrorCode SetDutyCycle(float value);
+
+  ErrorCode SetConfig(Configuration config);
+
+  ErrorCode Enable();
+
+  ErrorCode Disable();
+
+ private:
+  GPTIMER_Regs* timer_;
+  DL_TIMER_CC_INDEX channel_;
+  uint32_t clock_freq_;
+};
+
+// Helper macro to define PWM instance resources from SysConfig macros
+#define MSPM0_PWM_CH(name, ch)                                          \
+  LibXR::MSPM0PWM::Resources                                            \
+  {                                                                     \
+    name##_INST, DL_TIMER_CC_##ch##_INDEX,                              \
+        name##_INST_CLK_FREQ* LibXR::MSPM0Config::name##_INST_CLK_DIV*( \
+            LibXR::MSPM0Config::name##_INST_CLK_PSC + 1)                \
+  }
+
+}  // namespace LibXR


### PR DESCRIPTION
## 摘要
本 PR 为 LibXR 引入了 TI MSPM0 系列微控制器的 PWM 外设支持。

主要实现了 `MSPM0PWM` 类，对齐现有的 STM32 和 CH32 实现风格，提供提供基于硬件定时器（TIMG/TIMA）的频率设置、占空比控制及极性配置能力。

> Part of xrobot-org/XRobot-Dev-Roadmap#7

## 主要变更

**平台支持与功能实现：**
* **MSPM0PWM 实现**：添加了符合 LibXR 规范的 PWM 驱动。封装了底层的 PWM 相关寄存器操作。
* **优化 `SetConfig` 算法**：不同于 STM32/CH32 的 O(N) 枚举实现，MSPM0 的 SetConfig 算法使用了 O(1) 的贪婪实现。

**依赖：**
* 依赖 TI MSPM0 SDK (DriverLib)。

**注意：**
* 目前的构造函数需要借助 `MSPM0_PWM_CH` 宏手动传入定时器实例（`GPTIMER`）以及对应的通道索引。未来将通过代码自动生成工具 `XRobot` 实现自动配置定时器实例与通道索引。
* 由于 MSPM0 的定时器时钟源配置较为灵活，目前依赖 `mspm0_conf.hpp` 获取分频值。未来将通过代码自动生成工具 `XRobot` 读取 `.sysconfig` 文件生成 `mspm0_conf.hpp` ，用于保存 SysConfig 文件中的依赖项。

`mspm0_conf.hpp` 文件示例：

```cpp
#include "msp.h"

namespace LibXR::MSPM0Config
{
constexpr uint32_t PWM_0_INST_CLK_DIV = 4;
constexpr uint32_t PWM_0_INST_CLK_PSC = 0;
}  // namespace LibXR::MSPM0Config
```

### 测试逻辑

1. **呼吸灯/流水灯测试**
   - 初始化 `MSPM0PWM` 对象，绑定 **PB22** 引脚。
   - 在主循环中以正弦波或线性方式连续修改占空比（0% - 100%），模拟呼吸灯效果，验证 `SetDutyCycle` 的动态响应的平滑度。

2. **电压准确性测试**
   - 将 **PB22** 配置为 PWM 输出，频率设为 1kHz。
   - 分别设置占空比为 **0%**, **50%**, **100%**。
   - 使用万用表直流电压档测量 PB22 对地电压。

### 观察结果

- **视觉效果**：板载 LED (PB22) 呈现平滑的呼吸闪烁效果，无肉眼可见的频闪或突变，验证了定时器重载逻辑正确。
- **电压测量**：
  - 设定 **0% Duty** -> 万用表读数约为 **0.00V**。
  - 设定 **50% Duty** -> 万用表读数约为 **1.65V** (3.3V * 0.50)。
  - 设定 **75% Duty** -> 万用表读数约为 **3.3V**。
  - 误差在合理范围内，证明占空比计算逻辑准确。

3. 此外测试了`SetConfig()`（观察呼吸频率变化）、`Enable()` 和 `Disable()` 方法，同时测试了不同计数模式下呼吸灯的行为，保证 API 在不同计数模式下统一。

## Summary by Sourcery

Add a TI MSPM0-based PWM driver implementing the common LibXR PWM interface for configuring and driving hardware timers on MSPM0 MCUs.

New Features:
- Introduce the MSPM0PWM class providing PWM output control via MSPM0 hardware timers, including frequency, duty cycle, and enable/disable operations.
- Add a helper macro to construct MSPM0PWM resource descriptors from SysConfig-generated timer definitions.

Enhancements:
- Implement an O(1) configuration algorithm for mapping requested PWM frequencies onto MSPM0 timer clock, prescaler, and load values while validating supported ranges.