### PR TITLE
split(pr99): isolate callback and middleware semantics

### DIFF
--- a/src/core/libxr_cb.hpp
+++ b/src/core/libxr_cb.hpp
@@ -9,27 +9,24 @@
 namespace LibXR
 {
 
+template <typename... Args>
+struct CallbackBlockHeader
+{
+  using InvokeFunType = void (*)(void*, bool, Args...);
+
+  InvokeFunType run_fun_ = nullptr;
+};
+
 /**
- * @brief 回调函数封装块，提供重入保护与参数绑定 / Callback block with argument binding
- * and reentrancy guard
- *
- * @details
- *        当回调正在执行时再次触发（重入），不会递归调用回调函数，而是缓存一次“待执行请求”；
- *        待当前执行结束后在同一调用点以循环方式补跑，从而避免无限嵌套（trampoline
- * 扁平化）。 When reentered while running, the callback is not invoked recursively.
- * Instead, one pending request is cached and replayed in a loop after the current
- * invocation completes, flattening recursion via a trampoline-style execution.
+ * @brief 回调函数封装块，提供参数绑定与擦除调用入口 / Callback block with bound argument
+ * and erased invoke entry
  *
  * @tparam ArgType 绑定的第一个参数类型 / Type of the first bound argument
  * @tparam Args 额外的参数类型列表 / Additional argument types
  */
 template <typename ArgType, typename... Args>
-class CallbackBlock
+class CallbackBlock : public CallbackBlockHeader<Args...>
 {
-  bool running_ = false;
-  bool pending_ = false;
-  std::tuple<std::decay_t<Args>...> pending_args_{};
-
  public:
   /**
    * @brief 回调函数类型定义 / Callback function type definition
@@ -47,53 +44,10 @@ class CallbackBlock
    */
   template <typename FunType, typename ArgT>
   CallbackBlock(FunType&& fun, ArgT&& arg)
-      : fun_(std::forward<FunType>(fun)), arg_(std::forward<ArgT>(arg))
+      : CallbackBlockHeader<Args...>{&InvokeThunk},
+        fun_(std::forward<FunType>(fun)),
+        arg_(std::forward<ArgT>(arg))
   {
-  }
-
-  /**
-   * @brief 触发回调执行（带重入保护） / Trigger callback execution with reentrancy guard
-   *
-   * @param in_isr 是否在中断上下文中执行 / Whether executed in ISR context
-   * @param args 额外参数 / Additional arguments
-   *
-   * @note
-   *       若在执行过程中发生重入，本次重入不会递归执行回调，而是写入待执行参数并置
-   * pending 标志；当前执行结束后将补跑一次。
-   *       On reentry, the callback is not invoked recursively. A pending flag is set and
-   * arguments are stored for a single replay after the current run.
-   */
-  void Call(bool in_isr, Args... args)
-  {
-    if (!fun_)
-    {
-      return;
-    }
-
-    if (!running_)
-    {
-      running_ = true;
-
-      auto cur_args = std::tuple<std::decay_t<Args>...>{args...};
-
-      do
-      {
-        pending_ = false;
-        std::apply([&](auto&... a) { fun_(in_isr, arg_, a...); }, cur_args);
-
-        if (pending_)
-        {
-          cur_args = pending_args_;  // overwrite pending args on reentry
-        }
-      } while (pending_);
-
-      running_ = false;
-      return;
-    }
-
-    // reentrant: cache one pending request (overwrite)
-    pending_args_ = std::tuple<std::decay_t<Args>...>{args...};
-    pending_ = true;
   }
 
   /**
@@ -102,41 +56,70 @@ class CallbackBlock
   CallbackBlock(const CallbackBlock& other) = delete;
   CallbackBlock& operator=(const CallbackBlock& other) = delete;
 
-  /**
-   * @brief 移动构造函数，转移回调函数与参数 / Move constructor transferring function and
-   * argument
-   *
-   * @param other 另一个 CallbackBlock 实例 / Another CallbackBlock instance
-   */
-  CallbackBlock(CallbackBlock&& other) noexcept
-      : fun_(std::exchange(other.fun_, nullptr)),
-        arg_(std::move(other.arg_)),
-        in_isr_(other.in_isr_)
+  static void InvokeThunk(void* cb_block, bool in_isr, Args... args)
   {
+    auto* cb = static_cast<CallbackBlock<ArgType, Args...>*>(cb_block);
+    cb->Invoke(in_isr, std::forward<Args>(args)...);
   }
 
-  /**
-   * @brief 移动赋值运算符，转移回调函数与参数 / Move assignment operator transferring
-   * function and argument
-   *
-   * @param other 另一个 CallbackBlock 实例 / Another CallbackBlock instance
-   * @return 当前对象引用 / Reference to the current object
-   */
-  CallbackBlock& operator=(CallbackBlock&& other) noexcept
+ protected:
+  void Invoke(bool in_isr, Args... args)
   {
-    if (this != &other)
+    if (!fun_)
     {
-      fun_ = std::exchange(other.fun_, nullptr);
-      arg_ = std::move(other.arg_);
-      in_isr_ = other.in_isr_;
+      return;
     }
-    return *this;
+    fun_(in_isr, arg_, std::forward<Args>(args)...);
+  }
+
+  void (*fun_)(bool, ArgType, Args...);  ///< 绑定的回调函数 / Bound callback function
+  ArgType arg_;                          ///< 绑定的参数 / Bound argument
+};
+
+template <typename ArgType, typename... Args>
+class GuardedCallbackBlock : public CallbackBlock<ArgType, Args...>
+{
+ public:
+  /**
+   * @brief 带防重入保护的回调块 / Callback block with reentry guard
+   */
+  template <typename FunType, typename ArgT>
+  GuardedCallbackBlock(FunType&& fun, ArgT&& arg)
+      : CallbackBlock<ArgType, Args...>(std::forward<FunType>(fun),
+                                        std::forward<ArgT>(arg))
+  {
+    this->run_fun_ = &InvokeThunk;
+  }
+
+  static void InvokeThunk(void* cb_block, bool in_isr, Args... args)
+  {
+    auto* cb = static_cast<GuardedCallbackBlock<ArgType, Args...>*>(cb_block);
+
+    if (!cb->running_)
+    {
+      cb->running_ = true;
+      auto cur_args = std::tuple<std::decay_t<Args>...>{std::forward<Args>(args)...};
+      do
+      {
+        cb->pending_ = false;
+        std::apply([&](auto&... a) { cb->Invoke(in_isr, a...); }, cur_args);
+        if (cb->pending_)
+        {
+          cur_args = cb->pending_args_;
+        }
+      } while (cb->pending_);
+      cb->running_ = false;
+      return;
+    }
+
+    cb->pending_args_ = std::tuple<std::decay_t<Args>...>{std::forward<Args>(args)...};
+    cb->pending_ = true;
   }
 
  private:
-  void (*fun_)(bool, ArgType, Args...);  ///< 绑定的回调函数 / Bound callback function
-  ArgType arg_;                          ///< 绑定的参数 / Bound argument
-  bool in_isr_ = false;  ///< 是否在中断上下文中执行 / Whether executed in ISR context
+  bool running_ = false;
+  bool pending_ = false;
+  std::tuple<std::decay_t<Args>...> pending_args_{};
 };
 
 /**
@@ -148,7 +131,8 @@ class CallbackBlock
 template <typename... Args>
 class Callback
 {
-  static void FunctionDefault(bool, void*, Args...) {}
+  static void FunctionDefault(void*, bool, Args...) {}
+  inline static CallbackBlockHeader<Args...> empty_cb_block_ = {&FunctionDefault};
 
  public:
   /**
@@ -168,20 +152,24 @@ class Callback
   {
     void (*fun_ptr)(bool, ArgType, Args...) = fun;
     auto cb_block = new CallbackBlock<ArgType, Args...>(fun_ptr, arg);
+    return Callback(cb_block);
+  }
 
-    auto cb_fun = [](bool in_isr, void* cb_block, Args... args)
-    {
-      auto* cb = static_cast<CallbackBlock<ArgType, Args...>*>(cb_block);
-      cb->Call(in_isr, std::forward<Args>(args)...);
-    };
-
-    return Callback(cb_block, cb_fun);
+  /**
+   * @brief 创建带防重入保护的回调 / Create a guarded callback
+   */
+  template <typename FunType, typename ArgType>
+  [[nodiscard]] static Callback CreateGuarded(FunType fun, ArgType arg)
+  {
+    void (*fun_ptr)(bool, ArgType, Args...) = fun;
+    auto cb_block = new GuardedCallbackBlock<ArgType, Args...>(fun_ptr, arg);
+    return Callback(cb_block);
   }
 
   /**
    * @brief 默认构造函数，创建空回调对象 / Default constructor creating an empty callback
    */
-  Callback() {}
+  Callback() : cb_block_(&empty_cb_block_) {}
 
   Callback(const Callback&) = default;
   Callback& operator=(const Callback&) = default;
@@ -193,8 +181,7 @@ class Callback
    * @param other 另一个 Callback 实例 / Another Callback instance
    */
   Callback(Callback&& other) noexcept
-      : cb_block_(std::exchange(other.cb_block_, nullptr)),
-        cb_fun_(std::exchange(other.cb_fun_, nullptr))
+      : cb_block_(std::exchange(other.cb_block_, &empty_cb_block_))
   {
   }
 
@@ -209,22 +196,15 @@ class Callback
   {
     if (this != &other)
     {
-      cb_block_ = std::exchange(other.cb_block_, nullptr);
-      cb_fun_ = std::exchange(other.cb_fun_, nullptr);
+      cb_block_ = std::exchange(other.cb_block_, &empty_cb_block_);
     }
     return *this;
   }
 
-  /**
-   * @brief 执行回调函数并传递参数 / Execute the callback with arguments
-   *
-   * @param in_isr 是否在中断上下文中执行 / Whether executed in ISR context
-   * @param args 额外传递的参数 / Additional arguments to pass
-   */
   template <typename... PassArgs>
   void Run(bool in_isr, PassArgs&&... args) const
   {
-    cb_fun_(in_isr, cb_block_, std::forward<PassArgs>(args)...);
+    cb_block_->run_fun_(cb_block_, in_isr, std::forward<PassArgs>(args)...);
   }
 
   /**
@@ -233,7 +213,7 @@ class Callback
    * @return true 回调为空 / Callback is empty
    * @return false 回调非空 / Callback is not empty
    */
-  bool Empty() const { return cb_block_ == nullptr; }
+  bool Empty() const { return cb_block_ == &empty_cb_block_; }
 
  private:
   /**
@@ -243,14 +223,13 @@ class Callback
    * @param cb_block 回调块对象指针 / Pointer to the callback block
    * @param cb_fun 回调执行函数指针 / Callback invocation function pointer
    */
-  Callback(void* cb_block, void (*cb_fun)(bool, void*, Args...))
-      : cb_block_(cb_block), cb_fun_(cb_fun)
+  explicit Callback(CallbackBlockHeader<Args...>* cb_block)
+      : cb_block_((cb_block != nullptr) ? cb_block : &empty_cb_block_)
   {
   }
 
-  void* cb_block_ = nullptr;  ///< 回调块指针 / Pointer to the callback block
-  void (*cb_fun_)(bool, void*, Args...) =
-      FunctionDefault;  ///< 回调执行函数指针 / Callback invocation function pointer
+  CallbackBlockHeader<Args...>* cb_block_ =
+      &empty_cb_block_;  ///< 回调块指针 / Pointer to the callback block
 };
 
 }  // namespace LibXR

--- a/src/driver/usb/device/cdc/cdc_to_uart.hpp
+++ b/src/driver/usb/device/cdc/cdc_to_uart.hpp
@@ -57,7 +57,8 @@ class CDCToUart : public CDCUart
 
     // 1) CDC 读完成回调：从 CDC 读一段数据并写入 UART。
     // 1) CDC read callback: read one chunk from CDC and write it into UART.
-    cb_read_cdc_ = Callback<ErrorCode>::Create(
+    // Guarded to flatten the bridge pump chain.
+    cb_read_cdc_ = Callback<ErrorCode>::CreateGuarded(
         [](bool in_isr, CDCToUart* cdc_to_uart, ErrorCode)
         {
           auto size =
@@ -78,7 +79,8 @@ class CDCToUart : public CDCUart
 
     // 2) UART 写完成回调：继续触发下一次 CDC 读。
     // 2) UART write-complete callback: trigger the next CDC read.
-    cb_uart_write_ = Callback<ErrorCode>::Create(
+    // Guarded to flatten the bridge pump chain.
+    cb_uart_write_ = Callback<ErrorCode>::CreateGuarded(
         [](bool in_isr, CDCToUart* cdc_to_uart, ErrorCode)
         {
           auto ans = cdc_to_uart->Read({nullptr, 0}, cdc_to_uart->op_read_cdc_, in_isr);
@@ -90,7 +92,8 @@ class CDCToUart : public CDCUart
 
     // 3) UART 读完成回调：从 UART 读一段数据并写入 CDC。
     // 3) UART read callback: read one chunk from UART and write it into CDC.
-    cb_uart_read_ = Callback<ErrorCode>::Create(
+    // Guarded to flatten the bridge pump chain.
+    cb_uart_read_ = Callback<ErrorCode>::CreateGuarded(
         [](bool in_isr, CDCToUart* cdc_to_uart, ErrorCode)
         {
           auto size = LibXR::min(cdc_to_uart->uart_.read_port_->Size(),
@@ -111,7 +114,8 @@ class CDCToUart : public CDCUart
 
     // 4) CDC 写完成回调：继续触发下一次 UART 读。
     // 4) CDC write-complete callback: trigger the next UART read.
-    cb_cdc_write_ = Callback<ErrorCode>::Create(
+    // Guarded to flatten the bridge pump chain.
+    cb_cdc_write_ = Callback<ErrorCode>::CreateGuarded(
         [](bool in_isr, CDCToUart* cdc_to_uart, ErrorCode)
         {
           auto ans_uart_read =

--- a/src/libxr.cpp
+++ b/src/libxr.cpp
@@ -20,7 +20,7 @@ extern "C" void libxr_fatal_error(const char* file, uint32_t line, bool in_isr)
 
       if (!LibXR::Assert::libxr_fatal_error_callback_.Empty())
       {
-        LibXR::Assert::libxr_fatal_error_callback_.Run(in_isr, file, line);
+        LibXR::Assert::libxr_fatal_error_callback_.Run(false, file, line);
       }
 
       LibXR::Thread::Sleep(500);

--- a/src/libxr.cpp
+++ b/src/libxr.cpp
@@ -20,6 +20,9 @@ extern "C" void libxr_fatal_error(const char* file, uint32_t line, bool in_isr)
 
       if (!LibXR::Assert::libxr_fatal_error_callback_.Empty())
       {
+        // The fatal callback is executed only on the non-ISR fatal path here.
+        // Normalize the user callback to thread context instead of forwarding the
+        // original fault source flag.
         LibXR::Assert::libxr_fatal_error_callback_.Run(false, file, line);
       }
 

--- a/src/middleware/event.cpp
+++ b/src/middleware/event.cpp
@@ -44,7 +44,7 @@ void Event::Active(uint32_t event)
   list->data_.Foreach<LibXR::Event::Block>(foreach_fun);
 }
 
-void Event::ActiveFromCallback(CallbackList list, uint32_t event)
+void Event::ActiveFromCallback(CallbackList list, uint32_t event, bool in_isr)
 {
   if (!list)
   {
@@ -53,7 +53,7 @@ void Event::ActiveFromCallback(CallbackList list, uint32_t event)
 
   auto foreach_fun = [=](Block& block)
   {
-    block.cb.Run(true, event);
+    block.cb.Run(in_isr, event);
     return ErrorCode::OK;
   };
 
@@ -85,8 +85,8 @@ void Event::Bind(Event& sources, uint32_t source_event, uint32_t target_event)
   auto bind_fun = [](bool in_isr, BindBlock* block, uint32_t event)
   {
     UNUSED(event);
-    UNUSED(in_isr);
-    block->target->ActiveFromCallback(block->target->GetList(block->event), block->event);
+    block->target->ActiveFromCallback(block->target->GetList(block->event), block->event,
+                                      in_isr);
   };
 
   auto cb = Callback::Create(bind_fun, block);

--- a/src/middleware/event.hpp
+++ b/src/middleware/event.hpp
@@ -53,15 +53,21 @@ class Event
   void Active(uint32_t event);
 
   /**
-   * @brief 从回调函数中触发与特定事件关联的所有回调函数。
-   *        Triggers all callbacks associated with a specific event (interrupt
-   * context).
+   * @brief 从 callback-safe 路径触发与特定事件关联的所有回调函数。
+   *        Triggers all callbacks associated with a specific event from a callback-safe
+   * path.
    *
    * @param list 在非回调函数中获取的事件回调链表指针。 The event callback list pointer
    * obtained from the non-callback function.
    * @param event 要激活的事件 ID。 The event ID to activate.
+   * @param in_isr 当前 callback-safe 路径是否实际位于 ISR。 Whether the current
+   * callback-safe path is actually in ISR context.
+   *
+   * @note 默认值为 true，用于兼容旧代码中“FromCallback 等价于 ISR=true”的调用习惯。
+   *       The default remains true for backward compatibility with older callers that
+   * treated FromCallback as ISR=true.
    */
-  void ActiveFromCallback(CallbackList list, uint32_t event);
+  void ActiveFromCallback(CallbackList list, uint32_t event, bool in_isr = true);
 
   /**
    * @brief 获取指定事件的回调链表指针（必须在非中断上下文中调用）。

--- a/src/middleware/message.cpp
+++ b/src/middleware/message.cpp
@@ -263,7 +263,7 @@ void Topic::Publish(void* addr, uint32_t size)
       case SuberType::QUEUE:
       {
         auto queue_block = reinterpret_cast<QueueBlock*>(&block);
-        queue_block->fun(data, queue_block->queue, false);
+        queue_block->fun(data, queue_block->queue);
         break;
       }
       case SuberType::CALLBACK:
@@ -330,7 +330,7 @@ void Topic::PublishFromCallback(void* addr, uint32_t size, bool in_isr)
       case SuberType::QUEUE:
       {
         auto queue_block = reinterpret_cast<QueueBlock*>(&block);
-        queue_block->fun(data, queue_block->queue, false);
+        queue_block->fun(data, queue_block->queue);
         break;
       }
       case SuberType::CALLBACK:

--- a/src/middleware/message.hpp
+++ b/src/middleware/message.hpp
@@ -407,8 +407,8 @@ class Topic
   typedef struct QueueBlock : public SuberBlock
   {
     void* queue;  ///< 指向订阅队列的指针 Pointer to the subscribed queue
-    void (*fun)(RawData&, void*,
-                bool);  ///< 处理数据的回调函数 Callback function to handle data
+    void (*fun)(RawData&,
+                void*);  ///< 处理数据的回调函数 Callback function to handle data
   } QueueBlock;
 
   class QueuedSubscriber
@@ -458,9 +458,8 @@ class Topic
       auto block = new LockFreeList::Node<QueueBlock>;
       block->data_.type = SuberType::QUEUE;
       block->data_.queue = &queue;
-      block->data_.fun = [](RawData& data, void* arg, bool in_isr)
+      block->data_.fun = [](RawData& data, void* arg)
       {
-        UNUSED(in_isr);
         LockFreeQueue<Data>* queue = reinterpret_cast<LockFreeQueue<Data>*>(arg);
         queue->Push(*reinterpret_cast<Data*>(data.addr_));
       };

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -33,6 +33,7 @@ static void run_libxr_tests()
   XR_LOG_INFO("Running LibXR Tests...\n");
 
   TestCase core_tests[] = {
+      {"callback", test_cb},
       {"pipe", test_pipe},
       {"rw", test_rw},
       {"memory", test_memory},

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -24,6 +24,7 @@ void test_cycle_value();
 void test_pid();
 void test_pipe();
 void test_rw();
+void test_cb();
 void test_memory();
 
 bool equal(double a, double b);

--- a/test/test_cb.cpp
+++ b/test/test_cb.cpp
@@ -1,0 +1,201 @@
+#include <array>
+
+#include "libxr.hpp"
+#include "test.hpp"
+
+namespace
+{
+struct CallbackProbe
+{
+  LibXR::Callback<int> cb;
+  bool runtime_in_isr = true;
+  bool trigger_reentry = true;
+  std::array<int, 4> seen = {};
+  std::array<bool, 4> seen_in_isr = {};
+  int seen_count = 0;
+  int depth = 0;
+  int max_depth = 0;
+
+  CallbackProbe() : cb(LibXR::Callback<int>::Create(OnCallback, this)) {}
+
+  static void OnCallback(bool in_isr, CallbackProbe* self, int value)
+  {
+    if (self->seen_count < static_cast<int>(self->seen.size()))
+    {
+      self->seen[static_cast<size_t>(self->seen_count++)] = value;
+      self->seen_in_isr[static_cast<size_t>(self->seen_count - 1)] = in_isr;
+    }
+
+    self->depth++;
+    if (self->depth > self->max_depth)
+    {
+      self->max_depth = self->depth;
+    }
+
+    if (self->trigger_reentry && value == 1)
+    {
+      self->trigger_reentry = false;
+      if (self->runtime_in_isr)
+      {
+        self->cb.Run(true, 2);
+      }
+      else
+      {
+        self->cb.Run(false, 2);
+      }
+    }
+
+    self->depth--;
+  }
+};
+
+struct DirectCallbackProbe
+{
+  LibXR::Callback<int> cb;
+  bool runtime_in_isr = true;
+  bool trigger_reentry = true;
+  std::array<int, 4> seen = {};
+  std::array<bool, 4> seen_in_isr = {};
+  int seen_count = 0;
+  int depth = 0;
+  int max_depth = 0;
+
+  DirectCallbackProbe() : cb(LibXR::Callback<int>::Create(OnCallback, this)) {}
+
+  static void OnCallback(bool in_isr, DirectCallbackProbe* self, int value)
+  {
+    if (self->seen_count < static_cast<int>(self->seen.size()))
+    {
+      self->seen[static_cast<size_t>(self->seen_count++)] = value;
+      self->seen_in_isr[static_cast<size_t>(self->seen_count - 1)] = in_isr;
+    }
+
+    self->depth++;
+    if (self->depth > self->max_depth)
+    {
+      self->max_depth = self->depth;
+    }
+
+    if (self->trigger_reentry && value == 1)
+    {
+      self->trigger_reentry = false;
+      if (self->runtime_in_isr)
+      {
+        self->cb.Run(true, 2);
+      }
+      else
+      {
+        self->cb.Run(false, 2);
+      }
+    }
+
+    self->depth--;
+  }
+};
+
+struct GuardedCreationProbe
+{
+  LibXR::Callback<int> cb;
+  bool runtime_in_isr = true;
+  bool trigger_reentry = true;
+  std::array<int, 4> seen = {};
+  std::array<bool, 4> seen_in_isr = {};
+  int seen_count = 0;
+  int depth = 0;
+  int max_depth = 0;
+
+  GuardedCreationProbe() : cb(LibXR::Callback<int>::CreateGuarded(OnCallback, this)) {}
+
+  static void OnCallback(bool in_isr, GuardedCreationProbe* self, int value)
+  {
+    if (self->seen_count < static_cast<int>(self->seen.size()))
+    {
+      self->seen[static_cast<size_t>(self->seen_count++)] = value;
+      self->seen_in_isr[static_cast<size_t>(self->seen_count - 1)] = in_isr;
+    }
+
+    self->depth++;
+    if (self->depth > self->max_depth)
+    {
+      self->max_depth = self->depth;
+    }
+
+    if (self->trigger_reentry && value == 1)
+    {
+      self->trigger_reentry = false;
+      self->cb.Run(in_isr, 2);
+    }
+
+    self->depth--;
+  }
+};
+}  // namespace
+
+void test_cb()
+{
+  {
+    LibXR::Callback<int> empty_cb;
+    ASSERT(empty_cb.Empty());
+    empty_cb.Run(false, 1);
+  }
+
+  {
+    CallbackProbe probe;
+    probe.runtime_in_isr = true;
+    probe.cb.Run(probe.runtime_in_isr, 1);
+    ASSERT(probe.seen_count == 2);
+    ASSERT(probe.seen[0] == 1);
+    ASSERT(probe.seen[1] == 2);
+    ASSERT(probe.seen_in_isr[0] == true);
+    ASSERT(probe.seen_in_isr[1] == true);
+    ASSERT(probe.max_depth == 2);
+  }
+
+  {
+    CallbackProbe probe;
+    probe.runtime_in_isr = false;
+    probe.cb.Run(probe.runtime_in_isr, 1);
+    ASSERT(probe.seen_count == 2);
+    ASSERT(probe.seen[0] == 1);
+    ASSERT(probe.seen[1] == 2);
+    ASSERT(probe.seen_in_isr[0] == false);
+    ASSERT(probe.seen_in_isr[1] == false);
+    ASSERT(probe.max_depth == 2);
+  }
+
+  {
+    CallbackProbe probe;
+    probe.runtime_in_isr = true;
+    probe.cb.Run(true, 1);
+    ASSERT(probe.seen_count == 2);
+    ASSERT(probe.seen[0] == 1);
+    ASSERT(probe.seen[1] == 2);
+    ASSERT(probe.seen_in_isr[0] == true);
+    ASSERT(probe.seen_in_isr[1] == true);
+    ASSERT(probe.max_depth == 2);
+  }
+
+  {
+    CallbackProbe probe;
+    probe.runtime_in_isr = false;
+    probe.cb.Run(false, 1);
+    ASSERT(probe.seen_count == 2);
+    ASSERT(probe.seen[0] == 1);
+    ASSERT(probe.seen[1] == 2);
+    ASSERT(probe.seen_in_isr[0] == false);
+    ASSERT(probe.seen_in_isr[1] == false);
+    ASSERT(probe.max_depth == 2);
+  }
+
+  {
+    GuardedCreationProbe probe;
+    probe.runtime_in_isr = false;
+    probe.cb.Run(false, 1);
+    ASSERT(probe.seen_count == 2);
+    ASSERT(probe.seen[0] == 1);
+    ASSERT(probe.seen[1] == 2);
+    ASSERT(probe.seen_in_isr[0] == false);
+    ASSERT(probe.seen_in_isr[1] == false);
+    ASSERT(probe.max_depth == 1);
+  }
+}

--- a/test/test_cb.cpp
+++ b/test/test_cb.cpp
@@ -5,50 +5,6 @@
 
 namespace
 {
-struct CallbackProbe
-{
-  LibXR::Callback<int> cb;
-  bool runtime_in_isr = true;
-  bool trigger_reentry = true;
-  std::array<int, 4> seen = {};
-  std::array<bool, 4> seen_in_isr = {};
-  int seen_count = 0;
-  int depth = 0;
-  int max_depth = 0;
-
-  CallbackProbe() : cb(LibXR::Callback<int>::Create(OnCallback, this)) {}
-
-  static void OnCallback(bool in_isr, CallbackProbe* self, int value)
-  {
-    if (self->seen_count < static_cast<int>(self->seen.size()))
-    {
-      self->seen[static_cast<size_t>(self->seen_count++)] = value;
-      self->seen_in_isr[static_cast<size_t>(self->seen_count - 1)] = in_isr;
-    }
-
-    self->depth++;
-    if (self->depth > self->max_depth)
-    {
-      self->max_depth = self->depth;
-    }
-
-    if (self->trigger_reentry && value == 1)
-    {
-      self->trigger_reentry = false;
-      if (self->runtime_in_isr)
-      {
-        self->cb.Run(true, 2);
-      }
-      else
-      {
-        self->cb.Run(false, 2);
-      }
-    }
-
-    self->depth--;
-  }
-};
-
 struct DirectCallbackProbe
 {
   LibXR::Callback<int> cb;
@@ -134,13 +90,15 @@ struct GuardedCreationProbe
 void test_cb()
 {
   {
+    // Empty callbacks stay cheap no-ops.
     LibXR::Callback<int> empty_cb;
     ASSERT(empty_cb.Empty());
     empty_cb.Run(false, 1);
   }
 
   {
-    CallbackProbe probe;
+    // Direct callbacks preserve ISR=true and recurse with real stack depth.
+    DirectCallbackProbe probe;
     probe.runtime_in_isr = true;
     probe.cb.Run(probe.runtime_in_isr, 1);
     ASSERT(probe.seen_count == 2);
@@ -152,7 +110,8 @@ void test_cb()
   }
 
   {
-    CallbackProbe probe;
+    // Direct callbacks preserve ISR=false and recurse with real stack depth.
+    DirectCallbackProbe probe;
     probe.runtime_in_isr = false;
     probe.cb.Run(probe.runtime_in_isr, 1);
     ASSERT(probe.seen_count == 2);
@@ -164,7 +123,8 @@ void test_cb()
   }
 
   {
-    CallbackProbe probe;
+    // Passing the runtime flag directly keeps the observed callback context.
+    DirectCallbackProbe probe;
     probe.runtime_in_isr = true;
     probe.cb.Run(true, 1);
     ASSERT(probe.seen_count == 2);
@@ -176,7 +136,8 @@ void test_cb()
   }
 
   {
-    CallbackProbe probe;
+    // Direct non-ISR calls also keep their original callback context.
+    DirectCallbackProbe probe;
     probe.runtime_in_isr = false;
     probe.cb.Run(false, 1);
     ASSERT(probe.seen_count == 2);
@@ -188,6 +149,7 @@ void test_cb()
   }
 
   {
+    // Guarded callbacks flatten one-step bounded reentry back to one stack frame.
     GuardedCreationProbe probe;
     probe.runtime_in_isr = false;
     probe.cb.Run(false, 1);

--- a/test/test_event.cpp
+++ b/test/test_event.cpp
@@ -5,11 +5,12 @@
 void test_event()
 {
   static int event_arg = 0;
+  static bool last_in_isr = false;
 
   auto event_cb = LibXR::Event::Callback::Create(
       [](bool in_isr, int* arg, uint32_t event)
       {
-        UNUSED(in_isr);
+        last_in_isr = in_isr;
         *arg = *arg + 1;
         ASSERT(event == 0x1234);
       },
@@ -20,12 +21,27 @@ void test_event()
   event.Register(0x1234, event_cb);
   event.Active(0x1234);
   ASSERT(event_arg == 1);
+  ASSERT(last_in_isr == false);
   for (int i = 0; i <= 0x1234; i++)
   {
     event.Active(i);
   }
   ASSERT(event_arg == 2);
+  ASSERT(last_in_isr == false);
+  event.ActiveFromCallback(event.GetList(0x1234), 0x1234, false);
+  ASSERT(event_arg == 3);
+  ASSERT(last_in_isr == false);
+  event.ActiveFromCallback(event.GetList(0x1234), 0x1234, true);
+  ASSERT(event_arg == 4);
+  ASSERT(last_in_isr == true);
+  event.ActiveFromCallback(event.GetList(0x1234), 0x1234);
+  ASSERT(event_arg == 5);
+  ASSERT(last_in_isr == true);
   event.Bind(event_bind, 0x4321, 0x1234);
   event_bind.Active(0x4321);
-  ASSERT(event_arg == 3);
+  ASSERT(event_arg == 6);
+  ASSERT(last_in_isr == false);
+  event_bind.ActiveFromCallback(event_bind.GetList(0x4321), 0x4321, true);
+  ASSERT(event_arg == 7);
+  ASSERT(last_in_isr == true);
 }

--- a/test/test_event.cpp
+++ b/test/test_event.cpp
@@ -18,30 +18,44 @@ void test_event()
 
   LibXR::Event event, event_bind;
 
+  // Direct activation must report non-ISR context.
   event.Register(0x1234, event_cb);
   event.Active(0x1234);
   ASSERT(event_arg == 1);
   ASSERT(last_in_isr == false);
+
   for (int i = 0; i <= 0x1234; i++)
   {
     event.Active(i);
   }
   ASSERT(event_arg == 2);
   ASSERT(last_in_isr == false);
+
+  // Callback-safe activation must preserve the explicit in_isr flag.
   event.ActiveFromCallback(event.GetList(0x1234), 0x1234, false);
   ASSERT(event_arg == 3);
   ASSERT(last_in_isr == false);
+
   event.ActiveFromCallback(event.GetList(0x1234), 0x1234, true);
   ASSERT(event_arg == 4);
   ASSERT(last_in_isr == true);
+
+  // Default callback-safe behavior remains ISR=true for legacy callers.
   event.ActiveFromCallback(event.GetList(0x1234), 0x1234);
   ASSERT(event_arg == 5);
   ASSERT(last_in_isr == true);
+
+  // Bound events must keep the source callback context unchanged.
   event.Bind(event_bind, 0x4321, 0x1234);
   event_bind.Active(0x4321);
   ASSERT(event_arg == 6);
   ASSERT(last_in_isr == false);
-  event_bind.ActiveFromCallback(event_bind.GetList(0x4321), 0x4321, true);
+
+  event_bind.ActiveFromCallback(event_bind.GetList(0x4321), 0x4321, false);
   ASSERT(event_arg == 7);
+  ASSERT(last_in_isr == false);
+
+  event_bind.ActiveFromCallback(event_bind.GetList(0x4321), 0x4321, true);
+  ASSERT(event_arg == 8);
   ASSERT(last_in_isr == true);
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor the core callback abstraction to separate plain and reentrancy-guarded behaviors, propagate explicit ISR-context semantics through event and message middleware, and extend tests to validate the new callback and event behavior.

New Features:
- Introduce a generic callback header with an erased invoke entry to unify callback invocation across bound and guarded callbacks.
- Add an option to create reentrancy-guarded callbacks separately from plain callbacks in the callback API.

Bug Fixes:
- Ensure ISR context flags are correctly propagated through event activation and binding paths, including callback-safe event activation.
- Prevent potential recursive callback chains in the CDC-to-UART bridge by using guarded callbacks for its pump callbacks.
- Fix fatal error handling so that user fatal-error callbacks are always invoked as non-ISR callbacks.

Enhancements:
- Simplify the callback wrapper implementation by removing ad-hoc function pointers per instance and using a shared header structure.
- Align Topic queue subscriber callbacks to be ISR-agnostic by removing the unused ISR parameter from their handlers.

Tests:
- Add comprehensive callback tests covering empty callbacks, ISR flag propagation, reentrant invocation depth, and guarded callback behavior.
- Extend event tests to verify ISR flag handling across standard activation, callback-safe activation, and event binding paths.
- Register the new callback test suite in the main test harness.