### PR TITLE
feat(linux): add shared topic runtime and benchmarks

### DIFF
--- a/src/driver/usb/device/device_composition.cpp
+++ b/src/driver/usb/device/device_composition.cpp
@@ -350,7 +350,6 @@ DeviceComposition::DeviceComposition(
     ConstRawData uid, uint8_t bmAttributes, uint8_t bMaxPower)
     : endpoint_pool_(endpoint_pool),
       bm_attributes_(bmAttributes),
-      b_max_power_(bMaxPower),
       composite_(is_composite_device(configs)),
       config_num_(configs.size()),
       items_(new ConfigItems[config_num_]),

--- a/src/driver/usb/device/device_composition.hpp
+++ b/src/driver/usb/device/device_composition.hpp
@@ -177,7 +177,6 @@ class DeviceComposition
   uint8_t current_cfg_ = 0;      ///< 当前配置索引 / Current configuration index
   uint8_t i_configuration_ = 0;  ///< 配置字符串索引 / Configuration string index
   uint8_t bm_attributes_ = CFG_BUS_POWERED;  ///< 配置属性 / bmAttributes
-  uint8_t b_max_power_ = 50;  ///< 最大电流（2mA 单位）/ Max power (2mA units)
 
   const bool composite_ = false;     ///< 是否为复合设备 / Whether composite device
   const size_t config_num_ = 0;      ///< 配置数量 / Configuration count

--- a/src/middleware/message.cpp
+++ b/src/middleware/message.cpp
@@ -87,6 +87,8 @@ void Topic::UnlockFromCallback(Topic::TopicHandle topic)
 
 Topic::Domain::Domain(const char* name)
 {
+  ASSERT(name != nullptr);
+
   if (!domain_)
   {
     if (!domain_)

--- a/src/middleware/message.hpp
+++ b/src/middleware/message.hpp
@@ -2,7 +2,6 @@
 
 #include <atomic>
 #include <cstdint>
-
 #include "crc.hpp"
 #include "libxr_cb.hpp"
 #include "libxr_def.hpp"

--- a/src/utils/crc.hpp
+++ b/src/utils/crc.hpp
@@ -289,4 +289,72 @@ class CRC32
                            buf + (len % 4)))[len / sizeof(uint32_t) - 1];
   }
 };
+
+/**
+ * @class CRC64
+ * @brief 64 位循环冗余校验（CRC-64）计算类 / CRC-64 checksum computation class
+ *
+ * 该类实现了 CRC-64 校验算法，支持计算数据的 64 位校验值。
+ * This class implements the CRC-64 checksum algorithm and supports computing
+ * 64-bit checksums for input data.
+ */
+class CRC64
+{
+ private:
+  static const uint64_t INIT = 0xFFFFFFFFFFFFFFFFULL;  ///< CRC64 初始值 / CRC64 initial value
+
+ public:
+  static inline uint64_t tab_[256];  ///< CRC64 查找表 / CRC64 lookup table
+  static inline bool inited_ =
+      false;  ///< 查找表是否已初始化 / Whether the lookup table is initialized
+
+  CRC64() {}
+
+  /**
+   * @brief 生成 CRC64 查找表 / Generates the CRC64 lookup table
+   */
+  static void GenerateTable()
+  {
+    uint64_t crc = 0;
+    for (int i = 0; i < 256; ++i)
+    {
+      crc = static_cast<uint64_t>(i);
+      for (int j = 0; j < 8; ++j)
+      {
+        if (crc & 1ULL)
+        {
+          crc = (crc >> 1U) ^ 0xC96C5795D7870F42ULL;
+        }
+        else
+        {
+          crc >>= 1U;
+        }
+      }
+      tab_[i] = crc;
+    }
+    inited_ = true;
+  }
+
+  /**
+   * @brief 计算数据的 CRC64 校验码 / Computes the CRC64 checksum for the given data
+   * @param raw 输入数据指针 / Pointer to input data
+   * @param len 数据长度 / Length of the data
+   * @return 计算得到的 CRC64 值 / Computed CRC64 value
+   */
+  static uint64_t Calculate(const void* raw, size_t len)
+  {
+    const uint8_t* buf = reinterpret_cast<const uint8_t*>(raw);
+    if (!inited_)
+    {
+      GenerateTable();
+    }
+
+    uint64_t crc = INIT;
+    while (len--)
+    {
+      crc = tab_[(crc ^ *buf++) & 0xff] ^ (crc >> 8U);
+    }
+    return crc;
+  }
+};
 }  // namespace LibXR

--- a/system/Linux/linux_shared_topic_impl.hpp
+++ b/system/Linux/linux_shared_topic_impl.hpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <cerrno>
 #include <chrono>
+#include <cinttypes>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -87,6 +88,7 @@ class LinuxSharedTopic : public Topic
  public:
   class SharedData;
   using Data = SharedData;
+  static constexpr const char* DEFAULT_DOMAIN_NAME = "libxr_def_domain";
 
   /**
    * @class Subscriber
@@ -115,6 +117,28 @@ class LinuxSharedTopic : public Topic
                         LinuxSharedSubscriberMode mode =
                             LinuxSharedSubscriberMode::BROADCAST_FULL)
         : owned_topic_(new LinuxSharedTopic(name))
+    {
+      if (Attach(*owned_topic_, mode) != ErrorCode::OK)
+      {
+        delete owned_topic_;
+        owned_topic_ = nullptr;
+      }
+    }
+
+    Subscriber(const char* name, const char* domain_name,
+               LinuxSharedSubscriberMode mode = LinuxSharedSubscriberMode::BROADCAST_FULL)
+        : owned_topic_(new LinuxSharedTopic(name, domain_name))
+    {
+      if (Attach(*owned_topic_, mode) != ErrorCode::OK)
+      {
+        delete owned_topic_;
+        owned_topic_ = nullptr;
+      }
+    }
+
+    Subscriber(const char* name, Topic::Domain& domain,
+               LinuxSharedSubscriberMode mode = LinuxSharedSubscriberMode::BROADCAST_FULL)
+        : owned_topic_(new LinuxSharedTopic(name, domain))
     {
       if (Attach(*owned_topic_, mode) != ErrorCode::OK)
       {
@@ -594,7 +618,31 @@ class LinuxSharedTopic : public Topic
    * @param topic_name 主题名称。Topic name.
    */
   explicit LinuxSharedTopic(const char* topic_name)
-      : create_(false), publisher_(false), config_(), shm_name_(BuildShmName(topic_name))
+      : LinuxSharedTopic(topic_name, DEFAULT_DOMAIN_NAME)
+  {
+  }
+
+  LinuxSharedTopic(const char* topic_name, const char* domain_name)
+      : create_(false),
+        publisher_(false),
+        config_(),
+        domain_crc32_(ResolveDomainKey(domain_name)),
+        topic_name_(ResolveTopicName(topic_name)),
+        name_key_(BuildNameKey(domain_crc32_, topic_name_)),
+        shm_name_(BuildShmName(name_key_))
+  {
+    (void)ReadProcessIdentity(static_cast<uint32_t>(getpid()), self_identity_);
+    Open();
+  }
+
+  LinuxSharedTopic(const char* topic_name, Topic::Domain& domain)
+      : create_(false),
+        publisher_(false),
+        config_(),
+        domain_crc32_(domain.node_ != nullptr ? domain.node_->key : 0),
+        topic_name_(ResolveTopicName(topic_name)),
+        name_key_(BuildNameKey(domain_crc32_, topic_name_)),
+        shm_name_(BuildShmName(name_key_))
   {
     (void)ReadProcessIdentity(static_cast<uint32_t>(getpid()), self_identity_);
     Open();
@@ -607,7 +655,33 @@ class LinuxSharedTopic : public Topic
    * @param config 创建配置。Creation config.
    */
   LinuxSharedTopic(const char* topic_name, const LinuxSharedTopicConfig& config)
-      : create_(true), publisher_(true), config_(config), shm_name_(BuildShmName(topic_name))
+      : LinuxSharedTopic(topic_name, DEFAULT_DOMAIN_NAME, config)
+  {
+  }
+
+  LinuxSharedTopic(const char* topic_name, const char* domain_name,
+                   const LinuxSharedTopicConfig& config)
+      : create_(true),
+        publisher_(true),
+        config_(config),
+        domain_crc32_(ResolveDomainKey(domain_name)),
+        topic_name_(ResolveTopicName(topic_name)),
+        name_key_(BuildNameKey(domain_crc32_, topic_name_)),
+        shm_name_(BuildShmName(name_key_))
+  {
+    (void)ReadProcessIdentity(static_cast<uint32_t>(getpid()), self_identity_);
+    Open();
+  }
+
+  LinuxSharedTopic(const char* topic_name, Topic::Domain& domain,
+                   const LinuxSharedTopicConfig& config)
+      : create_(true),
+        publisher_(true),
+        config_(config),
+        domain_crc32_(domain.node_ != nullptr ? domain.node_->key : 0),
+        topic_name_(ResolveTopicName(topic_name)),
+        name_key_(BuildNameKey(domain_crc32_, topic_name_)),
+        shm_name_(BuildShmName(name_key_))
   {
     (void)ReadProcessIdentity(static_cast<uint32_t>(getpid()), self_identity_);
     Open();
@@ -752,7 +826,25 @@ class LinuxSharedTopic : public Topic
    */
   static ErrorCode Remove(const char* topic_name)
   {
-    const std::string shm_name = BuildShmName(topic_name);
+    return Remove(topic_name, DEFAULT_DOMAIN_NAME);
+  }
+
+  static ErrorCode Remove(const char* topic_name, const char* domain_name)
+  {
+    const std::string shm_name = BuildShmName(
+        BuildNameKey(ResolveDomainKey(domain_name), ResolveTopicName(topic_name)));
+    if (shm_unlink(shm_name.c_str()) == 0 || errno == ENOENT)
+    {
+      return ErrorCode::OK;
+    }
+    return ErrorCode::FAILED;
+  }
+
+  static ErrorCode Remove(const char* topic_name, Topic::Domain& domain)
+  {
+    const uint32_t domain_crc32 = (domain.node_ != nullptr) ? domain.node_->key : 0;
+    const std::string shm_name =
+        BuildShmName(BuildNameKey(domain_crc32, ResolveTopicName(topic_name)));
     if (shm_unlink(shm_name.c_str()) == 0 || errno == ENOENT)
     {
       return ErrorCode::OK;
@@ -764,12 +856,14 @@ class LinuxSharedTopic : public Topic
   struct alignas(64) SharedHeader
   {
     uint64_t magic = 0;
+    uint64_t name_key = 0;
+    uint32_t domain_crc32 = 0;
     uint32_t version = 0;
     uint32_t data_size = 0;
     uint32_t slot_count = 0;
     uint32_t subscriber_capacity = 0;
     uint32_t queue_capacity = 0;
-    uint32_t reserved = 0;
+    uint32_t topic_name_len = 0;
     std::atomic<uint32_t> init_state;
     std::atomic<uint32_t> publisher_pid;
     std::atomic<uint64_t> publisher_starttime;
@@ -828,11 +922,34 @@ class LinuxSharedTopic : public Topic
   static constexpr uint32_t kInitReady = 1;
   static constexpr uint32_t kInvalidIndex = UINT32_MAX;
 
-  static std::string BuildShmName(const char* topic_name)
+  static uint32_t ResolveDomainKey(const char* domain_name)
+  {
+    const std::string resolved =
+        (domain_name == nullptr || domain_name[0] == '\0') ? std::string(DEFAULT_DOMAIN_NAME)
+                                                            : std::string(domain_name);
+    return CRC32::Calculate(resolved.data(), resolved.size());
+  }
+
+  static std::string ResolveTopicName(const char* topic_name)
+  {
+    return (topic_name != nullptr) ? std::string(topic_name) : std::string();
+  }
+
+  static uint64_t BuildNameKey(uint32_t domain_crc32, const std::string& topic_name)
+  {
+    const uint32_t topic_len = static_cast<uint32_t>(topic_name.size());
+    std::string key_material;
+    key_material.reserve(sizeof(domain_crc32) + sizeof(topic_len) + topic_len);
+    key_material.append(reinterpret_cast<const char*>(&domain_crc32), sizeof(domain_crc32));
+    key_material.append(reinterpret_cast<const char*>(&topic_len), sizeof(topic_len));
+    key_material.append(topic_name.data(), topic_name.size());
+    return CRC64::Calculate(key_material.data(), key_material.size());
+  }
+
+  static std::string BuildShmName(uint64_t name_key)
   {
     char buffer[64] = {};
-    std::snprintf(buffer, sizeof(buffer), "/libxr_ipc_%08x",
-                  CRC32::Calculate(topic_name, std::strlen(topic_name)));
+    std::snprintf(buffer, sizeof(buffer), "/libxr_ipc_%016" PRIx64, name_key);
     return std::string(buffer);
   }
 
@@ -922,11 +1039,14 @@ class LinuxSharedTopic : public Topic
 
   static size_t ComputeSharedBytes(uint32_t slot_count,
                                    uint32_t subscriber_capacity,
-                                   uint32_t queue_capacity)
+                                   uint32_t queue_capacity,
+                                   uint32_t topic_name_len)
   {
     size_t offset = 0;
     offset = AlignUp(offset, alignof(SharedHeader));
     offset += sizeof(SharedHeader);
+
+    offset += static_cast<size_t>(topic_name_len) + 1U;
 
     offset = AlignUp(offset, alignof(SlotControl));
     offset += sizeof(SlotControl) * slot_count;
@@ -959,6 +1079,9 @@ class LinuxSharedTopic : public Topic
     header_ = reinterpret_cast<SharedHeader*>(base_ + offset);
     offset += sizeof(SharedHeader);
 
+    topic_name_ptr_ = reinterpret_cast<char*>(base_ + offset);
+    offset += static_cast<size_t>(header_->topic_name_len) + 1U;
+
     offset = AlignUp(offset, alignof(SlotControl));
     slots_ = reinterpret_cast<SlotControl*>(base_ + offset);
     offset += sizeof(SlotControl) * slot_count_;
@@ -987,6 +1110,27 @@ class LinuxSharedTopic : public Topic
     payloads_ = reinterpret_cast<TopicData*>(base_ + offset);
   }
 
+  bool HeaderMatchesIdentity() const
+  {
+    if (header_->name_key != name_key_)
+    {
+      return false;
+    }
+    if (header_->domain_crc32 != domain_crc32_)
+    {
+      return false;
+    }
+    if (header_->topic_name_len != topic_name_.size())
+    {
+      return false;
+    }
+    if (std::memcmp(topic_name_ptr_, topic_name_.c_str(), topic_name_.size() + 1U) != 0)
+    {
+      return false;
+    }
+    return true;
+  }
+
   ErrorCode InitializeLayout()
   {
     if (config_.slot_num == 0 || config_.subscriber_num == 0 || config_.queue_num < 2)
@@ -995,7 +1139,8 @@ class LinuxSharedTopic : public Topic
     }
 
     const size_t bytes =
-        ComputeSharedBytes(config_.slot_num, config_.subscriber_num, config_.queue_num);
+        ComputeSharedBytes(config_.slot_num, config_.subscriber_num, config_.queue_num,
+                           static_cast<uint32_t>(topic_name_.size()));
 
     if (ftruncate(fd_, static_cast<off_t>(bytes)) != 0)
     {
@@ -1020,14 +1165,19 @@ class LinuxSharedTopic : public Topic
     slot_count_ = config_.slot_num;
     subscriber_capacity_ = config_.subscriber_num;
     queue_capacity_ = config_.queue_num;
+    header_ = reinterpret_cast<SharedHeader*>(base_ + AlignUp(0, alignof(SharedHeader)));
+    header_->topic_name_len = static_cast<uint32_t>(topic_name_.size());
     SetupPointers();
 
     header_->magic = kMagic;
+    header_->name_key = name_key_;
+    header_->domain_crc32 = domain_crc32_;
     header_->version = kVersion;
     header_->data_size = sizeof(TopicData);
     header_->slot_count = slot_count_;
     header_->subscriber_capacity = subscriber_capacity_;
     header_->queue_capacity = queue_capacity_;
+    std::memcpy(topic_name_ptr_, topic_name_.c_str(), topic_name_.size() + 1U);
     header_->publisher_pid.store(self_identity_.pid, std::memory_order_release);
     header_->publisher_starttime.store(self_identity_.starttime, std::memory_order_release);
     header_->free_queue_head.store(0, std::memory_order_release);
@@ -1105,6 +1255,10 @@ class LinuxSharedTopic : public Topic
     subscriber_capacity_ = header_->subscriber_capacity;
     queue_capacity_ = header_->queue_capacity;
     SetupPointers();
+    if (!HeaderMatchesIdentity())
+    {
+      return ErrorCode::CHECK_ERR;
+    }
     return ErrorCode::OK;
   }
 
@@ -1130,18 +1284,40 @@ class LinuxSharedTopic : public Topic
     }
     else
     {
-      void* mapping = mmap(nullptr, sizeof(SharedHeader), PROT_READ | PROT_WRITE, MAP_SHARED,
-                           stale_fd, 0);
+      void* mapping = mmap(nullptr, static_cast<size_t>(st.st_size), PROT_READ | PROT_WRITE,
+                           MAP_SHARED, stale_fd, 0);
       if (mapping != MAP_FAILED)
       {
+        uint8_t* base = static_cast<uint8_t*>(mapping);
         auto* header = reinterpret_cast<SharedHeader*>(mapping);
         const uint32_t init_state = header->init_state.load(std::memory_order_acquire);
+        bool identity_match = false;
+        const size_t mapping_size = static_cast<size_t>(st.st_size);
+        const size_t topic_name_bytes = topic_name_.size() + 1U;
+        if (header->magic == kMagic && header->version == kVersion &&
+            header->domain_crc32 == domain_crc32_ &&
+            header->topic_name_len == topic_name_.size())
+        {
+          size_t offset = AlignUp(0, alignof(SharedHeader));
+          offset += sizeof(SharedHeader);
+          if (offset <= mapping_size && topic_name_bytes <= (mapping_size - offset))
+          {
+            const char* mapped_topic = reinterpret_cast<const char*>(base + offset);
+            identity_match =
+                (header->name_key == name_key_) &&
+                (std::memcmp(mapped_topic, topic_name_.c_str(), topic_name_bytes) == 0);
+          }
+        }
         const ProcessIdentity publisher_identity = {
             header->publisher_pid.load(std::memory_order_acquire),
             header->publisher_starttime.load(std::memory_order_acquire),
         };
 
-        if (init_state != kInitReady)
+        if (!identity_match)
+        {
+          reclaim = false;
+        }
+        else if (init_state != kInitReady)
         {
           reclaim = !ProcessAlive(publisher_identity);
         }
@@ -1150,7 +1326,7 @@ class LinuxSharedTopic : public Topic
           reclaim = true;
         }
 
-        munmap(mapping, sizeof(SharedHeader));
+        munmap(mapping, static_cast<size_t>(st.st_size));
       }
     }
 
@@ -1695,6 +1871,9 @@ class LinuxSharedTopic : public Topic
   bool create_ = false;
   bool publisher_ = false;
   LinuxSharedTopicConfig config_;
+  uint32_t domain_crc32_ = 0;
+  std::string topic_name_;
+  uint64_t name_key_ = 0;
   std::string shm_name_;
   ProcessIdentity self_identity_ = {};
 
@@ -1704,6 +1883,7 @@ class LinuxSharedTopic : public Topic
   size_t mapping_size_ = 0;
 
   SharedHeader* header_ = nullptr;
+  char* topic_name_ptr_ = nullptr;
   SlotControl* slots_ = nullptr;
   SubscriberControl* subscribers_ = nullptr;
   BalancedGroupControl* balanced_group_ = nullptr;

--- a/test/bench_linux_shared_topic.cpp
+++ b/test/bench_linux_shared_topic.cpp
@@ -167,6 +167,85 @@ BenchStats BuildStats(const std::vector<double>& lat_us, uint64_t sequence_error
   return stats;
 }
 
+bool WriteAll(int fd, const void* buffer, size_t size)
+{
+  const auto* bytes = static_cast<const uint8_t*>(buffer);
+  size_t written_total = 0;
+  while (written_total < size)
+  {
+    const ssize_t written = write(fd, bytes + written_total, size - written_total);
+    if (written > 0)
+    {
+      written_total += static_cast<size_t>(written);
+      continue;
+    }
+    if (written < 0 && errno == EINTR)
+    {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+bool ReadAll(int fd, void* buffer, size_t size)
+{
+  auto* bytes = static_cast<uint8_t*>(buffer);
+  size_t read_total = 0;
+  while (read_total < size)
+  {
+    const ssize_t read_size = read(fd, bytes + read_total, size - read_total);
+    if (read_size > 0)
+    {
+      read_total += static_cast<size_t>(read_size);
+      continue;
+    }
+    if (read_size < 0 && errno == EINTR)
+    {
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+template <typename TopicType>
+bool WaitForSubscriberAttach(TopicType& topic, uint32_t expected_num, const char* case_label)
+{
+  for (int retry = 0; retry < 500 && topic.GetSubscriberNum() < expected_num; ++retry)
+  {
+    usleep(1000);
+  }
+  if (topic.GetSubscriberNum() < expected_num)
+  {
+    std::fprintf(stderr, "%s subscriber attach timeout: expected=%u actual=%u\n", case_label,
+                 expected_num, topic.GetSubscriberNum());
+    return false;
+  }
+  return true;
+}
+
+template <size_t PayloadBytes>
+uint64_t LatencyCountForPayload()
+{
+  if constexpr (PayloadBytes <= 64)
+  {
+    return 20000;
+  }
+  else if constexpr (PayloadBytes <= 4096)
+  {
+    return 10000;
+  }
+  else if constexpr (PayloadBytes <= 65536)
+  {
+    return 2000;
+  }
+  else
+  {
+    return 128;
+  }
+}
+
 template <size_t PayloadBytes, bool TouchPayload>
 int RunBenchCase()
 {
@@ -183,7 +262,8 @@ int RunBenchCase()
   (void)Topic::Remove(topic_name);
 
   int stats_pipe[2] = {-1, -1};
-  if (pipe(stats_pipe) != 0)
+  int ready_pipe[2] = {-1, -1};
+  if (pipe(stats_pipe) != 0 || pipe(ready_pipe) != 0)
   {
     std::fprintf(stderr, "pipe failed: %s\n", std::strerror(errno));
     return 1;
@@ -206,6 +286,7 @@ int RunBenchCase()
   if (child == 0)
   {
     close(stats_pipe[0]);
+    close(ready_pipe[0]);
 
     Subscriber subscriber(topic_name);
     if (!subscriber.Valid())
@@ -218,6 +299,12 @@ int RunBenchCase()
     uint64_t sequence_errors = 0;
     uint64_t timeout_errors = 0;
     uint64_t expected_seq = 1;
+    const uint8_t ready = 1;
+    if (!WriteAll(ready_pipe[1], &ready, sizeof(ready)))
+    {
+      _exit(3);
+    }
+    close(ready_pipe[1]);
 
     for (uint64_t i = 0; i < count; ++i)
     {
@@ -248,18 +335,22 @@ int RunBenchCase()
     }
 
     BenchStats stats = BuildStats<PayloadBytes>(lat_us, sequence_errors, timeout_errors);
-    const ssize_t written = write(stats_pipe[1], &stats, sizeof(stats));
-    (void)written;
+    (void)WriteAll(stats_pipe[1], &stats, sizeof(stats));
     close(stats_pipe[1]);
     _exit(0);
   }
 
   close(stats_pipe[1]);
+  close(ready_pipe[1]);
 
-  for (int retry = 0; retry < 500 && publisher.GetSubscriberNum() == 0; ++retry)
+  uint8_t ready = 0;
+  if (!ReadAll(ready_pipe[0], &ready, sizeof(ready)) ||
+      !WaitForSubscriberAttach(publisher, 1, "standard"))
   {
-    usleep(1000);
+    close(ready_pipe[0]);
+    return 1;
   }
+  close(ready_pipe[0]);
 
   uint64_t create_retries = 0;
   uint64_t publish_retries = 0;
@@ -275,22 +366,21 @@ int RunBenchCase()
     }
 
     auto* frame = data.GetData();
-      frame->seq = seq;
-      frame->pub_ns = NowNs();
-      if constexpr (TouchPayload)
+    frame->seq = seq;
+    frame->pub_ns = NowNs();
+    if constexpr (TouchPayload)
+    {
+      std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU), frame->payload.size());
+    }
+    else
+    {
+      if constexpr (PayloadBytes > 0)
       {
-        std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU), frame->payload.size());
+        frame->payload[0] = static_cast<uint8_t>(seq & 0xFFU);
+        frame->payload[PayloadBytes - 1U] = static_cast<uint8_t>((seq >> 8U) & 0xFFU);
       }
-      else
-      {
-        if constexpr (PayloadBytes > 0)
-        {
-          frame->payload[0] = static_cast<uint8_t>(seq & 0xFFU);
-          frame->payload[PayloadBytes - 1U] =
-              static_cast<uint8_t>((seq >> 8U) & 0xFFU);
-        }
-      }
-      frame->checksum = ComputeChecksum(*frame);
+    }
+    frame->checksum = ComputeChecksum(*frame);
 
     while (publisher.Publish(data) != LibXR::ErrorCode::OK)
     {
@@ -301,14 +391,13 @@ int RunBenchCase()
   const uint64_t end_ns = NowNs();
 
   BenchStats stats = {};
-  const ssize_t read_ans = read(stats_pipe[0], &stats, sizeof(stats));
+  const bool read_ok = ReadAll(stats_pipe[0], &stats, sizeof(stats));
   close(stats_pipe[0]);
 
   int status = 0;
   waitpid(child, &status, 0);
 
-  if (read_ans != static_cast<ssize_t>(sizeof(stats)) || !WIFEXITED(status) ||
-      WEXITSTATUS(status) != 0)
+  if (!read_ok || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
   {
     std::fprintf(stderr, "bench child failed for payload=%zu\n", PayloadBytes);
     return 1;
@@ -324,7 +413,7 @@ int RunBenchCase()
                                 static_cast<double>(count);
 
   std::printf(
-      "[RESULT] mode=%s payload=%zuB count=%" PRIu64
+      "[BENCH] shared_standard mode=%s payload=%zuB count=%" PRIu64
       " publish_avg=%.3f us throughput=%.0f msg/s bandwidth=%.2f MiB/s "
       "create_retry=%" PRIu64 " publish_retry=%" PRIu64
       " latency_avg=%.3f us p50=%.3f us p95=%.3f us p99=%.3f us max=%.3f us "
@@ -333,6 +422,181 @@ int RunBenchCase()
       publish_avg_us, msg_per_s, mib_per_s,
       create_retries, publish_retries, stats.avg_us, stats.p50_us, stats.p95_us, stats.p99_us,
       stats.max_us, stats.sequence_errors, stats.timeout_errors);
+  std::fflush(stdout);
+
+  (void)Topic::Remove(topic_name);
+  return 0;
+}
+
+// Measure one-way delivery with at most one outstanding message so queueing backlog
+// and startup burst do not pollute the latency distribution.
+template <size_t PayloadBytes, bool TouchPayload>
+int RunLatencyCase()
+{
+  using Topic = LibXR::LinuxSharedTopic<BenchFrame<PayloadBytes>>;
+  using Data = typename Topic::Data;
+  using Subscriber = typename Topic::SyncSubscriber;
+
+  const uint64_t count = LatencyCountForPayload<PayloadBytes>();
+
+  LibXR::LinuxSharedTopicConfig config = {};
+  config.slot_num = 4;
+  config.subscriber_num = 1;
+  config.queue_num = 4;
+
+  char topic_name[96] = {};
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shared_latency_%zu_%d", PayloadBytes,
+                static_cast<int>(getpid()));
+  (void)Topic::Remove(topic_name);
+
+  int ready_pipe[2] = {-1, -1};
+  int ack_pipe[2] = {-1, -1};
+  if (pipe(ready_pipe) != 0 || pipe(ack_pipe) != 0)
+  {
+    std::fprintf(stderr, "latency pipe failed: %s\n", std::strerror(errno));
+    return 1;
+  }
+
+  Topic publisher(topic_name, config);
+  if (!publisher.Valid())
+  {
+    std::fprintf(stderr, "latency publisher open failed for payload=%zu\n", PayloadBytes);
+    return 1;
+  }
+
+  pid_t child = fork();
+  if (child < 0)
+  {
+    std::fprintf(stderr, "latency fork failed: %s\n", std::strerror(errno));
+    return 1;
+  }
+
+  if (child == 0)
+  {
+    close(ready_pipe[0]);
+    close(ack_pipe[0]);
+
+    Subscriber subscriber(topic_name);
+    if (!subscriber.Valid())
+    {
+      _exit(70);
+    }
+
+    const uint8_t ready = 1;
+    if (!WriteAll(ready_pipe[1], &ready, sizeof(ready)))
+    {
+      _exit(71);
+    }
+    close(ready_pipe[1]);
+
+    uint64_t expected_seq = 1;
+    for (uint64_t i = 0; i < count; ++i)
+    {
+      Data data;
+      if (subscriber.Wait(data, 5000) != LibXR::ErrorCode::OK)
+      {
+        _exit(72);
+      }
+
+      const auto* frame = data.GetData();
+      if (frame == nullptr || frame->seq != expected_seq ||
+          frame->checksum != ComputeChecksum(*frame))
+      {
+        _exit(73);
+      }
+      expected_seq = frame->seq + 1U;
+
+      const uint64_t latency_ns = NowNs() - frame->pub_ns;
+      if (!WriteAll(ack_pipe[1], &latency_ns, sizeof(latency_ns)))
+      {
+        _exit(74);
+      }
+    }
+
+    close(ack_pipe[1]);
+    _exit(0);
+  }
+
+  close(ready_pipe[1]);
+  close(ack_pipe[1]);
+
+  uint8_t ready = 0;
+  if (!ReadAll(ready_pipe[0], &ready, sizeof(ready)) ||
+      !WaitForSubscriberAttach(publisher, 1, "latency"))
+  {
+    close(ready_pipe[0]);
+    close(ack_pipe[0]);
+    return 1;
+  }
+  close(ready_pipe[0]);
+
+  std::vector<double> lat_us;
+  lat_us.reserve(static_cast<size_t>(count));
+  uint64_t create_retries = 0;
+  uint64_t publish_retries = 0;
+
+  const uint64_t start_ns = NowNs();
+  for (uint64_t seq = 1; seq <= count; ++seq)
+  {
+    Data data;
+    while (publisher.CreateData(data) != LibXR::ErrorCode::OK)
+    {
+      ++create_retries;
+      sched_yield();
+    }
+
+    auto* frame = data.GetData();
+    frame->seq = seq;
+    frame->pub_ns = NowNs();
+    if constexpr (TouchPayload)
+    {
+      std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU), frame->payload.size());
+    }
+    else if constexpr (PayloadBytes > 0)
+    {
+      frame->payload[0] = static_cast<uint8_t>(seq & 0xFFU);
+      frame->payload[PayloadBytes - 1U] = static_cast<uint8_t>((seq >> 8U) & 0xFFU);
+    }
+    frame->checksum = ComputeChecksum(*frame);
+
+    while (publisher.Publish(data) != LibXR::ErrorCode::OK)
+    {
+      ++publish_retries;
+      sched_yield();
+    }
+
+    uint64_t latency_ns = 0;
+    if (!ReadAll(ack_pipe[0], &latency_ns, sizeof(latency_ns)))
+    {
+      close(ack_pipe[0]);
+      waitpid(child, nullptr, 0);
+      std::fprintf(stderr, "latency child ack failed for payload=%zu\n", PayloadBytes);
+      return 1;
+    }
+    lat_us.push_back(static_cast<double>(latency_ns) / 1000.0);
+  }
+  const uint64_t end_ns = NowNs();
+
+  close(ack_pipe[0]);
+
+  int status = 0;
+  waitpid(child, &status, 0);
+  if (!WIFEXITED(status) || WEXITSTATUS(status) != 0)
+  {
+    std::fprintf(stderr, "latency child failed for payload=%zu\n", PayloadBytes);
+    return 1;
+  }
+
+  const BenchStats stats = BuildStats<PayloadBytes>(lat_us, 0, 0);
+  const double total_s = static_cast<double>(end_ns - start_ns) / 1e9;
+  const double exchange_rate = static_cast<double>(count) / total_s;
+  std::printf(
+      "[BENCH] shared_latency mode=%s payload=%zuB count=%" PRIu64
+      " exchange_rate=%.0f msg/s create_retry=%" PRIu64 " publish_retry=%" PRIu64
+      " one_way_avg=%.3f us p50=%.3f us p95=%.3f us p99=%.3f us max=%.3f us\n",
+      TouchPayload ? "full-touch" : "transport", sizeof(BenchFrame<PayloadBytes>), count,
+      exchange_rate, create_retries, publish_retries, stats.avg_us, stats.p50_us, stats.p95_us,
+      stats.p99_us, stats.max_us);
   std::fflush(stdout);
 
   (void)Topic::Remove(topic_name);
@@ -369,7 +633,8 @@ int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
 
   int done_pipe[2] = {-1, -1};
   int stats_pipe[2] = {-1, -1};
-  if (pipe(done_pipe) != 0 || pipe(stats_pipe) != 0)
+  int ready_pipe[2] = {-1, -1};
+  if (pipe(done_pipe) != 0 || pipe(stats_pipe) != 0 || pipe(ready_pipe) != 0)
   {
     std::fprintf(stderr, "pipe failed: %s\n", std::strerror(errno));
     return 1;
@@ -393,6 +658,7 @@ int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
   {
     close(done_pipe[1]);
     close(stats_pipe[0]);
+    close(ready_pipe[0]);
 
     const int flags = fcntl(done_pipe[0], F_GETFL, 0);
     (void)fcntl(done_pipe[0], F_SETFL, flags | O_NONBLOCK);
@@ -408,6 +674,12 @@ int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
     uint64_t expected_seq = 1;
     uint64_t sequence_gap = 0;
     uint64_t timeout_errors = 0;
+    const uint8_t ready = 1;
+    if (!WriteAll(ready_pipe[1], &ready, sizeof(ready)))
+    {
+      _exit(31);
+    }
+    close(ready_pipe[1]);
 
     while (true)
     {
@@ -457,8 +729,7 @@ int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
     stats.latency = BuildStats<PayloadBytes>(lat_us, 0, timeout_errors);
     stats.sequence_gap = sequence_gap;
     stats.subscriber_drop_num = subscriber.GetDropNum();
-    const ssize_t written = write(stats_pipe[1], &stats, sizeof(stats));
-    (void)written;
+    (void)WriteAll(stats_pipe[1], &stats, sizeof(stats));
     close(done_pipe[0]);
     close(stats_pipe[1]);
     _exit(0);
@@ -466,11 +737,16 @@ int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
 
   close(done_pipe[0]);
   close(stats_pipe[1]);
+  close(ready_pipe[1]);
 
-  for (int retry = 0; retry < 500 && publisher.GetSubscriberNum() == 0; ++retry)
+  uint8_t ready = 0;
+  if (!ReadAll(ready_pipe[0], &ready, sizeof(ready)) ||
+      !WaitForSubscriberAttach(publisher, 1, "overload"))
   {
-    usleep(1000);
+    close(ready_pipe[0]);
+    return 1;
   }
+  close(ready_pipe[0]);
 
   uint64_t create_fail = 0;
   uint64_t publish_fail = 0;
@@ -504,13 +780,12 @@ int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
   close(done_pipe[1]);
 
   OverloadStats stats = {};
-  const ssize_t read_ans = read(stats_pipe[0], &stats, sizeof(stats));
+  const bool read_ok = ReadAll(stats_pipe[0], &stats, sizeof(stats));
   close(stats_pipe[0]);
 
   int status = 0;
   waitpid(child, &status, 0);
-  if (read_ans != static_cast<ssize_t>(sizeof(stats)) || !WIFEXITED(status) ||
-      WEXITSTATUS(status) != 0)
+  if (!read_ok || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
   {
     std::fprintf(stderr, "overload child failed for payload=%zu\n", PayloadBytes);
     return 1;
@@ -520,7 +795,7 @@ int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
   const double attempt_rate = static_cast<double>(count) / total_s;
   const double ok_rate = static_cast<double>(publish_ok) / total_s;
   std::printf(
-      "[RESULT] overload policy=%s payload=%zuB count=%" PRIu64
+      "[BENCH] shared_overload policy=%s payload=%zuB count=%" PRIu64
       " delay=%u us attempt_rate=%.0f msg/s ok_rate=%.0f msg/s create_fail=%" PRIu64
       " publish_fail=%" PRIu64 " recv=%" PRIu64 " sub_drop=%" PRIu64
       " seq_gap=%" PRIu64 " lat_avg=%.3f us p50=%.3f us p95=%.3f us p99=%.3f us max=%.3f us\n",
@@ -564,6 +839,7 @@ int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscr
   struct ChildRuntime
   {
     pid_t pid = -1;
+    int ready_pipe[2] = {-1, -1};
     int done_pipe[2] = {-1, -1};
     int stats_pipe[2] = {-1, -1};
   };
@@ -572,7 +848,8 @@ int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscr
 
   for (size_t i = 0; i < subscribers.size(); ++i)
   {
-    if (pipe(runtimes[i].done_pipe) != 0 || pipe(runtimes[i].stats_pipe) != 0)
+    if (pipe(runtimes[i].ready_pipe) != 0 || pipe(runtimes[i].done_pipe) != 0 ||
+        pipe(runtimes[i].stats_pipe) != 0)
     {
       std::fprintf(stderr, "pipe failed for %s[%zu]: %s\n", case_label, i, std::strerror(errno));
       return 1;
@@ -588,6 +865,7 @@ int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscr
 
     if (child == 0)
     {
+      close(runtimes[i].ready_pipe[0]);
       close(runtimes[i].done_pipe[1]);
       close(runtimes[i].stats_pipe[0]);
 
@@ -604,6 +882,12 @@ int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscr
       lat_us.reserve(static_cast<size_t>(count));
 
       ModeSubResult result = {};
+      const uint8_t ready = 1;
+      if (!WriteAll(runtimes[i].ready_pipe[1], &ready, sizeof(ready)))
+      {
+        _exit(61);
+      }
+      close(runtimes[i].ready_pipe[1]);
       while (true)
       {
         Data data;
@@ -647,21 +931,33 @@ int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscr
 
       result.latency = BuildStats<PayloadBytes>(lat_us, 0, result.timeout_errors);
       result.drop_count = subscriber.GetDropNum();
-      const ssize_t written = write(runtimes[i].stats_pipe[1], &result, sizeof(result));
-      (void)written;
+      (void)WriteAll(runtimes[i].stats_pipe[1], &result, sizeof(result));
       close(runtimes[i].done_pipe[0]);
       close(runtimes[i].stats_pipe[1]);
       _exit(0);
     }
 
     runtimes[i].pid = child;
+    close(runtimes[i].ready_pipe[1]);
     close(runtimes[i].done_pipe[0]);
     close(runtimes[i].stats_pipe[1]);
   }
 
-  for (int retry = 0; retry < 500 && publisher.GetSubscriberNum() < subscribers.size(); ++retry)
+  for (size_t i = 0; i < subscribers.size(); ++i)
   {
-    usleep(1000);
+    uint8_t ready = 0;
+    if (!ReadAll(runtimes[i].ready_pipe[0], &ready, sizeof(ready)))
+    {
+      close(runtimes[i].ready_pipe[0]);
+      std::fprintf(stderr, "mode ready failed: %s[%zu]\n", case_label, i);
+      return 1;
+    }
+    close(runtimes[i].ready_pipe[0]);
+  }
+
+  if (!WaitForSubscriberAttach(publisher, static_cast<uint32_t>(subscribers.size()), case_label))
+  {
+    return 1;
   }
 
   uint64_t create_fail = 0;
@@ -701,12 +997,11 @@ int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscr
   std::vector<ModeSubResult> results(subscribers.size());
   for (size_t i = 0; i < subscribers.size(); ++i)
   {
-    const ssize_t read_ans = read(runtimes[i].stats_pipe[0], &results[i], sizeof(results[i]));
+    const bool read_ok = ReadAll(runtimes[i].stats_pipe[0], &results[i], sizeof(results[i]));
     close(runtimes[i].stats_pipe[0]);
     int status = 0;
     waitpid(runtimes[i].pid, &status, 0);
-    if (read_ans != static_cast<ssize_t>(sizeof(results[i])) || !WIFEXITED(status) ||
-        WEXITSTATUS(status) != 0)
+    if (!read_ok || !WIFEXITED(status) || WEXITSTATUS(status) != 0)
     {
       std::fprintf(stderr, "mode child failed: %s[%zu]\n", case_label, i);
       return 1;
@@ -715,14 +1010,14 @@ int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscr
 
   const double total_s = static_cast<double>(end_ns - start_ns) / 1e9;
   const double ok_rate = static_cast<double>(publish_ok) / total_s;
-  std::printf("[RESULT] modes case=%s payload=%zuB count=%" PRIu64
+  std::printf("[BENCH] shared_mode_summary case=%s payload=%zuB count=%" PRIu64
               " ok_rate=%.0f msg/s create_fail=%" PRIu64 " publish_fail=%" PRIu64 "\n",
               case_label, sizeof(BenchFrame<PayloadBytes>), count, ok_rate, create_fail,
               publish_fail);
 
   for (size_t i = 0; i < subscribers.size(); ++i)
   {
-    std::printf("[RESULT] modes case=%s sub=%s mode=%u recv=%" PRIu64
+    std::printf("[BENCH] shared_mode_subscriber case=%s sub=%s mode=%u recv=%" PRIu64
                 " drop=%" PRIu64 " first=%" PRIu64 " last=%" PRIu64
                 " lat_avg=%.3f us p95=%.3f us\n",
                 case_label, subscribers[i].label, static_cast<unsigned>(subscribers[i].mode),
@@ -744,6 +1039,7 @@ int main()
   int status = 0;
   const char* bench_set = std::getenv("BENCH_SET");
   const bool run_standard = (bench_set == nullptr) || (std::strcmp(bench_set, "standard") == 0);
+  const bool run_latency = (bench_set == nullptr) || (std::strcmp(bench_set, "latency") == 0);
   const bool run_overload = (bench_set == nullptr) || (std::strcmp(bench_set, "overload") == 0);
   const bool run_modes = (bench_set == nullptr) || (std::strcmp(bench_set, "modes") == 0);
 
@@ -757,6 +1053,18 @@ int main()
     status |= RunBenchCase<65536, true>();
     status |= RunBenchCase<1048576, false>();
     status |= RunBenchCase<1048576, true>();
+  }
+
+  if (run_latency)
+  {
+    status |= RunLatencyCase<64, false>();
+    status |= RunLatencyCase<64, true>();
+    status |= RunLatencyCase<4096, false>();
+    status |= RunLatencyCase<4096, true>();
+    status |= RunLatencyCase<65536, false>();
+    status |= RunLatencyCase<65536, true>();
+    status |= RunLatencyCase<1048576, false>();
+    status |= RunLatencyCase<1048576, true>();
   }
 
   if (run_overload)

--- a/test/bench_linux_system_sync.cpp
+++ b/test/bench_linux_system_sync.cpp
@@ -160,7 +160,7 @@ int RunMutexStress()
     return 3;
   }
 
-  std::printf("[RESULT] mutex_stress threads=%zu iterations=%" PRIu64
+  std::printf("[BENCH] sync_mutex threads=%zu iterations=%" PRIu64
               " counter=%" PRIu64 " wall_ms=%.3f\n",
               kThreadNum, kIterationsPerThread, counter.load(std::memory_order_relaxed),
               static_cast<double>(end_ns - start_ns) / 1000000.0);
@@ -238,7 +238,7 @@ int RunSemaphoreStress()
     }
   }
 
-  std::printf("[RESULT] semaphore_stress producers=%zu consumers=%zu posts=%" PRIu64
+  std::printf("[BENCH] sync_semaphore producers=%zu consumers=%zu posts=%" PRIu64
               " consumed=%" PRIu64 " wall_ms=%.3f\n",
               kProducerNum, kConsumerNum, kTotalPosts, kTotalPosts,
               static_cast<double>(end_ns - start_ns) / 1000000.0);
@@ -272,7 +272,7 @@ int RunThreadSleepStress()
     return 21;
   }
 
-  std::printf("[RESULT] thread_sleep_stress iterations=%u step_ms=%u elapsed_ms=%" PRIu64 "\n",
+  std::printf("[BENCH] sync_sleep_until iterations=%u step_ms=%u elapsed_ms=%" PRIu64 "\n",
               kIterations, kStepMs, elapsed_ms);
   return 0;
 }

--- a/test/test_linux_shm_topic.cpp
+++ b/test/test_linux_shm_topic.cpp
@@ -11,12 +11,19 @@
 namespace
 {
 
+constexpr uint32_t kShortWaitMs = 100;
+constexpr uint32_t kLongWaitMs = 2000;
+
 struct IPCFrame
 {
   uint32_t seq = 0;
   uint32_t checksum = 0;
   std::array<uint8_t, 128> payload = {};
 };
+
+using SharedTopic = LibXR::LinuxSharedTopic<IPCFrame>;
+using SharedData = SharedTopic::Data;
+using SharedSubscriber = SharedTopic::SyncSubscriber;
 
 uint32_t ComputeChecksum(const IPCFrame& frame)
 {
@@ -44,18 +51,36 @@ void AssertFrame(const IPCFrame& frame, uint32_t expected_seq)
   ASSERT(frame.checksum == ComputeChecksum(frame));
 }
 
+void MakeTopicName(char* topic_name, size_t topic_name_size, const char* prefix)
+{
+  std::snprintf(topic_name, topic_name_size, "%s_%d", prefix, static_cast<int>(getpid()));
+}
+
+void WaitForSubscriberNum(SharedTopic& topic, uint32_t expected_num)
+{
+  for (int retry = 0; retry < 200 && topic.GetSubscriberNum() < expected_num; ++retry)
+  {
+    usleep(10000);
+  }
+  ASSERT(topic.GetSubscriberNum() == expected_num);
+}
+
+void ExpectChildExit(pid_t child, int expected_code = 0)
+{
+  int status = 0;
+  ASSERT(waitpid(child, &status, 0) == child);
+  ASSERT(WIFEXITED(status));
+  ASSERT(WEXITSTATUS(status) == expected_code);
+}
+
 }  // namespace
 
 void test_linux_shm_topic()
 {
-  using SharedTopic = LibXR::LinuxSharedTopic<IPCFrame>;
-  using SharedData = SharedTopic::Data;
-  using SharedSubscriber = SharedTopic::SyncSubscriber;
-
   char topic_name[96] = {};
 
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_local_%d",
-                static_cast<int>(getpid()));
+  // Basic attach-only semantics and slot backpressure.
+  MakeTopicName(topic_name, sizeof(topic_name), "linux_shm_local");
   UNUSED(SharedTopic::Remove(topic_name));
 
   {
@@ -89,7 +114,7 @@ void test_linux_shm_topic()
     SharedData data2;
     ASSERT(publisher.CreateData(data2) == ErrorCode::FULL);
 
-    ASSERT(subscriber.Wait(100) == ErrorCode::OK);
+    ASSERT(subscriber.Wait(kShortWaitMs) == ErrorCode::OK);
     ASSERT(subscriber.GetData() != nullptr);
     AssertFrame(*subscriber.GetData(), 100);
     ASSERT(subscriber.GetPendingNum() == 1);
@@ -99,22 +124,21 @@ void test_linux_shm_topic()
     FillFrame(*data2.GetData(), 102);
     ASSERT(publisher.Publish(data2) == ErrorCode::OK);
 
-    ASSERT(subscriber.Wait(100) == ErrorCode::OK);
+    ASSERT(subscriber.Wait(kShortWaitMs) == ErrorCode::OK);
     ASSERT(subscriber.GetData() != nullptr);
     AssertFrame(*subscriber.GetData(), 101);
     subscriber.Release();
 
-    ASSERT(subscriber.Wait(100) == ErrorCode::OK);
+    ASSERT(subscriber.Wait(kShortWaitMs) == ErrorCode::OK);
     ASSERT(subscriber.GetData() != nullptr);
     AssertFrame(*subscriber.GetData(), 102);
     ASSERT(subscriber.GetPendingNum() == 0);
     subscriber.Release();
   }
 
+  // Stale publisher takeover should allow a fresh creator to reopen the segment.
   UNUSED(SharedTopic::Remove(topic_name));
-
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_takeover_%d",
-                static_cast<int>(getpid()));
+  MakeTopicName(topic_name, sizeof(topic_name), "linux_shm_takeover");
   UNUSED(SharedTopic::Remove(topic_name));
 
   {
@@ -144,10 +168,7 @@ void test_linux_shm_topic()
       _exit(0);
     }
 
-    int status = 0;
-    ASSERT(waitpid(child, &status, 0) == child);
-    ASSERT(WIFEXITED(status));
-    ASSERT(WEXITSTATUS(status) == 0);
+    ExpectChildExit(child);
 
     SharedTopic publisher(topic_name, config);
     ASSERT(publisher.Valid());
@@ -157,10 +178,9 @@ void test_linux_shm_topic()
     ASSERT(publisher.Publish(frame) == ErrorCode::OK);
   }
 
+  // BROADCAST_FULL should fail publish when the subscriber queue is saturated.
   UNUSED(SharedTopic::Remove(topic_name));
-
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_queue_%d",
-                static_cast<int>(getpid()));
+  MakeTopicName(topic_name, sizeof(topic_name), "linux_shm_queue");
   UNUSED(SharedTopic::Remove(topic_name));
 
   {
@@ -188,21 +208,20 @@ void test_linux_shm_topic()
     ASSERT(publisher.GetPublishFailedNum() == 1);
 
     SharedData recv_data;
-    ASSERT(subscriber.Wait(recv_data, 100) == ErrorCode::OK);
+    ASSERT(subscriber.Wait(recv_data, kShortWaitMs) == ErrorCode::OK);
     ASSERT(recv_data.GetSequence() == 1);
     AssertFrame(*recv_data.GetData(), 201);
     recv_data.Reset();
 
-    ASSERT(subscriber.Wait(recv_data, 100) == ErrorCode::OK);
+    ASSERT(subscriber.Wait(recv_data, kShortWaitMs) == ErrorCode::OK);
     ASSERT(recv_data.GetSequence() == 2);
     AssertFrame(*recv_data.GetData(), 202);
     recv_data.Reset();
   }
 
+  // BROADCAST_DROP_OLD should keep the newest descriptors without failing publish.
   UNUSED(SharedTopic::Remove(topic_name));
-
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_drop_old_%d",
-                static_cast<int>(getpid()));
+  MakeTopicName(topic_name, sizeof(topic_name), "linux_shm_drop_old");
   UNUSED(SharedTopic::Remove(topic_name));
 
   {
@@ -230,21 +249,20 @@ void test_linux_shm_topic()
     ASSERT(publisher.GetPublishFailedNum() == 0);
 
     SharedData recv_data;
-    ASSERT(subscriber.Wait(recv_data, 100) == ErrorCode::OK);
+    ASSERT(subscriber.Wait(recv_data, kShortWaitMs) == ErrorCode::OK);
     ASSERT(recv_data.GetSequence() == 2);
     AssertFrame(*recv_data.GetData(), 212);
     recv_data.Reset();
 
-    ASSERT(subscriber.Wait(recv_data, 100) == ErrorCode::OK);
+    ASSERT(subscriber.Wait(recv_data, kShortWaitMs) == ErrorCode::OK);
     ASSERT(recv_data.GetSequence() == 3);
     AssertFrame(*recv_data.GetData(), 213);
     recv_data.Reset();
   }
 
+  // A slot must stay pinned until every subscriber releases it.
   UNUSED(SharedTopic::Remove(topic_name));
-
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_ref_%d",
-                static_cast<int>(getpid()));
+  MakeTopicName(topic_name, sizeof(topic_name), "linux_shm_ref");
   UNUSED(SharedTopic::Remove(topic_name));
 
   {
@@ -265,8 +283,8 @@ void test_linux_shm_topic()
     FillFrame(frame, 301);
     ASSERT(publisher.Publish(frame) == ErrorCode::OK);
 
-    ASSERT(subscriber_a.Wait(100) == ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(100) == ErrorCode::OK);
+    ASSERT(subscriber_a.Wait(kShortWaitMs) == ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(kShortWaitMs) == ErrorCode::OK);
     AssertFrame(*subscriber_a.GetData(), 301);
     AssertFrame(*subscriber_b.GetData(), 301);
 
@@ -280,8 +298,8 @@ void test_linux_shm_topic()
     FillFrame(*blocked_data.GetData(), 302);
     ASSERT(publisher.Publish(blocked_data) == ErrorCode::OK);
 
-    ASSERT(subscriber_a.Wait(100) == ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(100) == ErrorCode::OK);
+    ASSERT(subscriber_a.Wait(kShortWaitMs) == ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(kShortWaitMs) == ErrorCode::OK);
     AssertFrame(*subscriber_a.GetData(), 302);
     AssertFrame(*subscriber_b.GetData(), 302);
     subscriber_a.Release();
@@ -290,8 +308,52 @@ void test_linux_shm_topic()
 
   UNUSED(SharedTopic::Remove(topic_name));
 
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_bal_rr_%d",
-                static_cast<int>(getpid()));
+  // The same topic name in different domains must stay isolated.
+  MakeTopicName(topic_name, sizeof(topic_name), "linux_shm_domain");
+
+  {
+    LibXR::Topic::Domain domain_a("linux_shm_domain_a");
+    LibXR::Topic::Domain domain_b("linux_shm_domain_b");
+
+    UNUSED(SharedTopic::Remove(topic_name, domain_a));
+    UNUSED(SharedTopic::Remove(topic_name, domain_b));
+
+    LibXR::LinuxSharedTopicConfig config;
+    config.slot_num = 4;
+    config.subscriber_num = 1;
+    config.queue_num = 4;
+
+    SharedTopic publisher_a(topic_name, domain_a, config);
+    SharedTopic publisher_b(topic_name, "linux_shm_domain_b", config);
+    ASSERT(publisher_a.Valid());
+    ASSERT(publisher_b.Valid());
+
+    SharedSubscriber subscriber_a(topic_name, "linux_shm_domain_a");
+    SharedSubscriber subscriber_b(topic_name, domain_b);
+    ASSERT(subscriber_a.Valid());
+    ASSERT(subscriber_b.Valid());
+
+    IPCFrame frame = {};
+    FillFrame(frame, 331);
+    ASSERT(publisher_a.Publish(frame) == ErrorCode::OK);
+    FillFrame(frame, 441);
+    ASSERT(publisher_b.Publish(frame) == ErrorCode::OK);
+
+    SharedData recv_a;
+    SharedData recv_b;
+    ASSERT(subscriber_a.Wait(recv_a, kShortWaitMs) == ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(recv_b, kShortWaitMs) == ErrorCode::OK);
+    ASSERT(recv_a.GetData()->seq == 331);
+    ASSERT(recv_b.GetData()->seq == 441);
+    recv_a.Reset();
+    recv_b.Reset();
+
+    UNUSED(SharedTopic::Remove(topic_name, domain_a));
+    UNUSED(SharedTopic::Remove(topic_name, domain_b));
+  }
+
+  // BALANCE_RR should rotate delivery between active balanced subscribers.
+  MakeTopicName(topic_name, sizeof(topic_name), "linux_shm_bal_rr");
   UNUSED(SharedTopic::Remove(topic_name));
 
   {
@@ -323,10 +385,10 @@ void test_linux_shm_topic()
     SharedData recv_b1;
     SharedData recv_b2;
 
-    ASSERT(subscriber_a.Wait(recv_a1, 100) == ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(recv_b1, 100) == ErrorCode::OK);
-    ASSERT(subscriber_a.Wait(recv_a2, 100) == ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(recv_b2, 100) == ErrorCode::OK);
+    ASSERT(subscriber_a.Wait(recv_a1, kShortWaitMs) == ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(recv_b1, kShortWaitMs) == ErrorCode::OK);
+    ASSERT(subscriber_a.Wait(recv_a2, kShortWaitMs) == ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(recv_b2, kShortWaitMs) == ErrorCode::OK);
 
     ASSERT(recv_a1.GetData()->seq == 351);
     ASSERT(recv_b1.GetData()->seq == 352);
@@ -336,8 +398,8 @@ void test_linux_shm_topic()
 
   UNUSED(SharedTopic::Remove(topic_name));
 
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_bal_rr_dead_%d",
-                static_cast<int>(getpid()));
+  // A dead balanced subscriber must be recycled so the group can keep running.
+  MakeTopicName(topic_name, sizeof(topic_name), "linux_shm_bal_rr_dead");
   UNUSED(SharedTopic::Remove(topic_name));
 
   {
@@ -369,7 +431,7 @@ void test_linux_shm_topic()
       }
 
       SharedData data;
-      if (subscriber.Wait(data, 2000) != ErrorCode::OK)
+      if (subscriber.Wait(data, kLongWaitMs) != ErrorCode::OK)
       {
         _exit(41);
       }
@@ -407,10 +469,7 @@ void test_linux_shm_topic()
     uint8_t cmd = 0xA5;
     ASSERT(write(cmd_pipe[1], &cmd, sizeof(cmd)) == static_cast<ssize_t>(sizeof(cmd)));
 
-    int status = 0;
-    ASSERT(waitpid(child, &status, 0) == child);
-    ASSERT(WIFEXITED(status));
-    ASSERT(WEXITSTATUS(status) == 0);
+    ExpectChildExit(child);
 
     FillFrame(frame, 362);
     ASSERT(publisher.Publish(frame) == ErrorCode::OK);
@@ -419,8 +478,8 @@ void test_linux_shm_topic()
 
     SharedData recv_alive1;
     SharedData recv_alive2;
-    ASSERT(subscriber_alive.Wait(recv_alive1, 2000) == ErrorCode::OK);
-    ASSERT(subscriber_alive.Wait(recv_alive2, 2000) == ErrorCode::OK);
+    ASSERT(subscriber_alive.Wait(recv_alive1, kLongWaitMs) == ErrorCode::OK);
+    ASSERT(subscriber_alive.Wait(recv_alive2, kLongWaitMs) == ErrorCode::OK);
     ASSERT(recv_alive1.GetData()->seq == 362);
     ASSERT(recv_alive2.GetData()->seq == 363);
 
@@ -430,8 +489,8 @@ void test_linux_shm_topic()
 
   UNUSED(SharedTopic::Remove(topic_name));
 
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_bal_rr_skip_full_%d",
-                static_cast<int>(getpid()));
+  // BALANCE_RR should skip a full member when another balanced subscriber can accept.
+  MakeTopicName(topic_name, sizeof(topic_name), "linux_shm_bal_rr_skip_full");
   UNUSED(SharedTopic::Remove(topic_name));
 
   {
@@ -459,7 +518,7 @@ void test_linux_shm_topic()
     ASSERT(publisher.Publish(frame) == ErrorCode::OK);
 
     SharedData recv_b0;
-    ASSERT(subscriber_b.Wait(recv_b0, 100) == ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(recv_b0, kShortWaitMs) == ErrorCode::OK);
     ASSERT(recv_b0.GetData()->seq == 372);
     recv_b0.Reset();
 
@@ -469,9 +528,9 @@ void test_linux_shm_topic()
     SharedData recv_a;
     SharedData recv_b1;
     SharedData recv_c;
-    ASSERT(subscriber_a.Wait(recv_a, 100) == ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(recv_b1, 100) == ErrorCode::OK);
-    ASSERT(subscriber_c.Wait(recv_c, 100) == ErrorCode::OK);
+    ASSERT(subscriber_a.Wait(recv_a, kShortWaitMs) == ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(recv_b1, kShortWaitMs) == ErrorCode::OK);
+    ASSERT(subscriber_c.Wait(recv_c, kShortWaitMs) == ErrorCode::OK);
 
     ASSERT(recv_a.GetData()->seq == 371);
     ASSERT(recv_b1.GetData()->seq == 374);
@@ -480,8 +539,8 @@ void test_linux_shm_topic()
 
   UNUSED(SharedTopic::Remove(topic_name));
 
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_mixed_modes_%d",
-                static_cast<int>(getpid()));
+  // Broadcast subscribers and balanced subscribers should coexist on one topic.
+  MakeTopicName(topic_name, sizeof(topic_name), "linux_shm_mixed_modes");
   UNUSED(SharedTopic::Remove(topic_name));
 
   {
@@ -511,9 +570,9 @@ void test_linux_shm_topic()
     SharedData bc0;
     SharedData bc1;
     SharedData bc2;
-    ASSERT(subscriber_broadcast.Wait(bc0, 100) == ErrorCode::OK);
-    ASSERT(subscriber_broadcast.Wait(bc1, 100) == ErrorCode::OK);
-    ASSERT(subscriber_broadcast.Wait(bc2, 100) == ErrorCode::OK);
+    ASSERT(subscriber_broadcast.Wait(bc0, kShortWaitMs) == ErrorCode::OK);
+    ASSERT(subscriber_broadcast.Wait(bc1, kShortWaitMs) == ErrorCode::OK);
+    ASSERT(subscriber_broadcast.Wait(bc2, kShortWaitMs) == ErrorCode::OK);
     ASSERT(bc0.GetData()->seq == 381);
     ASSERT(bc1.GetData()->seq == 382);
     ASSERT(bc2.GetData()->seq == 383);
@@ -521,9 +580,9 @@ void test_linux_shm_topic()
     SharedData rr_a0;
     SharedData rr_b0;
     SharedData rr_a1;
-    ASSERT(subscriber_rr_a.Wait(rr_a0, 100) == ErrorCode::OK);
-    ASSERT(subscriber_rr_b.Wait(rr_b0, 100) == ErrorCode::OK);
-    ASSERT(subscriber_rr_a.Wait(rr_a1, 100) == ErrorCode::OK);
+    ASSERT(subscriber_rr_a.Wait(rr_a0, kShortWaitMs) == ErrorCode::OK);
+    ASSERT(subscriber_rr_b.Wait(rr_b0, kShortWaitMs) == ErrorCode::OK);
+    ASSERT(subscriber_rr_a.Wait(rr_a1, kShortWaitMs) == ErrorCode::OK);
     ASSERT(rr_a0.GetData()->seq == 381);
     ASSERT(rr_b0.GetData()->seq == 382);
     ASSERT(rr_a1.GetData()->seq == 383);
@@ -531,8 +590,8 @@ void test_linux_shm_topic()
 
   UNUSED(SharedTopic::Remove(topic_name));
 
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_rr_group_required_%d",
-                static_cast<int>(getpid()));
+  // If the balanced group exists but cannot accept, publish should fail for everyone.
+  MakeTopicName(topic_name, sizeof(topic_name), "linux_shm_rr_group_required");
   UNUSED(SharedTopic::Remove(topic_name));
 
   {
@@ -557,18 +616,18 @@ void test_linux_shm_topic()
     ASSERT(publisher.Publish(frame) == ErrorCode::FULL);
 
     SharedData bc0;
-    ASSERT(subscriber_broadcast.Wait(bc0, 100) == ErrorCode::OK);
+    ASSERT(subscriber_broadcast.Wait(bc0, kShortWaitMs) == ErrorCode::OK);
     ASSERT(bc0.GetData()->seq == 391);
 
     SharedData rr0;
-    ASSERT(subscriber_rr.Wait(rr0, 100) == ErrorCode::OK);
+    ASSERT(subscriber_rr.Wait(rr0, kShortWaitMs) == ErrorCode::OK);
     ASSERT(rr0.GetData()->seq == 391);
   }
 
   UNUSED(SharedTopic::Remove(topic_name));
 
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_dead_sub_%d",
-                static_cast<int>(getpid()));
+  // A dead subscriber should be reclaimed together with its held slot state.
+  MakeTopicName(topic_name, sizeof(topic_name), "linux_shm_dead_sub");
   UNUSED(SharedTopic::Remove(topic_name));
 
   {
@@ -600,7 +659,7 @@ void test_linux_shm_topic()
       }
 
       SharedData recv_data;
-      if (subscriber.Wait(recv_data, 2000) != ErrorCode::OK)
+      if (subscriber.Wait(recv_data, kLongWaitMs) != ErrorCode::OK)
       {
         _exit(11);
       }
@@ -623,11 +682,7 @@ void test_linux_shm_topic()
     close(ack_pipe[1]);
     close(cmd_pipe[0]);
 
-    for (int retry = 0; retry < 200 && publisher.GetSubscriberNum() == 0; ++retry)
-    {
-      usleep(10000);
-    }
-    ASSERT(publisher.GetSubscriberNum() == 1);
+    WaitForSubscriberNum(publisher, 1);
 
     IPCFrame frame = {};
     FillFrame(frame, 401);
@@ -642,10 +697,7 @@ void test_linux_shm_topic()
     uint8_t cmd = 0x5A;
     ASSERT(write(cmd_pipe[1], &cmd, sizeof(cmd)) == static_cast<ssize_t>(sizeof(cmd)));
 
-    int status = 0;
-    ASSERT(waitpid(child, &status, 0) == child);
-    ASSERT(WIFEXITED(status));
-    ASSERT(WEXITSTATUS(status) == 0);
+    ExpectChildExit(child);
     ASSERT(publisher.GetSubscriberNum() == 0);
 
     SharedData data0;
@@ -661,8 +713,8 @@ void test_linux_shm_topic()
 
   UNUSED(SharedTopic::Remove(topic_name));
 
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shm_fork_%d",
-                static_cast<int>(getpid()));
+  // Cross-process publish/subscribe should preserve ordering and payload integrity.
+  MakeTopicName(topic_name, sizeof(topic_name), "linux_shm_fork");
   UNUSED(SharedTopic::Remove(topic_name));
 
   {
@@ -688,7 +740,7 @@ void test_linux_shm_topic()
       for (uint32_t seq = 1; seq <= 32; ++seq)
       {
         SharedData recv_data;
-        if (subscriber.Wait(recv_data, 2000) != ErrorCode::OK)
+        if (subscriber.Wait(recv_data, kLongWaitMs) != ErrorCode::OK)
         {
           _exit(3);
         }
@@ -709,11 +761,7 @@ void test_linux_shm_topic()
       _exit(0);
     }
 
-    for (int retry = 0; retry < 200 && publisher.GetSubscriberNum() == 0; ++retry)
-    {
-      usleep(10000);
-    }
-    ASSERT(publisher.GetSubscriberNum() == 1);
+    WaitForSubscriberNum(publisher, 1);
 
     for (uint32_t seq = 1; seq <= 32; ++seq)
     {
@@ -723,10 +771,7 @@ void test_linux_shm_topic()
       ASSERT(publisher.Publish(data) == ErrorCode::OK);
     }
 
-    int status = 0;
-    ASSERT(waitpid(child, &status, 0) == child);
-    ASSERT(WIFEXITED(status));
-    ASSERT(WEXITSTATUS(status) == 0);
+    ExpectChildExit(child);
   }
 
   UNUSED(SharedTopic::Remove(topic_name));


### PR DESCRIPTION
## Summary by Sourcery

Introduce domain-aware shared memory topic naming and validation for Linux shared topics, along with supporting CRC64 utilities and tests.

New Features:
- Add domain-aware LinuxSharedTopic construction, subscription, and removal APIs that distinguish shared memory topics by domain and topic name.
- Introduce a CRC64 utility class for computing 64-bit checksums used in shared topic identity keys.

Enhancements:
- Embed domain, topic name, and a 64-bit name key into the LinuxSharedTopic shared header and layout to uniquely identify segments and prevent cross-domain collisions.
- Extend shared memory layout to store and validate the topic name, rejecting stale or mismatched segments when attaching.
- Tighten Topic::Domain construction by asserting that the provided name is non-null.
- Clean up USB DeviceComposition by removing an unused b_max_power_ member.

Tests:
- Expand Linux shared memory topic tests to cover multiple domains sharing the same topic name and verify domain isolation in publish/subscribe behavior.