### PR TITLE
split(pr99): isolate spi and i2c semantics updates

### DIFF
--- a/driver/ch/ch32_i2c.cpp
+++ b/driver/ch/ch32_i2c.cpp
@@ -11,6 +11,16 @@ using namespace LibXR;
 
 CH32I2C* CH32I2C::map_[CH32_I2C_NUMBER] = {nullptr};
 
+namespace
+{
+
+constexpr uint32_t CH32_I2C_ERROR_FLAGS =
+    ((I2C_FLAG_BERR & 0xFFFFu) | (I2C_FLAG_ARLO & 0xFFFFu) | (I2C_FLAG_AF & 0xFFFFu) |
+     (I2C_FLAG_OVR & 0xFFFFu) | (I2C_FLAG_PECERR & 0xFFFFu) |
+     (I2C_FLAG_TIMEOUT & 0xFFFFu) | (I2C_FLAG_SMBALERT & 0xFFFFu));
+
+}  // namespace
+
 static inline void ch32_i2c_enable_clocks(ch32_i2c_id_t id)
 {
   RCC_APB1PeriphClockCmd(CH32_I2C_RCC_PERIPH_MAP[id], ENABLE);
@@ -158,6 +168,10 @@ bool CH32I2C::WaitEvent(uint32_t evt, uint32_t timeout_us)
   const uint64_t START = static_cast<uint64_t>(Timebase::GetMicroseconds());
   while ((static_cast<uint64_t>(Timebase::GetMicroseconds()) - START) < timeout_us)
   {
+    if ((instance_->STAR1 & CH32_I2C_ERROR_FLAGS) != 0u)
+    {
+      return false;
+    }
     if (I2C_CheckEvent(instance_, evt) == READY)
     {
       return true;
@@ -171,12 +185,36 @@ bool CH32I2C::WaitFlag(uint32_t flag, FlagStatus st, uint32_t timeout_us)
   const uint64_t START = static_cast<uint64_t>(Timebase::GetMicroseconds());
   while ((static_cast<uint64_t>(Timebase::GetMicroseconds()) - START) < timeout_us)
   {
+    if ((flag != I2C_FLAG_BUSY) && ((instance_->STAR1 & CH32_I2C_ERROR_FLAGS) != 0u))
+    {
+      return false;
+    }
     if (I2C_GetFlagStatus(instance_, flag) == st)
     {
       return true;
     }
   }
   return false;
+}
+
+ErrorCode CH32I2C::WaitEventOrRecover(uint32_t evt, uint32_t timeout_us)
+{
+  if (WaitEvent(evt, timeout_us))
+  {
+    return ErrorCode::OK;
+  }
+  RecoverAfterImmediateFailure();
+  return ErrorCode::BUSY;
+}
+
+ErrorCode CH32I2C::WaitFlagOrRecover(uint32_t flag, FlagStatus st, uint32_t timeout_us)
+{
+  if (WaitFlag(flag, st, timeout_us))
+  {
+    return ErrorCode::OK;
+  }
+  RecoverAfterImmediateFailure();
+  return ErrorCode::BUSY;
 }
 
 void CH32I2C::ClearAddrFlag()
@@ -192,16 +230,16 @@ ErrorCode CH32I2C::MasterStartAndAddress10Bit(uint16_t addr10, uint8_t final_dir
   addr10 = Addr10Clamp(addr10);
 
   // 等待 BUSY 释放
-  if (!WaitFlag(I2C_FLAG_BUSY, RESET))
+  if (auto ec = WaitFlagOrRecover(I2C_FLAG_BUSY, RESET); ec != ErrorCode::OK)
   {
-    return ErrorCode::BUSY;
+    return ec;
   }
 
   // --- 1) START ---
   I2C_GenerateSTART(instance_, ENABLE);
-  if (!WaitEvent(I2C_EVENT_MASTER_MODE_SELECT))
+  if (auto ec = WaitEventOrRecover(I2C_EVENT_MASTER_MODE_SELECT); ec != ErrorCode::OK)
   {
-    return ErrorCode::BUSY;
+    return ec;
   }
 
   // --- 2) 发送 10-bit 头字节（地址阶段固定以写方向发送，R/W=0）---
@@ -210,18 +248,19 @@ ErrorCode CH32I2C::MasterStartAndAddress10Bit(uint16_t addr10, uint8_t final_dir
   I2C_Send7bitAddress(instance_, HEADER, I2C_Direction_Transmitter);
 
   // 等待 EVT9（ADD10）
-  if (!WaitEvent(I2C_EVENT_MASTER_MODE_ADDRESS10))
+  if (auto ec = WaitEventOrRecover(I2C_EVENT_MASTER_MODE_ADDRESS10); ec != ErrorCode::OK)
   {
-    return ErrorCode::BUSY;
+    return ec;
   }
 
   // --- 3) 发送地址低 8 位 ---
   I2C_SendData(instance_, static_cast<uint8_t>(addr10 & 0xFF));
 
   // 等待 EVT6（作为 Transmitter 完成地址阶段）
-  if (!WaitEvent(I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED))
+  if (auto ec = WaitEventOrRecover(I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED);
+      ec != ErrorCode::OK)
   {
-    return ErrorCode::BUSY;
+    return ec;
   }
   ClearAddrFlag();
 
@@ -232,15 +271,16 @@ ErrorCode CH32I2C::MasterStartAndAddress10Bit(uint16_t addr10, uint8_t final_dir
 
   // --- 4) 若最终为读：Repeated START + 头字节（R/W=1） ---
   I2C_GenerateSTART(instance_, ENABLE);
-  if (!WaitEvent(I2C_EVENT_MASTER_MODE_SELECT))
+  if (auto ec = WaitEventOrRecover(I2C_EVENT_MASTER_MODE_SELECT); ec != ErrorCode::OK)
   {
-    return ErrorCode::BUSY;
+    return ec;
   }
 
   I2C_Send7bitAddress(instance_, HEADER, I2C_Direction_Receiver);
-  if (!WaitEvent(I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED))
+  if (auto ec = WaitEventOrRecover(I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED);
+      ec != ErrorCode::OK)
   {
-    return ErrorCode::BUSY;
+    return ec;
   }
   ClearAddrFlag();
 
@@ -254,31 +294,33 @@ ErrorCode CH32I2C::MasterStartAndAddress(uint16_t slave_addr, uint8_t dir)
     // 7-bit：输入为原始 7-bit 地址
     const uint8_t ADDR8 = Addr7ToAddr8(slave_addr);
 
-    if (!WaitFlag(I2C_FLAG_BUSY, RESET))
+    if (auto ec = WaitFlagOrRecover(I2C_FLAG_BUSY, RESET); ec != ErrorCode::OK)
     {
-      return ErrorCode::BUSY;
+      return ec;
     }
 
     I2C_GenerateSTART(instance_, ENABLE);
-    if (!WaitEvent(I2C_EVENT_MASTER_MODE_SELECT))
+    if (auto ec = WaitEventOrRecover(I2C_EVENT_MASTER_MODE_SELECT); ec != ErrorCode::OK)
     {
-      return ErrorCode::BUSY;
+      return ec;
     }
 
     I2C_Send7bitAddress(instance_, ADDR8, dir);
 
     if (dir == I2C_Direction_Transmitter)
     {
-      if (!WaitEvent(I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED))
+      if (auto ec = WaitEventOrRecover(I2C_EVENT_MASTER_TRANSMITTER_MODE_SELECTED);
+          ec != ErrorCode::OK)
       {
-        return ErrorCode::BUSY;
+        return ec;
       }
     }
     else
     {
-      if (!WaitEvent(I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED))
+      if (auto ec = WaitEventOrRecover(I2C_EVENT_MASTER_RECEIVER_MODE_SELECTED);
+          ec != ErrorCode::OK)
       {
-        return ErrorCode::BUSY;
+        return ec;
       }
     }
 
@@ -294,29 +336,29 @@ ErrorCode CH32I2C::SendMemAddr(uint16_t mem_addr, MemAddrLength len)
 {
   if (len == MemAddrLength::BYTE_16)
   {
-    if (!WaitFlag(I2C_FLAG_TXE, SET))
+    if (auto ec = WaitFlagOrRecover(I2C_FLAG_TXE, SET); ec != ErrorCode::OK)
     {
-      return ErrorCode::BUSY;
+      return ec;
     }
     I2C_SendData(instance_, static_cast<uint8_t>((mem_addr >> 8) & 0xFF));
-    if (!WaitFlag(I2C_FLAG_TXE, SET))
+    if (auto ec = WaitFlagOrRecover(I2C_FLAG_TXE, SET); ec != ErrorCode::OK)
     {
-      return ErrorCode::BUSY;
+      return ec;
     }
     I2C_SendData(instance_, static_cast<uint8_t>(mem_addr & 0xFF));
   }
   else
   {
-    if (!WaitFlag(I2C_FLAG_TXE, SET))
+    if (auto ec = WaitFlagOrRecover(I2C_FLAG_TXE, SET); ec != ErrorCode::OK)
     {
-      return ErrorCode::BUSY;
+      return ec;
     }
     I2C_SendData(instance_, static_cast<uint8_t>(mem_addr & 0xFF));
   }
 
-  if (!WaitFlag(I2C_FLAG_BTF, SET))
+  if (auto ec = WaitFlagOrRecover(I2C_FLAG_BTF, SET); ec != ErrorCode::OK)
   {
-    return ErrorCode::BUSY;
+    return ec;
   }
   return ErrorCode::OK;
 }
@@ -325,15 +367,15 @@ ErrorCode CH32I2C::PollingWriteBytes(const uint8_t* data, uint32_t len)
 {
   for (uint32_t i = 0; i < len; ++i)
   {
-    if (!WaitFlag(I2C_FLAG_TXE, SET))
+    if (auto ec = WaitFlagOrRecover(I2C_FLAG_TXE, SET); ec != ErrorCode::OK)
     {
-      return ErrorCode::BUSY;
+      return ec;
     }
     I2C_SendData(instance_, data[i]);
   }
-  if (!WaitFlag(I2C_FLAG_BTF, SET))
+  if (auto ec = WaitFlagOrRecover(I2C_FLAG_BTF, SET); ec != ErrorCode::OK)
   {
-    return ErrorCode::BUSY;
+    return ec;
   }
   return ErrorCode::OK;
 }
@@ -350,9 +392,9 @@ ErrorCode CH32I2C::PollingReadBytes(uint8_t* data, uint32_t len)
   {
     I2C_AcknowledgeConfig(instance_, DISABLE);
     I2C_GenerateSTOP(instance_, ENABLE);
-    if (!WaitFlag(I2C_FLAG_RXNE, SET))
+    if (auto ec = WaitFlagOrRecover(I2C_FLAG_RXNE, SET); ec != ErrorCode::OK)
     {
-      return ErrorCode::BUSY;
+      return ec;
     }
     data[0] = I2C_ReceiveData(instance_);
     I2C_AcknowledgeConfig(instance_, ENABLE);
@@ -365,9 +407,9 @@ ErrorCode CH32I2C::PollingReadBytes(uint8_t* data, uint32_t len)
     I2C_NACKPositionConfig(instance_, I2C_NACKPosition_Next);
     I2C_AcknowledgeConfig(instance_, DISABLE);
 
-    if (!WaitFlag(I2C_FLAG_BTF, SET))
+    if (auto ec = WaitFlagOrRecover(I2C_FLAG_BTF, SET); ec != ErrorCode::OK)
     {
-      return ErrorCode::BUSY;
+      return ec;
     }
     I2C_GenerateSTOP(instance_, ENABLE);
 
@@ -386,27 +428,27 @@ ErrorCode CH32I2C::PollingReadBytes(uint8_t* data, uint32_t len)
   uint32_t idx = 0;
   while (len > 3)
   {
-    if (!WaitFlag(I2C_FLAG_RXNE, SET))
+    if (auto ec = WaitFlagOrRecover(I2C_FLAG_RXNE, SET); ec != ErrorCode::OK)
     {
-      return ErrorCode::BUSY;
+      return ec;
     }
     data[idx++] = I2C_ReceiveData(instance_);
     --len;
   }
 
   // 剩余 3 字节处理
-  if (!WaitFlag(I2C_FLAG_BTF, SET))
+  if (auto ec = WaitFlagOrRecover(I2C_FLAG_BTF, SET); ec != ErrorCode::OK)
   {
-    return ErrorCode::BUSY;
+    return ec;
   }
   I2C_AcknowledgeConfig(instance_, DISABLE);
   data[idx++] = I2C_ReceiveData(instance_);
   I2C_GenerateSTOP(instance_, ENABLE);
   data[idx++] = I2C_ReceiveData(instance_);
 
-  if (!WaitFlag(I2C_FLAG_RXNE, SET))
+  if (auto ec = WaitFlagOrRecover(I2C_FLAG_RXNE, SET); ec != ErrorCode::OK)
   {
-    return ErrorCode::BUSY;
+    return ec;
   }
   data[idx++] = I2C_ReceiveData(instance_);
 
@@ -454,12 +496,67 @@ void CH32I2C::AbortTransfer(ErrorCode ec)
 
   if (read_)
   {
-    read_op_.UpdateStatus(true, ec);
+    if (read_op_.type == ReadOperation::OperationType::BLOCK)
+    {
+      (void)block_wait_.TryPost(true, ec);
+    }
+    else
+    {
+      read_op_.UpdateStatus(true, ec);
+    }
   }
   else
   {
-    write_op_.UpdateStatus(true, ec);
+    if (write_op_.type == WriteOperation::OperationType::BLOCK)
+    {
+      (void)block_wait_.TryPost(true, ec);
+    }
+    else
+    {
+      write_op_.UpdateStatus(true, ec);
+    }
   }
+}
+
+void CH32I2C::RecoverAfterImmediateFailure()
+{
+  recovering_ = true;
+  I2C_ITConfig(instance_, I2C_IT_ERR, DISABLE);
+  I2C_DMACmd(instance_, DISABLE);
+  I2C_DMALastTransferCmd(instance_, DISABLE);
+  DMA_Cmd(dma_tx_channel_, DISABLE);
+  DMA_Cmd(dma_rx_channel_, DISABLE);
+  dma_tx_channel_->CNTR = 0;
+  dma_rx_channel_->CNTR = 0;
+
+  DMA_ClearITPendingBit(CH32_I2C_TX_DMA_IT_MAP[id_]);
+  DMA_ClearITPendingBit(CH32_I2C_RX_DMA_IT_MAP[id_]);
+
+  const uint32_t err_its[] = {I2C_IT_BERR,   I2C_IT_ARLO,    I2C_IT_AF,      I2C_IT_OVR,
+                              I2C_IT_PECERR, I2C_IT_TIMEOUT, I2C_IT_SMBALERT};
+  for (uint32_t it : err_its)
+  {
+    I2C_ClearITPendingBit(instance_, it);
+  }
+
+  I2C_GenerateSTOP(instance_, ENABLE);
+  if (!WaitFlag(I2C_FLAG_BUSY, RESET, K_DEFAULT_TIMEOUT_US))
+  {
+    (void)SetConfig(cfg_);
+  }
+  else
+  {
+    I2C_AcknowledgeConfig(instance_, ENABLE);
+    I2C_NACKPositionConfig(instance_, I2C_NACKPosition_Current);
+  }
+
+  busy_ = false;
+  read_ = false;
+  read_op_ = {};
+  write_op_ = {};
+  read_buff_ = {nullptr, 0};
+  I2C_ITConfig(instance_, I2C_IT_ERR, ENABLE);
+  recovering_ = false;
 }
 
 ErrorCode CH32I2C::Write(uint16_t slave_addr, ConstRawData write_data, WriteOperation& op,
@@ -467,10 +564,9 @@ ErrorCode CH32I2C::Write(uint16_t slave_addr, ConstRawData write_data, WriteOper
 {
   if (write_data.size_ == 0)
   {
-    op.UpdateStatus(in_isr, ErrorCode::OK);
-    if (op.type == WriteOperation::OperationType::BLOCK)
+    if (op.type != WriteOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ErrorCode::OK);
     }
     return ErrorCode::OK;
   }
@@ -482,6 +578,7 @@ ErrorCode CH32I2C::Write(uint16_t slave_addr, ConstRawData write_data, WriteOper
   }
 
   read_ = false;
+  I2C_ITConfig(instance_, I2C_IT_ERR, DISABLE);
 
   ErrorCode ec = MasterStartAndAddress(slave_addr, I2C_Direction_Transmitter);
   if (ec != ErrorCode::OK)
@@ -495,11 +592,11 @@ ErrorCode CH32I2C::Write(uint16_t slave_addr, ConstRawData write_data, WriteOper
     ec = PollingWriteBytes(reinterpret_cast<const uint8_t*>(write_data.addr_),
                            write_data.size_);
     I2C_GenerateSTOP(instance_, ENABLE);
+    I2C_ITConfig(instance_, I2C_IT_ERR, ENABLE);
 
-    op.UpdateStatus(in_isr, ec);
-    if (op.type == WriteOperation::OperationType::BLOCK)
+    if (op.type != WriteOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ec);
     }
     return ec;
   }
@@ -510,12 +607,17 @@ ErrorCode CH32I2C::Write(uint16_t slave_addr, ConstRawData write_data, WriteOper
   write_op_ = op;
   busy_ = true;
 
+  if (op.type == WriteOperation::OperationType::BLOCK)
+  {
+    block_wait_.Start(*op.data.sem_info.sem);
+  }
+  I2C_ITConfig(instance_, I2C_IT_ERR, ENABLE);
   StartTxDma(write_data.size_);
 
   op.MarkAsRunning();
   if (op.type == WriteOperation::OperationType::BLOCK)
   {
-    return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+    return block_wait_.Wait(op.data.sem_info.timeout);
   }
   return ErrorCode::OK;
 }
@@ -525,10 +627,9 @@ ErrorCode CH32I2C::Read(uint16_t slave_addr, RawData read_data, ReadOperation& o
 {
   if (read_data.size_ == 0)
   {
-    op.UpdateStatus(in_isr, ErrorCode::OK);
-    if (op.type == ReadOperation::OperationType::BLOCK)
+    if (op.type != ReadOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ErrorCode::OK);
     }
     return ErrorCode::OK;
   }
@@ -540,6 +641,7 @@ ErrorCode CH32I2C::Read(uint16_t slave_addr, RawData read_data, ReadOperation& o
   }
 
   read_ = true;
+  I2C_ITConfig(instance_, I2C_IT_ERR, DISABLE);
 
   ErrorCode ec = MasterStartAndAddress(slave_addr, I2C_Direction_Receiver);
   if (ec != ErrorCode::OK)
@@ -551,10 +653,10 @@ ErrorCode CH32I2C::Read(uint16_t slave_addr, RawData read_data, ReadOperation& o
   if (read_data.size_ <= dma_enable_min_size_)
   {
     ec = PollingReadBytes(reinterpret_cast<uint8_t*>(read_data.addr_), read_data.size_);
-    op.UpdateStatus(in_isr, ec);
-    if (op.type == ReadOperation::OperationType::BLOCK)
+    I2C_ITConfig(instance_, I2C_IT_ERR, ENABLE);
+    if (op.type != ReadOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ec);
     }
     return ec;
   }
@@ -564,12 +666,17 @@ ErrorCode CH32I2C::Read(uint16_t slave_addr, RawData read_data, ReadOperation& o
   read_buff_ = read_data;
   busy_ = true;
 
+  if (op.type == ReadOperation::OperationType::BLOCK)
+  {
+    block_wait_.Start(*op.data.sem_info.sem);
+  }
+  I2C_ITConfig(instance_, I2C_IT_ERR, ENABLE);
   StartRxDma(read_data.size_);
 
   op.MarkAsRunning();
   if (op.type == ReadOperation::OperationType::BLOCK)
   {
-    return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+    return block_wait_.Wait(op.data.sem_info.timeout);
   }
   return ErrorCode::OK;
 }
@@ -580,10 +687,9 @@ ErrorCode CH32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
 {
   if (write_data.size_ == 0)
   {
-    op.UpdateStatus(in_isr, ErrorCode::OK);
-    if (op.type == WriteOperation::OperationType::BLOCK)
+    if (op.type != WriteOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ErrorCode::OK);
     }
     return ErrorCode::OK;
   }
@@ -595,6 +701,7 @@ ErrorCode CH32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
   }
 
   read_ = false;
+  I2C_ITConfig(instance_, I2C_IT_ERR, DISABLE);
 
   ErrorCode ec = MasterStartAndAddress(slave_addr, I2C_Direction_Transmitter);
   if (ec != ErrorCode::OK)
@@ -606,10 +713,9 @@ ErrorCode CH32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
   if (ec != ErrorCode::OK)
   {
     I2C_GenerateSTOP(instance_, ENABLE);
-    op.UpdateStatus(in_isr, ec);
-    if (op.type == WriteOperation::OperationType::BLOCK)
+    if (op.type != WriteOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ec);
     }
     return ec;
   }
@@ -619,11 +725,11 @@ ErrorCode CH32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
     ec = PollingWriteBytes(reinterpret_cast<const uint8_t*>(write_data.addr_),
                            write_data.size_);
     I2C_GenerateSTOP(instance_, ENABLE);
+    I2C_ITConfig(instance_, I2C_IT_ERR, ENABLE);
 
-    op.UpdateStatus(in_isr, ec);
-    if (op.type == WriteOperation::OperationType::BLOCK)
+    if (op.type != WriteOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ec);
     }
     return ec;
   }
@@ -633,12 +739,17 @@ ErrorCode CH32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
   write_op_ = op;
   busy_ = true;
 
+  if (op.type == WriteOperation::OperationType::BLOCK)
+  {
+    block_wait_.Start(*op.data.sem_info.sem);
+  }
+  I2C_ITConfig(instance_, I2C_IT_ERR, ENABLE);
   StartTxDma(write_data.size_);
 
   op.MarkAsRunning();
   if (op.type == WriteOperation::OperationType::BLOCK)
   {
-    return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+    return block_wait_.Wait(op.data.sem_info.timeout);
   }
   return ErrorCode::OK;
 }
@@ -648,10 +759,9 @@ ErrorCode CH32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_
 {
   if (read_data.size_ == 0)
   {
-    op.UpdateStatus(in_isr, ErrorCode::OK);
-    if (op.type == ReadOperation::OperationType::BLOCK)
+    if (op.type != ReadOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ErrorCode::OK);
     }
     return ErrorCode::OK;
   }
@@ -663,6 +773,7 @@ ErrorCode CH32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_
   }
 
   read_ = true;
+  I2C_ITConfig(instance_, I2C_IT_ERR, DISABLE);
 
   // 1) 地址阶段：发送写地址 + mem addr
   ErrorCode ec = MasterStartAndAddress(slave_addr, I2C_Direction_Transmitter);
@@ -675,10 +786,9 @@ ErrorCode CH32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_
   if (ec != ErrorCode::OK)
   {
     I2C_GenerateSTOP(instance_, ENABLE);
-    op.UpdateStatus(in_isr, ec);
-    if (op.type == ReadOperation::OperationType::BLOCK)
+    if (op.type != ReadOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ec);
     }
     return ec;
   }
@@ -693,10 +803,9 @@ ErrorCode CH32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_
     {
       I2C_GenerateSTOP(instance_, ENABLE);
       ec = ErrorCode::BUSY;
-      op.UpdateStatus(in_isr, ec);
-      if (op.type == ReadOperation::OperationType::BLOCK)
+      if (op.type != ReadOperation::OperationType::BLOCK)
       {
-        return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+        op.UpdateStatus(in_isr, ec);
       }
       return ec;
     }
@@ -706,10 +815,9 @@ ErrorCode CH32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_
     {
       I2C_GenerateSTOP(instance_, ENABLE);
       ec = ErrorCode::BUSY;
-      op.UpdateStatus(in_isr, ec);
-      if (op.type == ReadOperation::OperationType::BLOCK)
+      if (op.type != ReadOperation::OperationType::BLOCK)
       {
-        return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+        op.UpdateStatus(in_isr, ec);
       }
       return ec;
     }
@@ -725,10 +833,9 @@ ErrorCode CH32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_
     {
       I2C_GenerateSTOP(instance_, ENABLE);
       ec = ErrorCode::BUSY;
-      op.UpdateStatus(in_isr, ec);
-      if (op.type == ReadOperation::OperationType::BLOCK)
+      if (op.type != ReadOperation::OperationType::BLOCK)
       {
-        return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+        op.UpdateStatus(in_isr, ec);
       }
       return ec;
     }
@@ -738,10 +845,9 @@ ErrorCode CH32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_
     {
       I2C_GenerateSTOP(instance_, ENABLE);
       ec = ErrorCode::BUSY;
-      op.UpdateStatus(in_isr, ec);
-      if (op.type == ReadOperation::OperationType::BLOCK)
+      if (op.type != ReadOperation::OperationType::BLOCK)
       {
-        return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+        op.UpdateStatus(in_isr, ec);
       }
       return ec;
     }
@@ -752,10 +858,10 @@ ErrorCode CH32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_
   if (read_data.size_ <= dma_enable_min_size_)
   {
     ec = PollingReadBytes(reinterpret_cast<uint8_t*>(read_data.addr_), read_data.size_);
-    op.UpdateStatus(in_isr, ec);
-    if (op.type == ReadOperation::OperationType::BLOCK)
+    I2C_ITConfig(instance_, I2C_IT_ERR, ENABLE);
+    if (op.type != ReadOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ec);
     }
     return ec;
   }
@@ -765,12 +871,17 @@ ErrorCode CH32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_
   read_buff_ = read_data;
   busy_ = true;
 
+  if (op.type == ReadOperation::OperationType::BLOCK)
+  {
+    block_wait_.Start(*op.data.sem_info.sem);
+  }
+  I2C_ITConfig(instance_, I2C_IT_ERR, ENABLE);
   StartRxDma(read_data.size_);
 
   op.MarkAsRunning();
   if (op.type == ReadOperation::OperationType::BLOCK)
   {
-    return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+    return block_wait_.Wait(op.data.sem_info.timeout);
   }
   return ErrorCode::OK;
 }
@@ -786,11 +897,23 @@ void CH32I2C::TxDmaIRQHandler()
   DMA_Cmd(dma_tx_channel_, DISABLE);
   I2C_DMACmd(instance_, DISABLE);
 
+  if (recovering_ || !busy_)
+  {
+    return;
+  }
+
   (void)WaitFlag(I2C_FLAG_BTF, SET, 20000);
   I2C_GenerateSTOP(instance_, ENABLE);
 
   busy_ = false;
-  write_op_.UpdateStatus(true, ErrorCode::OK);
+  if (write_op_.type == WriteOperation::OperationType::BLOCK)
+  {
+    (void)block_wait_.TryPost(true, ErrorCode::OK);
+  }
+  else
+  {
+    write_op_.UpdateStatus(true, ErrorCode::OK);
+  }
 }
 
 void CH32I2C::RxDmaIRQHandler()
@@ -805,6 +928,11 @@ void CH32I2C::RxDmaIRQHandler()
   I2C_DMACmd(instance_, DISABLE);
   I2C_DMALastTransferCmd(instance_, DISABLE);
 
+  if (recovering_ || !busy_)
+  {
+    return;
+  }
+
   I2C_GenerateSTOP(instance_, ENABLE);
 
   if (read_buff_.size_ > 0)
@@ -818,7 +946,14 @@ void CH32I2C::RxDmaIRQHandler()
   I2C_NACKPositionConfig(instance_, I2C_NACKPosition_Current);
 
   busy_ = false;
-  read_op_.UpdateStatus(true, ErrorCode::OK);
+  if (read_op_.type == ReadOperation::OperationType::BLOCK)
+  {
+    (void)block_wait_.TryPost(true, ErrorCode::OK);
+  }
+  else
+  {
+    read_op_.UpdateStatus(true, ErrorCode::OK);
+  }
 }
 
 void CH32I2C::ErrorIRQHandler()
@@ -837,7 +972,7 @@ void CH32I2C::ErrorIRQHandler()
     }
   }
 
-  if (has_err && busy_)
+  if (has_err && busy_ && !recovering_)
   {
     AbortTransfer(ErrorCode::FAILED);
   }

--- a/driver/ch/ch32_i2c.hpp
+++ b/driver/ch/ch32_i2c.hpp
@@ -78,6 +78,9 @@ class CH32I2C : public I2C
 
   bool WaitEvent(uint32_t evt, uint32_t timeout_us = K_DEFAULT_TIMEOUT_US);
   bool WaitFlag(uint32_t flag, FlagStatus st, uint32_t timeout_us = K_DEFAULT_TIMEOUT_US);
+  ErrorCode WaitEventOrRecover(uint32_t evt, uint32_t timeout_us = K_DEFAULT_TIMEOUT_US);
+  ErrorCode WaitFlagOrRecover(uint32_t flag, FlagStatus st,
+                              uint32_t timeout_us = K_DEFAULT_TIMEOUT_US);
 
   void ClearAddrFlag();
 
@@ -97,6 +100,7 @@ class CH32I2C : public I2C
   void StartRxDma(uint32_t len);
 
   void AbortTransfer(ErrorCode ec);
+  void RecoverAfterImmediateFailure();
 
  public:
   I2C_TypeDef* instance_;
@@ -112,6 +116,7 @@ class CH32I2C : public I2C
   RawData read_buff_;
   bool read_ = false;
   bool busy_ = false;
+  bool recovering_ = false;
 
   GPIO_TypeDef* scl_port_;
   uint16_t scl_pin_;
@@ -121,6 +126,7 @@ class CH32I2C : public I2C
   Configuration cfg_{400000};
 
   bool ten_bit_addr_ = false;
+  AsyncBlockWait block_wait_{};
 };
 
 }  // namespace LibXR

--- a/driver/ch/ch32_spi.cpp
+++ b/driver/ch/ch32_spi.cpp
@@ -322,12 +322,16 @@ ErrorCode CH32SPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
 
     PrepareTxBuffer(write_data, NEED);
 
+    if (op.type == OperationRW::OperationType::BLOCK)
+    {
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
     StartDmaDuplex(NEED);
 
     op.MarkAsRunning();
     if (op.type == OperationRW::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      return block_wait_.Wait(op.data.sem_info.timeout);
     }
     return ErrorCode::OK;
   }
@@ -404,12 +408,15 @@ ErrorCode CH32SPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, boo
     rw_op_ = op;
     busy_ = true;
 
+    if (op.type == OperationRW::OperationType::BLOCK)
+    {
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
     StartDmaDuplex(TOTAL);
-
     op.MarkAsRunning();
     if (op.type == OperationRW::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      return block_wait_.Wait(op.data.sem_info.timeout);
     }
     return ErrorCode::OK;
   }
@@ -471,12 +478,16 @@ ErrorCode CH32SPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW& 
     rw_op_ = op;
     busy_ = true;
 
+    if (op.type == OperationRW::OperationType::BLOCK)
+    {
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
     StartDmaDuplex(TOTAL);
 
     op.MarkAsRunning();
     if (op.type == OperationRW::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      return block_wait_.Wait(op.data.sem_info.timeout);
     }
     return ErrorCode::OK;
   }
@@ -558,8 +569,14 @@ void CH32SPI::RxDmaIRQHandler()
   SPI_I2S_DMACmd(instance_, SPI_I2S_DMAReq_Rx, DISABLE);
   DMA_Cmd(dma_rx_channel_, DISABLE);
 
+  if (!busy_)
+  {
+    return;
+  }
+
   // 拷贝读数据（若有）
-  if (read_buff_.size_ > 0)
+  const bool has_user_read_copy = (read_buff_.size_ > 0);
+  if (has_user_read_copy)
   {
     RawData rx = GetRxBuffer();
     uint8_t* rxp = static_cast<uint8_t*>(rx.addr_);
@@ -577,7 +594,14 @@ void CH32SPI::RxDmaIRQHandler()
   // 双缓冲切换与状态更新
   SwitchBuffer();
   busy_ = false;
-  rw_op_.UpdateStatus(true, ErrorCode::OK);
+  if (rw_op_.type == OperationRW::OperationType::BLOCK)
+  {
+    (void)block_wait_.TryPost(true, ErrorCode::OK);
+  }
+  else
+  {
+    rw_op_.UpdateStatus(true, ErrorCode::OK);
+  }
 }
 
 void CH32SPI::TxDmaIRQHandler()
@@ -590,6 +614,11 @@ void CH32SPI::TxDmaIRQHandler()
 
   SPI_I2S_DMACmd(instance_, SPI_I2S_DMAReq_Tx, DISABLE);
   DMA_Cmd(dma_tx_channel_, DISABLE);
+
+  if (!busy_)
+  {
+    return;
+  }
 }
 
 // Zero-copy transfer path.
@@ -621,12 +650,16 @@ ErrorCode CH32SPI::Transfer(size_t size, OperationRW& op, bool in_isr)
     mem_read_ = false;
     busy_ = true;
 
+    if (op.type == OperationRW::OperationType::BLOCK)
+    {
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
     StartDmaDuplex(static_cast<uint32_t>(size));
 
     op.MarkAsRunning();
     if (op.type == OperationRW::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      return block_wait_.Wait(op.data.sem_info.timeout);
     }
     return ErrorCode::OK;
   }

--- a/driver/ch/ch32_spi.hpp
+++ b/driver/ch/ch32_spi.hpp
@@ -93,6 +93,8 @@ class CH32SPI : public SPI
   uint16_t miso_pin_;
   GPIO_TypeDef* mosi_port_;
   uint16_t mosi_pin_;
+
+  AsyncBlockWait block_wait_{};
 };
 
 }  // namespace LibXR

--- a/driver/esp/esp_i2c.cpp
+++ b/driver/esp/esp_i2c.cpp
@@ -135,18 +135,6 @@ ErrorCode Complete(OperationType& op, bool in_isr, ErrorCode result)
   return result;
 }
 
-template <typename OperationType>
-ErrorCode WaitAsyncIfBlock(OperationType& op, bool in_isr)
-{
-  if (op.type != OperationType::OperationType::BLOCK)
-  {
-    return ErrorCode::OK;
-  }
-
-  ASSERT(!in_isr);
-  return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
-}
-
 }  // namespace
 
 ESP32I2C::ESP32I2C(i2c_port_t port_num, int scl_pin, int sda_pin, uint32_t clock_speed,
@@ -665,7 +653,14 @@ void ESP32I2C::FinishAsync(bool in_isr, ErrorCode ec)
   async_read_addr_sent_ = false;
 
   Release();
-  op.UpdateStatus(in_isr, ec);
+  if (op.type == ReadOperation::OperationType::BLOCK)
+  {
+    (void)block_wait_.TryPost(in_isr, ec);
+  }
+  else
+  {
+    op.UpdateStatus(in_isr, ec);
+  }
 }
 
 ErrorCode ESP32I2C::InstallInterrupt()
@@ -990,15 +985,28 @@ ErrorCode ESP32I2C::Write(uint16_t slave_addr, ConstRawData write_data,
   const size_t total_size = write_data.size_;
   if (ShouldUseInterruptAsync(total_size))
   {
+    if (op.type == WriteOperation::OperationType::BLOCK)
+    {
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
     const ErrorCode ans = StartAsyncTransaction(
         slave_addr, nullptr, 0U, static_cast<const uint8_t*>(write_data.addr_),
         write_data.size_, nullptr, 0U, op);
     if (ans != ErrorCode::OK)
     {
+      if (op.type == WriteOperation::OperationType::BLOCK)
+      {
+        block_wait_.Cancel();
+      }
       Release();
       return Complete(op, in_isr, ans);
     }
-    return WaitAsyncIfBlock(op, in_isr);
+    if (op.type == WriteOperation::OperationType::BLOCK)
+    {
+      ASSERT(!in_isr);
+      return block_wait_.Wait(op.data.sem_info.timeout);
+    }
+    return ErrorCode::OK;
   }
 
   const ErrorCode ans =
@@ -1035,15 +1043,28 @@ ErrorCode ESP32I2C::Read(uint16_t slave_addr, RawData read_data, ReadOperation& 
   const size_t total_size = read_data.size_;
   if (ShouldUseInterruptAsync(total_size))
   {
+    if (op.type == ReadOperation::OperationType::BLOCK)
+    {
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
     const ErrorCode ans = StartAsyncTransaction(slave_addr, nullptr, 0U, nullptr, 0U,
                                                 static_cast<uint8_t*>(read_data.addr_),
                                                 read_data.size_, op);
     if (ans != ErrorCode::OK)
     {
+      if (op.type == ReadOperation::OperationType::BLOCK)
+      {
+        block_wait_.Cancel();
+      }
       Release();
       return Complete(op, in_isr, ans);
     }
-    return WaitAsyncIfBlock(op, in_isr);
+    if (op.type == ReadOperation::OperationType::BLOCK)
+    {
+      ASSERT(!in_isr);
+      return block_wait_.Wait(op.data.sem_info.timeout);
+    }
+    return ErrorCode::OK;
   }
 
   const ErrorCode ans = ExecuteTransaction(
@@ -1089,15 +1110,28 @@ ErrorCode ESP32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
   const size_t total_size = mem_len + write_data.size_;
   if (ShouldUseInterruptAsync(total_size))
   {
+    if (op.type == WriteOperation::OperationType::BLOCK)
+    {
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
     const ErrorCode ans = StartAsyncTransaction(
         slave_addr, mem_raw.data(), mem_len,
         static_cast<const uint8_t*>(write_data.addr_), write_data.size_, nullptr, 0U, op);
     if (ans != ErrorCode::OK)
     {
+      if (op.type == WriteOperation::OperationType::BLOCK)
+      {
+        block_wait_.Cancel();
+      }
       Release();
       return Complete(op, in_isr, ans);
     }
-    return WaitAsyncIfBlock(op, in_isr);
+    if (op.type == WriteOperation::OperationType::BLOCK)
+    {
+      ASSERT(!in_isr);
+      return block_wait_.Wait(op.data.sem_info.timeout);
+    }
+    return ErrorCode::OK;
   }
 
   std::array<uint8_t, kFifoLen> staging = {};
@@ -1169,14 +1203,27 @@ ErrorCode ESP32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read
   const size_t total_size = mem_len + read_data.size_;
   if ((read_data.size_ > 0U) && ShouldUseInterruptAsync(total_size))
   {
+    if (op.type == ReadOperation::OperationType::BLOCK)
+    {
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
     const ErrorCode ans = StartAsyncTransaction(slave_addr, mem_raw.data(), mem_len,
                                                 nullptr, 0U, dst, read_data.size_, op);
     if (ans != ErrorCode::OK)
     {
+      if (op.type == ReadOperation::OperationType::BLOCK)
+      {
+        block_wait_.Cancel();
+      }
       Release();
       return Complete(op, in_isr, ans);
     }
-    return WaitAsyncIfBlock(op, in_isr);
+    if (op.type == ReadOperation::OperationType::BLOCK)
+    {
+      ASSERT(!in_isr);
+      return block_wait_.Wait(op.data.sem_info.timeout);
+    }
+    return ErrorCode::OK;
   }
 
   size_t offset = 0U;

--- a/driver/esp/esp_i2c.hpp
+++ b/driver/esp/esp_i2c.hpp
@@ -114,6 +114,7 @@ class ESP32I2C : public I2C
   bool async_write_addr_sent_ = false;
   bool async_write_stop_sent_ = false;
   bool async_read_addr_sent_ = false;
+  AsyncBlockWait block_wait_{};
 };
 
 }  // namespace LibXR

--- a/driver/esp/esp_spi.cpp
+++ b/driver/esp/esp_spi.cpp
@@ -405,6 +405,8 @@ void IRAM_ATTR ESP32SPI::FinishAsync(bool in_isr, ErrorCode ec)
   spi_ll_clear_int_stat(hw_);
 
   RawData rx = {nullptr, 0U};
+  const RawData read_back = read_back_;
+  const bool mem_read = mem_read_;
   if ((ec == ErrorCode::OK) && async_dma_rx_enabled_)
   {
     rx = GetRxBuffer();
@@ -416,23 +418,23 @@ void IRAM_ATTR ESP32SPI::FinishAsync(bool in_isr, ErrorCode ec)
 #endif
   }
 
-  if ((ec == ErrorCode::OK) && (read_back_.size_ > 0U))
+  if ((ec == ErrorCode::OK) && (read_back.size_ > 0U))
   {
     if (rx.addr_ == nullptr)
     {
       rx = GetRxBuffer();
     }
     uint8_t* src = static_cast<uint8_t*>(rx.addr_);
-    if (mem_read_)
+    if (mem_read)
     {
-      ASSERT(rx.size_ >= (read_back_.size_ + 1U));
+      ASSERT(rx.size_ >= (read_back.size_ + 1U));
       src += 1;
     }
     else
     {
-      ASSERT(rx.size_ >= read_back_.size_);
+      ASSERT(rx.size_ >= read_back.size_);
     }
-    Memory::FastCopy(read_back_.addr_, src, read_back_.size_);
+    Memory::FastCopy(read_back.addr_, src, read_back.size_);
   }
 
   if (ec == ErrorCode::OK)
@@ -446,7 +448,14 @@ void IRAM_ATTR ESP32SPI::FinishAsync(bool in_isr, ErrorCode ec)
   mem_read_ = false;
   read_back_ = {nullptr, 0};
   Release();
-  rw_op_.UpdateStatus(in_isr, ec);
+  if (rw_op_.type == OperationRW::OperationType::BLOCK)
+  {
+    (void)block_wait_.TryPost(in_isr, ec);
+  }
+  else
+  {
+    rw_op_.UpdateStatus(in_isr, ec);
+  }
 }
 
 ErrorCode ESP32SPI::SetConfig(SPI::Configuration config)
@@ -670,6 +679,10 @@ ErrorCode ESP32SPI::StartAsyncTransfer(const uint8_t* tx, uint8_t* rx, size_t si
   mem_read_ = mem_read;
   async_dma_size_ = size;
   async_dma_rx_enabled_ = rx_enabled;
+  if (op.type == OperationRW::OperationType::BLOCK)
+  {
+    block_wait_.Start(*op.data.sem_info.sem);
+  }
   started = true;
 
   // On ESP32 classic, enable data lines only after DMA descriptors/channels are ready.
@@ -684,7 +697,7 @@ ErrorCode ESP32SPI::StartAsyncTransfer(const uint8_t* tx, uint8_t* rx, size_t si
   op.MarkAsRunning();
   if (op.type == OperationRW::OperationType::BLOCK)
   {
-    return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+    return block_wait_.Wait(op.data.sem_info.timeout);
   }
   return ErrorCode::OK;
 }

--- a/driver/esp/esp_spi.hpp
+++ b/driver/esp/esp_spi.hpp
@@ -118,6 +118,7 @@ class ESP32SPI : public SPI
   size_t dbuf_rx_block_size_ = 0;
   size_t dbuf_tx_block_size_ = 0;
   uint8_t dbuf_active_block_ = 0;
+  AsyncBlockWait block_wait_{};
   bool dbuf_enabled_ = false;
   intr_handle_t intr_handle_ = nullptr;
   bool intr_installed_ = false;

--- a/driver/st/stm32_i2c.cpp
+++ b/driver/st/stm32_i2c.cpp
@@ -87,6 +87,69 @@ static inline uint16_t EncodeHalDevAddress(const I2C_HandleTypeDef* hi2c,
   return static_cast<uint16_t>((slave_addr & 0x007F) << 1);
 }
 
+static inline ErrorCode MapHalStartFailure(const I2C_HandleTypeDef* hi2c,
+                                           HAL_StatusTypeDef st)
+{
+  // Preserve HAL's immediate start-failure signal without forcing a full controller
+  // reset.
+#ifdef HAL_I2C_ERROR_NONE
+  const uint32_t err = hi2c->ErrorCode;
+#ifdef HAL_I2C_WRONG_START
+  if ((err & (HAL_I2C_ERROR_TIMEOUT | HAL_I2C_WRONG_START)) != 0U)
+#else
+  if ((err & HAL_I2C_ERROR_TIMEOUT) != 0U)
+#endif
+  {
+    return ErrorCode::TIMEOUT;
+  }
+  if (err != HAL_I2C_ERROR_NONE)
+  {
+    return ErrorCode::FAILED;
+  }
+#else
+  UNUSED(hi2c);
+#endif
+  return (st == HAL_BUSY) ? ErrorCode::BUSY : ErrorCode::FAILED;
+}
+
+static void RecoverAfterBlockTimeout(STM32I2C* i2c)
+{
+  ASSERT(i2c != nullptr);
+
+  auto* hi2c = i2c->i2c_handle_;
+  i2c->recovering_ = true;
+  if (hi2c->hdmarx != nullptr)
+  {
+    (void)HAL_DMA_Abort(hi2c->hdmarx);
+  }
+  if (hi2c->hdmatx != nullptr)
+  {
+    (void)HAL_DMA_Abort(hi2c->hdmatx);
+  }
+
+  // Re-open the HAL handle after a detached BLOCK timeout without touching
+  // the larger software-side callback/semaphore semantics.
+  (void)HAL_I2C_DeInit(hi2c);
+  (void)HAL_I2C_Init(hi2c);
+
+  i2c->read_ = false;
+  i2c->read_op_ = {};
+  i2c->write_op_ = {};
+  i2c->read_buff_ = {nullptr, 0};
+  i2c->recovering_ = false;
+}
+
+static inline ErrorCode WaitBlockResultAndRecoverTimeout(STM32I2C* i2c, uint32_t timeout)
+{
+  ASSERT(i2c != nullptr);
+  const ErrorCode ans = i2c->block_wait_.Wait(timeout);
+  if (ans == ErrorCode::TIMEOUT)
+  {
+    RecoverAfterBlockTimeout(i2c);
+  }
+  return ans;
+}
+
 }  // namespace
 
 STM32I2C::STM32I2C(I2C_HandleTypeDef* hi2c, RawData dma_buff,
@@ -115,14 +178,28 @@ ErrorCode STM32I2C::Read(uint16_t slave_addr, RawData read_data, ReadOperation& 
   if (read_data.size_ > dma_enable_min_size_)
   {
     read_op_ = op;
-    HAL_I2C_Master_Receive_DMA(i2c_handle_, dev_addr,
-                               reinterpret_cast<uint8_t*>(dma_buff_.addr_),
-                               read_data.size_);
     read_buff_ = read_data;
+    if (op.type == ReadOperation::OperationType::BLOCK)
+    {
+      // Arm the BLOCK waiter before HAL exposes completion to IRQ context.
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
+    const HAL_StatusTypeDef st = HAL_I2C_Master_Receive_DMA(
+        i2c_handle_, dev_addr, reinterpret_cast<uint8_t*>(dma_buff_.addr_),
+        read_data.size_);
+    if (st != HAL_OK)
+    {
+      if (op.type == ReadOperation::OperationType::BLOCK)
+      {
+        block_wait_.Cancel();
+        return MapHalStartFailure(i2c_handle_, st);
+      }
+      return ErrorCode::BUSY;
+    }
     op.MarkAsRunning();
     if (op.type == ReadOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      return WaitBlockResultAndRecoverTimeout(this, op.data.sem_info.timeout);
     }
     return ErrorCode::OK;
   }
@@ -135,10 +212,9 @@ ErrorCode STM32I2C::Read(uint16_t slave_addr, RawData read_data, ReadOperation& 
                    : ErrorCode::BUSY;
     // BLOCK 模式下沿用统一状态更新路径。
     // Reuse the same status update path for BLOCK mode.
-    op.UpdateStatus(in_isr, ans);
-    if (op.type == ReadOperation::OperationType::BLOCK)
+    if (op.type != ReadOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ans);
     }
     return ans;
   }
@@ -161,17 +237,31 @@ ErrorCode STM32I2C::Write(uint16_t slave_addr, ConstRawData write_data,
   if (write_data.size_ > dma_enable_min_size_)
   {
     write_op_ = op;
+    if (op.type == WriteOperation::OperationType::BLOCK)
+    {
+      // Arm the BLOCK waiter before HAL exposes completion to IRQ context.
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     SCB_CleanDCache_by_Addr(reinterpret_cast<uint32_t*>(dma_buff_.addr_),
                             write_data.size_);
 #endif
-    HAL_I2C_Master_Transmit_DMA(i2c_handle_, dev_addr,
-                                reinterpret_cast<uint8_t*>(dma_buff_.addr_),
-                                write_data.size_);
+    const HAL_StatusTypeDef st = HAL_I2C_Master_Transmit_DMA(
+        i2c_handle_, dev_addr, reinterpret_cast<uint8_t*>(dma_buff_.addr_),
+        write_data.size_);
+    if (st != HAL_OK)
+    {
+      if (op.type == WriteOperation::OperationType::BLOCK)
+      {
+        block_wait_.Cancel();
+        return MapHalStartFailure(i2c_handle_, st);
+      }
+      return ErrorCode::BUSY;
+    }
     op.MarkAsRunning();
     if (op.type == WriteOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      return WaitBlockResultAndRecoverTimeout(this, op.data.sem_info.timeout);
     }
     return ErrorCode::OK;
   }
@@ -182,10 +272,9 @@ ErrorCode STM32I2C::Write(uint16_t slave_addr, ConstRawData write_data,
                                        write_data.size_, 20) == HAL_OK
                    ? ErrorCode::OK
                    : ErrorCode::BUSY;
-    op.UpdateStatus(in_isr, ans);
-    if (op.type == WriteOperation::OperationType::BLOCK)
+    if (op.type != WriteOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ans);
     }
     return ans;
   }
@@ -208,15 +297,30 @@ ErrorCode STM32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read
   if (read_data.size_ > dma_enable_min_size_)
   {
     read_op_ = op;
-    HAL_I2C_Mem_Read_DMA(i2c_handle_, dev_addr, mem_addr,
-                         mem_addr_size == MemAddrLength::BYTE_8 ? I2C_MEMADD_SIZE_8BIT
-                                                                : I2C_MEMADD_SIZE_16BIT,
-                         reinterpret_cast<uint8_t*>(dma_buff_.addr_), read_data.size_);
     read_buff_ = read_data;
+    if (op.type == ReadOperation::OperationType::BLOCK)
+    {
+      // Arm the BLOCK waiter before HAL exposes completion to IRQ context.
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
+    const HAL_StatusTypeDef st = HAL_I2C_Mem_Read_DMA(
+        i2c_handle_, dev_addr, mem_addr,
+        mem_addr_size == MemAddrLength::BYTE_8 ? I2C_MEMADD_SIZE_8BIT
+                                               : I2C_MEMADD_SIZE_16BIT,
+        reinterpret_cast<uint8_t*>(dma_buff_.addr_), read_data.size_);
+    if (st != HAL_OK)
+    {
+      if (op.type == ReadOperation::OperationType::BLOCK)
+      {
+        block_wait_.Cancel();
+        return MapHalStartFailure(i2c_handle_, st);
+      }
+      return ErrorCode::BUSY;
+    }
     op.MarkAsRunning();
     if (op.type == ReadOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      return WaitBlockResultAndRecoverTimeout(this, op.data.sem_info.timeout);
     }
     return ErrorCode::OK;
   }
@@ -231,10 +335,9 @@ ErrorCode STM32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read
             ? ErrorCode::OK
             : ErrorCode::BUSY;
 
-    op.UpdateStatus(in_isr, ans);
-    if (op.type == ReadOperation::OperationType::BLOCK)
+    if (op.type != ReadOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ans);
     }
     return ans;
   }
@@ -260,18 +363,33 @@ ErrorCode STM32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
   if (write_data.size_ > dma_enable_min_size_)
   {
     write_op_ = op;
+    if (op.type == WriteOperation::OperationType::BLOCK)
+    {
+      // Arm the BLOCK waiter before HAL exposes completion to IRQ context.
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     SCB_CleanDCache_by_Addr(reinterpret_cast<uint32_t*>(dma_buff_.addr_),
                             write_data.size_);
 #endif
-    HAL_I2C_Mem_Write_DMA(i2c_handle_, dev_addr, mem_addr,
-                          mem_addr_size == MemAddrLength::BYTE_8 ? I2C_MEMADD_SIZE_8BIT
-                                                                 : I2C_MEMADD_SIZE_16BIT,
-                          reinterpret_cast<uint8_t*>(dma_buff_.addr_), write_data.size_);
+    const HAL_StatusTypeDef st = HAL_I2C_Mem_Write_DMA(
+        i2c_handle_, dev_addr, mem_addr,
+        mem_addr_size == MemAddrLength::BYTE_8 ? I2C_MEMADD_SIZE_8BIT
+                                               : I2C_MEMADD_SIZE_16BIT,
+        reinterpret_cast<uint8_t*>(dma_buff_.addr_), write_data.size_);
+    if (st != HAL_OK)
+    {
+      if (op.type == WriteOperation::OperationType::BLOCK)
+      {
+        block_wait_.Cancel();
+        return MapHalStartFailure(i2c_handle_, st);
+      }
+      return ErrorCode::BUSY;
+    }
     op.MarkAsRunning();
     if (op.type == WriteOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      return WaitBlockResultAndRecoverTimeout(this, op.data.sem_info.timeout);
     }
     return ErrorCode::OK;
   }
@@ -286,10 +404,9 @@ ErrorCode STM32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
             ? ErrorCode::OK
             : ErrorCode::BUSY;
 
-    op.UpdateStatus(in_isr, ans);
-    if (op.type == WriteOperation::OperationType::BLOCK)
+    if (op.type != WriteOperation::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      op.UpdateStatus(in_isr, ans);
     }
     return ans;
   }
@@ -316,44 +433,100 @@ ErrorCode STM32I2C::SetConfig(Configuration config)
 extern "C" void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef* hi2c)
 {
   STM32I2C* i2c = STM32I2C::map[STM32_I2C_GetID(hi2c->Instance)];
-  if (i2c)
+  if (i2c && !i2c->recovering_ &&
+      (i2c->read_op_.type != ReadOperation::OperationType::NONE))
   {
+    ErrorCode ec = ErrorCode::OK;
+#ifdef HAL_I2C_ERROR_NONE
+    ec = (hi2c->ErrorCode == HAL_I2C_ERROR_NONE) ? ErrorCode::OK : ErrorCode::FAILED;
+#endif
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     SCB_InvalidateDCache_by_Addr(i2c->dma_buff_.addr_, i2c->read_buff_.size_);
 #endif
-    Memory::FastCopy(i2c->read_buff_.addr_, i2c->dma_buff_.addr_, i2c->read_buff_.size_);
-    i2c->read_op_.UpdateStatus(true, ErrorCode::OK);
+    if (ec == ErrorCode::OK)
+    {
+      Memory::FastCopy(i2c->read_buff_.addr_, i2c->dma_buff_.addr_,
+                       i2c->read_buff_.size_);
+    }
+    if (i2c->read_op_.type == ReadOperation::OperationType::BLOCK)
+    {
+      (void)i2c->block_wait_.TryPost(true, ec);
+    }
+    else
+    {
+      i2c->read_op_.UpdateStatus(true, ec);
+    }
   }
 }
 
 extern "C" void HAL_I2C_MasterTxCpltCallback(I2C_HandleTypeDef* hi2c)
 {
   STM32I2C* i2c = STM32I2C::map[STM32_I2C_GetID(hi2c->Instance)];
-  if (i2c)
+  if (i2c && !i2c->recovering_ &&
+      (i2c->write_op_.type != WriteOperation::OperationType::NONE))
   {
-    i2c->write_op_.UpdateStatus(true, ErrorCode::OK);
+    ErrorCode ec = ErrorCode::OK;
+#ifdef HAL_I2C_ERROR_NONE
+    ec = (hi2c->ErrorCode == HAL_I2C_ERROR_NONE) ? ErrorCode::OK : ErrorCode::FAILED;
+#endif
+    if (i2c->write_op_.type == WriteOperation::OperationType::BLOCK)
+    {
+      (void)i2c->block_wait_.TryPost(true, ec);
+    }
+    else
+    {
+      i2c->write_op_.UpdateStatus(true, ec);
+    }
   }
 }
 
 extern "C" void HAL_I2C_MemTxCpltCallback(I2C_HandleTypeDef* hi2c)
 {
   STM32I2C* i2c = STM32I2C::map[STM32_I2C_GetID(hi2c->Instance)];
-  if (i2c)
+  if (i2c && !i2c->recovering_ &&
+      (i2c->write_op_.type != WriteOperation::OperationType::NONE))
   {
-    i2c->write_op_.UpdateStatus(true, ErrorCode::OK);
+    ErrorCode ec = ErrorCode::OK;
+#ifdef HAL_I2C_ERROR_NONE
+    ec = (hi2c->ErrorCode == HAL_I2C_ERROR_NONE) ? ErrorCode::OK : ErrorCode::FAILED;
+#endif
+    if (i2c->write_op_.type == WriteOperation::OperationType::BLOCK)
+    {
+      (void)i2c->block_wait_.TryPost(true, ec);
+    }
+    else
+    {
+      i2c->write_op_.UpdateStatus(true, ec);
+    }
   }
 }
 
 extern "C" void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef* hi2c)
 {
   STM32I2C* i2c = STM32I2C::map[STM32_I2C_GetID(hi2c->Instance)];
-  if (i2c)
+  if (i2c && !i2c->recovering_ &&
+      (i2c->read_op_.type != ReadOperation::OperationType::NONE))
   {
+    ErrorCode ec = ErrorCode::OK;
+#ifdef HAL_I2C_ERROR_NONE
+    ec = (hi2c->ErrorCode == HAL_I2C_ERROR_NONE) ? ErrorCode::OK : ErrorCode::FAILED;
+#endif
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     SCB_InvalidateDCache_by_Addr(i2c->dma_buff_.addr_, i2c->read_buff_.size_);
 #endif
-    Memory::FastCopy(i2c->read_buff_.addr_, i2c->dma_buff_.addr_, i2c->read_buff_.size_);
-    i2c->read_op_.UpdateStatus(true, ErrorCode::OK);
+    if (ec == ErrorCode::OK)
+    {
+      Memory::FastCopy(i2c->read_buff_.addr_, i2c->dma_buff_.addr_,
+                       i2c->read_buff_.size_);
+    }
+    if (i2c->read_op_.type == ReadOperation::OperationType::BLOCK)
+    {
+      (void)i2c->block_wait_.TryPost(true, ec);
+    }
+    else
+    {
+      i2c->read_op_.UpdateStatus(true, ec);
+    }
   }
 }
 
@@ -361,15 +534,29 @@ extern "C" void HAL_I2C_ErrorCallback(I2C_HandleTypeDef* hi2c)
 {
   STM32I2C* i2c = STM32I2C::map[STM32_I2C_GetID(hi2c->Instance)];
 
-  if (i2c)
+  if (i2c && !i2c->recovering_)
   {
     if (i2c->read_)
     {
-      i2c->read_op_.UpdateStatus(true, ErrorCode::FAILED);
+      if (i2c->read_op_.type == ReadOperation::OperationType::BLOCK)
+      {
+        (void)i2c->block_wait_.TryPost(true, ErrorCode::FAILED);
+      }
+      else
+      {
+        i2c->read_op_.UpdateStatus(true, ErrorCode::FAILED);
+      }
     }
     else
     {
-      i2c->write_op_.UpdateStatus(true, ErrorCode::FAILED);
+      if (i2c->write_op_.type == WriteOperation::OperationType::BLOCK)
+      {
+        (void)i2c->block_wait_.TryPost(true, ErrorCode::FAILED);
+      }
+      else
+      {
+        i2c->write_op_.UpdateStatus(true, ErrorCode::FAILED);
+      }
     }
   }
 }

--- a/driver/st/stm32_i2c.hpp
+++ b/driver/st/stm32_i2c.hpp
@@ -106,6 +106,8 @@ class STM32I2C : public I2C
   RawData read_buff_;
 
   bool read_ = false;
+  bool recovering_ = false;
+  AsyncBlockWait block_wait_{};
 
   static STM32I2C* map[STM32_I2C_NUMBER];  // NOLINT
 };

--- a/driver/st/stm32_spi.cpp
+++ b/driver/st/stm32_spi.cpp
@@ -107,6 +107,10 @@ ErrorCode STM32SPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
   if (need_write > dma_enable_min_size_)
   {
     rw_op_ = op;
+    if (op.type == OperationRW::OperationType::BLOCK)
+    {
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
 
     HAL_StatusTypeDef st = HAL_OK;
 
@@ -161,13 +165,17 @@ ErrorCode STM32SPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
 
     if (st != HAL_OK)
     {
+      if (op.type == OperationRW::OperationType::BLOCK)
+      {
+        block_wait_.Cancel();
+      }
       return ErrorCode::BUSY;
     }
 
     op.MarkAsRunning();
     if (op.type == OperationRW::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      return block_wait_.Wait(op.data.sem_info.timeout);
     }
     return ErrorCode::OK;
   }
@@ -360,6 +368,10 @@ ErrorCode STM32SPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bo
   {
     mem_read_ = true;
     rw_op_ = op;
+    if (op.type == OperationRW::OperationType::BLOCK)
+    {
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
 
     uint8_t* txb = reinterpret_cast<uint8_t*>(tx.addr_);
     Memory::FastSet(txb, 0, need_read + 1);
@@ -376,13 +388,17 @@ ErrorCode STM32SPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bo
 
     if (st != HAL_OK)
     {
+      if (op.type == OperationRW::OperationType::BLOCK)
+      {
+        block_wait_.Cancel();
+      }
       return ErrorCode::BUSY;
     }
 
     op.MarkAsRunning();
     if (op.type == OperationRW::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      return block_wait_.Wait(op.data.sem_info.timeout);
     }
     return ErrorCode::OK;
   }
@@ -433,6 +449,10 @@ ErrorCode STM32SPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW&
   {
     mem_read_ = false;
     rw_op_ = op;
+    if (op.type == OperationRW::OperationType::BLOCK)
+    {
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
 
     uint8_t* txb = reinterpret_cast<uint8_t*>(tx.addr_);
     txb[0] = static_cast<uint8_t>(reg & 0x7F);
@@ -448,13 +468,17 @@ ErrorCode STM32SPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW&
 
     if (st != HAL_OK)
     {
+      if (op.type == OperationRW::OperationType::BLOCK)
+      {
+        block_wait_.Cancel();
+      }
       return ErrorCode::BUSY;
     }
 
     op.MarkAsRunning();
     if (op.type == OperationRW::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      return block_wait_.Wait(op.data.sem_info.timeout);
     }
     return ErrorCode::OK;
   }
@@ -678,6 +702,10 @@ ErrorCode STM32SPI::Transfer(size_t size, OperationRW& op, bool in_isr)
   if (size > dma_enable_min_size_)
   {
     rw_op_ = op;
+    if (op.type == OperationRW::OperationType::BLOCK)
+    {
+      block_wait_.Start(*op.data.sem_info.sem);
+    }
 
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     SCB_CleanDCache_by_Addr(static_cast<uint32_t*>(tx.addr_), static_cast<int32_t>(xfer));
@@ -691,13 +719,17 @@ ErrorCode STM32SPI::Transfer(size_t size, OperationRW& op, bool in_isr)
 
     if (st != HAL_OK)
     {
+      if (op.type == OperationRW::OperationType::BLOCK)
+      {
+        block_wait_.Cancel();
+      }
       return ErrorCode::BUSY;
     }
 
     op.MarkAsRunning();
     if (op.type == OperationRW::OperationType::BLOCK)
     {
-      return op.data.sem_info.sem->Wait(op.data.sem_info.timeout);
+      return block_wait_.Wait(op.data.sem_info.timeout);
     }
     return ErrorCode::OK;
   }
@@ -725,17 +757,35 @@ ErrorCode STM32SPI::Transfer(size_t size, OperationRW& op, bool in_isr)
 extern "C" void HAL_SPI_TxCpltCallback(SPI_HandleTypeDef* hspi)
 {
   STM32SPI* spi = STM32SPI::map[STM32_SPI_GetID(hspi->Instance)];
+  ASSERT(spi != nullptr);
+  if (spi->rw_op_.type == STM32SPI::OperationRW::OperationType::NONE)
+  {
+    return;
+  }
   spi->SwitchBuffer();
-  spi->rw_op_.UpdateStatus(true, ErrorCode::OK);
+  if (spi->rw_op_.type == STM32SPI::OperationRW::OperationType::BLOCK)
+  {
+    (void)spi->block_wait_.TryPost(true, ErrorCode::OK);
+  }
+  else
+  {
+    spi->rw_op_.UpdateStatus(true, ErrorCode::OK);
+  }
 }
 
 extern "C" void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef* hspi)
 {
   STM32SPI* spi = STM32SPI::map[STM32_SPI_GetID(hspi->Instance)];
+  ASSERT(spi != nullptr);
+  if (spi->rw_op_.type == STM32SPI::OperationRW::OperationType::NONE)
+  {
+    return;
+  }
 
   RawData rx = spi->GetRxBuffer();
+  const bool has_user_read_copy = (spi->read_buff_.size_ > 0);
 
-  if (spi->read_buff_.size_ > 0)
+  if (has_user_read_copy)
   {
     if (!spi->mem_read_)
     {
@@ -756,7 +806,14 @@ extern "C" void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef* hspi)
   }
 
   spi->SwitchBuffer();
-  spi->rw_op_.UpdateStatus(true, ErrorCode::OK);
+  if (spi->rw_op_.type == STM32SPI::OperationRW::OperationType::BLOCK)
+  {
+    (void)spi->block_wait_.TryPost(true, ErrorCode::OK);
+  }
+  else
+  {
+    spi->rw_op_.UpdateStatus(true, ErrorCode::OK);
+  }
 }
 
 extern "C" void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef* hspi)
@@ -767,7 +824,19 @@ extern "C" void HAL_SPI_TxRxCpltCallback(SPI_HandleTypeDef* hspi)
 extern "C" void HAL_SPI_ErrorCallback(SPI_HandleTypeDef* hspi)
 {
   STM32SPI* spi = STM32SPI::map[STM32_SPI_GetID(hspi->Instance)];
-  spi->rw_op_.UpdateStatus(true, ErrorCode::FAILED);
+  ASSERT(spi != nullptr);
+  if (spi->rw_op_.type == STM32SPI::OperationRW::OperationType::NONE)
+  {
+    return;
+  }
+  if (spi->rw_op_.type == STM32SPI::OperationRW::OperationType::BLOCK)
+  {
+    (void)spi->block_wait_.TryPost(true, ErrorCode::FAILED);
+  }
+  else
+  {
+    spi->rw_op_.UpdateStatus(true, ErrorCode::FAILED);
+  }
 }
 
 #endif

--- a/driver/st/stm32_spi.hpp
+++ b/driver/st/stm32_spi.hpp
@@ -88,6 +88,7 @@ class STM32SPI : public SPI
   RawData read_buff_;
 
   bool mem_read_ = false;
+  AsyncBlockWait block_wait_{};
 
   static STM32SPI* map[STM32_SPI_NUMBER];  // NOLINT
 };

--- a/src/core/libxr_rw.hpp
+++ b/src/core/libxr_rw.hpp
@@ -236,6 +236,103 @@ class Operation
   OperationType type;
 };
 
+/**
+ * @brief Shared BLOCK waiter handoff for synchronous driver operations.
+ *
+ * Timeout detaches the waiting caller. A late completion may still clear the
+ * in-flight state, but it no longer belongs to that timed-out caller.
+ */
+class AsyncBlockWait
+{
+ public:
+  enum class State : uint8_t
+  {
+    IDLE = 0,
+    PENDING = 1,
+    CLAIMED = 2,
+    DETACHED = 3,
+  };
+
+  void Start(Semaphore& sem)
+  {
+    sem_ = &sem;
+    result_ = ErrorCode::OK;
+    state_.store(State::PENDING, std::memory_order_release);
+  }
+
+  void Cancel() { state_.store(State::IDLE, std::memory_order_release); }
+
+  ErrorCode Wait(uint32_t timeout)
+  {
+    ASSERT(sem_ != nullptr);
+    auto wait_ans = sem_->Wait(timeout);
+    if (wait_ans == ErrorCode::OK)
+    {
+#ifdef LIBXR_DEBUG_BUILD
+      ASSERT(state_.load(std::memory_order_acquire) == State::CLAIMED);
+#endif
+      state_.store(State::IDLE, std::memory_order_release);
+      return result_;
+    }
+
+    State expected = State::PENDING;
+    if (state_.compare_exchange_strong(expected, State::DETACHED,
+                                       std::memory_order_acq_rel,
+                                       std::memory_order_acquire))
+    {
+      return ErrorCode::TIMEOUT;
+    }
+
+    ASSERT(expected == State::CLAIMED || expected == State::DETACHED ||
+           expected == State::IDLE);
+    if (expected == State::DETACHED)
+    {
+      state_.store(State::IDLE, std::memory_order_release);
+      return ErrorCode::TIMEOUT;
+    }
+    if (expected == State::IDLE)
+    {
+      return ErrorCode::TIMEOUT;
+    }
+
+    auto finish_wait_ans = sem_->Wait(UINT32_MAX);
+    UNUSED(finish_wait_ans);
+    ASSERT(finish_wait_ans == ErrorCode::OK);
+    state_.store(State::IDLE, std::memory_order_release);
+    return result_;
+  }
+
+  bool TryPost(bool in_isr, ErrorCode ec)
+  {
+    ASSERT(sem_ != nullptr);
+
+    State expected = State::PENDING;
+    if (!state_.compare_exchange_strong(expected, State::CLAIMED,
+                                        std::memory_order_acq_rel,
+                                        std::memory_order_acquire))
+    {
+      ASSERT(expected == State::DETACHED || expected == State::IDLE);
+      if (expected == State::DETACHED)
+      {
+        expected = State::DETACHED;
+        (void)state_.compare_exchange_strong(expected, State::IDLE,
+                                             std::memory_order_acq_rel,
+                                             std::memory_order_acquire);
+      }
+      return false;
+    }
+
+    result_ = ec;
+    sem_->PostFromCallback(in_isr);
+    return true;
+  }
+
+ private:
+  Semaphore* sem_ = nullptr;
+  std::atomic<State> state_{State::IDLE};
+  ErrorCode result_ = ErrorCode::OK;
+};
+
 class ReadPort;
 class WritePort;
 


### PR DESCRIPTION
## Scope
- isolate the PR99 SPI/I2C synchronous semantics update on its own branch
- keep the diff limited to CH32 / ESP / STM32 bus implementations plus the shared `libxr_rw.hpp` helper

## Included
- CH32 I2C/SPI block waiter handoff cleanup
- ESP I2C/SPI async block waiter handoff alignment
- STM32 I2C/SPI block waiter handoff alignment
- shared `AsyncBlockWait` helper in `src/core/libxr_rw.hpp`

## Validation
- Linux configure/build/test passed
- CH32V203 compile gate passed
- ESP32 real hardware `BLOCK_TIMEOUT_REVIEW(20)` passed
- CH32 real hardware passed
  - FT24C32A on `PB10/PB11`
  - W25Q on `PA2/PA5/PA6/PA7`
- STM32 real hardware passed
  - F407 C board timeout probe
  - F407 C board real BMI088/IST8310 device probe

## Summary by Sourcery

Align SPI and I2C synchronous/blocking semantics across CH32, ESP32, and STM32 drivers using a shared async block wait helper and improved error handling and recovery paths.

Bug Fixes:
- Prevent stale or late completion callbacks from being delivered to timed-out blocking callers by introducing a detached block wait state machine.
- Ensure CH32 I2C transactions abort and recover cleanly on early hardware error flags and DMA/interrupt faults.
- Avoid updating STM32 and ESP32 I2C/SPI operations after recovery or when no valid operation is in-flight, reducing spurious completions and races.
- Map STM32 HAL I2C start failures and error codes consistently into driver error codes, including handling timeout and wrong-start conditions.

Enhancements:
- Introduce a reusable AsyncBlockWait helper to coordinate semaphore-based blocking waits with asynchronous ISR completions.
- Standardize BLOCK-mode handoff for I2C/SPI DMA and interrupt-based operations across CH32, STM32, and ESP32 implementations.
- Improve STM32 I2C recovery after BLOCK timeouts by aborting DMA and reinitializing the HAL handle without disturbing higher-level semantics.