### PR TITLE
driver(linux): replace gpio backend with chardev uapi

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: setup deps
-      run: sudo apt-get update && sudo apt-get install -y libwpa-client-dev libnm-dev libudev-dev libgpiod-dev
+      run: sudo apt-get update && sudo apt-get install -y libwpa-client-dev libnm-dev libudev-dev
     - name: configure
       run: mkdir build && cd build && cmake -DLIBXR_TEST_BUILD=True ..
     - name: make

--- a/driver/Linux/CMakeLists.txt
+++ b/driver/Linux/CMakeLists.txt
@@ -4,13 +4,14 @@ target_sources(${PROJECT_NAME} PRIVATE ${${PROJECT_NAME}_DRIVER_SOURCES})
 
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 
+find_package(PkgConfig REQUIRED)
+
 find_library(WPA_CLIENT_LIB wpa_client)
 
 if(WPA_CLIENT_LIB)
   message(STATUS "wpa_client found.")
   target_compile_definitions(xr PUBLIC HAVE_WPA_CLIENT)
   target_link_libraries(xr PUBLIC ${WPA_CLIENT_LIB})
-  find_package(PkgConfig REQUIRED)
   pkg_check_modules(LIBNM REQUIRED libnm)
   target_compile_options(xr PUBLIC ${LIBNM_CFLAGS_OTHER})
   target_include_directories(xr PUBLIC ${LIBNM_INCLUDE_DIRS})
@@ -23,13 +24,6 @@ else()
   )
 endif()
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(LIBGPIOD REQUIRED libgpiod)
-
-target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${LIBGPIOD_INCLUDE_DIRS})
-target_link_libraries(${PROJECT_NAME} PUBLIC ${LIBGPIOD_LIBRARIES})
-
-find_package(PkgConfig REQUIRED)
 pkg_check_modules(LIBUDEV REQUIRED libudev)
 
 target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${LIBUDEV_INCLUDE_DIRS})

--- a/driver/Linux/linux_gpio.cpp
+++ b/driver/Linux/linux_gpio.cpp
@@ -1,0 +1,1027 @@
+#include "linux_gpio.hpp"
+
+#include <fcntl.h>
+#include <linux/gpio.h>
+#include <poll.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <cstring>
+
+#include "logger.hpp"
+
+namespace
+{
+constexpr const char* kLinuxGPIOConsumer = "LinuxGPIO";
+
+LibXR::GPIO::Configuration ResolveRequestConfig(LibXR::GPIO::Configuration desired,
+                                                bool interrupt_enabled)
+{
+  if (!interrupt_enabled &&
+      (desired.direction == LibXR::GPIO::Direction::RISING_INTERRUPT ||
+       desired.direction == LibXR::GPIO::Direction::FALL_INTERRUPT ||
+       desired.direction == LibXR::GPIO::Direction::FALL_RISING_INTERRUPT))
+  {
+    desired.direction = LibXR::GPIO::Direction::INPUT;
+  }
+
+  return desired;
+}
+
+template <size_t N>
+void CopyConsumer(char (&dst)[N], const char* src)
+{
+  std::strncpy(dst, src, N - 1U);
+  dst[N - 1U] = '\0';
+}
+
+uint64_t BuildLineFlagsV2(LibXR::GPIO::Configuration config)
+{
+  uint64_t flags = 0U;
+
+  switch (config.direction)
+  {
+    case LibXR::GPIO::Direction::INPUT:
+      flags |= GPIO_V2_LINE_FLAG_INPUT;
+      break;
+    case LibXR::GPIO::Direction::OUTPUT_PUSH_PULL:
+      flags |= GPIO_V2_LINE_FLAG_OUTPUT;
+      break;
+    case LibXR::GPIO::Direction::OUTPUT_OPEN_DRAIN:
+      flags |= GPIO_V2_LINE_FLAG_OUTPUT | GPIO_V2_LINE_FLAG_OPEN_DRAIN;
+      break;
+    case LibXR::GPIO::Direction::RISING_INTERRUPT:
+      flags |= GPIO_V2_LINE_FLAG_INPUT | GPIO_V2_LINE_FLAG_EDGE_RISING;
+      break;
+    case LibXR::GPIO::Direction::FALL_INTERRUPT:
+      flags |= GPIO_V2_LINE_FLAG_INPUT | GPIO_V2_LINE_FLAG_EDGE_FALLING;
+      break;
+    case LibXR::GPIO::Direction::FALL_RISING_INTERRUPT:
+      flags |= GPIO_V2_LINE_FLAG_INPUT | GPIO_V2_LINE_FLAG_EDGE_RISING |
+               GPIO_V2_LINE_FLAG_EDGE_FALLING;
+      break;
+  }
+
+  switch (config.pull)
+  {
+    case LibXR::GPIO::Pull::NONE:
+      flags |= GPIO_V2_LINE_FLAG_BIAS_DISABLED;
+      break;
+    case LibXR::GPIO::Pull::UP:
+      flags |= GPIO_V2_LINE_FLAG_BIAS_PULL_UP;
+      break;
+    case LibXR::GPIO::Pull::DOWN:
+      flags |= GPIO_V2_LINE_FLAG_BIAS_PULL_DOWN;
+      break;
+  }
+
+  return flags;
+}
+
+uint32_t BuildHandleFlagsV1(LibXR::GPIO::Configuration config)
+{
+  uint32_t flags = 0U;
+
+  switch (config.direction)
+  {
+    case LibXR::GPIO::Direction::INPUT:
+    case LibXR::GPIO::Direction::RISING_INTERRUPT:
+    case LibXR::GPIO::Direction::FALL_INTERRUPT:
+    case LibXR::GPIO::Direction::FALL_RISING_INTERRUPT:
+      flags |= GPIOHANDLE_REQUEST_INPUT;
+      break;
+    case LibXR::GPIO::Direction::OUTPUT_PUSH_PULL:
+      flags |= GPIOHANDLE_REQUEST_OUTPUT;
+      break;
+    case LibXR::GPIO::Direction::OUTPUT_OPEN_DRAIN:
+      flags |= GPIOHANDLE_REQUEST_OUTPUT | GPIOHANDLE_REQUEST_OPEN_DRAIN;
+      break;
+  }
+
+  switch (config.pull)
+  {
+    case LibXR::GPIO::Pull::NONE:
+      flags |= GPIOHANDLE_REQUEST_BIAS_DISABLE;
+      break;
+    case LibXR::GPIO::Pull::UP:
+      flags |= GPIOHANDLE_REQUEST_BIAS_PULL_UP;
+      break;
+    case LibXR::GPIO::Pull::DOWN:
+      flags |= GPIOHANDLE_REQUEST_BIAS_PULL_DOWN;
+      break;
+  }
+
+  return flags;
+}
+
+uint32_t BuildEventFlagsV1(LibXR::GPIO::Direction direction)
+{
+  switch (direction)
+  {
+    case LibXR::GPIO::Direction::RISING_INTERRUPT:
+      return GPIOEVENT_REQUEST_RISING_EDGE;
+    case LibXR::GPIO::Direction::FALL_INTERRUPT:
+      return GPIOEVENT_REQUEST_FALLING_EDGE;
+    case LibXR::GPIO::Direction::FALL_RISING_INTERRUPT:
+      return GPIOEVENT_REQUEST_BOTH_EDGES;
+    default:
+      return 0U;
+  }
+}
+
+int SetNonBlocking(int fd)
+{
+  const int flags = fcntl(fd, F_GETFL, 0);
+  if (flags < 0)
+  {
+    return -1;
+  }
+
+  return fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+}
+
+void DrainInterruptWakeFd(int fd)
+{
+  std::array<uint8_t, 32> buffer = {};
+  while (true)
+  {
+    const ssize_t bytes = read(fd, buffer.data(), buffer.size());
+    if (bytes > 0)
+    {
+      continue;
+    }
+
+    if ((bytes < 0) && ((errno == EAGAIN) || (errno == EWOULDBLOCK) || (errno == EINTR)))
+    {
+      return;
+    }
+
+    return;
+  }
+}
+
+enum class PollReadableResult : int8_t
+{
+  ERROR = -1,
+  TIMEOUT = 0,
+  DATA = 1,
+  WAKE = 2,
+};
+
+PollReadableResult PollReadable(int fd, int wake_fd, int timeout_ms)
+{
+  std::array<pollfd, 2> poll_fds = {};
+  nfds_t nfds = 0;
+
+  poll_fds[nfds++] = {
+      .fd = fd,
+      .events = POLLIN,
+      .revents = 0,
+  };
+
+  if (wake_fd >= 0)
+  {
+    poll_fds[nfds++] = {
+        .fd = wake_fd,
+        .events = POLLIN,
+        .revents = 0,
+    };
+  }
+
+  while (true)
+  {
+    const int ret = poll(poll_fds.data(), nfds, timeout_ms);
+    if ((ret < 0) && (errno == EINTR))
+    {
+      continue;
+    }
+    if (ret < 0)
+    {
+      return PollReadableResult::ERROR;
+    }
+
+    if (ret == 0)
+    {
+      return PollReadableResult::TIMEOUT;
+    }
+
+    if ((wake_fd >= 0) && ((poll_fds[1].revents & POLLIN) != 0))
+    {
+      DrainInterruptWakeFd(wake_fd);
+      return PollReadableResult::WAKE;
+    }
+
+    if ((poll_fds[0].revents & (POLLNVAL | POLLERR | POLLHUP)) != 0)
+    {
+      errno = EBADF;
+      return PollReadableResult::ERROR;
+    }
+
+    if ((poll_fds[0].revents & POLLIN) != 0)
+    {
+      return PollReadableResult::DATA;
+    }
+
+    errno = EIO;
+    return PollReadableResult::ERROR;
+  }
+}
+
+bool IsKnownGPIOEvent(uint32_t event_id)
+{
+  if (event_id == GPIO_V2_LINE_EVENT_RISING_EDGE ||
+      event_id == GPIOEVENT_EVENT_RISING_EDGE)
+  {
+    return true;
+  }
+
+  if (event_id == GPIO_V2_LINE_EVENT_FALLING_EDGE ||
+      event_id == GPIOEVENT_EVENT_FALLING_EDGE)
+  {
+    return true;
+  }
+
+  XR_LOG_WARN("Unknown GPIO event id: %u", event_id);
+  return false;
+}
+
+}  // namespace
+
+namespace LibXR
+{
+
+LinuxGPIO::LinuxGPIO(const std::string& chip_path, unsigned int line_offset)
+    : chip_path_(chip_path), line_offset_(line_offset)
+{
+  UNUSED(InitInterruptWakePipe());
+  UNUSED(OpenChip());
+}
+
+LinuxGPIO::~LinuxGPIO()
+{
+  interrupt_thread_exit_.store(true);
+  request_kind_.store(RequestKind::NONE);
+  interrupt_enabled_.store(false);
+  NotifyInterruptThread();
+  WaitForInterruptThreadStopped();
+  CloseRequest();
+  CloseChip();
+  CloseInterruptWakePipe();
+}
+
+bool LinuxGPIO::Read()
+{
+  if (EnsureConfigured() != ErrorCode::OK)
+  {
+    return false;
+  }
+
+  const int request_fd = request_fd_.load();
+  if (abi_version_.load() == AbiVersion::V2)
+  {
+    gpio_v2_line_values values = {};
+    values.mask = 1ULL;
+    if (ioctl(request_fd, GPIO_V2_LINE_GET_VALUES_IOCTL, &values) < 0)
+    {
+      XR_LOG_ERROR("Failed to read GPIO value: %s", std::strerror(errno));
+      return false;
+    }
+    return (values.bits & 1ULL) != 0U;
+  }
+
+  gpiohandle_data values = {};
+  if (ioctl(request_fd, GPIOHANDLE_GET_LINE_VALUES_IOCTL, &values) < 0)
+  {
+    XR_LOG_ERROR("Failed to read GPIO value: %s", std::strerror(errno));
+    return false;
+  }
+
+  return values.values[0] != 0U;
+}
+
+void LinuxGPIO::Write(bool value)
+{
+  if (EnsureConfigured() != ErrorCode::OK)
+  {
+    return;
+  }
+
+  const int request_fd = request_fd_.load();
+  if (abi_version_.load() == AbiVersion::V2)
+  {
+    gpio_v2_line_values values = {};
+    values.mask = 1ULL;
+    values.bits = value ? 1ULL : 0ULL;
+    if (ioctl(request_fd, GPIO_V2_LINE_SET_VALUES_IOCTL, &values) < 0)
+    {
+      XR_LOG_WARN("Failed to write GPIO value: %s", std::strerror(errno));
+    }
+    return;
+  }
+
+  gpiohandle_data values = {};
+  values.values[0] = value ? 1U : 0U;
+  if (ioctl(request_fd, GPIOHANDLE_SET_LINE_VALUES_IOCTL, &values) < 0)
+  {
+    XR_LOG_WARN("Failed to write GPIO value: %s", std::strerror(errno));
+  }
+}
+
+ErrorCode LinuxGPIO::EnableInterrupt()
+{
+  if (EnsureConfigured() != ErrorCode::OK)
+  {
+    return ErrorCode::STATE_ERR;
+  }
+
+  if (!IsInterruptDirection(current_config_.direction))
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  if (interrupt_enabled_.load())
+  {
+    return ErrorCode::OK;
+  }
+
+  ErrorCode ec = ErrorCode::OK;
+  if (NeedsRequestReopen(current_config_))
+  {
+    ec = ReopenRequest(current_config_);
+  }
+  else if (abi_version_.load() == AbiVersion::V2)
+  {
+    ec = ReconfigureRequestV2(current_config_);
+  }
+  else
+  {
+    ec = ReconfigureRequestV1(current_config_);
+  }
+  if (ec != ErrorCode::OK)
+  {
+    return ec;
+  }
+
+  has_config_ = true;
+  interrupt_enabled_.store(true);
+  StartInterruptThread();
+  return ErrorCode::OK;
+}
+
+ErrorCode LinuxGPIO::DisableInterrupt()
+{
+  if (EnsureConfigured() != ErrorCode::OK)
+  {
+    return ErrorCode::STATE_ERR;
+  }
+
+  if (!IsInterruptDirection(current_config_.direction))
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  if (!interrupt_enabled_.load())
+  {
+    return ErrorCode::OK;
+  }
+
+  const Configuration inactive_config = ResolveRequestConfig(current_config_, false);
+  ErrorCode ec = ErrorCode::OK;
+  if (NeedsRequestReopen(inactive_config))
+  {
+    ec = ReopenRequest(inactive_config);
+  }
+  else if (abi_version_.load() == AbiVersion::V2)
+  {
+    ec = ReconfigureRequestV2(inactive_config);
+  }
+  else
+  {
+    ec = ReconfigureRequestV1(inactive_config);
+  }
+  if (ec != ErrorCode::OK)
+  {
+    return ec;
+  }
+
+  has_config_ = true;
+  interrupt_enabled_.store(false);
+  return ErrorCode::OK;
+}
+
+ErrorCode LinuxGPIO::SetConfig(Configuration config)
+{
+  const ErrorCode chip_ready = OpenChip();
+  if (chip_ready != ErrorCode::OK)
+  {
+    return chip_ready;
+  }
+
+  const bool keep_interrupt_enabled =
+      interrupt_enabled_.load() && IsInterruptDirection(config.direction);
+  const Configuration request_config =
+      ResolveRequestConfig(config, keep_interrupt_enabled);
+
+  ErrorCode ec = ErrorCode::OK;
+  if (request_fd_.load() < 0)
+  {
+    ec = ReopenRequest(request_config);
+  }
+  else if (NeedsRequestReopen(request_config))
+  {
+    ec = ReopenRequest(request_config);
+  }
+  else if (abi_version_.load() == AbiVersion::V2)
+  {
+    ec = ReconfigureRequestV2(request_config);
+  }
+  else
+  {
+    ec = ReconfigureRequestV1(request_config);
+  }
+
+  if (ec != ErrorCode::OK)
+  {
+    return ec;
+  }
+
+  current_config_ = config;
+  has_config_ = true;
+  interrupt_enabled_.store(keep_interrupt_enabled);
+  if (keep_interrupt_enabled)
+  {
+    StartInterruptThread();
+  }
+  return ErrorCode::OK;
+}
+
+void LinuxGPIO::StartInterruptThread()
+{
+  if (interrupt_thread_started_.exchange(true))
+  {
+    return;
+  }
+
+  interrupt_thread_.Create<LinuxGPIO*>(
+      this, [](LinuxGPIO* self) { self->InterruptLoop(); }, "irq_gpio",
+      INTERRUPT_THREAD_STACK_SIZE, Thread::Priority::MEDIUM);
+}
+
+void LinuxGPIO::InterruptLoop()
+{
+  while (!interrupt_thread_exit_.load())
+  {
+    if (!interrupt_enabled_.load())
+    {
+      Thread::Sleep(1);
+      continue;
+    }
+
+    if (request_kind_.load() != RequestKind::EVENT)
+    {
+      Thread::Sleep(1);
+      continue;
+    }
+
+    const int fd = request_fd_.load();
+    if (fd < 0)
+    {
+      Thread::Sleep(1);
+      continue;
+    }
+
+    size_t event_count = 0;
+    interrupt_poll_active_.store(true);
+    const ErrorCode pump = PumpEventQueue(fd, abi_version_.load(), event_count, 100);
+    interrupt_poll_active_.store(false);
+    if (pump == ErrorCode::OK)
+    {
+      for (size_t i = 0; i < event_count; ++i)
+      {
+        callback_.Run(false);
+      }
+      continue;
+    }
+
+    if (pump != ErrorCode::EMPTY)
+    {
+      Thread::Sleep(1);
+    }
+  }
+
+  interrupt_poll_active_.store(false);
+  interrupt_thread_started_.store(false);
+}
+
+ErrorCode LinuxGPIO::OpenChip()
+{
+  if (chip_fd_ >= 0)
+  {
+    return ErrorCode::OK;
+  }
+
+  chip_fd_ = open(chip_path_.c_str(), O_RDONLY | O_CLOEXEC);
+  if (chip_fd_ < 0)
+  {
+    XR_LOG_ERROR("Failed to open GPIO chip: %s (%s)", chip_path_.c_str(),
+                 std::strerror(errno));
+    ASSERT(false);
+    return ErrorCode::INIT_ERR;
+  }
+
+  return DetectAbiVersion();
+}
+
+void LinuxGPIO::CloseChip()
+{
+  if (chip_fd_ >= 0)
+  {
+    close(chip_fd_);
+    chip_fd_ = -1;
+  }
+  abi_version_.store(AbiVersion::UNKNOWN);
+}
+
+void LinuxGPIO::CloseRequest()
+{
+  request_kind_.store(RequestKind::NONE);
+  interrupt_enabled_.store(false);
+  NotifyInterruptThread();
+  WaitForInterruptLoopIdle();
+
+  const int request_fd = request_fd_.exchange(-1);
+  if (request_fd >= 0)
+  {
+    close(request_fd);
+  }
+
+  request_kind_.store(RequestKind::NONE);
+  interrupt_enabled_.store(false);
+  has_config_ = false;
+}
+
+ErrorCode LinuxGPIO::InitInterruptWakePipe()
+{
+  if (interrupt_wake_pipe_[0] >= 0)
+  {
+    return ErrorCode::OK;
+  }
+
+  if (pipe(interrupt_wake_pipe_) < 0)
+  {
+    XR_LOG_ERROR("Failed to create GPIO interrupt wake pipe: %s", std::strerror(errno));
+    return ErrorCode::INIT_ERR;
+  }
+
+  if ((SetNonBlocking(interrupt_wake_pipe_[0]) < 0) ||
+      (SetNonBlocking(interrupt_wake_pipe_[1]) < 0))
+  {
+    XR_LOG_ERROR("Failed to configure GPIO interrupt wake pipe: %s",
+                 std::strerror(errno));
+    CloseInterruptWakePipe();
+    return ErrorCode::INIT_ERR;
+  }
+
+  return ErrorCode::OK;
+}
+
+void LinuxGPIO::CloseInterruptWakePipe()
+{
+  for (int& fd : interrupt_wake_pipe_)
+  {
+    if (fd >= 0)
+    {
+      close(fd);
+      fd = -1;
+    }
+  }
+}
+
+void LinuxGPIO::NotifyInterruptThread()
+{
+  if (interrupt_wake_pipe_[1] < 0)
+  {
+    return;
+  }
+
+  const uint8_t signal = 1U;
+  while (true)
+  {
+    const ssize_t ret = write(interrupt_wake_pipe_[1], &signal, sizeof(signal));
+    if (ret >= 0)
+    {
+      return;
+    }
+
+    if ((errno == EAGAIN) || (errno == EWOULDBLOCK))
+    {
+      DrainInterruptWakeFd(interrupt_wake_pipe_[0]);
+      continue;
+    }
+
+    if (errno == EINTR)
+    {
+      continue;
+    }
+
+    return;
+  }
+}
+
+void LinuxGPIO::WaitForInterruptLoopIdle()
+{
+  if (!interrupt_thread_started_.load())
+  {
+    return;
+  }
+
+  for (uint32_t i = 0; i < 200; ++i)
+  {
+    if (!interrupt_poll_active_.load())
+    {
+      return;
+    }
+
+    Thread::Sleep(1);
+  }
+
+  XR_LOG_WARN("Timed out waiting for GPIO interrupt loop to go idle");
+}
+
+void LinuxGPIO::WaitForInterruptThreadStopped()
+{
+  if (!interrupt_thread_started_.load())
+  {
+    return;
+  }
+
+  for (uint32_t i = 0; i < 500; ++i)
+  {
+    if (!interrupt_thread_started_.load())
+    {
+      return;
+    }
+
+    NotifyInterruptThread();
+    Thread::Sleep(1);
+  }
+
+  XR_LOG_WARN("Timed out waiting for GPIO interrupt thread to stop");
+}
+
+ErrorCode LinuxGPIO::DetectAbiVersion()
+{
+  if (abi_version_.load() != AbiVersion::UNKNOWN)
+  {
+    return ErrorCode::OK;
+  }
+
+  gpiochip_info chip_info = {};
+  if (ioctl(chip_fd_, GPIO_GET_CHIPINFO_IOCTL, &chip_info) < 0)
+  {
+    XR_LOG_ERROR("Failed to read GPIO chip info: %s", std::strerror(errno));
+    return ErrorCode::FAILED;
+  }
+
+  if (chip_info.lines == 0U)
+  {
+    XR_LOG_ERROR("GPIO chip exposes zero lines");
+    return ErrorCode::FAILED;
+  }
+
+  gpio_v2_line_info info = {};
+  info.offset = (line_offset_ < chip_info.lines) ? line_offset_ : 0U;
+  if (ioctl(chip_fd_, GPIO_V2_GET_LINEINFO_IOCTL, &info) == 0)
+  {
+    abi_version_.store(AbiVersion::V2);
+    return ErrorCode::OK;
+  }
+
+  if ((errno == ENOTTY) || (errno == EINVAL)
+#ifdef EOPNOTSUPP
+      || (errno == EOPNOTSUPP)
+#endif
+  )
+  {
+    abi_version_.store(AbiVersion::V1);
+    return ErrorCode::OK;
+  }
+
+  XR_LOG_ERROR("Failed to probe GPIO chardev ABI: %s", std::strerror(errno));
+  return ErrorCode::FAILED;
+}
+
+ErrorCode LinuxGPIO::ReopenRequest(Configuration config)
+{
+  CloseRequest();
+
+  if (abi_version_.load() == AbiVersion::V2)
+  {
+    return OpenRequestV2(config);
+  }
+
+  return OpenRequestV1(config);
+}
+
+ErrorCode LinuxGPIO::OpenRequestV2(Configuration config)
+{
+  gpio_v2_line_request request = {};
+  request.offsets[0] = line_offset_;
+  request.num_lines = 1U;
+  request.event_buffer_size =
+      IsInterruptDirection(config.direction) ? EVENT_BUFFER_CAPACITY : 0U;
+  CopyConsumer(request.consumer, kLinuxGPIOConsumer);
+  request.config.flags = BuildLineFlagsV2(config);
+
+  if (ioctl(chip_fd_, GPIO_V2_GET_LINE_IOCTL, &request) < 0)
+  {
+    XR_LOG_ERROR("Failed to request GPIO line (v2): %s", std::strerror(errno));
+    return ErrorCode::FAILED;
+  }
+
+  request_fd_.store(request.fd);
+  request_kind_.store(IsInterruptDirection(config.direction) ? RequestKind::EVENT
+                                                             : RequestKind::HANDLE);
+  if (SetNonBlocking(request.fd) < 0)
+  {
+    XR_LOG_ERROR("Failed to enable non-blocking GPIO request fd: %s",
+                 std::strerror(errno));
+    CloseRequest();
+    return ErrorCode::FAILED;
+  }
+
+  return ErrorCode::OK;
+}
+
+ErrorCode LinuxGPIO::ReconfigureRequestV2(Configuration config)
+{
+  const bool was_interrupt_request =
+      (request_kind_.load() == RequestKind::EVENT) && interrupt_enabled_.load();
+  if (was_interrupt_request)
+  {
+    request_kind_.store(RequestKind::NONE);
+    interrupt_enabled_.store(false);
+    NotifyInterruptThread();
+    WaitForInterruptLoopIdle();
+  }
+
+  gpio_v2_line_config line_config = {};
+  line_config.flags = BuildLineFlagsV2(config);
+
+  if (ioctl(request_fd_.load(), GPIO_V2_LINE_SET_CONFIG_IOCTL, &line_config) < 0)
+  {
+    XR_LOG_ERROR("Failed to reconfigure GPIO line (v2): %s", std::strerror(errno));
+    return ErrorCode::FAILED;
+  }
+
+  request_kind_.store(IsInterruptDirection(config.direction) ? RequestKind::EVENT
+                                                             : RequestKind::HANDLE);
+  if (was_interrupt_request && IsInterruptDirection(config.direction))
+  {
+    interrupt_enabled_.store(true);
+  }
+  return ErrorCode::OK;
+}
+
+ErrorCode LinuxGPIO::OpenRequestV1(Configuration config)
+{
+  if (IsInterruptDirection(config.direction))
+  {
+    gpioevent_request request = {};
+    request.lineoffset = line_offset_;
+    request.handleflags = BuildHandleFlagsV1(config);
+    request.eventflags = BuildEventFlagsV1(config.direction);
+    CopyConsumer(request.consumer_label, kLinuxGPIOConsumer);
+
+    if (ioctl(chip_fd_, GPIO_GET_LINEEVENT_IOCTL, &request) < 0)
+    {
+      XR_LOG_ERROR("Failed to request GPIO event line (v1): %s", std::strerror(errno));
+      return ErrorCode::FAILED;
+    }
+
+    request_fd_.store(request.fd);
+    request_kind_.store(RequestKind::EVENT);
+  }
+  else
+  {
+    gpiohandle_request request = {};
+    request.lineoffsets[0] = line_offset_;
+    request.lines = 1U;
+    request.flags = BuildHandleFlagsV1(config);
+    CopyConsumer(request.consumer_label, kLinuxGPIOConsumer);
+
+    if (ioctl(chip_fd_, GPIO_GET_LINEHANDLE_IOCTL, &request) < 0)
+    {
+      XR_LOG_ERROR("Failed to request GPIO handle line (v1): %s", std::strerror(errno));
+      return ErrorCode::FAILED;
+    }
+
+    request_fd_.store(request.fd);
+    request_kind_.store(RequestKind::HANDLE);
+  }
+
+  if (SetNonBlocking(request_fd_.load()) < 0)
+  {
+    XR_LOG_ERROR("Failed to enable non-blocking GPIO request fd: %s",
+                 std::strerror(errno));
+    CloseRequest();
+    return ErrorCode::FAILED;
+  }
+
+  return ErrorCode::OK;
+}
+
+ErrorCode LinuxGPIO::ReconfigureRequestV1(Configuration config)
+{
+  if (request_kind_.load() != RequestKind::HANDLE)
+  {
+    return ReopenRequest(config);
+  }
+
+  gpiohandle_config handle_config = {};
+  handle_config.flags = BuildHandleFlagsV1(config);
+  if (ioctl(request_fd_.load(), GPIOHANDLE_SET_CONFIG_IOCTL, &handle_config) < 0)
+  {
+    XR_LOG_ERROR("Failed to reconfigure GPIO line (v1): %s", std::strerror(errno));
+    return ErrorCode::FAILED;
+  }
+
+  return ErrorCode::OK;
+}
+
+ErrorCode LinuxGPIO::PumpEventQueue(int fd, AbiVersion abi_version, size_t& event_count,
+                                    int timeout_ms) const
+{
+  if (fd < 0)
+  {
+    return ErrorCode::STATE_ERR;
+  }
+
+  const PollReadableResult ready = PollReadable(fd, interrupt_wake_pipe_[0], timeout_ms);
+  if (ready == PollReadableResult::ERROR)
+  {
+    if (errno == EBADF)
+    {
+      return ErrorCode::EMPTY;
+    }
+    XR_LOG_ERROR("Failed to poll GPIO fd: %s", std::strerror(errno));
+    return ErrorCode::FAILED;
+  }
+
+  if ((ready == PollReadableResult::TIMEOUT) || (ready == PollReadableResult::WAKE))
+  {
+    return ErrorCode::EMPTY;
+  }
+
+  if (abi_version == AbiVersion::V2)
+  {
+    return ReadEventsV2(fd, event_count);
+  }
+
+  return ReadEventsV1(fd, event_count);
+}
+
+ErrorCode LinuxGPIO::ReadEventsV2(int fd, size_t& event_count) const
+{
+  bool received = false;
+  while (true)
+  {
+    std::array<gpio_v2_line_event, EVENT_BUFFER_CAPACITY> events = {};
+    const ssize_t bytes = read(fd, events.data(), sizeof(events));
+    if (bytes < 0)
+    {
+      if ((errno == EAGAIN) || (errno == EWOULDBLOCK))
+      {
+        break;
+      }
+      if (errno == EBADF)
+      {
+        return received ? ErrorCode::OK : ErrorCode::EMPTY;
+      }
+
+      XR_LOG_ERROR("Failed to read GPIO v2 events: %s", std::strerror(errno));
+      return ErrorCode::FAILED;
+    }
+
+    if (bytes == 0)
+    {
+      break;
+    }
+
+    if ((bytes % static_cast<ssize_t>(sizeof(gpio_v2_line_event))) != 0)
+    {
+      XR_LOG_ERROR("Corrupted GPIO v2 event payload length");
+      return ErrorCode::FAILED;
+    }
+
+    const size_t count = static_cast<size_t>(bytes / sizeof(gpio_v2_line_event));
+    for (size_t i = 0; i < count; ++i)
+    {
+      if (!IsKnownGPIOEvent(events[i].id))
+      {
+        continue;
+      }
+
+      ++event_count;
+      received = true;
+    }
+  }
+
+  return received ? ErrorCode::OK : ErrorCode::EMPTY;
+}
+
+ErrorCode LinuxGPIO::ReadEventsV1(int fd, size_t& event_count) const
+{
+  bool received = false;
+  while (true)
+  {
+    gpioevent_data event = {};
+    const ssize_t bytes = read(fd, &event, sizeof(event));
+    if (bytes < 0)
+    {
+      if ((errno == EAGAIN) || (errno == EWOULDBLOCK))
+      {
+        break;
+      }
+      if (errno == EBADF)
+      {
+        return received ? ErrorCode::OK : ErrorCode::EMPTY;
+      }
+
+      XR_LOG_ERROR("Failed to read GPIO v1 events: %s", std::strerror(errno));
+      return ErrorCode::FAILED;
+    }
+
+    if (bytes == 0)
+    {
+      break;
+    }
+
+    if (bytes != static_cast<ssize_t>(sizeof(event)))
+    {
+      XR_LOG_ERROR("Corrupted GPIO v1 event payload length");
+      return ErrorCode::FAILED;
+    }
+
+    if (!IsKnownGPIOEvent(event.id))
+    {
+      continue;
+    }
+
+    ++event_count;
+    received = true;
+  }
+
+  return received ? ErrorCode::OK : ErrorCode::EMPTY;
+}
+
+ErrorCode LinuxGPIO::EnsureConfigured() const
+{
+  if (!has_config_ || (request_fd_.load() < 0))
+  {
+    XR_LOG_ERROR("GPIO is not configured");
+    ASSERT(false);
+    return ErrorCode::STATE_ERR;
+  }
+
+  return ErrorCode::OK;
+}
+bool LinuxGPIO::IsInterruptDirection(Direction direction)
+{
+  return direction == Direction::RISING_INTERRUPT ||
+         direction == Direction::FALL_INTERRUPT ||
+         direction == Direction::FALL_RISING_INTERRUPT;
+}
+
+bool LinuxGPIO::NeedsRequestReopen(Configuration config) const
+{
+  if (request_fd_.load() < 0)
+  {
+    return true;
+  }
+
+  const bool old_interrupt =
+      interrupt_enabled_.load() && IsInterruptDirection(current_config_.direction);
+  const bool new_interrupt = IsInterruptDirection(config.direction);
+
+  if (abi_version_.load() == AbiVersion::V2)
+  {
+    return old_interrupt != new_interrupt;
+  }
+
+  if (new_interrupt)
+  {
+    return true;
+  }
+
+  if (old_interrupt)
+  {
+    return true;
+  }
+
+  return request_kind_.load() != RequestKind::HANDLE;
+}
+
+}  // namespace LibXR

--- a/driver/Linux/linux_gpio.hpp
+++ b/driver/Linux/linux_gpio.hpp
@@ -1,552 +1,98 @@
 #pragma once
 
-#include <gpiod.h>
-
-#include <cerrno>
+#include <atomic>
 #include <cstddef>
-#include <cstring>
-#include <limits>
+#include <cstdint>
 #include <string>
 
 #include "gpio.hpp"
-#include "logger.hpp"
+#include "thread.hpp"
 
 namespace LibXR
 {
 
 /**
- * @enum GPIOEventType
- * @brief GPIO 事件类型。GPIO event type.
- */
-enum class GPIOEventType : uint8_t
-{
-  RISING_EDGE,  ///< 上升沿事件。Rising edge event.
-  FALLING_EDGE  ///< 下降沿事件。Falling edge event.
-};
-
-/**
- * @struct GPIOEvent
- * @brief GPIO 事件结构体。GPIO event structure.
- */
-struct GPIOEvent
-{
-  int64_t timestamp;   ///< 事件时间戳（纳秒）。Event timestamp in nanoseconds.
-  GPIOEventType type;  ///< 事件类型。Event type.
-};
-
-/**
  * @class LinuxGPIO
- * @brief 基于 libgpiod v2.x 的 Linux GPIO 实现
- *        Linux GPIO implementation using libgpiod v2.x
+ * @brief 基于 Linux GPIO character device uAPI 的 Linux GPIO 实现
+ *        Linux GPIO implementation based on the Linux GPIO character-device uAPI
+ *
+ * @note 优先使用 GPIO chardev v2；旧内核仅在需要时回退到 v1。
+ * @note Prefer GPIO chardev v2; fall back to v1 only on older kernels.
+ * @note 当前运行级验证聚焦在 chardev v2；v1 fallback 目前仅作为兼容路径保留。
+ * @note Runtime validation currently focuses on chardev v2; the v1 fallback is kept as a
+ *       compatibility path.
  */
 class LinuxGPIO : public GPIO
 {
  public:
-  static constexpr size_t EVENT_BUFFER_CAPACITY = 64;
-
-  /**
-   * @brief 构造 LinuxGPIO 对象。Constructs a LinuxGPIO instance.
-   * @param chip_path GPIO chip 设备路径（如 "/dev/gpiochip0"）。
-   *                  GPIO chip device path (e.g. "/dev/gpiochip0").
-   * @param line_offset GPIO line 偏移量。GPIO line offset.
-   */
-  LinuxGPIO(const std::string& chip_path, unsigned int line_offset)
-      : chip_path_(chip_path),
-        line_offset_(line_offset),
-        chip_(gpiod_chip_open(chip_path.c_str()))
-  {
-    if (!chip_)
-    {
-      XR_LOG_ERROR("Failed to open GPIO chip: %s", chip_path.c_str());
-      ASSERT(false);
-      return;
-    }
-
-    settings_ = gpiod_line_settings_new();
-    if (!settings_)
-    {
-      XR_LOG_ERROR("Failed to create GPIO line settings");
-      ASSERT(false);
-      return;
-    }
-
-    line_cfg_ = gpiod_line_config_new();
-    if (!line_cfg_)
-    {
-      XR_LOG_ERROR("Failed to create GPIO line config");
-      ASSERT(false);
-      return;
-    }
-
-    req_cfg_ = gpiod_request_config_new();
-    if (!req_cfg_)
-    {
-      XR_LOG_ERROR("Failed to create GPIO request config");
-      ASSERT(false);
-      return;
-    }
-
-    gpiod_request_config_set_consumer(req_cfg_, "LinuxGPIO");
-    gpiod_request_config_set_event_buffer_size(req_cfg_, EVENT_BUFFER_CAPACITY);
-
-    event_buffer_ = gpiod_edge_event_buffer_new(EVENT_BUFFER_CAPACITY);
-    if (!event_buffer_)
-    {
-      XR_LOG_ERROR("Failed to allocate GPIO edge event buffer");
-      ASSERT(false);
-      return;
-    }
-  }
+  LinuxGPIO(const std::string& chip_path, unsigned int line_offset);
+  ~LinuxGPIO() override;
 
   LinuxGPIO(const LinuxGPIO&) = delete;
   LinuxGPIO& operator=(const LinuxGPIO&) = delete;
 
-  /**
-   * @brief 读取 GPIO 引脚状态。Reads the GPIO line level.
-   * @return true 高电平，false 低电平。True for high level, false for low level.
-   */
-  bool Read() override
-  {
-    if (!EnsureConfigured())
-    {
-      return false;
-    }
-
-    enum gpiod_line_value value = gpiod_line_request_get_value(request_, line_offset_);
-    if (value == GPIOD_LINE_VALUE_ERROR)
-    {
-      XR_LOG_ERROR("Failed to read GPIO value: %s", std::strerror(errno));
-      return false;
-    }
-
-    return value == GPIOD_LINE_VALUE_ACTIVE;
-  }
-
-  /**
-   * @brief 写入 GPIO 引脚状态。Writes a level to the GPIO line.
-   * @param value true 高电平，false 低电平。True for high level, false for low level.
-   */
-  void Write(bool value) override
-  {
-    if (!EnsureConfigured())
-    {
-      return;
-    }
-
-    enum gpiod_line_value line_value =
-        value ? GPIOD_LINE_VALUE_ACTIVE : GPIOD_LINE_VALUE_INACTIVE;
-
-    if (gpiod_line_request_set_value(request_, line_offset_, line_value) < 0)
-    {
-      XR_LOG_WARN("Failed to write GPIO value: %s", std::strerror(errno));
-    }
-  }
-
-  /**
-   * @brief 使能 GPIO 中断处理状态。Enables GPIO interrupt handling state.
-   * @return 操作结果。Operation result.
-   */
-  ErrorCode EnableInterrupt() override
-  {
-    if (!has_config_ || !request_)
-    {
-      return ErrorCode::STATE_ERR;
-    }
-
-    if (!IsInterruptDirection(current_config_.direction))
-    {
-      return ErrorCode::ARG_ERR;
-    }
-
-    interrupt_enabled_ = true;
-    return ErrorCode::OK;
-  }
-
-  /**
-   * @brief 禁用 GPIO 中断处理状态。Disables GPIO interrupt handling state.
-   * @return 操作结果。Operation result.
-   */
-  ErrorCode DisableInterrupt() override
-  {
-    interrupt_enabled_ = false;
-    return ErrorCode::OK;
-  }
-
-  /**
-   * @brief 获取 GPIO request 对应的文件描述符，用于 epoll/poll 注册。
-   *        Gets the request file descriptor for epoll/poll registration.
-   * @return request 文件描述符。Request file descriptor.
-   */
-  int GetFd() const
-  {
-    if (EnsureInterruptReady() != ErrorCode::OK)
-    {
-      return -1;
-    }
-
-    return gpiod_line_request_get_fd(request_);
-  }
-
-  /**
-   * @brief 非阻塞处理中断事件，排空队列并触发回调。
-   *        Handles GPIO interrupt events in non-blocking mode, drains queued events and
-   *        dispatches callbacks.
-   * @return ErrorCode::OK 表示处理了至少一个事件，ErrorCode::EMPTY 表示无事件。
-   *         ErrorCode::OK means at least one event was handled; ErrorCode::EMPTY means no
-   *         pending event.
-   */
-  ErrorCode HandleInterrupt()
-  {
-    const ErrorCode READY = EnsureInterruptReady();
-    if (READY != ErrorCode::OK)
-    {
-      return READY;
-    }
-
-    bool handled = false;
-    while (true)
-    {
-      int ready = gpiod_line_request_wait_edge_events(request_, 0);
-      if (ready < 0)
-      {
-        XR_LOG_ERROR("Failed to poll GPIO edge events: %s", std::strerror(errno));
-        return ErrorCode::FAILED;
-      }
-
-      if (ready == 0)
-      {
-        break;
-      }
-
-      int read = gpiod_line_request_read_edge_events(request_, event_buffer_,
-                                                     EVENT_BUFFER_CAPACITY);
-      if (read < 0)
-      {
-        XR_LOG_ERROR("Failed to read GPIO edge events: %s", std::strerror(errno));
-        return ErrorCode::FAILED;
-      }
-
-      if (read == 0)
-      {
-        break;
-      }
-
-      handled = true;
-      if (!callback_.Empty())
-      {
-        for (int i = 0; i < read; ++i)
-        {
-          callback_.Run(false);
-        }
-      }
-    }
-
-    return handled ? ErrorCode::OK : ErrorCode::EMPTY;
-  }
-
-  /**
-   * @brief 读取单个中断事件。Reads a single interrupt edge event.
-   * @param event 输出事件结构体。Output edge event structure.
-   * @return 操作结果。Operation result.
-   */
-  ErrorCode ReadEvent(GPIOEvent& event)
-  {
-    const ErrorCode READY_STATUS = EnsureInterruptReady();
-    if (READY_STATUS != ErrorCode::OK)
-    {
-      return READY_STATUS;
-    }
-
-    int ready = gpiod_line_request_wait_edge_events(request_, 0);
-    if (ready < 0)
-    {
-      XR_LOG_ERROR("Failed to poll GPIO edge events: %s", std::strerror(errno));
-      return ErrorCode::FAILED;
-    }
-
-    if (ready == 0)
-    {
-      return ErrorCode::EMPTY;
-    }
-
-    int ret = gpiod_line_request_read_edge_events(request_, event_buffer_, 1);
-
-    if (ret < 0)
-    {
-      XR_LOG_ERROR("Failed to read GPIO edge event: %s", std::strerror(errno));
-      return ErrorCode::FAILED;
-    }
-
-    if (ret == 0)
-    {
-      return ErrorCode::EMPTY;
-    }
-
-    struct gpiod_edge_event* edge_event =
-        gpiod_edge_event_buffer_get_event(event_buffer_, ret - 1);
-    if (!edge_event)
-    {
-      XR_LOG_ERROR("Failed to access GPIO edge event from buffer");
-      return ErrorCode::FAILED;
-    }
-
-    const uint64_t TIMESTAMP_NS = gpiod_edge_event_get_timestamp_ns(edge_event);
-    if (TIMESTAMP_NS > static_cast<uint64_t>(std::numeric_limits<int64_t>::max()))
-    {
-      XR_LOG_ERROR("GPIO edge event timestamp out of int64 range");
-      return ErrorCode::OUT_OF_RANGE;
-    }
-
-    event.timestamp = static_cast<int64_t>(TIMESTAMP_NS);
-    event.type =
-        (gpiod_edge_event_get_event_type(edge_event) == GPIOD_EDGE_EVENT_RISING_EDGE)
-            ? GPIOEventType::RISING_EDGE
-            : GPIOEventType::FALLING_EDGE;
-
-    return ErrorCode::OK;
-  }
-
-  /**
-   * @brief 配置 GPIO 引脚参数。Configures GPIO line settings.
-   * @param config GPIO 配置。GPIO configuration.
-   * @return 操作结果。Operation result.
-   */
-  ErrorCode SetConfig(Configuration config) override
-  {
-    if (!settings_ || !line_cfg_ || !req_cfg_ || !chip_)
-    {
-      return ErrorCode::INIT_ERR;
-    }
-
-    interrupt_enabled_ = false;
-
-    gpiod_line_settings_reset(settings_);
-    gpiod_line_config_reset(line_cfg_);
-
-    if (ApplyDirection(config.direction) != ErrorCode::OK)
-    {
-      return ErrorCode::ARG_ERR;
-    }
-
-    if (ApplyPull(config.pull) != ErrorCode::OK)
-    {
-      return ErrorCode::ARG_ERR;
-    }
-
-    if (gpiod_line_config_add_line_settings(line_cfg_, &line_offset_, 1, settings_) < 0)
-    {
-      return ErrorCode::FAILED;
-    }
-
-    if (!request_)
-    {
-      request_ = gpiod_chip_request_lines(chip_, req_cfg_, line_cfg_);
-      if (!request_)
-      {
-        return ErrorCode::FAILED;
-      }
-    }
-    else
-    {
-      if (gpiod_line_request_reconfigure_lines(request_, line_cfg_) < 0)
-      {
-        return ErrorCode::FAILED;
-      }
-    }
-
-    current_config_ = config;
-    has_config_ = true;
-
-    return ErrorCode::OK;
-  }
+  bool Read() override;
+  void Write(bool value) override;
+  ErrorCode EnableInterrupt() override;
+  ErrorCode DisableInterrupt() override;
+  ErrorCode SetConfig(Configuration config) override;
 
  private:
+  static constexpr size_t EVENT_BUFFER_CAPACITY = 64;
+  static constexpr size_t INTERRUPT_THREAD_STACK_SIZE = 16384;
+
+  enum class AbiVersion : uint8_t
+  {
+    UNKNOWN = 0,
+    V2 = 1,
+    V1 = 2,
+  };
+
+  enum class RequestKind : uint8_t
+  {
+    NONE = 0,
+    HANDLE = 1,
+    EVENT = 2,
+  };
+
   std::string chip_path_;
-  unsigned int line_offset_;
-  gpiod_chip* chip_ = nullptr;
-  gpiod_edge_event_buffer* event_buffer_ =
-      nullptr;  ///< 持久化事件缓冲区。Persistent edge event buffer.
-  gpiod_line_settings* settings_ = nullptr;
-  gpiod_request_config* req_cfg_ = nullptr;
-  gpiod_line_config* line_cfg_ = nullptr;
-  gpiod_line_request* request_ = nullptr;
+  unsigned int line_offset_ = 0U;
+  int chip_fd_ = -1;
+  std::atomic<int> request_fd_{-1};
+  std::atomic<AbiVersion> abi_version_{AbiVersion::UNKNOWN};
+  std::atomic<RequestKind> request_kind_{RequestKind::NONE};
   Configuration current_config_ = {Direction::INPUT, Pull::NONE};
   bool has_config_ = false;
-  bool interrupt_enabled_ = false;
+  std::atomic<bool> interrupt_enabled_{false};
+  std::atomic<bool> interrupt_thread_started_{false};
+  std::atomic<bool> interrupt_thread_exit_{false};
+  std::atomic<bool> interrupt_poll_active_{false};
+  Thread interrupt_thread_;
+  int interrupt_wake_pipe_[2] = {-1, -1};
 
-  /**
-   * @brief 根据 GPIO 方向配置 line settings。
-   *        Applies line settings according to GPIO direction.
-   * @return 操作结果。Operation result.
-   */
-  ErrorCode ApplyDirection(Direction direction)
-  {
-    if (!settings_)
-    {
-      return ErrorCode::FAILED;
-    }
-
-    switch (direction)
-    {
-      case Direction::INPUT:
-        if (gpiod_line_settings_set_direction(settings_, GPIOD_LINE_DIRECTION_INPUT) < 0)
-        {
-          return ErrorCode::FAILED;
-        }
-        if (gpiod_line_settings_set_edge_detection(settings_, GPIOD_LINE_EDGE_NONE) < 0)
-        {
-          return ErrorCode::FAILED;
-        }
-        break;
-
-      case Direction::OUTPUT_PUSH_PULL:
-        if (gpiod_line_settings_set_direction(settings_, GPIOD_LINE_DIRECTION_OUTPUT) < 0)
-        {
-          return ErrorCode::FAILED;
-        }
-        if (gpiod_line_settings_set_drive(settings_, GPIOD_LINE_DRIVE_PUSH_PULL) < 0)
-        {
-          return ErrorCode::FAILED;
-        }
-        if (gpiod_line_settings_set_edge_detection(settings_, GPIOD_LINE_EDGE_NONE) < 0)
-        {
-          return ErrorCode::FAILED;
-        }
-        break;
-
-      case Direction::OUTPUT_OPEN_DRAIN:
-        if (gpiod_line_settings_set_direction(settings_, GPIOD_LINE_DIRECTION_OUTPUT) < 0)
-        {
-          return ErrorCode::FAILED;
-        }
-        if (gpiod_line_settings_set_drive(settings_, GPIOD_LINE_DRIVE_OPEN_DRAIN) < 0)
-        {
-          return ErrorCode::FAILED;
-        }
-        if (gpiod_line_settings_set_edge_detection(settings_, GPIOD_LINE_EDGE_NONE) < 0)
-        {
-          return ErrorCode::FAILED;
-        }
-        break;
-
-      case Direction::RISING_INTERRUPT:
-        if (gpiod_line_settings_set_direction(settings_, GPIOD_LINE_DIRECTION_INPUT) < 0)
-        {
-          return ErrorCode::FAILED;
-        }
-        if (gpiod_line_settings_set_edge_detection(settings_, GPIOD_LINE_EDGE_RISING) < 0)
-        {
-          return ErrorCode::FAILED;
-        }
-        break;
-
-      case Direction::FALL_INTERRUPT:
-        if (gpiod_line_settings_set_direction(settings_, GPIOD_LINE_DIRECTION_INPUT) < 0)
-        {
-          return ErrorCode::FAILED;
-        }
-        if (gpiod_line_settings_set_edge_detection(settings_, GPIOD_LINE_EDGE_FALLING) <
-            0)
-        {
-          return ErrorCode::FAILED;
-        }
-        break;
-
-      case Direction::FALL_RISING_INTERRUPT:
-        if (gpiod_line_settings_set_direction(settings_, GPIOD_LINE_DIRECTION_INPUT) < 0)
-        {
-          return ErrorCode::FAILED;
-        }
-        if (gpiod_line_settings_set_edge_detection(settings_, GPIOD_LINE_EDGE_BOTH) < 0)
-        {
-          return ErrorCode::FAILED;
-        }
-        break;
-    }
-
-    return ErrorCode::OK;
-  }
-
-  /**
-   * @brief 根据 GPIO 上拉/下拉配置 line settings。
-   *        Applies line settings according to GPIO pull mode.
-   * @return 操作结果。Operation result.
-   */
-  ErrorCode ApplyPull(Pull pull)
-  {
-    if (!settings_)
-    {
-      return ErrorCode::FAILED;
-    }
-
-    int ret = 0;
-    switch (pull)
-    {
-      case Pull::NONE:
-        ret = gpiod_line_settings_set_bias(settings_, GPIOD_LINE_BIAS_DISABLED);
-        break;
-      case Pull::UP:
-        ret = gpiod_line_settings_set_bias(settings_, GPIOD_LINE_BIAS_PULL_UP);
-        break;
-      case Pull::DOWN:
-        ret = gpiod_line_settings_set_bias(settings_, GPIOD_LINE_BIAS_PULL_DOWN);
-        break;
-    }
-
-    return ret < 0 ? ErrorCode::FAILED : ErrorCode::OK;
-  }
-
-  /**
-   * @brief 判断 direction 是否为中断方向。Checks whether direction is interrupt mode.
-   * @return true 表示中断方向。True if direction is interrupt mode.
-   */
-  static bool IsInterruptDirection(Direction direction)
-  {
-    return direction == Direction::RISING_INTERRUPT ||
-           direction == Direction::FALL_INTERRUPT ||
-           direction == Direction::FALL_RISING_INTERRUPT;
-  }
-
-  /**
-   * @brief 确保 GPIO 已配置。Ensures GPIO has been configured.
-   */
-  bool EnsureConfigured() const
-  {
-    if (!has_config_ || !request_)
-    {
-      XR_LOG_ERROR("GPIO is not configured");
-      ASSERT(false);
-      return false;
-    }
-
-    return true;
-  }
-
-  /**
-   * @brief 确保中断路径已启用。Ensures interrupt path is enabled and ready.
-   */
-  ErrorCode EnsureInterruptReady() const
-  {
-    if (!EnsureConfigured())
-    {
-      return ErrorCode::STATE_ERR;
-    }
-
-    if (!IsInterruptDirection(current_config_.direction))
-    {
-      XR_LOG_ERROR("GPIO is not configured for interrupt mode");
-      ASSERT(false);
-      return ErrorCode::ARG_ERR;
-    }
-
-    if (!interrupt_enabled_)
-    {
-      XR_LOG_ERROR("GPIO interrupt is not enabled");
-      return ErrorCode::STATE_ERR;
-    }
-
-    return ErrorCode::OK;
-  }
+  ErrorCode OpenChip();
+  void CloseChip();
+  void CloseRequest();
+  ErrorCode InitInterruptWakePipe();
+  void CloseInterruptWakePipe();
+  void NotifyInterruptThread();
+  void WaitForInterruptLoopIdle();
+  void WaitForInterruptThreadStopped();
+  ErrorCode DetectAbiVersion();
+  ErrorCode ReopenRequest(Configuration config);
+  ErrorCode OpenRequestV2(Configuration config);
+  ErrorCode ReconfigureRequestV2(Configuration config);
+  ErrorCode OpenRequestV1(Configuration config);
+  ErrorCode ReconfigureRequestV1(Configuration config);
+  ErrorCode PumpEventQueue(int fd, AbiVersion abi_version, size_t& event_count,
+                           int timeout_ms) const;
+  ErrorCode ReadEventsV2(int fd, size_t& event_count) const;
+  ErrorCode ReadEventsV1(int fd, size_t& event_count) const;
+  void StartInterruptThread();
+  void InterruptLoop();
+  ErrorCode EnsureConfigured() const;
+  static bool IsInterruptDirection(Direction direction);
+  bool NeedsRequestReopen(Configuration config) const;
 };
 
 }  // namespace LibXR

--- a/src/driver/gpio.hpp
+++ b/src/driver/gpio.hpp
@@ -61,6 +61,11 @@ class GPIO
   GPIO() {}
 
   /**
+   * @brief 虚析构函数。Virtual destructor.
+   */
+  virtual ~GPIO() = default;
+
+  /**
    * @brief 读取 GPIO 引脚状态。Reads the GPIO pin state.
    * @return 返回引脚状态，true 表示高电平，false 表示低电平。Returns the pin state, true
    * for high, false for low.


### PR DESCRIPTION
## Summary by Sourcery

Replace the Linux GPIO driver’s libgpiod-based implementation with a direct Linux GPIO character-device uAPI backend, including interrupt handling and ABI v1/v2 support.

Enhancements:
- Introduce a new LinuxGPIO implementation using the Linux GPIO chardev v2 API with a compatibility fallback to v1, supporting non-blocking I/O and interrupt/event handling.
- Refactor GPIO base class to have a virtual destructor to support polymorphic deletion of GPIO implementations.

Build:
- Remove libgpiod from the Linux build configuration and dependency list, simplifying external library requirements.

CI:
- Update CI workflow to stop installing libgpiod development packages as part of the check job.