### PR TITLE
feat(linux): add shared topic runtime and benchmarks

### DIFF
--- a/CMake/test.cmake
+++ b/CMake/test.cmake
@@ -8,15 +8,50 @@ project(test)
 
 add_compile_options(-g)
 
-file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/test/*.cpp")
+set(LIBXR_UNION_TEST_SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_async.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_cb.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_crc.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_cycle_value.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_database.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_double_buffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_encoder.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_event.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_inertia.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_kinematic.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_linux_shm_topic.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_list.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_mem.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_message.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_mutex.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_pid.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_pipe.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_pool.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_queue.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_ramfs.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_rbt.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_rw.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_semaphore.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_stack.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_string.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_terminal.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_thread.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_timebase.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_timer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/test/test_transform.cpp)
 
-add_executable(test ${TEST_SOURCES})
+function(libxr_add_test_target target_name)
+  add_executable(${target_name} ${ARGN})
+  add_dependencies(${target_name} xr)
+  target_link_libraries(${target_name} PRIVATE xr)
+  target_include_directories(${target_name} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/lib/Eigen)
+endfunction()
 
-add_dependencies(test xr)
+libxr_add_test_target(test ${LIBXR_UNION_TEST_SOURCES})
 
-target_link_libraries(test PUBLIC xr)
+libxr_add_test_target(bench_linux_shared_topic
+                      ${CMAKE_CURRENT_SOURCE_DIR}/test/bench_linux_shared_topic.cpp)
 
-target_include_directories(
-  test
-  PUBLIC $<TARGET_PROPERTY:xr,INTERFACE_INCLUDE_DIRECTORIES>
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/lib/Eigen)
+libxr_add_test_target(bench_linux_system_sync
+                      ${CMAKE_CURRENT_SOURCE_DIR}/test/bench_linux_system_sync.cpp)

--- a/driver/Linux/linux_timebase.hpp
+++ b/driver/Linux/linux_timebase.hpp
@@ -1,8 +1,8 @@
-#include <sys/time.h>
+#include <time.h>
 
 #include "timebase.hpp"
 
-extern struct timeval libxr_linux_start_time;
+extern struct timespec libxr_linux_start_time_spec;
 
 namespace LibXR
 {
@@ -36,10 +36,10 @@ class LinuxTimebase : public Timebase
  private:
   static int64_t GetElapsedMicroseconds()
   {
-    struct timeval tv;
-    gettimeofday(&tv, nullptr);
-    return static_cast<int64_t>(tv.tv_sec - libxr_linux_start_time.tv_sec) * 1000000LL +
-           static_cast<int64_t>(tv.tv_usec - libxr_linux_start_time.tv_usec);
+    struct timespec ts = {};
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<int64_t>(ts.tv_sec - libxr_linux_start_time_spec.tv_sec) * 1000000LL +
+           static_cast<int64_t>(ts.tv_nsec - libxr_linux_start_time_spec.tv_nsec) / 1000LL;
   }
 };
 }  // namespace LibXR

--- a/src/libxr.hpp
+++ b/src/libxr.hpp
@@ -25,6 +25,9 @@
 #include "lockfree_queue.hpp"
 #include "logger.hpp"
 #include "message.hpp"
+#if defined(LIBXR_SYSTEM_Linux) || defined(LIBXR_SYSTEM_Webots)
+#include "linux_shared_topic.hpp"
+#endif
 #include "mutex.hpp"
 #include "queue.hpp"
 #include "ramfs.hpp"

--- a/system/Linux/libxr_system.cpp
+++ b/system/Linux/libxr_system.cpp
@@ -1,9 +1,7 @@
 #include "libxr_system.hpp"
 
-#include <bits/types/FILE.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
-#include <sys/time.h>
 #include <sys/types.h>
 #include <termios.h>
 #include <unistd.h>
@@ -17,8 +15,6 @@
 #include "logger.hpp"
 #include "thread.hpp"
 #include "timer.hpp"
-
-struct timeval libxr_linux_start_time;
 
 struct timespec libxr_linux_start_time_spec;  // NOLINT
 
@@ -124,8 +120,7 @@ void LibXR::PlatformInit(uint32_t timer_pri, uint32_t timer_stack_depth)
 
   *LibXR::STDIO::read_ = read_fun;
 
-  gettimeofday(&libxr_linux_start_time, nullptr);
-  UNUSED(clock_gettime(CLOCK_REALTIME, &libxr_linux_start_time_spec));
+  UNUSED(clock_gettime(CLOCK_MONOTONIC, &libxr_linux_start_time_spec));
 
   struct termios tty;
   tcgetattr(STDIN_FILENO, &tty);           // 获取当前终端属性

--- a/system/Linux/libxr_system.hpp
+++ b/system/Linux/libxr_system.hpp
@@ -1,14 +1,19 @@
 #pragma once
 
 #include <pthread.h>
-#include <semaphore.h>
+
+#include <atomic>
 
 #include <cstdint>
 
 namespace LibXR
 {
 typedef pthread_mutex_t libxr_mutex_handle;
-typedef sem_t* libxr_semaphore_handle;
+struct libxr_linux_futex_semaphore
+{
+  std::atomic<uint32_t> count;
+};
+typedef libxr_linux_futex_semaphore* libxr_semaphore_handle;
 typedef pthread_t libxr_thread_handle;
 
 /**
@@ -21,12 +26,19 @@ typedef pthread_t libxr_thread_handle;
  *                            Timer task stack depth (default: 65536)
  *
  * @details
- * 该函数用于初始化 POSIX 线程相关的资源，例如互斥锁、信号量和条件变量。
- * 在使用 `LibXR` 线程库之前，应调用该函数进行必要的系统初始化。
+ * 该函数用于初始化 Linux 主机运行时，包括：
+ * - 定时器线程默认参数
+ * - 标准输入输出端口
+ * - 终端模式
+ * - 后台 STDIO 线程
+ * 在使用依赖主机运行时的 `LibXR` 组件之前，应调用该函数。
  *
- * This function initializes POSIX thread-related resources such as mutexes,
- * semaphores, and condition variables. It should be called before using the
- * `LibXR` threading library for proper system setup.
+ * This function initializes the Linux host runtime, including:
+ * - default timer-thread parameters
+ * - STDIO ports
+ * - terminal mode
+ * - background STDIO threads
+ * It should be called before using `LibXR` components that depend on the host runtime.
  *
  */
 void PlatformInit(uint32_t timer_pri = 2, uint32_t timer_stack_depth = 65536);

--- a/system/Linux/linux_shared_topic.hpp
+++ b/system/Linux/linux_shared_topic.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "linux_shared_topic_impl.hpp"

--- a/system/Linux/linux_shared_topic_impl.hpp
+++ b/system/Linux/linux_shared_topic_impl.hpp
@@ -1,0 +1,1726 @@
+#pragma once
+
+#if defined(LIBXR_SYSTEM_Linux) || defined(LIBXR_SYSTEM_Webots)
+
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <type_traits>
+
+#include <fcntl.h>
+#include <linux/futex.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+#include <signal.h>
+
+#include "crc.hpp"
+#include "libxr_def.hpp"
+#include "message.hpp"
+#include "monotonic_time.hpp"
+
+namespace LibXR
+{
+/**
+ * @enum LinuxSharedSubscriberMode
+ * @brief 订阅者接收模式。Receive mode of a Linux shared subscriber.
+ */
+enum class LinuxSharedSubscriberMode : uint8_t
+{
+  BROADCAST_FULL = 0,      ///< 广播到该订阅者，满队列时报错。Broadcast and fail on full.
+  BROADCAST_DROP_OLD = 1,  ///< 广播到该订阅者，满队列时丢最旧。Broadcast and drop oldest on full.
+  BALANCE_RR = 2,          ///< 参与 RR 负载均衡组。Participate in the RR balanced group.
+};
+
+/**
+ * @struct LinuxSharedTopicConfig
+ * @brief Linux 共享 Topic 的创建配置。Creation config for Linux shared topics.
+ */
+struct LinuxSharedTopicConfig
+{
+  uint32_t slot_num = 64;  ///< 共享 payload 槽位数。Number of shared payload slots.
+  uint32_t subscriber_num = 8;  ///< 最大订阅者数量。Maximum number of subscribers.
+  uint32_t queue_num = 64;      ///< 每订阅者描述符队列长度。Descriptor queue length per subscriber.
+};
+
+/**
+ * @class LinuxSharedTopic
+ * @brief Linux 主机进程间共享 Topic。Linux-host shared-memory topic.
+ *
+ * 该类提供 Linux 主机上的固定大小进程间消息通道，使用共享内存保存 payload，
+ * 使用原子变量和 futex 完成发布/接收同步。在 `Webots` 系统配置下仍复用这套实现，
+ * 但超时语义遵循 `Webots` 的系统时间。
+ * This class provides a fixed-size host-side IPC topic. Payloads live in shared memory,
+ * while publish/receive synchronization is handled with atomics and futex. Under the
+ * `Webots` system configuration it still reuses this implementation, but timeout behavior
+ * follows the `Webots` system time model.
+ *
+ * @tparam TopicData 话题数据类型，必须为平凡可拷贝类型。Topic data type, must be
+ * trivially copyable.
+ */
+template <typename TopicData>
+class LinuxSharedTopic : public Topic
+{
+  static_assert(std::is_trivially_copyable<TopicData>::value,
+                "LinuxSharedTopic requires trivially copyable data");
+  static_assert(std::atomic<uint32_t>::is_always_lock_free,
+                "LinuxSharedTopic requires lock-free 32-bit atomics");
+  static_assert(std::atomic<uint64_t>::is_always_lock_free,
+                "LinuxSharedTopic requires lock-free 64-bit atomics");
+
+  enum class SharedDataState : uint8_t
+  {
+    EMPTY = 0,
+    PUBLISHER = 1,
+    SUBSCRIBER = 2,
+  };
+
+ public:
+  class SharedData;
+  using Data = SharedData;
+
+  /**
+   * @class Subscriber
+   * @brief 同步订阅者，用于从共享 Topic 中等待并读取消息。
+   *        Synchronous subscriber for waiting on and reading messages from a shared topic.
+   */
+  class Subscriber
+  {
+   public:
+    using Data = SharedData;
+
+    /**
+     * @brief 默认构造函数，创建空订阅者。Default constructor creating an empty subscriber.
+     */
+    Subscriber() = default;
+
+    /**
+     * @brief 通过主题名附着并创建订阅者。Attach and create a subscriber by topic name.
+     * @param name 主题名称。Topic name.
+     * @param mode 订阅模式。Subscriber mode.
+     *
+     * @note 包含动态内存分配。
+     *       Contains dynamic memory allocation.
+     */
+    explicit Subscriber(const char* name,
+                        LinuxSharedSubscriberMode mode =
+                            LinuxSharedSubscriberMode::BROADCAST_FULL)
+        : owned_topic_(new LinuxSharedTopic(name))
+    {
+      if (Attach(*owned_topic_, mode) != ErrorCode::OK)
+      {
+        delete owned_topic_;
+        owned_topic_ = nullptr;
+      }
+    }
+
+    /**
+     * @brief 基于现有共享 Topic 创建订阅者。Create a subscriber from an existing shared
+     * topic.
+     * @param topic 已打开的共享 Topic。Opened shared topic.
+     * @param mode 订阅模式。Subscriber mode.
+     */
+    explicit Subscriber(LinuxSharedTopic& topic,
+                        LinuxSharedSubscriberMode mode =
+                            LinuxSharedSubscriberMode::BROADCAST_FULL)
+    {
+      (void)Attach(topic, mode);
+    }
+
+    /**
+     * @brief 析构函数，自动释放订阅者占用的状态。Destructor releasing subscriber state.
+     */
+    ~Subscriber() { Reset(); }
+
+    Subscriber(const Subscriber&) = delete;
+    Subscriber& operator=(const Subscriber&) = delete;
+
+    Subscriber(Subscriber&& other) noexcept { *this = std::move(other); }
+
+    Subscriber& operator=(Subscriber&& other) noexcept
+    {
+      if (this == &other)
+      {
+        return *this;
+      }
+
+      Reset();
+
+      topic_ = other.topic_;
+      owned_topic_ = other.owned_topic_;
+      subscriber_index_ = other.subscriber_index_;
+      current_slot_index_ = other.current_slot_index_;
+      current_sequence_ = other.current_sequence_;
+
+      other.topic_ = nullptr;
+      other.owned_topic_ = nullptr;
+      other.subscriber_index_ = kInvalidIndex;
+      other.current_slot_index_ = kInvalidIndex;
+      other.current_sequence_ = 0;
+      return *this;
+    }
+
+    /**
+     * @brief 检查订阅者是否有效。Checks whether the subscriber is valid.
+     * @return true 订阅者有效。Subscriber is valid.
+     * @return false 订阅者无效。Subscriber is invalid.
+     */
+    bool Valid() const
+    {
+      return topic_ != nullptr && subscriber_index_ != kInvalidIndex;
+    }
+
+    /**
+     * @brief 等待一条消息，并把当前订阅者切到该 payload。
+     *        Wait for one message and bind the subscriber to that payload.
+     * @param timeout_ms 超时时间，默认无限等待。Timeout in milliseconds, default is wait
+     * forever.
+     * @return 错误码。Error code indicating the wait result.
+     */
+    ErrorCode Wait(uint32_t timeout_ms = UINT32_MAX)
+    {
+      if (!Valid())
+      {
+        return ErrorCode::STATE_ERR;
+      }
+
+      const uint64_t deadline_ms =
+          (timeout_ms == UINT32_MAX) ? 0 : (NowMonotonicMs() + timeout_ms);
+
+      Descriptor desc = {};
+      while (true)
+      {
+        ErrorCode pop_ans = topic_->TryPopDescriptor(subscriber_index_, desc);
+        if (pop_ans == ErrorCode::OK)
+        {
+          Release();
+          topic_->HoldSlot(subscriber_index_, desc.slot_index);
+          current_slot_index_ = desc.slot_index;
+          current_sequence_ = desc.sequence;
+          return ErrorCode::OK;
+        }
+
+        uint32_t wait_ms = UINT32_MAX;
+        if (timeout_ms != UINT32_MAX)
+        {
+          const uint64_t now_ms = NowMonotonicMs();
+          if (now_ms >= deadline_ms)
+          {
+            return ErrorCode::TIMEOUT;
+          }
+          wait_ms = static_cast<uint32_t>(deadline_ms - now_ms);
+        }
+
+        const ErrorCode wait_ans = topic_->WaitReady(topic_->subscribers_[subscriber_index_],
+                                                     wait_ms);
+        if (wait_ans == ErrorCode::OK)
+        {
+          continue;
+        }
+        return wait_ans;
+      }
+    }
+
+    /**
+     * @brief 等待一条消息，并通过句柄返回该 payload。
+     *        Wait for one message and return the payload through a handle.
+     * @param data 输出句柄。Output data handle.
+     * @param timeout_ms 超时时间，默认无限等待。Timeout in milliseconds, default is wait
+     * forever.
+     * @return 错误码。Error code indicating the wait result.
+     */
+    ErrorCode Wait(SharedData& data, uint32_t timeout_ms = UINT32_MAX)
+    {
+      data.Reset();
+
+      if (!Valid())
+      {
+        return ErrorCode::STATE_ERR;
+      }
+
+      const uint64_t deadline_ms =
+          (timeout_ms == UINT32_MAX) ? 0 : (NowMonotonicMs() + timeout_ms);
+
+      Descriptor desc = {};
+      while (true)
+      {
+        ErrorCode pop_ans = topic_->TryPopDescriptor(subscriber_index_, desc);
+        if (pop_ans == ErrorCode::OK)
+        {
+          data.topic_ = topic_;
+          data.slot_index_ = desc.slot_index;
+          data.sequence_ = desc.sequence;
+          data.state_ = SharedDataState::SUBSCRIBER;
+          data.subscriber_index_ = subscriber_index_;
+          topic_->HoldSlot(subscriber_index_, desc.slot_index);
+          return ErrorCode::OK;
+        }
+
+        uint32_t wait_ms = UINT32_MAX;
+        if (timeout_ms != UINT32_MAX)
+        {
+          const uint64_t now_ms = NowMonotonicMs();
+          if (now_ms >= deadline_ms)
+          {
+            return ErrorCode::TIMEOUT;
+          }
+          wait_ms = static_cast<uint32_t>(deadline_ms - now_ms);
+        }
+
+        const ErrorCode wait_ans = topic_->WaitReady(topic_->subscribers_[subscriber_index_],
+                                                     wait_ms);
+        if (wait_ans == ErrorCode::OK)
+        {
+          continue;
+        }
+        return wait_ans;
+      }
+    }
+
+    /**
+     * @brief 获取当前持有的消息数据指针。Get the pointer to the currently held payload.
+     * @return 当前消息指针；若未持有消息则返回 nullptr。
+     *         Pointer to current payload, or nullptr if none is held.
+     */
+    const TopicData* GetData() const
+    {
+      if (!Valid() || current_slot_index_ == kInvalidIndex)
+      {
+        return nullptr;
+      }
+
+      return &topic_->payloads_[current_slot_index_];
+    }
+
+    /**
+     * @brief 获取当前消息序号。Get the sequence number of the current message.
+     */
+    uint64_t GetSequence() const { return current_sequence_; }
+
+    /**
+     * @brief 获取当前待消费描述符数量。Get the number of queued pending descriptors.
+     */
+    uint32_t GetPendingNum() const
+    {
+      if (!Valid())
+      {
+        return 0;
+      }
+
+      const SubscriberControl& control = topic_->subscribers_[subscriber_index_];
+      const uint32_t head = control.queue_head.load(std::memory_order_acquire);
+      const uint32_t tail = control.queue_tail.load(std::memory_order_acquire);
+      if (tail >= head)
+      {
+        return tail - head;
+      }
+      return topic_->queue_capacity_ - (head - tail);
+    }
+
+    /**
+     * @brief 获取该订阅者累计丢弃消息数。Get the accumulated drop count of this subscriber.
+     */
+    uint64_t GetDropNum() const
+    {
+      if (!Valid())
+      {
+        return 0;
+      }
+
+      return topic_->subscribers_[subscriber_index_].dropped_messages.load(
+          std::memory_order_acquire);
+    }
+
+    /**
+     * @brief 释放当前持有的消息槽位。Release the currently held payload slot.
+     */
+    void Release()
+    {
+      if (!Valid() || current_slot_index_ == kInvalidIndex)
+      {
+        return;
+      }
+
+      topic_->ClearHeldSlot(subscriber_index_, current_slot_index_);
+      topic_->ReleaseSlot(current_slot_index_);
+      current_slot_index_ = kInvalidIndex;
+      current_sequence_ = 0;
+    }
+
+    /**
+     * @brief 注销订阅者并释放所有持有资源。Unregister the subscriber and release owned
+     * resources.
+     */
+    void Reset()
+    {
+      if (!Valid())
+      {
+        return;
+      }
+
+      topic_->UnregisterBalancedSubscriber(subscriber_index_);
+      topic_->subscribers_[subscriber_index_].active.store(0, std::memory_order_release);
+      topic_->subscribers_[subscriber_index_].owner_pid.store(0, std::memory_order_release);
+      topic_->subscribers_[subscriber_index_].owner_starttime.store(0,
+                                                                    std::memory_order_release);
+
+      Descriptor desc = {};
+      while (topic_->TryPopDescriptor(subscriber_index_, desc) == ErrorCode::OK)
+      {
+        topic_->ReleaseSlot(desc.slot_index);
+      }
+
+      Release();
+
+      topic_ = nullptr;
+      delete owned_topic_;
+      owned_topic_ = nullptr;
+      subscriber_index_ = kInvalidIndex;
+      current_slot_index_ = kInvalidIndex;
+      current_sequence_ = 0;
+    }
+
+   private:
+    ErrorCode Attach(LinuxSharedTopic& topic, LinuxSharedSubscriberMode mode)
+    {
+      Reset();
+
+      if (!topic.Valid())
+      {
+        return ErrorCode::STATE_ERR;
+      }
+
+      if (topic.self_identity_.starttime == 0)
+      {
+        return ErrorCode::STATE_ERR;
+      }
+
+      for (uint32_t i = 0; i < topic.subscriber_capacity_; ++i)
+      {
+        uint32_t expected = 0;
+        auto& active = topic.subscribers_[i].active;
+        if (active.compare_exchange_strong(expected, 1, std::memory_order_acq_rel,
+                                           std::memory_order_relaxed))
+        {
+          topic.subscribers_[i].queue_head.store(0, std::memory_order_release);
+          topic.subscribers_[i].queue_tail.store(0, std::memory_order_release);
+          topic.subscribers_[i].ready_sem_count.store(0, std::memory_order_release);
+          topic.subscribers_[i].dropped_messages.store(0, std::memory_order_release);
+          topic.subscribers_[i].owner_pid.store(topic.self_identity_.pid,
+                                                std::memory_order_release);
+          topic.subscribers_[i].owner_starttime.store(topic.self_identity_.starttime,
+                                                      std::memory_order_release);
+          topic.subscribers_[i].held_slot.store(kInvalidIndex, std::memory_order_release);
+          topic.subscribers_[i].mode.store(static_cast<uint32_t>(mode),
+                                           std::memory_order_release);
+          if (mode == LinuxSharedSubscriberMode::BALANCE_RR)
+          {
+            const ErrorCode join_ans = topic.RegisterBalancedSubscriber(i);
+            if (join_ans != ErrorCode::OK)
+            {
+              topic.subscribers_[i].active.store(0, std::memory_order_release);
+              topic.subscribers_[i].owner_pid.store(0, std::memory_order_release);
+              topic.subscribers_[i].owner_starttime.store(0,
+                                                          std::memory_order_release);
+              topic.subscribers_[i].mode.store(
+                  static_cast<uint32_t>(LinuxSharedSubscriberMode::BROADCAST_FULL),
+                  std::memory_order_release);
+              return join_ans;
+            }
+          }
+          topic_ = &topic;
+          subscriber_index_ = i;
+          current_slot_index_ = kInvalidIndex;
+          current_sequence_ = 0;
+          return ErrorCode::OK;
+        }
+      }
+
+      return ErrorCode::FULL;
+    }
+
+    LinuxSharedTopic* topic_ = nullptr;
+    LinuxSharedTopic* owned_topic_ = nullptr;
+    uint32_t subscriber_index_ = kInvalidIndex;
+    uint32_t current_slot_index_ = kInvalidIndex;
+    uint64_t current_sequence_ = 0;
+  };
+
+  /**
+   * @class SharedData
+   * @brief 共享 Topic payload 句柄。Payload handle for Linux shared topics.
+   *
+   * 该句柄可由发布者通过 `CreateData()` 获得，也可由订阅者通过 `Wait(data)` 获得。
+   * 句柄析构或 `Reset()` 时会自动回收对应槽位。
+   * This handle can be acquired by publishers via `CreateData()` or by subscribers via
+   * `Wait(data)`. The slot is released automatically on destruction or `Reset()`.
+   */
+  class SharedData
+  {
+   public:
+    /**
+     * @brief 默认构造函数，创建空句柄。Default constructor creating an empty handle.
+     */
+    SharedData() = default;
+
+    /**
+     * @brief 析构函数，自动回收句柄持有的槽位。Destructor automatically releasing the held
+     * slot.
+     */
+    ~SharedData() { Reset(); }
+
+    SharedData(const SharedData&) = delete;
+    SharedData& operator=(const SharedData&) = delete;
+
+    SharedData(SharedData&& other) noexcept { *this = std::move(other); }
+
+    /**
+     * @brief 移动赋值，转移槽位所有权。Move assignment transferring slot ownership.
+     */
+    SharedData& operator=(SharedData&& other) noexcept
+    {
+      if (this == &other)
+      {
+        return *this;
+      }
+
+      Reset();
+
+      topic_ = other.topic_;
+      slot_index_ = other.slot_index_;
+      sequence_ = other.sequence_;
+      state_ = other.state_;
+      subscriber_index_ = other.subscriber_index_;
+
+      other.topic_ = nullptr;
+      other.slot_index_ = kInvalidIndex;
+      other.sequence_ = 0;
+      other.state_ = SharedDataState::EMPTY;
+      other.subscriber_index_ = kInvalidIndex;
+      return *this;
+    }
+
+    /**
+     * @brief 检查句柄是否有效。Checks whether the handle is valid.
+     */
+    bool Valid() const { return topic_ != nullptr && slot_index_ != kInvalidIndex; }
+
+    /**
+     * @brief 检查句柄是否为空。Checks whether the handle is empty.
+     */
+    bool Empty() const { return !Valid(); }
+
+    /**
+     * @brief 获取消息序号。Get the sequence number of the held message.
+     */
+    uint64_t GetSequence() const { return sequence_; }
+
+    /**
+     * @brief 获取可写数据指针。Get a writable pointer to the payload.
+     * @return 数据指针；若句柄无效则返回 nullptr。
+     *         Payload pointer, or nullptr if the handle is invalid.
+     */
+    TopicData* GetData()
+    {
+      if (!Valid())
+      {
+        return nullptr;
+      }
+      return &topic_->payloads_[slot_index_];
+    }
+
+    /**
+     * @brief 获取只读数据指针。Get a read-only pointer to the payload.
+     * @return 数据指针；若句柄无效则返回 nullptr。
+     *         Payload pointer, or nullptr if the handle is invalid.
+     */
+    const TopicData* GetData() const
+    {
+      if (!Valid())
+      {
+        return nullptr;
+      }
+      return &topic_->payloads_[slot_index_];
+    }
+
+    /**
+     * @brief 释放句柄持有的槽位。Release the slot held by this handle.
+     */
+    void Reset()
+    {
+      if (!Valid())
+      {
+        return;
+      }
+
+      if (state_ == SharedDataState::PUBLISHER)
+      {
+        topic_->RecycleSlot(slot_index_);
+      }
+      else if (state_ == SharedDataState::SUBSCRIBER)
+      {
+        topic_->ClearHeldSlot(subscriber_index_, slot_index_);
+        topic_->ReleaseSlot(slot_index_);
+      }
+      topic_ = nullptr;
+      slot_index_ = kInvalidIndex;
+      sequence_ = 0;
+      state_ = SharedDataState::EMPTY;
+      subscriber_index_ = kInvalidIndex;
+    }
+
+   private:
+    friend class LinuxSharedTopic<TopicData>;
+    friend class Subscriber;
+
+    LinuxSharedTopic* topic_ = nullptr;
+    uint32_t slot_index_ = kInvalidIndex;
+    uint64_t sequence_ = 0;
+    SharedDataState state_ = SharedDataState::EMPTY;
+    uint32_t subscriber_index_ = kInvalidIndex;
+  };
+
+  /**
+   * @brief 以附着模式打开已有共享 Topic。Open an existing shared topic in attach mode.
+   * @param topic_name 主题名称。Topic name.
+   */
+  explicit LinuxSharedTopic(const char* topic_name)
+      : create_(false), publisher_(false), config_(), shm_name_(BuildShmName(topic_name))
+  {
+    (void)ReadProcessIdentity(static_cast<uint32_t>(getpid()), self_identity_);
+    Open();
+  }
+
+  /**
+   * @brief 以发布者模式创建或接管共享 Topic。Create or take over a shared topic as
+   * publisher.
+   * @param topic_name 主题名称。Topic name.
+   * @param config 创建配置。Creation config.
+   */
+  LinuxSharedTopic(const char* topic_name, const LinuxSharedTopicConfig& config)
+      : create_(true), publisher_(true), config_(config), shm_name_(BuildShmName(topic_name))
+  {
+    (void)ReadProcessIdentity(static_cast<uint32_t>(getpid()), self_identity_);
+    Open();
+  }
+
+  /**
+   * @typedef SyncSubscriber
+   * @brief 同步订阅者别名。Alias of the synchronous shared subscriber.
+   */
+  using SyncSubscriber = Subscriber;
+
+  /**
+   * @brief 析构函数，关闭共享 Topic。Destructor closing the shared topic.
+   */
+  ~LinuxSharedTopic() { Close(); }
+
+  LinuxSharedTopic(const LinuxSharedTopic&) = delete;
+  LinuxSharedTopic& operator=(const LinuxSharedTopic&) = delete;
+
+  LinuxSharedTopic(LinuxSharedTopic&&) = delete;
+  LinuxSharedTopic& operator=(LinuxSharedTopic&&) = delete;
+
+  /**
+   * @brief 检查共享 Topic 是否已成功打开。Checks whether the shared topic is opened
+   * successfully.
+   */
+  bool Valid() const { return open_ok_; }
+
+  /**
+   * @brief 获取打开阶段的错误码。Get the error code from the open stage.
+   */
+  ErrorCode GetError() const { return open_status_; }
+
+  /**
+   * @brief 获取当前活跃订阅者数量。Get the current number of active subscribers.
+   */
+  uint32_t GetSubscriberNum() const
+  {
+    if (!Valid())
+    {
+      return 0;
+    }
+
+    uint32_t count = 0;
+    for (uint32_t i = 0; i < subscriber_capacity_; ++i)
+    {
+      if (subscribers_[i].active.load(std::memory_order_acquire) != 0)
+      {
+        ++count;
+      }
+    }
+    return count;
+  }
+
+  /**
+   * @brief 为发布者申请一个可写 payload 槽位。Acquire a writable payload slot for the
+   * publisher.
+   * @param data 输出句柄。Output payload handle.
+   * @return 错误码。Error code indicating the acquisition result.
+   */
+  ErrorCode CreateData(SharedData& data)
+  {
+    if (!Valid())
+    {
+      return ErrorCode::STATE_ERR;
+    }
+
+    if (!PublisherValid())
+    {
+      return ErrorCode::STATE_ERR;
+    }
+
+    data.Reset();
+
+    uint32_t slot_index = kInvalidIndex;
+    ErrorCode pop_ans = PopFreeSlot(slot_index);
+    if (pop_ans != ErrorCode::OK)
+    {
+      ScavengeDeadSubscribers();
+      pop_ans = PopFreeSlot(slot_index);
+      if (pop_ans != ErrorCode::OK)
+      {
+        return pop_ans;
+      }
+    }
+
+    slots_[slot_index].refcount.store(0, std::memory_order_release);
+    slots_[slot_index].sequence.store(0, std::memory_order_release);
+
+    data.topic_ = this;
+    data.slot_index_ = slot_index;
+    data.sequence_ = 0;
+    data.state_ = SharedDataState::PUBLISHER;
+    data.subscriber_index_ = kInvalidIndex;
+    return ErrorCode::OK;
+  }
+
+  /**
+   * @brief 复制一份数据并发布。Copy one payload and publish it.
+   * @param data 待发布的数据。Payload to publish.
+   * @return 错误码。Error code indicating the publish result.
+   */
+  ErrorCode Publish(const TopicData& data)
+  {
+    SharedData topic_data;
+    const ErrorCode acquire_ans = CreateData(topic_data);
+    if (acquire_ans != ErrorCode::OK)
+    {
+      return acquire_ans;
+    }
+
+    *topic_data.GetData() = data;
+    return Publish(topic_data);
+  }
+
+  /**
+   * @brief 发布一个已申请好的 payload 句柄。Publish a pre-acquired payload handle.
+   */
+  ErrorCode Publish(SharedData&& data) { return PublishData(data); }
+
+  /**
+   * @brief 发布一个已申请好的 payload 句柄。Publish a pre-acquired payload handle.
+   */
+  ErrorCode Publish(SharedData& data) { return PublishData(data); }
+
+  /**
+   * @brief 获取累计发布失败次数。Get the accumulated publish failure count.
+   */
+  uint64_t GetPublishFailedNum() const
+  {
+    if (!Valid())
+    {
+      return 0;
+    }
+    return header_->publish_failures.load(std::memory_order_acquire);
+  }
+
+  /**
+   * @brief 删除对应的共享内存对象。Remove the backing shared-memory object.
+   * @param topic_name 主题名称。Topic name.
+   * @return 错误码。Error code indicating the removal result.
+   */
+  static ErrorCode Remove(const char* topic_name)
+  {
+    const std::string shm_name = BuildShmName(topic_name);
+    if (shm_unlink(shm_name.c_str()) == 0 || errno == ENOENT)
+    {
+      return ErrorCode::OK;
+    }
+    return ErrorCode::FAILED;
+  }
+
+ private:
+  struct alignas(64) SharedHeader
+  {
+    uint64_t magic = 0;
+    uint32_t version = 0;
+    uint32_t data_size = 0;
+    uint32_t slot_count = 0;
+    uint32_t subscriber_capacity = 0;
+    uint32_t queue_capacity = 0;
+    uint32_t reserved = 0;
+    std::atomic<uint32_t> init_state;
+    std::atomic<uint32_t> publisher_pid;
+    std::atomic<uint64_t> publisher_starttime;
+    std::atomic<uint64_t> free_queue_head;
+    std::atomic<uint64_t> free_queue_tail;
+    std::atomic<uint64_t> next_sequence;
+    std::atomic<uint64_t> publish_failures;
+  };
+
+  struct alignas(64) SlotControl
+  {
+    std::atomic<uint32_t> refcount;
+    std::atomic<uint64_t> sequence;
+  };
+
+  struct alignas(16) FreeSlotCell
+  {
+    std::atomic<uint64_t> sequence;
+    uint32_t slot_index = 0;
+    uint32_t reserved = 0;
+  };
+
+  struct Descriptor
+  {
+    uint32_t slot_index = kInvalidIndex;
+    uint32_t reserved = 0;
+    uint64_t sequence = 0;
+  };
+
+  struct alignas(64) SubscriberControl
+  {
+    std::atomic<uint32_t> active;
+    std::atomic<uint32_t> mode;
+    std::atomic<uint32_t> queue_head;
+    std::atomic<uint32_t> queue_tail;
+    std::atomic<uint32_t> ready_sem_count;
+    std::atomic<uint64_t> dropped_messages;
+    std::atomic<uint32_t> owner_pid;
+    std::atomic<uint64_t> owner_starttime;
+    std::atomic<uint32_t> held_slot;
+  };
+
+  struct alignas(64) BalancedGroupControl
+  {
+    std::atomic<uint64_t> rr_cursor;
+  };
+
+  struct ProcessIdentity
+  {
+    uint32_t pid = 0;
+    uint64_t starttime = 0;
+  };
+
+  static constexpr uint64_t kMagic = 0x4c58524950435348ULL;
+  static constexpr uint32_t kVersion = 1;
+  static constexpr uint32_t kInitReady = 1;
+  static constexpr uint32_t kInvalidIndex = UINT32_MAX;
+
+  static std::string BuildShmName(const char* topic_name)
+  {
+    char buffer[64] = {};
+    std::snprintf(buffer, sizeof(buffer), "/libxr_ipc_%08x",
+                  CRC32::Calculate(topic_name, std::strlen(topic_name)));
+    return std::string(buffer);
+  }
+
+  static size_t AlignUp(size_t value, size_t alignment)
+  {
+    return (value + alignment - 1U) & ~(alignment - 1U);
+  }
+
+  static uint64_t NowMonotonicMs() { return MonotonicTime::NowMilliseconds(); }
+
+  static bool ReadProcessIdentity(uint32_t pid, ProcessIdentity& identity)
+  {
+    identity = {};
+    if (pid == 0)
+    {
+      return false;
+    }
+
+    char path[64] = {};
+    std::snprintf(path, sizeof(path), "/proc/%u/stat", pid);
+
+    std::ifstream file(path);
+    if (!file.is_open())
+    {
+      return false;
+    }
+
+    std::string line;
+    std::getline(file, line);
+    if (line.empty())
+    {
+      return false;
+    }
+
+    const size_t rparen = line.rfind(')');
+    if (rparen == std::string::npos || rparen + 2U >= line.size())
+    {
+      return false;
+    }
+
+    std::istringstream iss(line.substr(rparen + 2U));
+    std::string token;
+    for (int field = 3; field <= 22; ++field)
+    {
+      if (!(iss >> token))
+      {
+        return false;
+      }
+
+      if (field == 22)
+      {
+        identity.pid = pid;
+        identity.starttime = std::strtoull(token.c_str(), nullptr, 10);
+        return identity.starttime != 0;
+      }
+    }
+
+    return false;
+  }
+
+  static int FutexWait(std::atomic<uint32_t>* word, uint32_t expected, uint32_t timeout_ms)
+  {
+    struct timespec timeout = {};
+    struct timespec* timeout_ptr = nullptr;
+    if (timeout_ms != UINT32_MAX)
+    {
+      timeout.tv_sec = static_cast<time_t>(timeout_ms / 1000U);
+      timeout.tv_nsec = static_cast<long>(timeout_ms % 1000U) * 1000000L;
+      timeout_ptr = &timeout;
+    }
+
+    return static_cast<int>(syscall(SYS_futex,
+                                    reinterpret_cast<uint32_t*>(word),
+                                    FUTEX_WAIT,
+                                    expected,
+                                    timeout_ptr,
+                                    nullptr,
+                                    0));
+  }
+
+  static int FutexWake(std::atomic<uint32_t>* word)
+  {
+    return static_cast<int>(
+        syscall(SYS_futex, reinterpret_cast<uint32_t*>(word), FUTEX_WAKE, INT32_MAX, nullptr,
+                nullptr, 0));
+  }
+
+  static size_t ComputeSharedBytes(uint32_t slot_count,
+                                   uint32_t subscriber_capacity,
+                                   uint32_t queue_capacity)
+  {
+    size_t offset = 0;
+    offset = AlignUp(offset, alignof(SharedHeader));
+    offset += sizeof(SharedHeader);
+
+    offset = AlignUp(offset, alignof(SlotControl));
+    offset += sizeof(SlotControl) * slot_count;
+
+    offset = AlignUp(offset, alignof(SubscriberControl));
+    offset += sizeof(SubscriberControl) * subscriber_capacity;
+
+    offset = AlignUp(offset, alignof(BalancedGroupControl));
+    offset += sizeof(BalancedGroupControl);
+
+    offset = AlignUp(offset, alignof(std::atomic<uint32_t>));
+    offset += sizeof(std::atomic<uint32_t>) * subscriber_capacity;
+
+    offset = AlignUp(offset, alignof(FreeSlotCell));
+    offset += sizeof(FreeSlotCell) * slot_count;
+
+    offset = AlignUp(offset, alignof(Descriptor));
+    offset += sizeof(Descriptor) * subscriber_capacity * queue_capacity;
+
+    offset = AlignUp(offset, alignof(TopicData));
+    offset += sizeof(TopicData) * slot_count;
+    return offset;
+  }
+
+  void SetupPointers()
+  {
+    size_t offset = 0;
+
+    offset = AlignUp(offset, alignof(SharedHeader));
+    header_ = reinterpret_cast<SharedHeader*>(base_ + offset);
+    offset += sizeof(SharedHeader);
+
+    offset = AlignUp(offset, alignof(SlotControl));
+    slots_ = reinterpret_cast<SlotControl*>(base_ + offset);
+    offset += sizeof(SlotControl) * slot_count_;
+
+    offset = AlignUp(offset, alignof(SubscriberControl));
+    subscribers_ = reinterpret_cast<SubscriberControl*>(base_ + offset);
+    offset += sizeof(SubscriberControl) * subscriber_capacity_;
+
+    offset = AlignUp(offset, alignof(BalancedGroupControl));
+    balanced_group_ = reinterpret_cast<BalancedGroupControl*>(base_ + offset);
+    offset += sizeof(BalancedGroupControl);
+
+    offset = AlignUp(offset, alignof(std::atomic<uint32_t>));
+    balanced_members_ = reinterpret_cast<std::atomic<uint32_t>*>(base_ + offset);
+    offset += sizeof(std::atomic<uint32_t>) * subscriber_capacity_;
+
+    offset = AlignUp(offset, alignof(FreeSlotCell));
+    free_slots_ = reinterpret_cast<FreeSlotCell*>(base_ + offset);
+    offset += sizeof(FreeSlotCell) * slot_count_;
+
+    offset = AlignUp(offset, alignof(Descriptor));
+    descriptors_ = reinterpret_cast<Descriptor*>(base_ + offset);
+    offset += sizeof(Descriptor) * subscriber_capacity_ * queue_capacity_;
+
+    offset = AlignUp(offset, alignof(TopicData));
+    payloads_ = reinterpret_cast<TopicData*>(base_ + offset);
+  }
+
+  ErrorCode InitializeLayout()
+  {
+    if (config_.slot_num == 0 || config_.subscriber_num == 0 || config_.queue_num < 2)
+    {
+      return ErrorCode::ARG_ERR;
+    }
+
+    const size_t bytes =
+        ComputeSharedBytes(config_.slot_num, config_.subscriber_num, config_.queue_num);
+
+    if (ftruncate(fd_, static_cast<off_t>(bytes)) != 0)
+    {
+      return ErrorCode::INIT_ERR;
+    }
+
+    const struct stat st = GetStat();
+    if (st.st_size <= 0)
+    {
+      return ErrorCode::INIT_ERR;
+    }
+
+    mapping_size_ = static_cast<size_t>(st.st_size);
+    mapping_ = mmap(nullptr, mapping_size_, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+    if (mapping_ == MAP_FAILED)
+    {
+      mapping_ = nullptr;
+      return ErrorCode::INIT_ERR;
+    }
+
+    base_ = static_cast<uint8_t*>(mapping_);
+    slot_count_ = config_.slot_num;
+    subscriber_capacity_ = config_.subscriber_num;
+    queue_capacity_ = config_.queue_num;
+    SetupPointers();
+
+    header_->magic = kMagic;
+    header_->version = kVersion;
+    header_->data_size = sizeof(TopicData);
+    header_->slot_count = slot_count_;
+    header_->subscriber_capacity = subscriber_capacity_;
+    header_->queue_capacity = queue_capacity_;
+    header_->publisher_pid.store(self_identity_.pid, std::memory_order_release);
+    header_->publisher_starttime.store(self_identity_.starttime, std::memory_order_release);
+    header_->free_queue_head.store(0, std::memory_order_release);
+    header_->free_queue_tail.store(slot_count_, std::memory_order_release);
+    header_->next_sequence.store(0, std::memory_order_release);
+    header_->publish_failures.store(0, std::memory_order_release);
+
+    for (uint32_t i = 0; i < slot_count_; ++i)
+    {
+      slots_[i].refcount.store(0, std::memory_order_release);
+      slots_[i].sequence.store(0, std::memory_order_release);
+      std::memset(&payloads_[i], 0, sizeof(TopicData));
+      free_slots_[i].slot_index = i;
+      free_slots_[i].sequence.store(static_cast<uint64_t>(i) + 1U,
+                                    std::memory_order_release);
+    }
+
+    for (uint32_t i = 0; i < subscriber_capacity_; ++i)
+    {
+      subscribers_[i].active.store(0, std::memory_order_release);
+      subscribers_[i].mode.store(static_cast<uint32_t>(LinuxSharedSubscriberMode::BROADCAST_FULL),
+                                 std::memory_order_release);
+      subscribers_[i].queue_head.store(0, std::memory_order_release);
+      subscribers_[i].queue_tail.store(0, std::memory_order_release);
+      subscribers_[i].ready_sem_count.store(0, std::memory_order_release);
+      subscribers_[i].dropped_messages.store(0, std::memory_order_release);
+      subscribers_[i].owner_pid.store(0, std::memory_order_release);
+      subscribers_[i].owner_starttime.store(0, std::memory_order_release);
+      subscribers_[i].held_slot.store(kInvalidIndex, std::memory_order_release);
+      balanced_members_[i].store(kInvalidIndex, std::memory_order_release);
+    }
+
+    balanced_group_->rr_cursor.store(0, std::memory_order_release);
+
+    for (size_t i = 0; i < static_cast<size_t>(subscriber_capacity_) * queue_capacity_; ++i)
+    {
+      descriptors_[i] = Descriptor{};
+    }
+
+    header_->init_state.store(kInitReady, std::memory_order_release);
+    return ErrorCode::OK;
+  }
+
+  ErrorCode AttachLayout()
+  {
+    const struct stat st = GetStat();
+    if (st.st_size <= 0)
+    {
+      return ErrorCode::NOT_FOUND;
+    }
+
+    mapping_size_ = static_cast<size_t>(st.st_size);
+    mapping_ = mmap(nullptr, mapping_size_, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+    if (mapping_ == MAP_FAILED)
+    {
+      mapping_ = nullptr;
+      return ErrorCode::INIT_ERR;
+    }
+
+    base_ = static_cast<uint8_t*>(mapping_);
+    header_ = reinterpret_cast<SharedHeader*>(base_);
+
+    while (header_->init_state.load(std::memory_order_acquire) != kInitReady)
+    {
+      usleep(1000);
+    }
+
+    if (header_->magic != kMagic || header_->version != kVersion ||
+        header_->data_size != sizeof(TopicData))
+    {
+      return ErrorCode::CHECK_ERR;
+    }
+
+    slot_count_ = header_->slot_count;
+    subscriber_capacity_ = header_->subscriber_capacity;
+    queue_capacity_ = header_->queue_capacity;
+    SetupPointers();
+    return ErrorCode::OK;
+  }
+
+  bool TryReclaimStaleSegment()
+  {
+    int stale_fd = shm_open(shm_name_.c_str(), O_RDWR, 0600);
+    if (stale_fd < 0)
+    {
+      return errno == ENOENT;
+    }
+
+    struct stat st = {};
+    if (fstat(stale_fd, &st) != 0)
+    {
+      close(stale_fd);
+      return false;
+    }
+
+    bool reclaim = false;
+    if (st.st_size < static_cast<off_t>(sizeof(SharedHeader)))
+    {
+      reclaim = true;
+    }
+    else
+    {
+      void* mapping = mmap(nullptr, sizeof(SharedHeader), PROT_READ | PROT_WRITE, MAP_SHARED,
+                           stale_fd, 0);
+      if (mapping != MAP_FAILED)
+      {
+        auto* header = reinterpret_cast<SharedHeader*>(mapping);
+        const uint32_t init_state = header->init_state.load(std::memory_order_acquire);
+        const ProcessIdentity publisher_identity = {
+            header->publisher_pid.load(std::memory_order_acquire),
+            header->publisher_starttime.load(std::memory_order_acquire),
+        };
+
+        if (init_state != kInitReady)
+        {
+          reclaim = !ProcessAlive(publisher_identity);
+        }
+        else if (!ProcessAlive(publisher_identity))
+        {
+          reclaim = true;
+        }
+
+        munmap(mapping, sizeof(SharedHeader));
+      }
+    }
+
+    close(stale_fd);
+
+    if (!reclaim)
+    {
+      return false;
+    }
+
+    return shm_unlink(shm_name_.c_str()) == 0 || errno == ENOENT;
+  }
+
+  void Open()
+  {
+    open_status_ = ErrorCode::STATE_ERR;
+    open_ok_ = false;
+
+    if (create_)
+    {
+      for (int attempt = 0; attempt < 2; ++attempt)
+      {
+        fd_ = shm_open(shm_name_.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+        if (fd_ >= 0)
+        {
+          break;
+        }
+
+        if (errno != EEXIST || !TryReclaimStaleSegment())
+        {
+          break;
+        }
+      }
+
+      if (fd_ < 0)
+      {
+        open_status_ = (errno == EEXIST) ? ErrorCode::BUSY : ErrorCode::INIT_ERR;
+        return;
+      }
+
+      open_status_ = InitializeLayout();
+    }
+    else
+    {
+      fd_ = shm_open(shm_name_.c_str(), O_RDWR, 0600);
+      if (fd_ < 0)
+      {
+        open_status_ = (errno == ENOENT) ? ErrorCode::NOT_FOUND : ErrorCode::INIT_ERR;
+        return;
+      }
+
+      open_status_ = AttachLayout();
+    }
+
+    if (fd_ >= 0)
+    {
+      close(fd_);
+      fd_ = -1;
+    }
+
+    open_ok_ = (open_status_ == ErrorCode::OK);
+  }
+
+  void Close()
+  {
+    if (mapping_ != nullptr)
+    {
+      munmap(mapping_, mapping_size_);
+    }
+
+    mapping_ = nullptr;
+    base_ = nullptr;
+    header_ = nullptr;
+    slots_ = nullptr;
+    subscribers_ = nullptr;
+    free_slots_ = nullptr;
+    descriptors_ = nullptr;
+    payloads_ = nullptr;
+    mapping_size_ = 0;
+    open_ok_ = false;
+    open_status_ = ErrorCode::STATE_ERR;
+  }
+
+  struct stat GetStat() const
+  {
+    struct stat st = {};
+    fstat(fd_, &st);
+    return st;
+  }
+
+  Descriptor* DescriptorRing(uint32_t subscriber_index) const
+  {
+    return descriptors_ + static_cast<size_t>(subscriber_index) * queue_capacity_;
+  }
+
+  static bool ProcessAlive(const ProcessIdentity& identity)
+  {
+    ProcessIdentity current = {};
+    if (!ReadProcessIdentity(identity.pid, current))
+    {
+      return false;
+    }
+
+    return current.starttime == identity.starttime;
+  }
+
+  bool PublisherValid() const
+  {
+    if (!publisher_ || header_ == nullptr)
+    {
+      return false;
+    }
+
+    const ProcessIdentity owner = {
+        header_->publisher_pid.load(std::memory_order_acquire),
+        header_->publisher_starttime.load(std::memory_order_acquire),
+    };
+    return owner.pid == self_identity_.pid && owner.starttime == self_identity_.starttime;
+  }
+
+  void HoldSlot(uint32_t subscriber_index, uint32_t slot_index)
+  {
+    subscribers_[subscriber_index].held_slot.store(slot_index, std::memory_order_release);
+  }
+
+  void ClearHeldSlot(uint32_t subscriber_index, uint32_t slot_index)
+  {
+    uint32_t expected = slot_index;
+    subscribers_[subscriber_index].held_slot.compare_exchange_strong(
+        expected, kInvalidIndex, std::memory_order_acq_rel, std::memory_order_relaxed);
+  }
+
+  ErrorCode RegisterBalancedSubscriber(uint32_t subscriber_index)
+  {
+    for (uint32_t i = 0; i < subscriber_capacity_; ++i)
+    {
+      uint32_t expected = kInvalidIndex;
+      if (balanced_members_[i].compare_exchange_strong(expected, subscriber_index,
+                                                       std::memory_order_acq_rel,
+                                                       std::memory_order_relaxed))
+      {
+        return ErrorCode::OK;
+      }
+    }
+    return ErrorCode::FULL;
+  }
+
+  void UnregisterBalancedSubscriber(uint32_t subscriber_index)
+  {
+    for (uint32_t i = 0; i < subscriber_capacity_; ++i)
+    {
+      uint32_t expected = subscriber_index;
+      if (balanced_members_[i].compare_exchange_strong(expected, kInvalidIndex,
+                                                       std::memory_order_acq_rel,
+                                                       std::memory_order_relaxed))
+      {
+        return;
+      }
+    }
+  }
+
+  bool SelectBalancedSubscriber(uint32_t& subscriber_index)
+  {
+    const uint64_t base = balanced_group_->rr_cursor.fetch_add(1, std::memory_order_acq_rel);
+    for (uint32_t offset = 0; offset < subscriber_capacity_; ++offset)
+    {
+      const uint32_t member_index =
+          balanced_members_[(base + offset) % subscriber_capacity_].load(std::memory_order_acquire);
+      if (member_index == kInvalidIndex)
+      {
+        continue;
+      }
+      if (subscribers_[member_index].active.load(std::memory_order_acquire) == 0)
+      {
+        continue;
+      }
+      if (subscribers_[member_index].mode.load(std::memory_order_acquire) !=
+          static_cast<uint32_t>(LinuxSharedSubscriberMode::BALANCE_RR))
+      {
+        continue;
+      }
+      if (!QueueHasSpace(member_index))
+      {
+        continue;
+      }
+      subscriber_index = member_index;
+      return true;
+    }
+    return false;
+  }
+
+  static void PostReady(SubscriberControl& control)
+  {
+    control.ready_sem_count.fetch_add(1, std::memory_order_release);
+    FutexWake(&control.ready_sem_count);
+  }
+
+  static void ConsumeReady(SubscriberControl& control)
+  {
+    const uint32_t prev = control.ready_sem_count.fetch_sub(1, std::memory_order_acq_rel);
+    ASSERT(prev > 0);
+  }
+
+  static ErrorCode WaitReady(SubscriberControl& control, uint32_t timeout_ms)
+  {
+    if (control.ready_sem_count.load(std::memory_order_acquire) != 0)
+    {
+      return ErrorCode::OK;
+    }
+
+    const bool infinite_wait = (timeout_ms == UINT32_MAX);
+    const uint64_t deadline_ms = infinite_wait ? 0 : (NowMonotonicMs() + timeout_ms);
+
+    while (true)
+    {
+      if (control.ready_sem_count.load(std::memory_order_acquire) != 0)
+      {
+        return ErrorCode::OK;
+      }
+
+      uint32_t wait_ms = UINT32_MAX;
+      if (!infinite_wait)
+      {
+        wait_ms = MonotonicTime::RemainingMilliseconds(deadline_ms);
+        if (wait_ms == 0)
+        {
+          return ErrorCode::TIMEOUT;
+        }
+      }
+
+      wait_ms = MonotonicTime::WaitSliceMilliseconds(wait_ms);
+
+      const int futex_ans = FutexWait(&control.ready_sem_count, 0, wait_ms);
+      if (futex_ans == 0 || errno == EAGAIN || errno == EINTR)
+      {
+        continue;
+      }
+
+      if (errno == ETIMEDOUT)
+      {
+        if (infinite_wait)
+        {
+          continue;
+        }
+        if (MonotonicTime::RemainingMilliseconds(deadline_ms) == 0 &&
+            control.ready_sem_count.load(std::memory_order_acquire) == 0)
+        {
+          return ErrorCode::TIMEOUT;
+        }
+        continue;
+      }
+
+      return ErrorCode::FAILED;
+    }
+  }
+
+  void ScavengeDeadSubscribers()
+  {
+    for (uint32_t i = 0; i < subscriber_capacity_; ++i)
+    {
+      if (subscribers_[i].active.load(std::memory_order_acquire) == 0)
+      {
+        continue;
+      }
+
+      const ProcessIdentity owner_identity = {
+          subscribers_[i].owner_pid.load(std::memory_order_acquire),
+          subscribers_[i].owner_starttime.load(std::memory_order_acquire),
+      };
+      if (ProcessAlive(owner_identity))
+      {
+        continue;
+      }
+
+      uint32_t expected = 1;
+      if (!subscribers_[i].active.compare_exchange_strong(expected, 0, std::memory_order_acq_rel,
+                                                          std::memory_order_relaxed))
+      {
+        continue;
+      }
+
+      subscribers_[i].owner_pid.store(0, std::memory_order_release);
+      subscribers_[i].owner_starttime.store(0, std::memory_order_release);
+
+      const uint32_t held_slot =
+          subscribers_[i].held_slot.exchange(kInvalidIndex, std::memory_order_acq_rel);
+      if (held_slot != kInvalidIndex)
+      {
+        ReleaseSlot(held_slot);
+      }
+
+      Descriptor desc = {};
+      while (TryPopDescriptor(i, desc) == ErrorCode::OK)
+      {
+        ReleaseSlot(desc.slot_index);
+      }
+    }
+  }
+
+  bool QueueHasSpace(uint32_t subscriber_index) const
+  {
+    const SubscriberControl& control = subscribers_[subscriber_index];
+    const uint32_t head = control.queue_head.load(std::memory_order_acquire);
+    const uint32_t tail = control.queue_tail.load(std::memory_order_relaxed);
+    const uint32_t next_tail = (tail + 1U) % queue_capacity_;
+    return next_tail != head;
+  }
+
+  void PushDescriptor(uint32_t subscriber_index, const Descriptor& descriptor)
+  {
+    SubscriberControl& control = subscribers_[subscriber_index];
+    Descriptor* ring = DescriptorRing(subscriber_index);
+
+    const uint32_t tail = control.queue_tail.load(std::memory_order_relaxed);
+    ring[tail] = descriptor;
+    const uint32_t next_tail = (tail + 1U) % queue_capacity_;
+    control.queue_tail.store(next_tail, std::memory_order_release);
+    PostReady(control);
+  }
+
+  ErrorCode TryPopDescriptor(uint32_t subscriber_index, Descriptor& descriptor)
+  {
+    SubscriberControl& control = subscribers_[subscriber_index];
+    Descriptor* ring = DescriptorRing(subscriber_index);
+
+    while (true)
+    {
+      uint32_t head = control.queue_head.load(std::memory_order_relaxed);
+      const uint32_t tail = control.queue_tail.load(std::memory_order_acquire);
+      if (head == tail)
+      {
+        return ErrorCode::EMPTY;
+      }
+
+      descriptor = ring[head];
+      const uint32_t next_head = (head + 1U) % queue_capacity_;
+      if (control.queue_head.compare_exchange_weak(head, next_head, std::memory_order_acq_rel,
+                                                   std::memory_order_relaxed))
+      {
+        ConsumeReady(control);
+        return ErrorCode::OK;
+      }
+    }
+  }
+
+  ErrorCode DropDescriptor(uint32_t subscriber_index)
+  {
+    SubscriberControl& control = subscribers_[subscriber_index];
+    Descriptor* ring = DescriptorRing(subscriber_index);
+
+    while (true)
+    {
+      uint32_t head = control.queue_head.load(std::memory_order_relaxed);
+      const uint32_t tail = control.queue_tail.load(std::memory_order_acquire);
+      if (head == tail)
+      {
+        return ErrorCode::EMPTY;
+      }
+
+      const Descriptor descriptor = ring[head];
+      const uint32_t next_head = (head + 1U) % queue_capacity_;
+      if (control.queue_head.compare_exchange_weak(head, next_head, std::memory_order_acq_rel,
+                                                   std::memory_order_relaxed))
+      {
+        control.dropped_messages.fetch_add(1, std::memory_order_relaxed);
+        ConsumeReady(control);
+        ReleaseSlot(descriptor.slot_index);
+        return ErrorCode::OK;
+      }
+    }
+  }
+
+  ErrorCode PopFreeSlot(uint32_t& slot_index)
+  {
+    while (true)
+    {
+      uint64_t head = header_->free_queue_head.load(std::memory_order_relaxed);
+      FreeSlotCell& cell = free_slots_[head % slot_count_];
+      const uint64_t seq = cell.sequence.load(std::memory_order_acquire);
+      const intptr_t diff = static_cast<intptr_t>(seq) - static_cast<intptr_t>(head + 1U);
+
+      if (diff == 0)
+      {
+        if (header_->free_queue_head.compare_exchange_weak(head, head + 1U,
+                                                           std::memory_order_acq_rel,
+                                                           std::memory_order_relaxed))
+        {
+          slot_index = cell.slot_index;
+          cell.sequence.store(head + slot_count_, std::memory_order_release);
+          return ErrorCode::OK;
+        }
+      }
+      else if (diff < 0)
+      {
+        return ErrorCode::FULL;
+      }
+    }
+  }
+
+  void RecycleSlot(uint32_t slot_index)
+  {
+    slots_[slot_index].sequence.store(0, std::memory_order_release);
+
+    while (true)
+    {
+      uint64_t tail = header_->free_queue_tail.load(std::memory_order_relaxed);
+      FreeSlotCell& cell = free_slots_[tail % slot_count_];
+      const uint64_t seq = cell.sequence.load(std::memory_order_acquire);
+      const intptr_t diff = static_cast<intptr_t>(seq) - static_cast<intptr_t>(tail);
+
+      if (diff == 0)
+      {
+        if (header_->free_queue_tail.compare_exchange_weak(tail, tail + 1U,
+                                                           std::memory_order_acq_rel,
+                                                           std::memory_order_relaxed))
+        {
+          cell.slot_index = slot_index;
+          cell.sequence.store(tail + 1U, std::memory_order_release);
+          return;
+        }
+      }
+    }
+  }
+
+  void ReleaseSlot(uint32_t slot_index)
+  {
+    const uint32_t prev = slots_[slot_index].refcount.fetch_sub(1, std::memory_order_acq_rel);
+    ASSERT(prev > 0);
+    if (prev == 1)
+    {
+      RecycleSlot(slot_index);
+    }
+  }
+
+  ErrorCode PublishData(SharedData& data)
+  {
+    if (!data.Valid() || data.topic_ != this)
+    {
+      return ErrorCode::STATE_ERR;
+    }
+
+    uint32_t active_count = 0;
+    uint32_t balanced_target = kInvalidIndex;
+    bool has_balanced_subscriber = false;
+    for (uint32_t i = 0; i < subscriber_capacity_; ++i)
+    {
+      if (subscribers_[i].active.load(std::memory_order_acquire) == 0)
+      {
+        continue;
+      }
+
+      const LinuxSharedSubscriberMode mode = static_cast<LinuxSharedSubscriberMode>(
+          subscribers_[i].mode.load(std::memory_order_acquire));
+      if (mode == LinuxSharedSubscriberMode::BALANCE_RR)
+      {
+        has_balanced_subscriber = true;
+        continue;
+      }
+
+      if (!QueueHasSpace(i))
+      {
+        ScavengeDeadSubscribers();
+        if (subscribers_[i].active.load(std::memory_order_acquire) == 0)
+        {
+          continue;
+        }
+
+        if (mode == LinuxSharedSubscriberMode::BROADCAST_DROP_OLD)
+        {
+          if (DropDescriptor(i) != ErrorCode::OK)
+          {
+            header_->publish_failures.fetch_add(1, std::memory_order_relaxed);
+            data.Reset();
+            return ErrorCode::FULL;
+          }
+        }
+        else
+        {
+          subscribers_[i].dropped_messages.fetch_add(1, std::memory_order_relaxed);
+          header_->publish_failures.fetch_add(1, std::memory_order_relaxed);
+          data.Reset();
+          return ErrorCode::FULL;
+        }
+      }
+
+      ++active_count;
+    }
+
+    if (has_balanced_subscriber)
+    {
+      if (!SelectBalancedSubscriber(balanced_target))
+      {
+        ScavengeDeadSubscribers();
+        if (!SelectBalancedSubscriber(balanced_target))
+        {
+          header_->publish_failures.fetch_add(1, std::memory_order_relaxed);
+          data.Reset();
+          return ErrorCode::FULL;
+        }
+      }
+      ++active_count;
+    }
+
+    if (active_count == 0)
+    {
+      data.Reset();
+      return ErrorCode::OK;
+    }
+
+    const uint64_t sequence =
+        header_->next_sequence.fetch_add(1, std::memory_order_acq_rel) + 1ULL;
+    SlotControl& slot = slots_[data.slot_index_];
+    slot.refcount.store(active_count, std::memory_order_release);
+    slot.sequence.store(sequence, std::memory_order_release);
+
+    const Descriptor descriptor = {data.slot_index_, 0U, sequence};
+    for (uint32_t i = 0; i < subscriber_capacity_; ++i)
+    {
+      if (subscribers_[i].active.load(std::memory_order_acquire) == 0)
+      {
+        continue;
+      }
+      const LinuxSharedSubscriberMode mode = static_cast<LinuxSharedSubscriberMode>(
+          subscribers_[i].mode.load(std::memory_order_acquire));
+      if (mode == LinuxSharedSubscriberMode::BALANCE_RR)
+      {
+        continue;
+      }
+      PushDescriptor(i, descriptor);
+    }
+
+    if (balanced_target != kInvalidIndex)
+    {
+      PushDescriptor(balanced_target, descriptor);
+    }
+
+    data.topic_ = nullptr;
+    data.slot_index_ = kInvalidIndex;
+    return ErrorCode::OK;
+  }
+
+  bool create_ = false;
+  bool publisher_ = false;
+  LinuxSharedTopicConfig config_;
+  std::string shm_name_;
+  ProcessIdentity self_identity_ = {};
+
+  int fd_ = -1;
+  void* mapping_ = nullptr;
+  uint8_t* base_ = nullptr;
+  size_t mapping_size_ = 0;
+
+  SharedHeader* header_ = nullptr;
+  SlotControl* slots_ = nullptr;
+  SubscriberControl* subscribers_ = nullptr;
+  BalancedGroupControl* balanced_group_ = nullptr;
+  std::atomic<uint32_t>* balanced_members_ = nullptr;
+  FreeSlotCell* free_slots_ = nullptr;
+  Descriptor* descriptors_ = nullptr;
+  TopicData* payloads_ = nullptr;
+
+  uint32_t slot_count_ = 0;
+  uint32_t subscriber_capacity_ = 0;
+  uint32_t queue_capacity_ = 0;
+
+  bool open_ok_ = false;
+  ErrorCode open_status_ = ErrorCode::STATE_ERR;
+
+};
+
+}  // namespace LibXR
+
+#endif

--- a/system/Linux/lock_queue.hpp
+++ b/system/Linux/lock_queue.hpp
@@ -41,7 +41,12 @@ class LockQueue
    */
   ErrorCode Push(const Data &data)
   {
-    mutex_.Lock();
+    const ErrorCode lock_ans = mutex_.Lock();
+    if (lock_ans != ErrorCode::OK)
+    {
+      return lock_ans;
+    }
+
     auto ans = queue_handle_.Push(data);
     if (ans == ErrorCode::OK)
     {
@@ -60,17 +65,22 @@ class LockQueue
    */
   ErrorCode Pop(Data &data, uint32_t timeout)
   {
-    if (semaphore_handle_.Wait(timeout) == ErrorCode::OK)
+    const ErrorCode wait_ans = semaphore_handle_.Wait(timeout);
+    if (wait_ans == ErrorCode::OK)
     {
-      mutex_.Lock();
+      const ErrorCode lock_ans = mutex_.Lock();
+      if (lock_ans != ErrorCode::OK)
+      {
+        semaphore_handle_.Post();
+        return lock_ans;
+      }
+
       auto ans = queue_handle_.Pop(data);
       mutex_.Unlock();
       return ans;
     }
-    else
-    {
-      return ErrorCode::TIMEOUT;
-    }
+
+    return wait_ans;
   }
 
   /**
@@ -80,7 +90,11 @@ class LockQueue
    */
   ErrorCode Pop()
   {
-    mutex_.Lock();
+    const ErrorCode lock_ans = mutex_.Lock();
+    if (lock_ans != ErrorCode::OK)
+    {
+      return lock_ans;
+    }
     auto ans = queue_handle_.Pop();
     mutex_.Unlock();
     return ans;
@@ -94,17 +108,22 @@ class LockQueue
    */
   ErrorCode Pop(uint32_t timeout)
   {
-    if (semaphore_handle_.Wait(timeout) == ErrorCode::OK)
+    const ErrorCode wait_ans = semaphore_handle_.Wait(timeout);
+    if (wait_ans == ErrorCode::OK)
     {
-      mutex_.Lock();
+      const ErrorCode lock_ans = mutex_.Lock();
+      if (lock_ans != ErrorCode::OK)
+      {
+        semaphore_handle_.Post();
+        return lock_ans;
+      }
+
       auto ans = queue_handle_.Pop();
       mutex_.Unlock();
       return ans;
     }
-    else
-    {
-      return ErrorCode::TIMEOUT;
-    }
+
+    return wait_ans;
   }
 
   /**
@@ -127,7 +146,10 @@ class LockQueue
    */
   size_t Size()
   {
-    mutex_.Lock();
+    if (mutex_.Lock() != ErrorCode::OK)
+    {
+      return 0;
+    }
     auto ans = queue_handle_.Size();
     mutex_.Unlock();
     return ans;
@@ -140,7 +162,10 @@ class LockQueue
    */
   size_t EmptySize()
   {
-    mutex_.Lock();
+    if (mutex_.Lock() != ErrorCode::OK)
+    {
+      return 0;
+    }
     auto ans = queue_handle_.EmptySize();
     mutex_.Unlock();
     return ans;

--- a/system/Linux/monotonic_time.hpp
+++ b/system/Linux/monotonic_time.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <time.h>
+
+#include <cstdint>
+
+namespace LibXR
+{
+namespace MonotonicTime
+{
+
+inline timespec NowSpec()
+{
+  timespec ts = {};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return ts;
+}
+
+inline uint64_t NowMilliseconds()
+{
+  const timespec ts = NowSpec();
+  return static_cast<uint64_t>(ts.tv_sec) * 1000ULL +
+         static_cast<uint64_t>(ts.tv_nsec) / 1000000ULL;
+}
+
+inline timespec RelativeFromMilliseconds(uint32_t milliseconds)
+{
+  timespec ts = {};
+  ts.tv_sec = static_cast<time_t>(milliseconds / 1000U);
+  ts.tv_nsec = static_cast<long>(milliseconds % 1000U) * 1000000L;
+  return ts;
+}
+
+inline timespec AddMilliseconds(timespec base, uint64_t milliseconds)
+{
+  base.tv_sec += static_cast<time_t>(milliseconds / 1000ULL);
+  base.tv_nsec += static_cast<long>(milliseconds % 1000ULL) * 1000000L;
+  if (base.tv_nsec >= 1000000000L)
+  {
+    base.tv_sec += base.tv_nsec / 1000000000L;
+    base.tv_nsec %= 1000000000L;
+  }
+  return base;
+}
+
+inline uint32_t RemainingMilliseconds(uint64_t deadline_ms)
+{
+  const uint64_t now_ms = NowMilliseconds();
+  if (now_ms >= deadline_ms)
+  {
+    return 0;
+  }
+  return static_cast<uint32_t>(deadline_ms - now_ms);
+}
+
+inline int64_t ElapsedMicroseconds(const timespec& start)
+{
+  const timespec now = NowSpec();
+  return static_cast<int64_t>(now.tv_sec - start.tv_sec) * 1000000LL +
+         static_cast<int64_t>(now.tv_nsec - start.tv_nsec) / 1000LL;
+}
+
+inline uint32_t WaitSliceMilliseconds(uint32_t remaining_ms)
+{
+  return remaining_ms;
+}
+
+}  // namespace MonotonicTime
+}  // namespace LibXR

--- a/system/Linux/mutex.cpp
+++ b/system/Linux/mutex.cpp
@@ -2,6 +2,8 @@
 
 #include <pthread.h>
 
+#include <cerrno>
+
 #include "libxr_def.hpp"
 #include "libxr_system.hpp"
 
@@ -13,18 +15,24 @@ Mutex::~Mutex() { pthread_mutex_destroy(&mutex_handle_); }
 
 ErrorCode Mutex::Lock()
 {
-  if (pthread_mutex_lock(&mutex_handle_) != 0)
+  const int ans = pthread_mutex_lock(&mutex_handle_);
+  if (ans != 0)
   {
-    return ErrorCode::BUSY;
+    return ErrorCode::FAILED;
   }
   return ErrorCode::OK;
 }
 
 ErrorCode Mutex::TryLock()
 {
-  if (pthread_mutex_trylock(&mutex_handle_) != 0)
+  const int ans = pthread_mutex_trylock(&mutex_handle_);
+  if (ans == EBUSY)
   {
     return ErrorCode::BUSY;
+  }
+  if (ans != 0)
+  {
+    return ErrorCode::FAILED;
   }
   return ErrorCode::OK;
 }

--- a/system/Linux/semaphore.cpp
+++ b/system/Linux/semaphore.cpp
@@ -1,47 +1,99 @@
 #include "semaphore.hpp"
 
-#include <semaphore.h>
+#include <linux/futex.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
 
+#include <atomic>
+#include <cerrno>
 #include <cstddef>
-#include <iostream>
 
 #include "libxr_def.hpp"
+#include "monotonic_time.hpp"
 
 using namespace LibXR;
 
-Semaphore::Semaphore(uint32_t init_count) : semaphore_handle_(new sem_t)
+namespace
 {
-  sem_init(semaphore_handle_, 0, init_count);
+
+int FutexWait(std::atomic<uint32_t>* word, uint32_t expected, const struct timespec* timeout)
+{
+  return static_cast<int>(syscall(SYS_futex, reinterpret_cast<uint32_t*>(word), FUTEX_WAIT,
+                                  expected, timeout, nullptr, 0));
+}
+
+int FutexWake(std::atomic<uint32_t>* word, int count)
+{
+  return static_cast<int>(syscall(SYS_futex, reinterpret_cast<uint32_t*>(word), FUTEX_WAKE,
+                                  count, nullptr, nullptr, 0));
+}
+
+}  // namespace
+
+Semaphore::Semaphore(uint32_t init_count) : semaphore_handle_(new libxr_linux_futex_semaphore)
+{
+  semaphore_handle_->count.store(init_count, std::memory_order_release);
 }
 
 Semaphore::~Semaphore()
 {
-  sem_destroy(semaphore_handle_);
   delete semaphore_handle_;
 }
 
-void Semaphore::Post() { sem_post(semaphore_handle_); }
+void Semaphore::Post()
+{
+  const uint32_t prev = semaphore_handle_->count.fetch_add(1, std::memory_order_release);
+  if (prev == 0)
+  {
+    (void)FutexWake(&semaphore_handle_->count, 1);
+  }
+}
 
 ErrorCode Semaphore::Wait(uint32_t timeout)
 {
-  struct timespec ts;
-  UNUSED(clock_gettime(CLOCK_REALTIME, &ts));
-  uint32_t secs = timeout / 1000;
-  timeout = timeout % 1000;
+  const uint64_t deadline_ms =
+      (timeout == UINT32_MAX) ? UINT64_MAX : (MonotonicTime::NowMilliseconds() + timeout);
 
-  uint32_t add = 0;
-  int64_t raw_time = static_cast<__syscall_slong_t>(timeout * 1000U * 1000U) + ts.tv_nsec;
-  add = raw_time / (static_cast<int64_t>(1000U * 1000U * 1000U));
-  ts.tv_sec += (add + secs);
-  ts.tv_nsec = raw_time % (static_cast<int64_t>(1000U * 1000U * 1000U));
+  while (true)
+  {
+    uint32_t current = semaphore_handle_->count.load(std::memory_order_acquire);
 
-  if (sem_timedwait(semaphore_handle_, &ts) == 0)
-  {
-    return ErrorCode::OK;
-  }
-  else
-  {
-    return ErrorCode::TIMEOUT;
+    while (current > 0)
+    {
+      if (semaphore_handle_->count.compare_exchange_weak(current, current - 1U,
+                                                         std::memory_order_acq_rel,
+                                                         std::memory_order_relaxed))
+      {
+        return ErrorCode::OK;
+      }
+    }
+
+    timespec ts = {};
+    timespec* ts_ptr = nullptr;
+    if (timeout != UINT32_MAX)
+    {
+      const uint32_t remaining_ms = MonotonicTime::RemainingMilliseconds(deadline_ms);
+      if (remaining_ms == 0)
+      {
+        return ErrorCode::TIMEOUT;
+      }
+      ts = MonotonicTime::RelativeFromMilliseconds(remaining_ms);
+      ts_ptr = &ts;
+    }
+
+    const int ans = FutexWait(&semaphore_handle_->count, 0, ts_ptr);
+    if (ans == 0 || errno == EAGAIN || errno == EINTR)
+    {
+      continue;
+    }
+
+    if (errno == ETIMEDOUT)
+    {
+      return ErrorCode::TIMEOUT;
+    }
+
+    return ErrorCode::FAILED;
   }
 }
 
@@ -53,7 +105,5 @@ void Semaphore::PostFromCallback(bool in_isr)
 
 size_t Semaphore::Value()
 {
-  int value = 0;
-  sem_getvalue(semaphore_handle_, &value);
-  return value;
+  return semaphore_handle_->count.load(std::memory_order_acquire);
 }

--- a/system/Linux/thread.cpp
+++ b/system/Linux/thread.cpp
@@ -1,40 +1,33 @@
 #include "thread.hpp"
 
-#include <sys/time.h>
-
 #include <cerrno>
 
 #include "libxr_def.hpp"
+#include "monotonic_time.hpp"
 #include "timebase.hpp"
 
 using namespace LibXR;
 
-extern struct timeval libxr_linux_start_time;
 extern struct timespec libxr_linux_start_time_spec;
 
 Thread Thread::Current(void) { return Thread(pthread_self()); }
 
 void Thread::Sleep(uint32_t milliseconds)
 {
-  struct timespec ts;
-  ts.tv_sec = milliseconds / 1000;
-  ts.tv_nsec = static_cast<__syscall_slong_t>((milliseconds % 1000) * 1000000);
-  UNUSED(clock_nanosleep(CLOCK_REALTIME, 0, &ts, nullptr));
+  timespec ts = MonotonicTime::RelativeFromMilliseconds(milliseconds);
+  while (clock_nanosleep(CLOCK_MONOTONIC, 0, &ts, &ts) == EINTR)
+  {
+  }
 }
 
 void Thread::SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep)
 {
   last_waskup_time = last_waskup_time + time_to_sleep;
 
-  struct timespec ts = libxr_linux_start_time_spec;
-  uint32_t add = 0;
-  uint32_t secs = last_waskup_time / 1000;
-  int64_t raw_time = static_cast<int64_t>(last_waskup_time) * 1000U * 1000U;
-  add = raw_time / (static_cast<int64_t>(1000U * 1000U * 1000U));
-  ts.tv_sec += (add + secs);
-  ts.tv_nsec = raw_time % (static_cast<int64_t>(1000U * 1000U * 1000U));
+  const timespec ts =
+      MonotonicTime::AddMilliseconds(libxr_linux_start_time_spec, last_waskup_time);
 
-  while (clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &ts, &ts) && errno == EINTR)
+  while (clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, nullptr) == EINTR)
   {
   }
 }

--- a/system/Linux/thread.hpp
+++ b/system/Linux/thread.hpp
@@ -2,6 +2,8 @@
 
 #include <climits>
 
+#include <cstring>
+
 #include "libxr_system.hpp"
 #include "libxr_time.hpp"
 #include "logger.hpp"
@@ -68,10 +70,7 @@ class Thread
   {
     pthread_attr_t attr;
     pthread_attr_init(&attr);
-
-    // 线程栈大小设定，至少满足 PTHREAD_STACK_MIN
-    size_t stack_size = LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
-    pthread_attr_setstacksize(&attr, stack_size);
+    ConfigureAttributes(attr, stack_depth, priority);
 
     /**
      * @brief  线程数据封装类
@@ -89,13 +88,14 @@ class Thread
        */
       ThreadBlock(decltype(function) fun, ArgType arg, const char *name)
           : fun_(fun),
-            arg_(arg),
-            name_(reinterpret_cast<char *>(malloc(strlen(name) + 1)))
+            arg_(arg)
       {
-        strcpy(name_, name);
+        std::memset(name_, 0, sizeof(name_));
+        if (name != nullptr)
+        {
+          std::strncpy(name_, name, sizeof(name_) - 1);
+        }
       }
-
-      ~ThreadBlock() { free(name_); }
 
       /**
        * @brief  线程入口函数，执行用户定义的线程函数
@@ -108,62 +108,22 @@ class Thread
       {
         ThreadBlock *block = static_cast<ThreadBlock *>(arg);
 
-        if (block->name_ && block->name_[0] != '\0')
+        if (block->name_[0] != '\0')
         {
-          char name_buf[16];
-          std::strncpy(name_buf, block->name_, sizeof(name_buf) - 1);
-          name_buf[sizeof(name_buf) - 1] = '\0';
-          pthread_setname_np(pthread_self(), name_buf);
+          pthread_setname_np(pthread_self(), block->name_);
         }
 
-        volatile const char *thread_name = block->name_;
         block->fun_(block->arg_);
-
-        UNUSED(thread_name);
         delete block;
         return static_cast<void *>(nullptr);
       }
 
       decltype(function) fun_;  ///< 线程执行的函数 Function executed by the thread
       ArgType arg_;  ///< 线程函数的参数 Argument passed to the thread function
-      char *name_;   ///< 线程名称 Thread name
+      char name_[16];  ///< 线程名称 Thread name
     };
 
     auto block = new ThreadBlock(function, arg, name);
-
-    // 优先尝试设置 SCHED_FIFO 和线程优先级
-    int min_priority = sched_get_priority_min(SCHED_FIFO);
-    int max_priority = sched_get_priority_max(SCHED_FIFO);
-    bool scheduling_set = false;
-
-    UNUSED(scheduling_set);
-
-    if (max_priority - min_priority >= static_cast<int>(Priority::REALTIME))
-    {
-      pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
-      pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
-
-      struct sched_param sp;
-      Memory::FastSet(&sp, 0, sizeof(sp));
-      sp.sched_priority = min_priority + static_cast<int>(priority);
-
-      if (pthread_attr_setschedparam(&attr, &sp) == 0)
-      {
-        scheduling_set = true;
-      }
-      else
-      {
-        XR_LOG_WARN("Failed to set thread priority. Falling back to default policy.");
-        pthread_attr_setschedpolicy(&attr, SCHED_OTHER);
-        pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
-      }
-    }
-    else
-    {
-      XR_LOG_WARN(
-          "SCHED_FIFO not supported or insufficient range. Using default policy.");
-      pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
-    }
 
     // 创建线程
     int ans = pthread_create(&this->thread_handle_, &attr, ThreadBlock::Port, block);
@@ -229,6 +189,43 @@ class Thread
   operator libxr_thread_handle() { return thread_handle_; }
 
  private:
+  static void ConfigureAttributes(pthread_attr_t& attr, size_t stack_depth,
+                                  Thread::Priority priority)
+  {
+    const size_t stack_size = LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
+    pthread_attr_setstacksize(&attr, stack_size);
+    ConfigureScheduling(attr, priority);
+  }
+
+  static void ConfigureScheduling(pthread_attr_t& attr, Thread::Priority priority)
+  {
+    const int min_priority = sched_get_priority_min(SCHED_FIFO);
+    const int max_priority = sched_get_priority_max(SCHED_FIFO);
+    if (max_priority - min_priority < static_cast<int>(Priority::REALTIME))
+    {
+      XR_LOG_WARN(
+          "SCHED_FIFO not supported or insufficient range. Using default policy.");
+      pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
+      return;
+    }
+
+    pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+    pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
+
+    struct sched_param sp;
+    Memory::FastSet(&sp, 0, sizeof(sp));
+    sp.sched_priority = min_priority + static_cast<int>(priority);
+
+    if (pthread_attr_setschedparam(&attr, &sp) == 0)
+    {
+      return;
+    }
+
+    XR_LOG_WARN("Failed to set thread priority. Falling back to default policy.");
+    pthread_attr_setschedpolicy(&attr, SCHED_OTHER);
+    pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
+  }
+
   libxr_thread_handle thread_handle_;  ///< POSIX 线程句柄 POSIX thread handle
 };
 

--- a/system/Webots/libxr_system.cpp
+++ b/system/Webots/libxr_system.cpp
@@ -1,6 +1,5 @@
 #include "libxr_system.hpp"
 
-#include <bits/types/FILE.h>
 #include <poll.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>

--- a/system/Webots/linux_shared_topic.hpp
+++ b/system/Webots/linux_shared_topic.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "../Linux/linux_shared_topic_impl.hpp"

--- a/system/Webots/monotonic_time.hpp
+++ b/system/Webots/monotonic_time.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <time.h>
+
+#include <cstdint>
+
+#include "libxr_def.hpp"
+#include "libxr_system.hpp"
+
+namespace LibXR
+{
+namespace MonotonicTime
+{
+
+inline uint64_t NowMilliseconds()
+{
+  return _libxr_webots_time_count;
+}
+
+inline uint32_t RemainingMilliseconds(uint64_t deadline_ms)
+{
+  const uint64_t now_ms = NowMilliseconds();
+  if (now_ms >= deadline_ms)
+  {
+    return 0;
+  }
+  return static_cast<uint32_t>(deadline_ms - now_ms);
+}
+
+inline uint32_t WaitSliceMilliseconds(uint32_t remaining_ms)
+{
+  UNUSED(remaining_ms);
+  return 1;
+}
+
+inline timespec RealtimeDeadlineFromNow(uint32_t milliseconds)
+{
+  timespec ts = {};
+  clock_gettime(CLOCK_REALTIME, &ts);
+  ts.tv_sec += static_cast<time_t>(milliseconds / 1000U);
+  ts.tv_nsec += static_cast<long>(milliseconds % 1000U) * 1000000L;
+  if (ts.tv_nsec >= 1000000000L)
+  {
+    ts.tv_sec += ts.tv_nsec / 1000000000L;
+    ts.tv_nsec %= 1000000000L;
+  }
+  return ts;
+}
+
+}  // namespace MonotonicTime
+}  // namespace LibXR

--- a/system/Webots/semaphore.cpp
+++ b/system/Webots/semaphore.cpp
@@ -6,6 +6,7 @@
 
 #include "libxr_def.hpp"
 #include "libxr_system.hpp"
+#include "monotonic_time.hpp"
 
 using namespace LibXR;
 
@@ -34,23 +35,15 @@ ErrorCode Semaphore::Wait(uint32_t timeout)
     return ErrorCode::TIMEOUT;
   }
 
-  uint32_t start_time = _libxr_webots_time_count;
-  bool ans = false;
+  const uint64_t deadline_ms = MonotonicTime::NowMilliseconds() + timeout;
 
-  struct timespec ts;
-  UNUSED(clock_gettime(CLOCK_REALTIME, &ts));
-
-  uint32_t add = 0;
-  int64_t raw_time = static_cast<__syscall_slong_t>(1U * 1000U * 1000U) + ts.tv_nsec;
-  add = raw_time / (static_cast<int64_t>(1000U * 1000U * 1000U));
-
-  ts.tv_sec += add;
-  ts.tv_nsec = raw_time % (static_cast<int64_t>(1000U * 1000U * 1000U));
-
-  while (_libxr_webots_time_count - start_time < timeout)
+  while (MonotonicTime::RemainingMilliseconds(deadline_ms) > 0)
   {
-    ans = !sem_timedwait(semaphore_handle_, &ts);
-    if (ans)
+    const timespec ts =
+        MonotonicTime::RealtimeDeadlineFromNow(MonotonicTime::WaitSliceMilliseconds(
+            MonotonicTime::RemainingMilliseconds(deadline_ms)));
+
+    if (!sem_timedwait(semaphore_handle_, &ts))
     {
       return ErrorCode::OK;
     }

--- a/system/Webots/thread.cpp
+++ b/system/Webots/thread.cpp
@@ -4,6 +4,7 @@
 #include <webots/robot.h>
 
 #include "libxr_system.hpp"
+#include "monotonic_time.hpp"
 
 using namespace LibXR;
 
@@ -13,21 +14,14 @@ Thread Thread::Current(void) { return Thread(pthread_self()); }
 
 static ErrorCode ConditionVarWait(uint32_t timeout)
 {
-  uint32_t start_time = _libxr_webots_time_count;
+  const uint64_t deadline_ms = MonotonicTime::NowMilliseconds() + timeout;
 
-  struct timespec ts;
-  UNUSED(clock_gettime(CLOCK_REALTIME, &ts));
-
-  uint32_t add = 0;
-  int64_t raw_time = static_cast<__syscall_slong_t>(1U * 1000U * 1000U) + ts.tv_nsec;
-  add = raw_time / (static_cast<int64_t>(1000U * 1000U * 1000U));
-
-  ts.tv_sec += add;
-  ts.tv_nsec = raw_time % (static_cast<int64_t>(1000U * 1000U * 1000U));
-
-  while (_libxr_webots_time_count - start_time < timeout)
+  while (MonotonicTime::RemainingMilliseconds(deadline_ms) > 0)
   {
     pthread_mutex_lock(&_libxr_webots_time_notify->mutex);
+    const timespec ts =
+        MonotonicTime::RealtimeDeadlineFromNow(MonotonicTime::WaitSliceMilliseconds(
+            MonotonicTime::RemainingMilliseconds(deadline_ms)));
     auto ans = pthread_cond_timedwait(&_libxr_webots_time_notify->cond,
                                       &_libxr_webots_time_notify->mutex, &ts);
     pthread_mutex_unlock(&_libxr_webots_time_notify->mutex);
@@ -42,10 +36,11 @@ static ErrorCode ConditionVarWait(uint32_t timeout)
 
 void Thread::Sleep(uint32_t milliseconds)
 {
-  uint32_t now = _libxr_webots_time_count;
-  while (_libxr_webots_time_count - now < milliseconds)
+  const uint64_t deadline_ms = MonotonicTime::NowMilliseconds() + milliseconds;
+  while (MonotonicTime::RemainingMilliseconds(deadline_ms) > 0)
   {
-    ConditionVarWait(1);
+    ConditionVarWait(MonotonicTime::WaitSliceMilliseconds(
+        MonotonicTime::RemainingMilliseconds(deadline_ms)));
   }
 }
 
@@ -53,12 +48,13 @@ void Thread::SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to
 {
   last_waskup_time = last_waskup_time + time_to_sleep;
 
-  while (_libxr_webots_time_count < last_waskup_time)
+  while (MonotonicTime::NowMilliseconds() < last_waskup_time)
   {
-    ConditionVarWait(1);
+    ConditionVarWait(MonotonicTime::WaitSliceMilliseconds(
+        MonotonicTime::RemainingMilliseconds(last_waskup_time)));
   }
 }
 
-uint32_t Thread::GetTime() { return _libxr_webots_time_count; }
+uint32_t Thread::GetTime() { return static_cast<uint32_t>(MonotonicTime::NowMilliseconds()); }
 
 void Thread::Yield() { sched_yield(); }

--- a/system/Webots/thread.hpp
+++ b/system/Webots/thread.hpp
@@ -4,6 +4,8 @@
 #include "libxr_time.hpp"
 #include "logger.hpp"
 
+#include <cstring>
+
 namespace LibXR
 {
 
@@ -67,10 +69,7 @@ class Thread
   {
     pthread_attr_t attr;
     pthread_attr_init(&attr);
-
-    // 线程栈大小设定，至少满足 PTHREAD_STACK_MIN
-    size_t stack_size = LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
-    pthread_attr_setstacksize(&attr, stack_size);
+    ConfigureAttributes(attr, stack_depth, priority);
 
     /**
      * @brief  线程数据封装类
@@ -88,13 +87,14 @@ class Thread
        */
       ThreadBlock(decltype(function) fun, ArgType arg, const char *name)
           : fun_(fun),
-            arg_(arg),
-            name_(reinterpret_cast<char *>(malloc(strlen(name) + 1)))
+            arg_(arg)
       {
-        strcpy(name_, name);
+        std::memset(name_, 0, sizeof(name_));
+        if (name != nullptr)
+        {
+          std::strncpy(name_, name, sizeof(name_) - 1);
+        }
       }
-
-      ~ThreadBlock() { free(name_); }
 
       /**
        * @brief  线程入口函数，执行用户定义的线程函数
@@ -106,54 +106,17 @@ class Thread
       static void *Port(void *arg)
       {
         ThreadBlock *block = static_cast<ThreadBlock *>(arg);
-        volatile const char *thread_name = block->name_;
         block->fun_(block->arg_);
-
-        UNUSED(thread_name);
         delete block;
         return static_cast<void *>(nullptr);
       }
 
       decltype(function) fun_;  ///< 线程执行的函数 Function executed by the thread
       ArgType arg_;             ///< 线程函数的参数 Argument passed to the thread function
-      char *name_;              ///< 线程名称 Thread name
+      char name_[16];           ///< 线程名称 Thread name
     };
 
     auto block = new ThreadBlock(function, arg, name);
-
-    // 优先尝试设置 SCHED_FIFO 和线程优先级
-    int min_priority = sched_get_priority_min(SCHED_FIFO);
-    int max_priority = sched_get_priority_max(SCHED_FIFO);
-    bool scheduling_set = false;
-
-    UNUSED(scheduling_set);
-
-    if (max_priority - min_priority >= static_cast<int>(Priority::REALTIME))
-    {
-      pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
-      pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
-
-      struct sched_param sp;
-      Memory::FastSet(&sp, 0, sizeof(sp));
-      sp.sched_priority = min_priority + static_cast<int>(priority);
-
-      if (pthread_attr_setschedparam(&attr, &sp) == 0)
-      {
-        scheduling_set = true;
-      }
-      else
-      {
-        XR_LOG_WARN("Failed to set thread priority. Falling back to default policy.");
-        pthread_attr_setschedpolicy(&attr, SCHED_OTHER);
-        pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
-      }
-    }
-    else
-    {
-      XR_LOG_WARN(
-          "SCHED_FIFO not supported or insufficient range. Using default policy.");
-      pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
-    }
 
     // 创建线程
     int ans = pthread_create(&this->thread_handle_, &attr, ThreadBlock::Port, block);
@@ -219,6 +182,43 @@ class Thread
   operator libxr_thread_handle() { return thread_handle_; }
 
  private:
+  static void ConfigureAttributes(pthread_attr_t& attr, size_t stack_depth,
+                                  Thread::Priority priority)
+  {
+    const size_t stack_size = LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
+    pthread_attr_setstacksize(&attr, stack_size);
+    ConfigureScheduling(attr, priority);
+  }
+
+  static void ConfigureScheduling(pthread_attr_t& attr, Thread::Priority priority)
+  {
+    const int min_priority = sched_get_priority_min(SCHED_FIFO);
+    const int max_priority = sched_get_priority_max(SCHED_FIFO);
+    if (max_priority - min_priority < static_cast<int>(Priority::REALTIME))
+    {
+      XR_LOG_WARN(
+          "SCHED_FIFO not supported or insufficient range. Using default policy.");
+      pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
+      return;
+    }
+
+    pthread_attr_setinheritsched(&attr, PTHREAD_EXPLICIT_SCHED);
+    pthread_attr_setschedpolicy(&attr, SCHED_FIFO);
+
+    struct sched_param sp;
+    Memory::FastSet(&sp, 0, sizeof(sp));
+    sp.sched_priority = min_priority + static_cast<int>(priority);
+
+    if (pthread_attr_setschedparam(&attr, &sp) == 0)
+    {
+      return;
+    }
+
+    XR_LOG_WARN("Failed to set thread priority. Falling back to default policy.");
+    pthread_attr_setschedpolicy(&attr, SCHED_OTHER);
+    pthread_attr_setinheritsched(&attr, PTHREAD_INHERIT_SCHED);
+  }
+
   libxr_thread_handle thread_handle_;  ///< POSIX 线程句柄 POSIX thread handle
 };
 

--- a/test/bench_linux_shared_topic.cpp
+++ b/test/bench_linux_shared_topic.cpp
@@ -1,0 +1,807 @@
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <chrono>
+#include <cinttypes>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "libxr.hpp"
+
+namespace
+{
+
+using Clock = std::chrono::steady_clock;
+
+uint64_t NowNs()
+{
+  return static_cast<uint64_t>(
+      std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now().time_since_epoch())
+          .count());
+}
+
+struct BenchStats
+{
+  uint64_t count = 0;
+  uint64_t sequence_errors = 0;
+  uint64_t timeout_errors = 0;
+  double min_us = 0.0;
+  double avg_us = 0.0;
+  double p50_us = 0.0;
+  double p95_us = 0.0;
+  double p99_us = 0.0;
+  double max_us = 0.0;
+};
+
+struct OverloadStats
+{
+  BenchStats latency = {};
+  uint64_t subscriber_drop_num = 0;
+  uint64_t sequence_gap = 0;
+};
+
+struct ModeSubConfig
+{
+  LibXR::LinuxSharedSubscriberMode mode = LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL;
+  uint32_t delay_us = 0;
+  const char* label = "";
+};
+
+struct ModeSubResult
+{
+  BenchStats latency = {};
+  uint64_t recv_count = 0;
+  uint64_t drop_count = 0;
+  uint64_t first_seq = 0;
+  uint64_t last_seq = 0;
+  uint64_t timeout_errors = 0;
+};
+
+template <size_t PayloadBytes>
+struct BenchFrame
+{
+  uint64_t seq = 0;
+  uint64_t pub_ns = 0;
+  uint32_t checksum = 0;
+  uint32_t reserved = 0;
+  std::array<uint8_t, PayloadBytes> payload = {};
+};
+
+template <size_t PayloadBytes>
+uint32_t ComputeChecksum(const BenchFrame<PayloadBytes>& frame)
+{
+  return static_cast<uint32_t>((frame.seq * 1315423911ULL) ^
+                               (frame.pub_ns * 2654435761ULL) ^ PayloadBytes);
+}
+
+template <size_t PayloadBytes>
+uint64_t CountForPayload()
+{
+  if constexpr (PayloadBytes <= 64)
+  {
+    return 100000;
+  }
+  else if constexpr (PayloadBytes <= 4096)
+  {
+    return 50000;
+  }
+  else if constexpr (PayloadBytes <= 65536)
+  {
+    return 5000;
+  }
+  else
+  {
+    return 256;
+  }
+}
+
+template <size_t PayloadBytes>
+LibXR::LinuxSharedTopicConfig ConfigForPayload()
+{
+  LibXR::LinuxSharedTopicConfig config;
+  config.subscriber_num = 1;
+  if constexpr (PayloadBytes <= 64)
+  {
+    config.slot_num = 4096;
+    config.queue_num = 4096;
+  }
+  else if constexpr (PayloadBytes <= 4096)
+  {
+    config.slot_num = 2048;
+    config.queue_num = 2048;
+  }
+  else if constexpr (PayloadBytes <= 65536)
+  {
+    config.slot_num = 256;
+    config.queue_num = 256;
+  }
+  else
+  {
+    config.slot_num = 64;
+    config.queue_num = 64;
+  }
+  return config;
+}
+
+template <size_t PayloadBytes>
+BenchStats BuildStats(const std::vector<double>& lat_us, uint64_t sequence_errors,
+                      uint64_t timeout_errors)
+{
+  BenchStats stats = {};
+  stats.sequence_errors = sequence_errors;
+  stats.timeout_errors = timeout_errors;
+  if (lat_us.empty())
+  {
+    return stats;
+  }
+
+  stats.count = lat_us.size();
+  stats.min_us = lat_us.front();
+  stats.max_us = lat_us.front();
+  double sum_us = 0.0;
+  for (double value : lat_us)
+  {
+    stats.min_us = std::min(stats.min_us, value);
+    stats.max_us = std::max(stats.max_us, value);
+    sum_us += value;
+  }
+  stats.avg_us = sum_us / static_cast<double>(lat_us.size());
+
+  std::vector<double> sorted = lat_us;
+  std::sort(sorted.begin(), sorted.end());
+  auto percentile = [&](double p) {
+    const size_t index = static_cast<size_t>(
+        std::floor((static_cast<double>(sorted.size() - 1U)) * p + 0.5));
+    return sorted[index];
+  };
+  stats.p50_us = percentile(0.50);
+  stats.p95_us = percentile(0.95);
+  stats.p99_us = percentile(0.99);
+  return stats;
+}
+
+template <size_t PayloadBytes, bool TouchPayload>
+int RunBenchCase()
+{
+  using Topic = LibXR::LinuxSharedTopic<BenchFrame<PayloadBytes>>;
+  using Data = typename Topic::Data;
+  using Subscriber = typename Topic::SyncSubscriber;
+
+  const uint64_t count = CountForPayload<PayloadBytes>();
+  const LibXR::LinuxSharedTopicConfig config = ConfigForPayload<PayloadBytes>();
+
+  char topic_name[96] = {};
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shared_bench_%zu_%d", PayloadBytes,
+                static_cast<int>(getpid()));
+  (void)Topic::Remove(topic_name);
+
+  int stats_pipe[2] = {-1, -1};
+  if (pipe(stats_pipe) != 0)
+  {
+    std::fprintf(stderr, "pipe failed: %s\n", std::strerror(errno));
+    return 1;
+  }
+
+  Topic publisher(topic_name, config);
+  if (!publisher.Valid())
+  {
+    std::fprintf(stderr, "publisher open failed for payload=%zu\n", PayloadBytes);
+    return 1;
+  }
+
+  pid_t child = fork();
+  if (child < 0)
+  {
+    std::fprintf(stderr, "fork failed: %s\n", std::strerror(errno));
+    return 1;
+  }
+
+  if (child == 0)
+  {
+    close(stats_pipe[0]);
+
+    Subscriber subscriber(topic_name);
+    if (!subscriber.Valid())
+    {
+      _exit(2);
+    }
+
+    std::vector<double> lat_us;
+    lat_us.reserve(static_cast<size_t>(count));
+    uint64_t sequence_errors = 0;
+    uint64_t timeout_errors = 0;
+    uint64_t expected_seq = 1;
+
+    for (uint64_t i = 0; i < count; ++i)
+    {
+      Data data;
+      LibXR::ErrorCode ans = subscriber.Wait(data, 5000);
+      if (ans != LibXR::ErrorCode::OK)
+      {
+        ++timeout_errors;
+        continue;
+      }
+
+      const auto* frame = data.GetData();
+      if (frame == nullptr)
+      {
+        ++timeout_errors;
+        continue;
+      }
+
+      if (frame->seq != expected_seq || frame->checksum != ComputeChecksum(*frame))
+      {
+        ++sequence_errors;
+      }
+      expected_seq = frame->seq + 1U;
+
+      const double latency_us =
+          static_cast<double>(NowNs() - frame->pub_ns) / 1000.0;
+      lat_us.push_back(latency_us);
+    }
+
+    BenchStats stats = BuildStats<PayloadBytes>(lat_us, sequence_errors, timeout_errors);
+    const ssize_t written = write(stats_pipe[1], &stats, sizeof(stats));
+    (void)written;
+    close(stats_pipe[1]);
+    _exit(0);
+  }
+
+  close(stats_pipe[1]);
+
+  for (int retry = 0; retry < 500 && publisher.GetSubscriberNum() == 0; ++retry)
+  {
+    usleep(1000);
+  }
+
+  uint64_t create_retries = 0;
+  uint64_t publish_retries = 0;
+
+  const uint64_t start_ns = NowNs();
+  for (uint64_t seq = 1; seq <= count; ++seq)
+  {
+    Data data;
+    while (publisher.CreateData(data) != LibXR::ErrorCode::OK)
+    {
+      ++create_retries;
+      sched_yield();
+    }
+
+    auto* frame = data.GetData();
+      frame->seq = seq;
+      frame->pub_ns = NowNs();
+      if constexpr (TouchPayload)
+      {
+        std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU), frame->payload.size());
+      }
+      else
+      {
+        if constexpr (PayloadBytes > 0)
+        {
+          frame->payload[0] = static_cast<uint8_t>(seq & 0xFFU);
+          frame->payload[PayloadBytes - 1U] =
+              static_cast<uint8_t>((seq >> 8U) & 0xFFU);
+        }
+      }
+      frame->checksum = ComputeChecksum(*frame);
+
+    while (publisher.Publish(data) != LibXR::ErrorCode::OK)
+    {
+      ++publish_retries;
+      sched_yield();
+    }
+  }
+  const uint64_t end_ns = NowNs();
+
+  BenchStats stats = {};
+  const ssize_t read_ans = read(stats_pipe[0], &stats, sizeof(stats));
+  close(stats_pipe[0]);
+
+  int status = 0;
+  waitpid(child, &status, 0);
+
+  if (read_ans != static_cast<ssize_t>(sizeof(stats)) || !WIFEXITED(status) ||
+      WEXITSTATUS(status) != 0)
+  {
+    std::fprintf(stderr, "bench child failed for payload=%zu\n", PayloadBytes);
+    return 1;
+  }
+
+  const double total_s = static_cast<double>(end_ns - start_ns) / 1e9;
+  const double msg_per_s = static_cast<double>(count) / total_s;
+  const double mib_per_s =
+      (static_cast<double>(count) * static_cast<double>(sizeof(BenchFrame<PayloadBytes>)) /
+       (1024.0 * 1024.0)) /
+      total_s;
+  const double publish_avg_us = static_cast<double>(end_ns - start_ns) / 1000.0 /
+                                static_cast<double>(count);
+
+  std::printf(
+      "[RESULT] mode=%s payload=%zuB count=%" PRIu64
+      " publish_avg=%.3f us throughput=%.0f msg/s bandwidth=%.2f MiB/s "
+      "create_retry=%" PRIu64 " publish_retry=%" PRIu64
+      " latency_avg=%.3f us p50=%.3f us p95=%.3f us p99=%.3f us max=%.3f us "
+      "seq_err=%" PRIu64 " timeout_err=%" PRIu64 "\n",
+      TouchPayload ? "full-touch" : "transport", sizeof(BenchFrame<PayloadBytes>), count,
+      publish_avg_us, msg_per_s, mib_per_s,
+      create_retries, publish_retries, stats.avg_us, stats.p50_us, stats.p95_us, stats.p99_us,
+      stats.max_us, stats.sequence_errors, stats.timeout_errors);
+  std::fflush(stdout);
+
+  (void)Topic::Remove(topic_name);
+  return 0;
+}
+
+template <size_t PayloadBytes>
+int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
+                    uint32_t subscriber_delay_us)
+{
+  using Topic = LibXR::LinuxSharedTopic<BenchFrame<PayloadBytes>>;
+  using Data = typename Topic::Data;
+  using Subscriber = typename Topic::SyncSubscriber;
+
+  const uint64_t count = (PayloadBytes >= 1048576U) ? 256U : 4000U;
+
+  LibXR::LinuxSharedTopicConfig config = {};
+  config.subscriber_num = 1;
+  if constexpr (PayloadBytes >= 1048576U)
+  {
+    config.slot_num = 64;
+    config.queue_num = 4;
+  }
+  else
+  {
+    config.slot_num = 512;
+    config.queue_num = 8;
+  }
+
+  char topic_name[96] = {};
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shared_overload_%zu_%u_%d", PayloadBytes,
+                static_cast<unsigned>(subscriber_mode), static_cast<int>(getpid()));
+  (void)Topic::Remove(topic_name);
+
+  int done_pipe[2] = {-1, -1};
+  int stats_pipe[2] = {-1, -1};
+  if (pipe(done_pipe) != 0 || pipe(stats_pipe) != 0)
+  {
+    std::fprintf(stderr, "pipe failed: %s\n", std::strerror(errno));
+    return 1;
+  }
+
+  Topic publisher(topic_name, config);
+  if (!publisher.Valid())
+  {
+    std::fprintf(stderr, "overload publisher open failed for payload=%zu\n", PayloadBytes);
+    return 1;
+  }
+
+  pid_t child = fork();
+  if (child < 0)
+  {
+    std::fprintf(stderr, "fork failed: %s\n", std::strerror(errno));
+    return 1;
+  }
+
+  if (child == 0)
+  {
+    close(done_pipe[1]);
+    close(stats_pipe[0]);
+
+    const int flags = fcntl(done_pipe[0], F_GETFL, 0);
+    (void)fcntl(done_pipe[0], F_SETFL, flags | O_NONBLOCK);
+
+    Subscriber subscriber(topic_name, subscriber_mode);
+    if (!subscriber.Valid())
+    {
+      _exit(30);
+    }
+
+    std::vector<double> lat_us;
+    lat_us.reserve(static_cast<size_t>(count));
+    uint64_t expected_seq = 1;
+    uint64_t sequence_gap = 0;
+    uint64_t timeout_errors = 0;
+
+    while (true)
+    {
+      Data data;
+      LibXR::ErrorCode ans = subscriber.Wait(data, 100);
+      if (ans == LibXR::ErrorCode::OK)
+      {
+        const auto* frame = data.GetData();
+        if (frame == nullptr)
+        {
+          ++timeout_errors;
+          continue;
+        }
+
+        if (frame->seq > expected_seq)
+        {
+          sequence_gap += (frame->seq - expected_seq);
+        }
+        expected_seq = frame->seq + 1U;
+
+        lat_us.push_back(static_cast<double>(NowNs() - frame->pub_ns) / 1000.0);
+        if (subscriber_delay_us > 0)
+        {
+          usleep(subscriber_delay_us);
+        }
+        continue;
+      }
+
+      if (ans != LibXR::ErrorCode::TIMEOUT)
+      {
+        ++timeout_errors;
+      }
+
+      uint8_t done = 0;
+      const ssize_t read_ans = read(done_pipe[0], &done, sizeof(done));
+      if (read_ans == 0)
+      {
+        break;
+      }
+      if (read_ans < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
+      {
+        break;
+      }
+    }
+
+    OverloadStats stats = {};
+    stats.latency = BuildStats<PayloadBytes>(lat_us, 0, timeout_errors);
+    stats.sequence_gap = sequence_gap;
+    stats.subscriber_drop_num = subscriber.GetDropNum();
+    const ssize_t written = write(stats_pipe[1], &stats, sizeof(stats));
+    (void)written;
+    close(done_pipe[0]);
+    close(stats_pipe[1]);
+    _exit(0);
+  }
+
+  close(done_pipe[0]);
+  close(stats_pipe[1]);
+
+  for (int retry = 0; retry < 500 && publisher.GetSubscriberNum() == 0; ++retry)
+  {
+    usleep(1000);
+  }
+
+  uint64_t create_fail = 0;
+  uint64_t publish_fail = 0;
+  uint64_t publish_ok = 0;
+
+  const uint64_t start_ns = NowNs();
+  for (uint64_t seq = 1; seq <= count; ++seq)
+  {
+    Data data;
+    if (publisher.CreateData(data) != LibXR::ErrorCode::OK)
+    {
+      ++create_fail;
+      continue;
+    }
+
+    auto* frame = data.GetData();
+    frame->seq = seq;
+    frame->pub_ns = NowNs();
+    std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU), frame->payload.size());
+    frame->checksum = ComputeChecksum(*frame);
+
+    if (publisher.Publish(data) != LibXR::ErrorCode::OK)
+    {
+      ++publish_fail;
+      continue;
+    }
+    ++publish_ok;
+  }
+  const uint64_t end_ns = NowNs();
+
+  close(done_pipe[1]);
+
+  OverloadStats stats = {};
+  const ssize_t read_ans = read(stats_pipe[0], &stats, sizeof(stats));
+  close(stats_pipe[0]);
+
+  int status = 0;
+  waitpid(child, &status, 0);
+  if (read_ans != static_cast<ssize_t>(sizeof(stats)) || !WIFEXITED(status) ||
+      WEXITSTATUS(status) != 0)
+  {
+    std::fprintf(stderr, "overload child failed for payload=%zu\n", PayloadBytes);
+    return 1;
+  }
+
+  const double total_s = static_cast<double>(end_ns - start_ns) / 1e9;
+  const double attempt_rate = static_cast<double>(count) / total_s;
+  const double ok_rate = static_cast<double>(publish_ok) / total_s;
+  std::printf(
+      "[RESULT] overload policy=%s payload=%zuB count=%" PRIu64
+      " delay=%u us attempt_rate=%.0f msg/s ok_rate=%.0f msg/s create_fail=%" PRIu64
+      " publish_fail=%" PRIu64 " recv=%" PRIu64 " sub_drop=%" PRIu64
+      " seq_gap=%" PRIu64 " lat_avg=%.3f us p50=%.3f us p95=%.3f us p99=%.3f us max=%.3f us\n",
+      subscriber_mode == LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL ? "FULL" : "DROP_OLD",
+      sizeof(BenchFrame<PayloadBytes>), count, subscriber_delay_us, attempt_rate, ok_rate,
+      create_fail, publish_fail, stats.latency.count, stats.subscriber_drop_num,
+      stats.sequence_gap, stats.latency.avg_us, stats.latency.p50_us, stats.latency.p95_us,
+      stats.latency.p99_us, stats.latency.max_us);
+  std::fflush(stdout);
+
+  (void)Topic::Remove(topic_name);
+  return 0;
+}
+
+template <size_t PayloadBytes>
+int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscribers,
+                uint64_t count, uint32_t slot_num, uint32_t queue_num)
+{
+  using Topic = LibXR::LinuxSharedTopic<BenchFrame<PayloadBytes>>;
+  using Data = typename Topic::Data;
+  using Subscriber = typename Topic::SyncSubscriber;
+
+  LibXR::LinuxSharedTopicConfig config = {};
+  config.subscriber_num = static_cast<uint32_t>(subscribers.size());
+  config.slot_num = slot_num;
+  config.queue_num = queue_num;
+
+  char topic_name[96] = {};
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shared_modes_%zu_%d", PayloadBytes,
+                static_cast<int>(getpid()));
+  (void)Topic::Remove(topic_name);
+
+  Topic publisher(topic_name, config);
+  if (!publisher.Valid())
+  {
+    std::fprintf(stderr, "mode publisher open failed: %s payload=%zu\n", case_label,
+                 PayloadBytes);
+    return 1;
+  }
+
+  struct ChildRuntime
+  {
+    pid_t pid = -1;
+    int done_pipe[2] = {-1, -1};
+    int stats_pipe[2] = {-1, -1};
+  };
+
+  std::vector<ChildRuntime> runtimes(subscribers.size());
+
+  for (size_t i = 0; i < subscribers.size(); ++i)
+  {
+    if (pipe(runtimes[i].done_pipe) != 0 || pipe(runtimes[i].stats_pipe) != 0)
+    {
+      std::fprintf(stderr, "pipe failed for %s[%zu]: %s\n", case_label, i, std::strerror(errno));
+      return 1;
+    }
+
+    pid_t child = fork();
+    if (child < 0)
+    {
+      std::fprintf(stderr, "fork failed for %s[%zu]: %s\n", case_label, i,
+                   std::strerror(errno));
+      return 1;
+    }
+
+    if (child == 0)
+    {
+      close(runtimes[i].done_pipe[1]);
+      close(runtimes[i].stats_pipe[0]);
+
+      const int flags = fcntl(runtimes[i].done_pipe[0], F_GETFL, 0);
+      (void)fcntl(runtimes[i].done_pipe[0], F_SETFL, flags | O_NONBLOCK);
+
+      Subscriber subscriber(topic_name, subscribers[i].mode);
+      if (!subscriber.Valid())
+      {
+        _exit(60);
+      }
+
+      std::vector<double> lat_us;
+      lat_us.reserve(static_cast<size_t>(count));
+
+      ModeSubResult result = {};
+      while (true)
+      {
+        Data data;
+        const LibXR::ErrorCode ans = subscriber.Wait(data, 100);
+        if (ans == LibXR::ErrorCode::OK)
+        {
+          const auto* frame = data.GetData();
+          if (frame != nullptr)
+          {
+            if (result.recv_count == 0)
+            {
+              result.first_seq = frame->seq;
+            }
+            result.last_seq = frame->seq;
+            ++result.recv_count;
+            lat_us.push_back(static_cast<double>(NowNs() - frame->pub_ns) / 1000.0);
+          }
+          if (subscribers[i].delay_us > 0)
+          {
+            usleep(subscribers[i].delay_us);
+          }
+          continue;
+        }
+
+        if (ans != LibXR::ErrorCode::TIMEOUT)
+        {
+          ++result.timeout_errors;
+        }
+
+        uint8_t done = 0;
+        const ssize_t read_ans = read(runtimes[i].done_pipe[0], &done, sizeof(done));
+        if (read_ans == 0)
+        {
+          break;
+        }
+        if (read_ans < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
+        {
+          break;
+        }
+      }
+
+      result.latency = BuildStats<PayloadBytes>(lat_us, 0, result.timeout_errors);
+      result.drop_count = subscriber.GetDropNum();
+      const ssize_t written = write(runtimes[i].stats_pipe[1], &result, sizeof(result));
+      (void)written;
+      close(runtimes[i].done_pipe[0]);
+      close(runtimes[i].stats_pipe[1]);
+      _exit(0);
+    }
+
+    runtimes[i].pid = child;
+    close(runtimes[i].done_pipe[0]);
+    close(runtimes[i].stats_pipe[1]);
+  }
+
+  for (int retry = 0; retry < 500 && publisher.GetSubscriberNum() < subscribers.size(); ++retry)
+  {
+    usleep(1000);
+  }
+
+  uint64_t create_fail = 0;
+  uint64_t publish_fail = 0;
+  uint64_t publish_ok = 0;
+
+  const uint64_t start_ns = NowNs();
+  for (uint64_t seq = 1; seq <= count; ++seq)
+  {
+    Data data;
+    if (publisher.CreateData(data) != LibXR::ErrorCode::OK)
+    {
+      ++create_fail;
+      continue;
+    }
+
+    auto* frame = data.GetData();
+    frame->seq = seq;
+    frame->pub_ns = NowNs();
+    std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU), frame->payload.size());
+    frame->checksum = ComputeChecksum(*frame);
+
+    if (publisher.Publish(data) != LibXR::ErrorCode::OK)
+    {
+      ++publish_fail;
+      continue;
+    }
+    ++publish_ok;
+  }
+  const uint64_t end_ns = NowNs();
+
+  for (const auto& runtime : runtimes)
+  {
+    close(runtime.done_pipe[1]);
+  }
+
+  std::vector<ModeSubResult> results(subscribers.size());
+  for (size_t i = 0; i < subscribers.size(); ++i)
+  {
+    const ssize_t read_ans = read(runtimes[i].stats_pipe[0], &results[i], sizeof(results[i]));
+    close(runtimes[i].stats_pipe[0]);
+    int status = 0;
+    waitpid(runtimes[i].pid, &status, 0);
+    if (read_ans != static_cast<ssize_t>(sizeof(results[i])) || !WIFEXITED(status) ||
+        WEXITSTATUS(status) != 0)
+    {
+      std::fprintf(stderr, "mode child failed: %s[%zu]\n", case_label, i);
+      return 1;
+    }
+  }
+
+  const double total_s = static_cast<double>(end_ns - start_ns) / 1e9;
+  const double ok_rate = static_cast<double>(publish_ok) / total_s;
+  std::printf("[RESULT] modes case=%s payload=%zuB count=%" PRIu64
+              " ok_rate=%.0f msg/s create_fail=%" PRIu64 " publish_fail=%" PRIu64 "\n",
+              case_label, sizeof(BenchFrame<PayloadBytes>), count, ok_rate, create_fail,
+              publish_fail);
+
+  for (size_t i = 0; i < subscribers.size(); ++i)
+  {
+    std::printf("[RESULT] modes case=%s sub=%s mode=%u recv=%" PRIu64
+                " drop=%" PRIu64 " first=%" PRIu64 " last=%" PRIu64
+                " lat_avg=%.3f us p95=%.3f us\n",
+                case_label, subscribers[i].label, static_cast<unsigned>(subscribers[i].mode),
+                results[i].recv_count, results[i].drop_count, results[i].first_seq,
+                results[i].last_seq, results[i].latency.avg_us, results[i].latency.p95_us);
+  }
+  std::fflush(stdout);
+
+  (void)Topic::Remove(topic_name);
+  return 0;
+}
+
+}  // namespace
+
+int main()
+{
+  LibXR::PlatformInit();
+
+  int status = 0;
+  const char* bench_set = std::getenv("BENCH_SET");
+  const bool run_standard = (bench_set == nullptr) || (std::strcmp(bench_set, "standard") == 0);
+  const bool run_overload = (bench_set == nullptr) || (std::strcmp(bench_set, "overload") == 0);
+  const bool run_modes = (bench_set == nullptr) || (std::strcmp(bench_set, "modes") == 0);
+
+  if (run_standard)
+  {
+    status |= RunBenchCase<64, false>();
+    status |= RunBenchCase<64, true>();
+    status |= RunBenchCase<4096, false>();
+    status |= RunBenchCase<4096, true>();
+    status |= RunBenchCase<65536, false>();
+    status |= RunBenchCase<65536, true>();
+    status |= RunBenchCase<1048576, false>();
+    status |= RunBenchCase<1048576, true>();
+  }
+
+  if (run_overload)
+  {
+    status |= RunOverloadCase<65536>(LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 50);
+    status |=
+        RunOverloadCase<65536>(LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD, 50);
+    status |= RunOverloadCase<1048576>(LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 50);
+    status |=
+        RunOverloadCase<1048576>(LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD, 50);
+  }
+
+  if (run_modes)
+  {
+    status |= RunModeCase<65536>(
+        "broadcast_full_64k",
+        {{LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 0, "sub_a"},
+         {LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 0, "sub_b"}},
+        4000, 512, 32);
+    status |= RunModeCase<65536>(
+        "broadcast_drop_old_64k",
+        {{LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD, 50, "sub_slow"},
+         {LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD, 0, "sub_fast"}},
+        4000, 512, 8);
+    status |= RunModeCase<65536>(
+        "balance_rr_64k",
+        {{LibXR::LinuxSharedSubscriberMode::BALANCE_RR, 0, "worker_a"},
+         {LibXR::LinuxSharedSubscriberMode::BALANCE_RR, 0, "worker_b"}},
+        4000, 512, 32);
+    status |= RunModeCase<1048576>(
+        "broadcast_full_1m",
+        {{LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 0, "sub_a"},
+         {LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 0, "sub_b"}},
+        256, 64, 8);
+    status |= RunModeCase<1048576>(
+        "broadcast_drop_old_1m",
+        {{LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD, 50, "sub_slow"},
+         {LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD, 0, "sub_fast"}},
+        256, 64, 4);
+    status |= RunModeCase<1048576>(
+        "balance_rr_1m",
+        {{LibXR::LinuxSharedSubscriberMode::BALANCE_RR, 0, "worker_a"},
+         {LibXR::LinuxSharedSubscriberMode::BALANCE_RR, 0, "worker_b"}},
+        256, 64, 8);
+  }
+
+  return status;
+}

--- a/test/bench_linux_system_sync.cpp
+++ b/test/bench_linux_system_sync.cpp
@@ -1,0 +1,291 @@
+#include <array>
+#include <atomic>
+#include <cinttypes>
+#include <cstdio>
+#include <pthread.h>
+#include <time.h>
+
+#include "linux_timebase.hpp"
+#include "libxr.hpp"
+
+extern struct timespec libxr_linux_start_time_spec;
+
+namespace
+{
+
+uint64_t NowMonotonicNs()
+{
+  timespec ts = {};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1000000000ULL +
+         static_cast<uint64_t>(ts.tv_nsec);
+}
+
+void InitMinimalLinuxTimebase()
+{
+  static bool initialized = false;
+  static LibXR::LinuxTimebase timebase;
+  if (initialized)
+  {
+    return;
+  }
+
+  clock_gettime(CLOCK_MONOTONIC, &libxr_linux_start_time_spec);
+  initialized = true;
+  UNUSED(timebase);
+}
+
+void JoinThreadIfNeeded(LibXR::Thread& thread)
+{
+#if defined(LIBXR_SYSTEM_Linux) || defined(LIBXR_SYSTEM_Webots)
+  pthread_join(thread, nullptr);
+#else
+  UNUSED(thread);
+#endif
+}
+
+struct MutexWorkerContext
+{
+  LibXR::Mutex* mutex = nullptr;
+  std::atomic<uint64_t>* counter = nullptr;
+  LibXR::Semaphore* done = nullptr;
+  uint64_t iterations = 0;
+  int failure = 0;
+};
+
+void MutexWorker(MutexWorkerContext* ctx)
+{
+  for (uint64_t i = 0; i < ctx->iterations; ++i)
+  {
+    if (ctx->mutex->Lock() != ErrorCode::OK)
+    {
+      ctx->failure = 1;
+      break;
+    }
+
+    ctx->counter->fetch_add(1, std::memory_order_relaxed);
+    ctx->mutex->Unlock();
+  }
+
+  ctx->done->Post();
+}
+
+struct SemaphoreProducerContext
+{
+  LibXR::Semaphore* sem = nullptr;
+  LibXR::Semaphore* done = nullptr;
+  uint64_t iterations = 0;
+};
+
+void SemaphoreProducer(SemaphoreProducerContext* ctx)
+{
+  for (uint64_t i = 0; i < ctx->iterations; ++i)
+  {
+    ctx->sem->Post();
+  }
+
+  ctx->done->Post();
+}
+
+struct SemaphoreConsumerContext
+{
+  LibXR::Semaphore* sem = nullptr;
+  LibXR::Semaphore* done = nullptr;
+  uint64_t iterations = 0;
+  int failure = 0;
+};
+
+void SemaphoreConsumer(SemaphoreConsumerContext* ctx)
+{
+  for (uint64_t i = 0; i < ctx->iterations; ++i)
+  {
+    if (ctx->sem->Wait(10000) != ErrorCode::OK)
+    {
+      ctx->failure = 1;
+      break;
+    }
+  }
+
+  ctx->done->Post();
+}
+
+int RunMutexStress()
+{
+  constexpr size_t kThreadNum = 4;
+  constexpr uint64_t kIterationsPerThread = 200000;
+  constexpr size_t kThreadStackBytes = 8192;
+
+  LibXR::Mutex mutex;
+  std::atomic<uint64_t> counter(0);
+  LibXR::Semaphore done(0);
+  std::array<LibXR::Thread, kThreadNum> threads = {};
+  std::array<MutexWorkerContext, kThreadNum> ctx = {};
+
+  for (size_t i = 0; i < kThreadNum; ++i)
+  {
+    ctx[i].mutex = &mutex;
+    ctx[i].counter = &counter;
+    ctx[i].done = &done;
+    ctx[i].iterations = kIterationsPerThread;
+    threads[i].Create<MutexWorkerContext*>(&ctx[i], MutexWorker, "mtx_stress", kThreadStackBytes,
+                                           LibXR::Thread::Priority::MEDIUM);
+  }
+
+  const uint64_t start_ns = NowMonotonicNs();
+  for (size_t i = 0; i < kThreadNum; ++i)
+  {
+    if (done.Wait(10000) != ErrorCode::OK)
+    {
+      return 1;
+    }
+  }
+  const uint64_t end_ns = NowMonotonicNs();
+
+  for (auto& thread : threads)
+  {
+    JoinThreadIfNeeded(thread);
+  }
+
+  for (const auto& item : ctx)
+  {
+    if (item.failure != 0)
+    {
+      return 2;
+    }
+  }
+
+  const uint64_t expected = kThreadNum * kIterationsPerThread;
+  if (counter.load(std::memory_order_relaxed) != expected)
+  {
+    return 3;
+  }
+
+  std::printf("[RESULT] mutex_stress threads=%zu iterations=%" PRIu64
+              " counter=%" PRIu64 " wall_ms=%.3f\n",
+              kThreadNum, kIterationsPerThread, counter.load(std::memory_order_relaxed),
+              static_cast<double>(end_ns - start_ns) / 1000000.0);
+  return 0;
+}
+
+int RunSemaphoreStress()
+{
+  constexpr size_t kProducerNum = 4;
+  constexpr size_t kConsumerNum = 1;
+  constexpr uint64_t kIterationsPerProducer = 50000;
+  constexpr uint64_t kTotalPosts = kProducerNum * kIterationsPerProducer;
+  constexpr size_t kThreadStackBytes = 8192;
+
+  LibXR::Semaphore sem(0);
+  LibXR::Semaphore producer_done(0);
+  LibXR::Semaphore consumer_done(0);
+  std::array<LibXR::Thread, kProducerNum> producers = {};
+  std::array<LibXR::Thread, kConsumerNum> consumers = {};
+  std::array<SemaphoreProducerContext, kProducerNum> producer_ctx = {};
+  std::array<SemaphoreConsumerContext, kConsumerNum> consumer_ctx = {};
+
+  for (size_t i = 0; i < kConsumerNum; ++i)
+  {
+    consumer_ctx[i].sem = &sem;
+    consumer_ctx[i].done = &consumer_done;
+    consumer_ctx[i].iterations = kTotalPosts / kConsumerNum;
+    consumers[i].Create<SemaphoreConsumerContext*>(&consumer_ctx[i], SemaphoreConsumer,
+                                                  "sem_cons", kThreadStackBytes,
+                                                  LibXR::Thread::Priority::MEDIUM);
+  }
+
+  for (size_t i = 0; i < kProducerNum; ++i)
+  {
+    producer_ctx[i].sem = &sem;
+    producer_ctx[i].done = &producer_done;
+    producer_ctx[i].iterations = kIterationsPerProducer;
+    producers[i].Create<SemaphoreProducerContext*>(&producer_ctx[i], SemaphoreProducer,
+                                                  "sem_prod", kThreadStackBytes,
+                                                  LibXR::Thread::Priority::MEDIUM);
+  }
+
+  const uint64_t start_ns = NowMonotonicNs();
+  for (size_t i = 0; i < kProducerNum; ++i)
+  {
+    if (producer_done.Wait(10000) != ErrorCode::OK)
+    {
+      return 10;
+    }
+  }
+
+  for (size_t i = 0; i < kConsumerNum; ++i)
+  {
+    if (consumer_done.Wait(10000) != ErrorCode::OK)
+    {
+      return 11;
+    }
+  }
+  const uint64_t end_ns = NowMonotonicNs();
+
+  for (auto& thread : producers)
+  {
+    JoinThreadIfNeeded(thread);
+  }
+  for (auto& thread : consumers)
+  {
+    JoinThreadIfNeeded(thread);
+  }
+
+  for (const auto& item : consumer_ctx)
+  {
+    if (item.failure != 0)
+    {
+      return 12;
+    }
+  }
+
+  std::printf("[RESULT] semaphore_stress producers=%zu consumers=%zu posts=%" PRIu64
+              " consumed=%" PRIu64 " wall_ms=%.3f\n",
+              kProducerNum, kConsumerNum, kTotalPosts, kTotalPosts,
+              static_cast<double>(end_ns - start_ns) / 1000000.0);
+  return 0;
+}
+
+int RunThreadSleepStress()
+{
+  constexpr uint32_t kStepMs = 2;
+  constexpr uint32_t kIterations = 200;
+
+  const uint64_t start_ns = NowMonotonicNs();
+  LibXR::MillisecondTimestamp wake = LibXR::Thread::GetTime();
+  uint32_t last_tick = wake;
+
+  for (uint32_t i = 0; i < kIterations; ++i)
+  {
+    LibXR::Thread::SleepUntil(wake, kStepMs);
+    const uint32_t now_tick = LibXR::Thread::GetTime();
+    if (now_tick < last_tick)
+    {
+      return 20;
+    }
+    last_tick = now_tick;
+  }
+
+  const uint64_t end_ns = NowMonotonicNs();
+  const uint64_t elapsed_ms = (end_ns - start_ns) / 1000000ULL;
+  if (elapsed_ms + 20U < static_cast<uint64_t>(kIterations) * kStepMs)
+  {
+    return 21;
+  }
+
+  std::printf("[RESULT] thread_sleep_stress iterations=%u step_ms=%u elapsed_ms=%" PRIu64 "\n",
+              kIterations, kStepMs, elapsed_ms);
+  return 0;
+}
+
+}  // namespace
+
+int main()
+{
+  InitMinimalLinuxTimebase();
+
+  int status = 0;
+  status |= RunMutexStress();
+  status |= RunSemaphoreStress();
+  status |= RunThreadSleepStress();
+  return status;
+}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -3,6 +3,8 @@
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include "libxr.hpp"
 #include "logger.hpp"
@@ -26,58 +28,87 @@ struct TestCase
 {
   const char* name;
   void (*function)();
+  bool isolated;
 };
+
+static void run_test_case(const TestCase& test_case)
+{
+  test_name = test_case.name;
+
+  if (!test_case.isolated)
+  {
+    test_case.function();
+    return;
+  }
+
+  pid_t child = fork();
+  ASSERT(child >= 0);
+
+  if (child == 0)
+  {
+    test_case.function();
+    _exit(0);
+  }
+
+  int status = 0;
+  ASSERT(waitpid(child, &status, 0) == child);
+  ASSERT(WIFEXITED(status));
+  ASSERT(WEXITSTATUS(status) == 0);
+}
 
 static void run_libxr_tests()
 {
   XR_LOG_INFO("Running LibXR Tests...\n");
 
   TestCase core_tests[] = {
-      {"callback", test_cb},
-      {"pipe", test_pipe},
-      {"rw", test_rw},
-      {"memory", test_memory},
+      {"callback", test_cb, false},
+      {"pipe", test_pipe, false},
+      {"rw", test_rw, false},
+      {"memory", test_memory, false},
   };
 
   TestCase synchronization_tests[] = {
-      {"semaphore", test_semaphore},
-      {"async", test_async},
+      {"semaphore", test_semaphore, false},
+      {"mutex", test_mutex, false},
+      {"async", test_async, false},
   };
 
   TestCase utility_tests[] = {
-      {"crc", test_crc},
-      {"encoder", test_float_encoder},
-      {"cycle_value", test_cycle_value},
+      {"crc", test_crc, false},
+      {"encoder", test_float_encoder, false},
+      {"cycle_value", test_cycle_value, false},
   };
 
-  TestCase data_structure_tests[] = {{"rbt", test_rbt},
-                                     {"queue", test_queue},
-                                     {"pool", test_lock_free_pool},
-                                     {"stack", test_stack},
-                                     {"list", test_list},
-                                     {"double_buffer", test_double_buffer},
-                                     {"string", test_string}};
+  TestCase data_structure_tests[] = {{"rbt", test_rbt, false},
+                                     {"queue", test_queue, false},
+                                     {"pool", test_lock_free_pool, false},
+                                     {"stack", test_stack, false},
+                                     {"list", test_list, false},
+                                     {"double_buffer", test_double_buffer, false},
+                                     {"string", test_string, false}};
 
   TestCase threading_tests[] = {
-      {"thread", test_thread},
-      {"timebase", test_timebase},
-      {"timer", test_timer},
+      {"thread", test_thread, false},
+      {"timebase", test_timebase, false},
+      {"timer", test_timer, false},
   };
 
   TestCase motion_tests[] = {
-      {"inertia", test_inertia},
-      {"kinematic", test_kinematic},
-      {"transform", test_transform},
+      {"inertia", test_inertia, false},
+      {"kinematic", test_kinematic, false},
+      {"transform", test_transform, false},
   };
 
   TestCase control_tests[] = {
-      {"pid", test_pid},
+      {"pid", test_pid, false},
   };
 
-  TestCase system_tests[] = {
-      {"ramfs", test_ramfs},       {"event", test_event},       {"message", test_message},
-      {"database", test_database}, {"terminal", test_terminal},
-  };
+  TestCase system_tests[] = {{"ramfs", test_ramfs, false},
+                             {"event", test_event, false},
+                             {"message", test_message, false},
+                             {"database", test_database, false},
+                             {"terminal", test_terminal, true},
+                             {"linux_shm_topic", test_linux_shm_topic, true}};
 
   struct
   {
@@ -110,7 +141,7 @@ static void run_libxr_tests()
     XR_LOG_INFO("Test Group [%s]\n", test_groups[g].name);
     for (size_t i = 0; i < group_sizes[g]; ++i)
     {
-      test_groups[g].tests[i].function();
+      run_test_case(test_groups[g].tests[i]);
       TEST_STEP(test_groups[g].tests[i].name);
     }
   }

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -11,6 +11,7 @@ void test_lock_free_pool();
 void test_rbt();
 void test_ramfs();
 void test_semaphore();
+void test_mutex();
 void test_stack();
 void test_terminal();
 void test_thread();
@@ -26,5 +27,6 @@ void test_pipe();
 void test_rw();
 void test_cb();
 void test_memory();
+void test_linux_shm_topic();
 
 bool equal(double a, double b);

--- a/test/test_linux_shm_topic.cpp
+++ b/test/test_linux_shm_topic.cpp
@@ -1,0 +1,733 @@
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "libxr.hpp"
+#include "test.hpp"
+
+namespace
+{
+
+struct IPCFrame
+{
+  uint32_t seq = 0;
+  uint32_t checksum = 0;
+  std::array<uint8_t, 128> payload = {};
+};
+
+uint32_t ComputeChecksum(const IPCFrame& frame)
+{
+  uint32_t sum = frame.seq;
+  for (uint8_t byte : frame.payload)
+  {
+    sum = sum * 131U + byte;
+  }
+  return sum;
+}
+
+void FillFrame(IPCFrame& frame, uint32_t seq)
+{
+  frame.seq = seq;
+  for (size_t i = 0; i < frame.payload.size(); ++i)
+  {
+    frame.payload[i] = static_cast<uint8_t>((seq + i * 3U) & 0xFFU);
+  }
+  frame.checksum = ComputeChecksum(frame);
+}
+
+void AssertFrame(const IPCFrame& frame, uint32_t expected_seq)
+{
+  ASSERT(frame.seq == expected_seq);
+  ASSERT(frame.checksum == ComputeChecksum(frame));
+}
+
+}  // namespace
+
+void test_linux_shm_topic()
+{
+  using SharedTopic = LibXR::LinuxSharedTopic<IPCFrame>;
+  using SharedData = SharedTopic::Data;
+  using SharedSubscriber = SharedTopic::SyncSubscriber;
+
+  char topic_name[96] = {};
+
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_local_%d",
+                static_cast<int>(getpid()));
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  {
+    LibXR::LinuxSharedTopicConfig config;
+    config.slot_num = 2;
+    config.subscriber_num = 2;
+    config.queue_num = 4;
+
+    SharedTopic publisher(topic_name, config);
+    ASSERT(publisher.Valid());
+
+    SharedSubscriber subscriber(topic_name);
+    ASSERT(subscriber.Valid());
+    ASSERT(publisher.GetSubscriberNum() == 1);
+
+    SharedTopic attach_only(topic_name);
+    ASSERT(attach_only.Valid());
+    SharedData attach_data;
+    ASSERT(attach_only.CreateData(attach_data) == ErrorCode::STATE_ERR);
+
+    SharedData data0;
+    ASSERT(publisher.CreateData(data0) == ErrorCode::OK);
+    FillFrame(*data0.GetData(), 100);
+    ASSERT(publisher.Publish(data0) == ErrorCode::OK);
+
+    SharedData data1;
+    ASSERT(publisher.CreateData(data1) == ErrorCode::OK);
+    FillFrame(*data1.GetData(), 101);
+    ASSERT(publisher.Publish(data1) == ErrorCode::OK);
+
+    SharedData data2;
+    ASSERT(publisher.CreateData(data2) == ErrorCode::FULL);
+
+    ASSERT(subscriber.Wait(100) == ErrorCode::OK);
+    ASSERT(subscriber.GetData() != nullptr);
+    AssertFrame(*subscriber.GetData(), 100);
+    ASSERT(subscriber.GetPendingNum() == 1);
+    subscriber.Release();
+
+    ASSERT(publisher.CreateData(data2) == ErrorCode::OK);
+    FillFrame(*data2.GetData(), 102);
+    ASSERT(publisher.Publish(data2) == ErrorCode::OK);
+
+    ASSERT(subscriber.Wait(100) == ErrorCode::OK);
+    ASSERT(subscriber.GetData() != nullptr);
+    AssertFrame(*subscriber.GetData(), 101);
+    subscriber.Release();
+
+    ASSERT(subscriber.Wait(100) == ErrorCode::OK);
+    ASSERT(subscriber.GetData() != nullptr);
+    AssertFrame(*subscriber.GetData(), 102);
+    ASSERT(subscriber.GetPendingNum() == 0);
+    subscriber.Release();
+  }
+
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_takeover_%d",
+                static_cast<int>(getpid()));
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  {
+    LibXR::LinuxSharedTopicConfig config;
+    config.slot_num = 4;
+    config.subscriber_num = 1;
+    config.queue_num = 4;
+
+    pid_t child = fork();
+    ASSERT(child >= 0);
+
+    if (child == 0)
+    {
+      SharedTopic publisher(topic_name, config);
+      if (!publisher.Valid())
+      {
+        _exit(20);
+      }
+
+      IPCFrame frame = {};
+      FillFrame(frame, 150);
+      if (publisher.Publish(frame) != ErrorCode::OK)
+      {
+        _exit(21);
+      }
+
+      _exit(0);
+    }
+
+    int status = 0;
+    ASSERT(waitpid(child, &status, 0) == child);
+    ASSERT(WIFEXITED(status));
+    ASSERT(WEXITSTATUS(status) == 0);
+
+    SharedTopic publisher(topic_name, config);
+    ASSERT(publisher.Valid());
+
+    IPCFrame frame = {};
+    FillFrame(frame, 151);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+  }
+
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_queue_%d",
+                static_cast<int>(getpid()));
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  {
+    LibXR::LinuxSharedTopicConfig config;
+    config.slot_num = 8;
+    config.subscriber_num = 1;
+    config.queue_num = 3;
+
+    SharedTopic publisher(topic_name, config);
+    ASSERT(publisher.Valid());
+
+    SharedSubscriber subscriber(topic_name);
+    ASSERT(subscriber.Valid());
+
+    IPCFrame frame = {};
+    FillFrame(frame, 201);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+    FillFrame(frame, 202);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+    FillFrame(frame, 203);
+    ASSERT(publisher.Publish(frame) == ErrorCode::FULL);
+
+    ASSERT(subscriber.GetPendingNum() == 2);
+    ASSERT(subscriber.GetDropNum() == 1);
+    ASSERT(publisher.GetPublishFailedNum() == 1);
+
+    SharedData recv_data;
+    ASSERT(subscriber.Wait(recv_data, 100) == ErrorCode::OK);
+    ASSERT(recv_data.GetSequence() == 1);
+    AssertFrame(*recv_data.GetData(), 201);
+    recv_data.Reset();
+
+    ASSERT(subscriber.Wait(recv_data, 100) == ErrorCode::OK);
+    ASSERT(recv_data.GetSequence() == 2);
+    AssertFrame(*recv_data.GetData(), 202);
+    recv_data.Reset();
+  }
+
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_drop_old_%d",
+                static_cast<int>(getpid()));
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  {
+    LibXR::LinuxSharedTopicConfig config;
+    config.slot_num = 8;
+    config.subscriber_num = 1;
+    config.queue_num = 3;
+
+    SharedTopic publisher(topic_name, config);
+    ASSERT(publisher.Valid());
+
+    SharedSubscriber subscriber(topic_name, LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD);
+    ASSERT(subscriber.Valid());
+
+    IPCFrame frame = {};
+    FillFrame(frame, 211);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+    FillFrame(frame, 212);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+    FillFrame(frame, 213);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+
+    ASSERT(subscriber.GetPendingNum() == 2);
+    ASSERT(subscriber.GetDropNum() == 1);
+    ASSERT(publisher.GetPublishFailedNum() == 0);
+
+    SharedData recv_data;
+    ASSERT(subscriber.Wait(recv_data, 100) == ErrorCode::OK);
+    ASSERT(recv_data.GetSequence() == 2);
+    AssertFrame(*recv_data.GetData(), 212);
+    recv_data.Reset();
+
+    ASSERT(subscriber.Wait(recv_data, 100) == ErrorCode::OK);
+    ASSERT(recv_data.GetSequence() == 3);
+    AssertFrame(*recv_data.GetData(), 213);
+    recv_data.Reset();
+  }
+
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_ref_%d",
+                static_cast<int>(getpid()));
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  {
+    LibXR::LinuxSharedTopicConfig config;
+    config.slot_num = 1;
+    config.subscriber_num = 2;
+    config.queue_num = 4;
+
+    SharedTopic publisher(topic_name, config);
+    ASSERT(publisher.Valid());
+
+    SharedSubscriber subscriber_a(topic_name);
+    SharedSubscriber subscriber_b(topic_name);
+    ASSERT(subscriber_a.Valid());
+    ASSERT(subscriber_b.Valid());
+
+    IPCFrame frame = {};
+    FillFrame(frame, 301);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+
+    ASSERT(subscriber_a.Wait(100) == ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(100) == ErrorCode::OK);
+    AssertFrame(*subscriber_a.GetData(), 301);
+    AssertFrame(*subscriber_b.GetData(), 301);
+
+    subscriber_a.Release();
+
+    SharedData blocked_data;
+    ASSERT(publisher.CreateData(blocked_data) == ErrorCode::FULL);
+
+    subscriber_b.Release();
+    ASSERT(publisher.CreateData(blocked_data) == ErrorCode::OK);
+    FillFrame(*blocked_data.GetData(), 302);
+    ASSERT(publisher.Publish(blocked_data) == ErrorCode::OK);
+
+    ASSERT(subscriber_a.Wait(100) == ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(100) == ErrorCode::OK);
+    AssertFrame(*subscriber_a.GetData(), 302);
+    AssertFrame(*subscriber_b.GetData(), 302);
+    subscriber_a.Release();
+    subscriber_b.Release();
+  }
+
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_bal_rr_%d",
+                static_cast<int>(getpid()));
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  {
+    LibXR::LinuxSharedTopicConfig config;
+    config.slot_num = 4;
+    config.subscriber_num = 2;
+    config.queue_num = 4;
+
+    SharedTopic publisher(topic_name, config);
+    ASSERT(publisher.Valid());
+
+    SharedSubscriber subscriber_a(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    SharedSubscriber subscriber_b(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    ASSERT(subscriber_a.Valid());
+    ASSERT(subscriber_b.Valid());
+
+    IPCFrame frame = {};
+    FillFrame(frame, 351);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+    FillFrame(frame, 352);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+    FillFrame(frame, 353);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+    FillFrame(frame, 354);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+
+    SharedData recv_a1;
+    SharedData recv_a2;
+    SharedData recv_b1;
+    SharedData recv_b2;
+
+    ASSERT(subscriber_a.Wait(recv_a1, 100) == ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(recv_b1, 100) == ErrorCode::OK);
+    ASSERT(subscriber_a.Wait(recv_a2, 100) == ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(recv_b2, 100) == ErrorCode::OK);
+
+    ASSERT(recv_a1.GetData()->seq == 351);
+    ASSERT(recv_b1.GetData()->seq == 352);
+    ASSERT(recv_a2.GetData()->seq == 353);
+    ASSERT(recv_b2.GetData()->seq == 354);
+  }
+
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_bal_rr_dead_%d",
+                static_cast<int>(getpid()));
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  {
+    LibXR::LinuxSharedTopicConfig config;
+    config.slot_num = 8;
+    config.subscriber_num = 2;
+    config.queue_num = 4;
+
+    SharedTopic publisher(topic_name, config);
+    ASSERT(publisher.Valid());
+
+    int ack_pipe[2] = {-1, -1};
+    int cmd_pipe[2] = {-1, -1};
+    ASSERT(pipe(ack_pipe) == 0);
+    ASSERT(pipe(cmd_pipe) == 0);
+
+    pid_t child = fork();
+    ASSERT(child >= 0);
+
+    if (child == 0)
+    {
+      close(ack_pipe[0]);
+      close(cmd_pipe[1]);
+
+      SharedSubscriber subscriber(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+      if (!subscriber.Valid())
+      {
+        _exit(40);
+      }
+
+      SharedData data;
+      if (subscriber.Wait(data, 2000) != ErrorCode::OK)
+      {
+        _exit(41);
+      }
+
+      const uint32_t seq = data.GetData()->seq;
+      if (write(ack_pipe[1], &seq, sizeof(seq)) != static_cast<ssize_t>(sizeof(seq)))
+      {
+        _exit(42);
+      }
+
+      uint8_t cmd = 0;
+      if (read(cmd_pipe[0], &cmd, sizeof(cmd)) != static_cast<ssize_t>(sizeof(cmd)))
+      {
+        _exit(43);
+      }
+
+      _exit(0);
+    }
+
+    close(ack_pipe[1]);
+    close(cmd_pipe[0]);
+
+    SharedSubscriber subscriber_alive(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    ASSERT(subscriber_alive.Valid());
+
+    IPCFrame frame = {};
+    FillFrame(frame, 361);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+
+    uint32_t first_seq = 0;
+    ASSERT(read(ack_pipe[0], &first_seq, sizeof(first_seq)) ==
+           static_cast<ssize_t>(sizeof(first_seq)));
+    ASSERT(first_seq == 361);
+
+    uint8_t cmd = 0xA5;
+    ASSERT(write(cmd_pipe[1], &cmd, sizeof(cmd)) == static_cast<ssize_t>(sizeof(cmd)));
+
+    int status = 0;
+    ASSERT(waitpid(child, &status, 0) == child);
+    ASSERT(WIFEXITED(status));
+    ASSERT(WEXITSTATUS(status) == 0);
+
+    FillFrame(frame, 362);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+    FillFrame(frame, 363);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+
+    SharedData recv_alive1;
+    SharedData recv_alive2;
+    ASSERT(subscriber_alive.Wait(recv_alive1, 2000) == ErrorCode::OK);
+    ASSERT(subscriber_alive.Wait(recv_alive2, 2000) == ErrorCode::OK);
+    ASSERT(recv_alive1.GetData()->seq == 362);
+    ASSERT(recv_alive2.GetData()->seq == 363);
+
+    close(ack_pipe[0]);
+    close(cmd_pipe[1]);
+  }
+
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_bal_rr_skip_full_%d",
+                static_cast<int>(getpid()));
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  {
+    LibXR::LinuxSharedTopicConfig config;
+    config.slot_num = 8;
+    config.subscriber_num = 3;
+    config.queue_num = 2;
+
+    SharedTopic publisher(topic_name, config);
+    ASSERT(publisher.Valid());
+
+    SharedSubscriber subscriber_a(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    SharedSubscriber subscriber_b(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    SharedSubscriber subscriber_c(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    ASSERT(subscriber_a.Valid());
+    ASSERT(subscriber_b.Valid());
+    ASSERT(subscriber_c.Valid());
+
+    IPCFrame frame = {};
+    FillFrame(frame, 371);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+    FillFrame(frame, 372);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+    FillFrame(frame, 373);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+
+    SharedData recv_b0;
+    ASSERT(subscriber_b.Wait(recv_b0, 100) == ErrorCode::OK);
+    ASSERT(recv_b0.GetData()->seq == 372);
+    recv_b0.Reset();
+
+    FillFrame(frame, 374);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+
+    SharedData recv_a;
+    SharedData recv_b1;
+    SharedData recv_c;
+    ASSERT(subscriber_a.Wait(recv_a, 100) == ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(recv_b1, 100) == ErrorCode::OK);
+    ASSERT(subscriber_c.Wait(recv_c, 100) == ErrorCode::OK);
+
+    ASSERT(recv_a.GetData()->seq == 371);
+    ASSERT(recv_b1.GetData()->seq == 374);
+    ASSERT(recv_c.GetData()->seq == 373);
+  }
+
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_mixed_modes_%d",
+                static_cast<int>(getpid()));
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  {
+    LibXR::LinuxSharedTopicConfig config;
+    config.slot_num = 8;
+    config.subscriber_num = 3;
+    config.queue_num = 4;
+
+    SharedTopic publisher(topic_name, config);
+    ASSERT(publisher.Valid());
+
+    SharedSubscriber subscriber_broadcast(topic_name);
+    SharedSubscriber subscriber_rr_a(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    SharedSubscriber subscriber_rr_b(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    ASSERT(subscriber_broadcast.Valid());
+    ASSERT(subscriber_rr_a.Valid());
+    ASSERT(subscriber_rr_b.Valid());
+
+    IPCFrame frame = {};
+    FillFrame(frame, 381);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+    FillFrame(frame, 382);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+    FillFrame(frame, 383);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+
+    SharedData bc0;
+    SharedData bc1;
+    SharedData bc2;
+    ASSERT(subscriber_broadcast.Wait(bc0, 100) == ErrorCode::OK);
+    ASSERT(subscriber_broadcast.Wait(bc1, 100) == ErrorCode::OK);
+    ASSERT(subscriber_broadcast.Wait(bc2, 100) == ErrorCode::OK);
+    ASSERT(bc0.GetData()->seq == 381);
+    ASSERT(bc1.GetData()->seq == 382);
+    ASSERT(bc2.GetData()->seq == 383);
+
+    SharedData rr_a0;
+    SharedData rr_b0;
+    SharedData rr_a1;
+    ASSERT(subscriber_rr_a.Wait(rr_a0, 100) == ErrorCode::OK);
+    ASSERT(subscriber_rr_b.Wait(rr_b0, 100) == ErrorCode::OK);
+    ASSERT(subscriber_rr_a.Wait(rr_a1, 100) == ErrorCode::OK);
+    ASSERT(rr_a0.GetData()->seq == 381);
+    ASSERT(rr_b0.GetData()->seq == 382);
+    ASSERT(rr_a1.GetData()->seq == 383);
+  }
+
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_rr_group_required_%d",
+                static_cast<int>(getpid()));
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  {
+    LibXR::LinuxSharedTopicConfig config;
+    config.slot_num = 4;
+    config.subscriber_num = 2;
+    config.queue_num = 2;
+
+    SharedTopic publisher(topic_name, config);
+    ASSERT(publisher.Valid());
+
+    SharedSubscriber subscriber_broadcast(topic_name);
+    SharedSubscriber subscriber_rr(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    ASSERT(subscriber_broadcast.Valid());
+    ASSERT(subscriber_rr.Valid());
+
+    IPCFrame frame = {};
+    FillFrame(frame, 391);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+
+    FillFrame(frame, 392);
+    ASSERT(publisher.Publish(frame) == ErrorCode::FULL);
+
+    SharedData bc0;
+    ASSERT(subscriber_broadcast.Wait(bc0, 100) == ErrorCode::OK);
+    ASSERT(bc0.GetData()->seq == 391);
+
+    SharedData rr0;
+    ASSERT(subscriber_rr.Wait(rr0, 100) == ErrorCode::OK);
+    ASSERT(rr0.GetData()->seq == 391);
+  }
+
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_dead_sub_%d",
+                static_cast<int>(getpid()));
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  {
+    LibXR::LinuxSharedTopicConfig config;
+    config.slot_num = 2;
+    config.subscriber_num = 1;
+    config.queue_num = 4;
+
+    SharedTopic publisher(topic_name, config);
+    ASSERT(publisher.Valid());
+
+    int ack_pipe[2] = {-1, -1};
+    int cmd_pipe[2] = {-1, -1};
+    ASSERT(pipe(ack_pipe) == 0);
+    ASSERT(pipe(cmd_pipe) == 0);
+
+    pid_t child = fork();
+    ASSERT(child >= 0);
+
+    if (child == 0)
+    {
+      close(ack_pipe[0]);
+      close(cmd_pipe[1]);
+
+      SharedSubscriber subscriber(topic_name);
+      if (!subscriber.Valid())
+      {
+        _exit(10);
+      }
+
+      SharedData recv_data;
+      if (subscriber.Wait(recv_data, 2000) != ErrorCode::OK)
+      {
+        _exit(11);
+      }
+
+      uint8_t ack = 0xA5;
+      if (write(ack_pipe[1], &ack, sizeof(ack)) != static_cast<ssize_t>(sizeof(ack)))
+      {
+        _exit(12);
+      }
+
+      uint8_t cmd = 0;
+      if (read(cmd_pipe[0], &cmd, sizeof(cmd)) != static_cast<ssize_t>(sizeof(cmd)))
+      {
+        _exit(13);
+      }
+
+      _exit(0);
+    }
+
+    close(ack_pipe[1]);
+    close(cmd_pipe[0]);
+
+    for (int retry = 0; retry < 200 && publisher.GetSubscriberNum() == 0; ++retry)
+    {
+      usleep(10000);
+    }
+    ASSERT(publisher.GetSubscriberNum() == 1);
+
+    IPCFrame frame = {};
+    FillFrame(frame, 401);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+
+    uint8_t ack = 0;
+    ASSERT(read(ack_pipe[0], &ack, sizeof(ack)) == static_cast<ssize_t>(sizeof(ack)));
+
+    FillFrame(frame, 402);
+    ASSERT(publisher.Publish(frame) == ErrorCode::OK);
+
+    uint8_t cmd = 0x5A;
+    ASSERT(write(cmd_pipe[1], &cmd, sizeof(cmd)) == static_cast<ssize_t>(sizeof(cmd)));
+
+    int status = 0;
+    ASSERT(waitpid(child, &status, 0) == child);
+    ASSERT(WIFEXITED(status));
+    ASSERT(WEXITSTATUS(status) == 0);
+    ASSERT(publisher.GetSubscriberNum() == 0);
+
+    SharedData data0;
+    SharedData data1;
+    SharedData data2;
+    ASSERT(publisher.CreateData(data0) == ErrorCode::OK);
+    ASSERT(publisher.CreateData(data1) == ErrorCode::OK);
+    ASSERT(publisher.CreateData(data2) == ErrorCode::FULL);
+
+    close(ack_pipe[0]);
+    close(cmd_pipe[1]);
+  }
+
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_fork_%d",
+                static_cast<int>(getpid()));
+  UNUSED(SharedTopic::Remove(topic_name));
+
+  {
+    LibXR::LinuxSharedTopicConfig config;
+    config.slot_num = 64;
+    config.subscriber_num = 4;
+    config.queue_num = 64;
+
+    SharedTopic publisher(topic_name, config);
+    ASSERT(publisher.Valid());
+
+    pid_t child = fork();
+    ASSERT(child >= 0);
+
+    if (child == 0)
+    {
+      SharedSubscriber subscriber(topic_name);
+      if (!subscriber.Valid())
+      {
+        _exit(2);
+      }
+
+      for (uint32_t seq = 1; seq <= 32; ++seq)
+      {
+        SharedData recv_data;
+        if (subscriber.Wait(recv_data, 2000) != ErrorCode::OK)
+        {
+          _exit(3);
+        }
+
+        const IPCFrame* frame = recv_data.GetData();
+        if (frame == nullptr)
+        {
+          _exit(4);
+        }
+
+        if (recv_data.GetSequence() != seq || frame->seq != seq ||
+            frame->checksum != ComputeChecksum(*frame))
+        {
+          _exit(5);
+        }
+      }
+
+      _exit(0);
+    }
+
+    for (int retry = 0; retry < 200 && publisher.GetSubscriberNum() == 0; ++retry)
+    {
+      usleep(10000);
+    }
+    ASSERT(publisher.GetSubscriberNum() == 1);
+
+    for (uint32_t seq = 1; seq <= 32; ++seq)
+    {
+      SharedData data;
+      ASSERT(publisher.CreateData(data) == ErrorCode::OK);
+      FillFrame(*data.GetData(), seq);
+      ASSERT(publisher.Publish(data) == ErrorCode::OK);
+    }
+
+    int status = 0;
+    ASSERT(waitpid(child, &status, 0) == child);
+    ASSERT(WIFEXITED(status));
+    ASSERT(WEXITSTATUS(status) == 0);
+  }
+
+  UNUSED(SharedTopic::Remove(topic_name));
+}

--- a/test/test_mutex.cpp
+++ b/test/test_mutex.cpp
@@ -1,0 +1,62 @@
+#include <atomic>
+#include <pthread.h>
+
+#include "libxr.hpp"
+#include "libxr_def.hpp"
+#include "test.hpp"
+
+namespace
+{
+
+void JoinThreadIfNeeded(LibXR::Thread& thread)
+{
+#if defined(LIBXR_SYSTEM_Linux) || defined(LIBXR_SYSTEM_Webots)
+  pthread_join(thread, nullptr);
+#else
+  UNUSED(thread);
+#endif
+}
+
+struct MutexAcquireContext
+{
+  LibXR::Mutex* mutex;
+  std::atomic<bool>* acquired;
+  LibXR::Semaphore* done;
+};
+
+void AcquireMutex(MutexAcquireContext* ctx)
+{
+  ASSERT(ctx->mutex->Lock() == ErrorCode::OK);
+  ctx->acquired->store(true, std::memory_order_release);
+  ctx->mutex->Unlock();
+  ctx->done->Post();
+}
+
+}  // namespace
+
+void test_mutex()
+{
+  LibXR::Mutex mutex;
+  LibXR::Semaphore done(0);
+  std::atomic<bool> acquired(false);
+  LibXR::Thread waiter;
+
+  ASSERT(mutex.Lock() == ErrorCode::OK);
+  ASSERT(mutex.TryLock() == ErrorCode::BUSY);
+
+  MutexAcquireContext ctx = {&mutex, &acquired, &done};
+  waiter.Create<MutexAcquireContext*>(&ctx, AcquireMutex, "mutex_waiter", 1024,
+                                     LibXR::Thread::Priority::MEDIUM);
+
+  LibXR::Thread::Sleep(20);
+  ASSERT(!acquired.load(std::memory_order_acquire));
+
+  mutex.Unlock();
+
+  ASSERT(done.Wait(500) == ErrorCode::OK);
+  JoinThreadIfNeeded(waiter);
+  ASSERT(acquired.load(std::memory_order_acquire));
+
+  ASSERT(mutex.TryLock() == ErrorCode::OK);
+  mutex.Unlock();
+}

--- a/test/test_semaphore.cpp
+++ b/test/test_semaphore.cpp
@@ -2,10 +2,34 @@
 #include "libxr_def.hpp"
 #include "test.hpp"
 
+#include <pthread.h>
+
+namespace
+{
+
+void JoinThreadIfNeeded(LibXR::Thread& thread)
+{
+#if defined(LIBXR_SYSTEM_Linux) || defined(LIBXR_SYSTEM_Webots)
+  pthread_join(thread, nullptr);
+#else
+  UNUSED(thread);
+#endif
+}
+
+}  // namespace
+
 void test_semaphore()
 {
-  static LibXR::Semaphore sem(0);
+  LibXR::Semaphore sem(0);
   LibXR::Thread thread;
+
+  ASSERT(sem.Wait(0) == ErrorCode::TIMEOUT);
+
+  sem.Post();
+  sem.Post();
+  ASSERT(sem.Wait(0) == ErrorCode::OK);
+  ASSERT(sem.Wait(0) == ErrorCode::OK);
+  ASSERT(sem.Wait(0) == ErrorCode::TIMEOUT);
 
   thread.Create<LibXR::Semaphore*>(
       &sem,
@@ -17,5 +41,6 @@ void test_semaphore()
       },
       "semaphore_thread", 512, LibXR::Thread::Priority::REALTIME);
 
-  ASSERT(sem.Wait(100) == ErrorCode::OK);
+  ASSERT(sem.Wait(200) == ErrorCode::OK);
+  JoinThreadIfNeeded(thread);
 }

--- a/test/test_thread.cpp
+++ b/test/test_thread.cpp
@@ -2,13 +2,37 @@
 #include "libxr_def.hpp"
 #include "test.hpp"
 
+#include <pthread.h>
+#include <time.h>
+
+namespace
+{
+
+void JoinThreadIfNeeded(LibXR::Thread& thread)
+{
+#if defined(LIBXR_SYSTEM_Linux) || defined(LIBXR_SYSTEM_Webots)
+  pthread_join(thread, nullptr);
+#else
+  UNUSED(thread);
+#endif
+}
+
+uint64_t NowMonotonicMs()
+{
+  struct timespec ts = {};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1000ULL +
+         static_cast<uint64_t>(ts.tv_nsec) / 1000000ULL;
+}
+
+}  // namespace
+
 void test_thread()
 {
   LibXR::Thread thread;
+  LibXR::Semaphore sem(0);
 
-  static LibXR::Semaphore sem(0);
-
-  ASSERT(sem.Wait(0) != ErrorCode::OK);
+  ASSERT(sem.Wait(0) == ErrorCode::TIMEOUT);
 
   thread.Create<LibXR::Semaphore*>(
       &sem,
@@ -19,7 +43,21 @@ void test_thread()
       },
       "test_task", 512, LibXR::Thread::Priority::REALTIME);
 
-  LibXR::Thread::Sleep(100);
+  ASSERT(sem.Wait(200) == ErrorCode::OK);
+  JoinThreadIfNeeded(thread);
 
-  ASSERT(sem.Wait(100) == ErrorCode::OK);
+  const uint64_t sleep_start_ms = NowMonotonicMs();
+  LibXR::Thread::Sleep(20);
+  const uint64_t sleep_elapsed_ms = NowMonotonicMs() - sleep_start_ms;
+  ASSERT(sleep_elapsed_ms >= 15);
+
+  LibXR::MillisecondTimestamp wakeup = LibXR::Thread::GetTime();
+  const uint32_t periodic_start_ms = wakeup;
+  LibXR::Thread::SleepUntil(wakeup, 10);
+  const uint32_t first_wakeup_ms = LibXR::Thread::GetTime();
+  LibXR::Thread::SleepUntil(wakeup, 10);
+  const uint32_t second_wakeup_ms = LibXR::Thread::GetTime();
+  ASSERT(first_wakeup_ms - periodic_start_ms >= 8);
+  ASSERT(second_wakeup_ms - periodic_start_ms >= 18);
+  ASSERT(second_wakeup_ms >= first_wakeup_ms);
 }


### PR DESCRIPTION
## Summary by Sourcery

Introduce a Linux/Webots shared-memory topic runtime with futex-based synchronization, integrate it into the platform, and add benchmarks and tests, while refactoring threading, timing, mutex, semaphore, and queue primitives for more robust, monotonic-time-based behavior.

New Features:
- Add a Linux/Webots shared-memory topic implementation with configurable slots, subscriber modes, and round-robin balancing, exposed via linux_shared_topic.hpp and integrated into libxr.hpp.
- Add comprehensive benchmarks for the Linux shared topic transport and system synchronization primitives, including throughput, latency, overload behavior, and subscriber modes.
- Extend the LibXR test harness to support isolated tests in child processes and add new tests for Linux shared topic IPC, mutex behavior, and enhanced thread and semaphore semantics.

Bug Fixes:
- Fix potential crashes and memory issues in thread name handling by removing dynamic allocation and enforcing fixed-size buffers with safe string operations.
- Correct semaphore, mutex, and lock queue behavior under failure and timeout conditions, propagating error codes and preventing lost wakeups or leaked permits.
- Align Linux and Webots timing, sleep, and semaphore waits to a monotonic timebase to avoid issues with realtime clock adjustments and improve timeout accuracy.

Enhancements:
- Refactor POSIX thread attribute and scheduling setup into reusable helpers for Linux and Webots targets.
- Improve Webots and Linux Thread::Sleep, SleepUntil, and GetTime implementations to use shared monotonic timing utilities and handle EINTR robustly.
- Tighten Mutex error handling and TryLock semantics to distinguish busy from failure, and make queue size/empty-size queries resilient to lock failures.
- Scavenge dead subscribers and reclaim resources in the shared topic implementation to keep slot and queue management robust across process lifecycles.

Build:
- Restructure CMake test configuration to explicitly list test sources, introduce a reusable helper for defining test targets, and add dedicated binaries for shared-topic and system-sync benchmarks.

Tests:
- Broaden unit coverage for threads, semaphores, and mutexes to validate timeouts, periodic sleep behavior, and proper thread joining on POSIX platforms.
- Add multi-process integration tests for Linux shared-memory topics, covering publisher/attach-only roles, queue overflow policies, round-robin balancing, dead-subscriber cleanup, and fork semantics.

Chores:
- Remove unused includes and legacy timeval-based timing globals in favor of consistent timespec/CLOCK_MONOTONIC usage across Linux and Webots backends.