### PR TITLE
fix(linux): clean up CMake 3.12 compatibility and improve UART/GPIO support

### DIFF
--- a/CMake/compile_options.cmake
+++ b/CMake/compile_options.cmake
@@ -1,0 +1,10 @@
+include(CheckCXXCompilerFlag)
+
+set(LIBXR_COMMON_COMPILE_OPTIONS -Wno-psabi)
+
+check_cxx_compiler_flag("-fmacro-prefix-map=${CMAKE_SOURCE_DIR}=."
+                        LIBXR_HAS_FMACRO_PREFIX_MAP)
+if(LIBXR_HAS_FMACRO_PREFIX_MAP)
+  list(APPEND LIBXR_COMMON_COMPILE_OPTIONS
+       -fmacro-prefix-map=${CMAKE_SOURCE_DIR}=.)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,8 @@ else()
   add_library(${PROJECT_NAME} OBJECT)
 endif()
 
-target_compile_options(
-  xr
-  PUBLIC -Wno-psabi
-  PUBLIC -fmacro-prefix-map=${CMAKE_SOURCE_DIR}=.)
+include(CMake/compile_options.cmake)
+target_compile_options(xr PUBLIC ${LIBXR_COMMON_COMPILE_OPTIONS})
 
 include(CMake/config.cmake)
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ set(LIBXR_DRIVER Linux)
 
 ### Build as Shared/Static Library
 
-By default, the library is built as an object target. You can explicitly set the build type in the CMake command line or your own CMakeLists.txt:
+LibXR now requires CMake 3.12 or newer. By default, the library is built as an object target. You can explicitly set the build type in the CMake command line or your own CMakeLists.txt:
 
 ```cmake
 # Build as a shared library

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -119,7 +119,7 @@ set(LIBXR_DRIVER Linux)
 
 ### 编译为共享/静态库
 
-默认编译为object目标，可以在 CMake 命令行或外部 CMakeLists.txt 中预先指定
+LibXR 现在要求 CMake 3.12 或更新版本。默认编译为 object 目标，可以在 CMake 命令行或外部 CMakeLists.txt 中预先指定
 
 ```cmake
 # 编译为共享库

--- a/driver/Linux/linux_gpio.cpp
+++ b/driver/Linux/linux_gpio.cpp
@@ -12,6 +12,30 @@
 
 #include "logger.hpp"
 
+#if !defined(XR_LINUX_GPIO_DISABLE_V2) && defined(GPIO_V2_LINE_FLAG_INPUT) &&            \
+    defined(GPIO_V2_GET_LINEINFO_IOCTL) && defined(GPIO_V2_GET_LINE_IOCTL) &&            \
+    defined(GPIO_V2_LINE_SET_CONFIG_IOCTL) && defined(GPIO_V2_LINE_GET_VALUES_IOCTL) &&  \
+    defined(GPIO_V2_LINE_SET_VALUES_IOCTL) && defined(GPIO_V2_LINE_EVENT_RISING_EDGE) && \
+    defined(GPIO_V2_LINE_EVENT_FALLING_EDGE)
+#define XR_LINUX_GPIO_HAS_V2 1
+#else
+#define XR_LINUX_GPIO_HAS_V2 0
+#endif
+
+#if defined(GPIOHANDLE_REQUEST_BIAS_DISABLE) && \
+    defined(GPIOHANDLE_REQUEST_BIAS_PULL_UP) && \
+    defined(GPIOHANDLE_REQUEST_BIAS_PULL_DOWN)
+#define XR_LINUX_GPIO_V1_HAS_BIAS_FLAGS 1
+#else
+#define XR_LINUX_GPIO_V1_HAS_BIAS_FLAGS 0
+#endif
+
+#if defined(GPIOHANDLE_SET_CONFIG_IOCTL)
+#define XR_LINUX_GPIO_V1_HAS_SET_CONFIG 1
+#else
+#define XR_LINUX_GPIO_V1_HAS_SET_CONFIG 0
+#endif
+
 namespace
 {
 constexpr const char* kLinuxGPIOConsumer = "LinuxGPIO";
@@ -37,6 +61,7 @@ void CopyConsumer(char (&dst)[N], const char* src)
   dst[N - 1U] = '\0';
 }
 
+#if XR_LINUX_GPIO_HAS_V2
 uint64_t BuildLineFlagsV2(LibXR::GPIO::Configuration config)
 {
   uint64_t flags = 0U;
@@ -79,6 +104,7 @@ uint64_t BuildLineFlagsV2(LibXR::GPIO::Configuration config)
 
   return flags;
 }
+#endif
 
 uint32_t BuildHandleFlagsV1(LibXR::GPIO::Configuration config)
 {
@@ -103,13 +129,19 @@ uint32_t BuildHandleFlagsV1(LibXR::GPIO::Configuration config)
   switch (config.pull)
   {
     case LibXR::GPIO::Pull::NONE:
+#if XR_LINUX_GPIO_V1_HAS_BIAS_FLAGS
       flags |= GPIOHANDLE_REQUEST_BIAS_DISABLE;
+#endif
       break;
     case LibXR::GPIO::Pull::UP:
+#if XR_LINUX_GPIO_V1_HAS_BIAS_FLAGS
       flags |= GPIOHANDLE_REQUEST_BIAS_PULL_UP;
+#endif
       break;
     case LibXR::GPIO::Pull::DOWN:
+#if XR_LINUX_GPIO_V1_HAS_BIAS_FLAGS
       flags |= GPIOHANDLE_REQUEST_BIAS_PULL_DOWN;
+#endif
       break;
   }
 
@@ -175,19 +207,17 @@ PollReadableResult PollReadable(int fd, int wake_fd, int timeout_ms)
   std::array<pollfd, 2> poll_fds = {};
   nfds_t nfds = 0;
 
-  poll_fds[nfds++] = {
-      .fd = fd,
-      .events = POLLIN,
-      .revents = 0,
-  };
+  poll_fds[nfds] = {};
+  poll_fds[nfds].fd = fd;
+  poll_fds[nfds].events = POLLIN;
+  ++nfds;
 
   if (wake_fd >= 0)
   {
-    poll_fds[nfds++] = {
-        .fd = wake_fd,
-        .events = POLLIN,
-        .revents = 0,
-    };
+    poll_fds[nfds] = {};
+    poll_fds[nfds].fd = wake_fd;
+    poll_fds[nfds].events = POLLIN;
+    ++nfds;
   }
 
   while (true)
@@ -231,17 +261,27 @@ PollReadableResult PollReadable(int fd, int wake_fd, int timeout_ms)
 
 bool IsKnownGPIOEvent(uint32_t event_id)
 {
-  if (event_id == GPIO_V2_LINE_EVENT_RISING_EDGE ||
-      event_id == GPIOEVENT_EVENT_RISING_EDGE)
+  if (event_id == GPIOEVENT_EVENT_RISING_EDGE)
   {
     return true;
   }
 
-  if (event_id == GPIO_V2_LINE_EVENT_FALLING_EDGE ||
-      event_id == GPIOEVENT_EVENT_FALLING_EDGE)
+  if (event_id == GPIOEVENT_EVENT_FALLING_EDGE)
   {
     return true;
   }
+
+#if XR_LINUX_GPIO_HAS_V2
+  if (event_id == GPIO_V2_LINE_EVENT_RISING_EDGE)
+  {
+    return true;
+  }
+
+  if (event_id == GPIO_V2_LINE_EVENT_FALLING_EDGE)
+  {
+    return true;
+  }
+#endif
 
   XR_LOG_WARN("Unknown GPIO event id: %u", event_id);
   return false;
@@ -281,6 +321,7 @@ bool LinuxGPIO::Read()
   const int request_fd = request_fd_.load();
   if (abi_version_.load() == AbiVersion::V2)
   {
+#if XR_LINUX_GPIO_HAS_V2
     gpio_v2_line_values values = {};
     values.mask = 1ULL;
     if (ioctl(request_fd, GPIO_V2_LINE_GET_VALUES_IOCTL, &values) < 0)
@@ -289,6 +330,10 @@ bool LinuxGPIO::Read()
       return false;
     }
     return (values.bits & 1ULL) != 0U;
+#else
+    ASSERT(false);
+    return false;
+#endif
   }
 
   gpiohandle_data values = {};
@@ -311,6 +356,7 @@ void LinuxGPIO::Write(bool value)
   const int request_fd = request_fd_.load();
   if (abi_version_.load() == AbiVersion::V2)
   {
+#if XR_LINUX_GPIO_HAS_V2
     gpio_v2_line_values values = {};
     values.mask = 1ULL;
     values.bits = value ? 1ULL : 0ULL;
@@ -319,6 +365,10 @@ void LinuxGPIO::Write(bool value)
       XR_LOG_WARN("Failed to write GPIO value: %s", std::strerror(errno));
     }
     return;
+#else
+    ASSERT(false);
+    return;
+#endif
   }
 
   gpiohandle_data values = {};
@@ -691,6 +741,7 @@ ErrorCode LinuxGPIO::DetectAbiVersion()
     return ErrorCode::FAILED;
   }
 
+#if XR_LINUX_GPIO_HAS_V2
   gpio_v2_line_info info = {};
   info.offset = (line_offset_ < chip_info.lines) ? line_offset_ : 0U;
   if (ioctl(chip_fd_, GPIO_V2_GET_LINEINFO_IOCTL, &info) == 0)
@@ -711,6 +762,10 @@ ErrorCode LinuxGPIO::DetectAbiVersion()
 
   XR_LOG_ERROR("Failed to probe GPIO chardev ABI: %s", std::strerror(errno));
   return ErrorCode::FAILED;
+#else
+  abi_version_.store(AbiVersion::V1);
+  return ErrorCode::OK;
+#endif
 }
 
 ErrorCode LinuxGPIO::ReopenRequest(Configuration config)
@@ -727,6 +782,7 @@ ErrorCode LinuxGPIO::ReopenRequest(Configuration config)
 
 ErrorCode LinuxGPIO::OpenRequestV2(Configuration config)
 {
+#if XR_LINUX_GPIO_HAS_V2
   gpio_v2_line_request request = {};
   request.offsets[0] = line_offset_;
   request.num_lines = 1U;
@@ -753,10 +809,16 @@ ErrorCode LinuxGPIO::OpenRequestV2(Configuration config)
   }
 
   return ErrorCode::OK;
+#else
+  (void)config;
+  ASSERT(false);
+  return ErrorCode::FAILED;
+#endif
 }
 
 ErrorCode LinuxGPIO::ReconfigureRequestV2(Configuration config)
 {
+#if XR_LINUX_GPIO_HAS_V2
   const bool was_interrupt_request =
       (request_kind_.load() == RequestKind::EVENT) && interrupt_enabled_.load();
   if (was_interrupt_request)
@@ -783,6 +845,11 @@ ErrorCode LinuxGPIO::ReconfigureRequestV2(Configuration config)
     interrupt_enabled_.store(true);
   }
   return ErrorCode::OK;
+#else
+  (void)config;
+  ASSERT(false);
+  return ErrorCode::FAILED;
+#endif
 }
 
 ErrorCode LinuxGPIO::OpenRequestV1(Configuration config)
@@ -840,6 +907,7 @@ ErrorCode LinuxGPIO::ReconfigureRequestV1(Configuration config)
     return ReopenRequest(config);
   }
 
+#if XR_LINUX_GPIO_V1_HAS_SET_CONFIG
   gpiohandle_config handle_config = {};
   handle_config.flags = BuildHandleFlagsV1(config);
   if (ioctl(request_fd_.load(), GPIOHANDLE_SET_CONFIG_IOCTL, &handle_config) < 0)
@@ -849,6 +917,9 @@ ErrorCode LinuxGPIO::ReconfigureRequestV1(Configuration config)
   }
 
   return ErrorCode::OK;
+#else
+  return ReopenRequest(config);
+#endif
 }
 
 ErrorCode LinuxGPIO::PumpEventQueue(int fd, AbiVersion abi_version, size_t& event_count,
@@ -885,6 +956,7 @@ ErrorCode LinuxGPIO::PumpEventQueue(int fd, AbiVersion abi_version, size_t& even
 
 ErrorCode LinuxGPIO::ReadEventsV2(int fd, size_t& event_count) const
 {
+#if XR_LINUX_GPIO_HAS_V2
   bool received = false;
   while (true)
   {
@@ -930,6 +1002,12 @@ ErrorCode LinuxGPIO::ReadEventsV2(int fd, size_t& event_count) const
   }
 
   return received ? ErrorCode::OK : ErrorCode::EMPTY;
+#else
+  (void)fd;
+  event_count = 0U;
+  ASSERT(false);
+  return ErrorCode::FAILED;
+#endif
 }
 
 ErrorCode LinuxGPIO::ReadEventsV1(int fd, size_t& event_count) const

--- a/driver/Linux/linux_uart.hpp
+++ b/driver/Linux/linux_uart.hpp
@@ -13,7 +13,10 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <algorithm>
 #include <filesystem>
+#include <system_error>
+#include <vector>
 
 #include "libxr_def.hpp"
 #include "libxr_rw.hpp"
@@ -22,12 +25,11 @@
 
 namespace LibXR
 {
-
 /**
  * @brief Linux UART 串口驱动实现 / Linux UART driver implementation
  *
- * 支持按设备路径或 USB VID/PID 自动发现并创建 UART 通道。
- * Supports UART creation by device path or USB VID/PID auto discovery.
+ * 支持按设备路径或 USB VID/PID(/serial) 自动发现并创建 UART 通道。
+ * Supports UART creation by device path or USB VID/PID(/serial) auto discovery.
  */
 class LinuxUART : public UART
 {
@@ -67,10 +69,11 @@ class LinuxUART : public UART
       XR_LOG_PASS("Open UART device: %s", device_path_.c_str());
     }
 
-    config_ = {.baudrate = baudrate,
-               .parity = parity,
-               .data_bits = data_bits,
-               .stop_bits = stop_bits};
+    config_ = {};
+    config_.baudrate = baudrate;
+    config_.parity = parity;
+    config_.data_bits = data_bits;
+    config_.stop_bits = stop_bits;
 
     SetConfig(config_);
 
@@ -93,6 +96,18 @@ class LinuxUART : public UART
             unsigned int baudrate = 115200, Parity parity = Parity::NO_PARITY,
             uint8_t data_bits = 8, uint8_t stop_bits = 1, uint32_t tx_queue_size = 5,
             size_t buffer_size = 512, size_t thread_stack_size = 65536)
+      : LinuxUART(vid, pid, "", baudrate, parity, data_bits, stop_bits, tx_queue_size,
+                  buffer_size, thread_stack_size)
+  {
+  }
+
+  /**
+   * @brief 通过 USB VID/PID/序列号构造 UART / Construct UART by USB VID/PID/serial
+   */
+  LinuxUART(const std::string& vid, const std::string& pid, const std::string& serial,
+            unsigned int baudrate = 115200, Parity parity = Parity::NO_PARITY,
+            uint8_t data_bits = 8, uint8_t stop_bits = 1, uint32_t tx_queue_size = 5,
+            size_t buffer_size = 512, size_t thread_stack_size = 65536)
       : UART(&_read_port, &_write_port),
         rx_buff_(new uint8_t[buffer_size]),
         tx_buff_(new uint8_t[buffer_size]),
@@ -100,10 +115,18 @@ class LinuxUART : public UART
         _read_port(buffer_size),
         _write_port(tx_queue_size, buffer_size)
   {
-    while (!FindUSBTTYByVidPid(vid, pid, device_path_))
+    while (!FindUSBTTYByVidPid(vid, pid, serial, device_path_))
     {
-      XR_LOG_WARN("Cannot find USB TTY device with VID=%s PID=%s, retrying...",
-                  vid.c_str(), pid.c_str());
+      if (serial.empty())
+      {
+        XR_LOG_WARN("Cannot find USB TTY device with VID=%s PID=%s, retrying...",
+                    vid.c_str(), pid.c_str());
+      }
+      else
+      {
+        XR_LOG_WARN("Cannot find USB TTY device with VID=%s PID=%s SERIAL=%s, retrying...",
+                    vid.c_str(), pid.c_str(), serial.c_str());
+      }
       Thread::Sleep(100);
     }
 
@@ -129,10 +152,11 @@ class LinuxUART : public UART
       XR_LOG_PASS("Open UART device: %s", device_path_.c_str());
     }
 
-    config_ = {.baudrate = baudrate,
-               .parity = parity,
-               .data_bits = data_bits,
-               .stop_bits = stop_bits};
+    config_ = {};
+    config_.baudrate = baudrate;
+    config_.parity = parity;
+    config_.data_bits = data_bits;
+    config_.stop_bits = stop_bits;
 
     SetConfig(config_);
 
@@ -158,17 +182,23 @@ class LinuxUART : public UART
     }
     for (const auto& entry : std::filesystem::directory_iterator(BASE))
     {
-      std::string full = std::filesystem::canonical(entry.path());
+      std::error_code ec;
+      const auto full = std::filesystem::canonical(entry.path(), ec);
+      if (ec)
+      {
+        continue;
+      }
       if (full == tty_name)
       {
-        return entry.path();  // 返回符号链接路径
+        return entry.path().string();  // 返回符号链接路径
       }
     }
-    return "";  // 没找到
+    return tty_name;  // 未命中 by-path 时保留原始 tty 路径
   }
 
   static bool FindUSBTTYByVidPid(const std::string& target_vid,
-                                 const std::string& target_pid, std::string& tty_path)
+                                 const std::string& target_pid,
+                                 const std::string& target_serial, std::string& tty_path)
   {
     struct udev* udev = udev_new();
     if (!udev)
@@ -183,7 +213,7 @@ class LinuxUART : public UART
 
     struct udev_list_entry* devices = udev_enumerate_get_list_entry(enumerate);
     struct udev_list_entry* entry = nullptr;
-    bool found = false;
+    std::vector<std::string> matches;
 
     udev_list_entry_foreach(entry, devices)
     {
@@ -201,16 +231,15 @@ class LinuxUART : public UART
       {
         const char* vid = udev_device_get_sysattr_value(usb_dev, "idVendor");
         const char* pid = udev_device_get_sysattr_value(usb_dev, "idProduct");
+        const char* serial = udev_device_get_sysattr_value(usb_dev, "serial");
 
-        if (vid && pid && target_vid == vid && target_pid == pid)
+        if (vid && pid && target_vid == vid && target_pid == pid &&
+            (target_serial.empty() || (serial && target_serial == serial)))
         {
           const char* devnode = udev_device_get_devnode(tty_dev);
           if (devnode)
           {
-            tty_path = devnode;
-            found = true;
-            udev_device_unref(tty_dev);
-            break;
+            matches.emplace_back(devnode);
           }
         }
       }
@@ -220,7 +249,22 @@ class LinuxUART : public UART
 
     udev_enumerate_unref(enumerate);
     udev_unref(udev);
-    return found;
+    if (matches.empty())
+    {
+      return false;
+    }
+
+    std::sort(matches.begin(), matches.end());
+    tty_path = matches.front();
+
+    if (matches.size() > 1 && target_serial.empty())
+    {
+      XR_LOG_WARN(
+          "Multiple USB TTY devices found with VID=%s PID=%s, using %s. Specify serial to disambiguate.",
+          target_vid.c_str(), target_pid.c_str(), tty_path.c_str());
+    }
+
+    return true;
   }
 
   void SetLowLatency(int fd)
@@ -342,9 +386,9 @@ class LinuxUART : public UART
     return ErrorCode::OK;
   }
 
-  static ErrorCode ReadFun(ReadPort&) { return ErrorCode::EMPTY; }
+  static ErrorCode ReadFun(ReadPort&, bool) { return ErrorCode::EMPTY; }
 
-  static ErrorCode WriteFun(WritePort& port)
+  static ErrorCode WriteFun(WritePort& port, bool)
   {
     auto uart = CONTAINER_OF(&port, LinuxUART, _write_port);
     uart->write_sem_.Post();
@@ -418,7 +462,7 @@ class LinuxUART : public UART
                               (written == static_cast<int>(info.data.size_))
                                   ? ErrorCode::OK
                                   : ErrorCode::FAILED,
-                              info, written);
+                              info);
         }
         else
         {

--- a/driver/mspm0/mspm0_uart.cpp
+++ b/driver/mspm0/mspm0_uart.cpp
@@ -342,7 +342,7 @@ ErrorCode MSPM0UART::SetConfig(UART::Configuration config)
   return ErrorCode::OK;
 }
 
-ErrorCode MSPM0UART::WriteFun(WritePort& port)
+ErrorCode MSPM0UART::WriteFun(WritePort& port, bool)
 {
   auto* uart = CONTAINER_OF(&port, MSPM0UART, _write_port);
   AtomicCounterGuard io_guard(uart->io_handler_inflight_);
@@ -362,7 +362,7 @@ ErrorCode MSPM0UART::WriteFun(WritePort& port)
   return ErrorCode::PENDING;
 }
 
-ErrorCode MSPM0UART::ReadFun(ReadPort& port)
+ErrorCode MSPM0UART::ReadFun(ReadPort& port, bool)
 {
   auto* uart = CONTAINER_OF(&port, MSPM0UART, _read_port);
   AtomicCounterGuard io_guard(uart->io_handler_inflight_);
@@ -1254,9 +1254,7 @@ void MSPM0UART::HandleTxInterrupt(bool in_isr)
       uint8_t tx_byte = 0;
       if (write_port_->queue_data_->Pop(tx_byte) != ErrorCode::OK)
       {
-        const uint32_t SENT =
-            static_cast<uint32_t>(tx_active_total_ - tx_active_remaining_);
-        write_port_->Finish(in_isr, ErrorCode::FAILED, tx_active_info_, SENT);
+        write_port_->Finish(in_isr, ErrorCode::FAILED, tx_active_info_);
         tx_active_valid_.store(false, std::memory_order_release);
         tx_active_remaining_ = 0;
         tx_active_total_ = 0;
@@ -1273,8 +1271,7 @@ void MSPM0UART::HandleTxInterrupt(bool in_isr)
       return;
     }
 
-    write_port_->Finish(in_isr, ErrorCode::OK, tx_active_info_,
-                        static_cast<uint32_t>(tx_active_total_));
+    write_port_->Finish(in_isr, ErrorCode::OK, tx_active_info_);
     tx_active_valid_.store(false, std::memory_order_release);
     tx_active_remaining_ = 0;
     tx_active_total_ = 0;
@@ -1287,7 +1284,7 @@ void MSPM0UART::AbortTx(bool in_isr)
 
   if (tx_active_valid_.exchange(false, std::memory_order_acq_rel))
   {
-    write_port_->Finish(in_isr, ErrorCode::FAILED, tx_active_info_, 0U);
+    write_port_->Finish(in_isr, ErrorCode::FAILED, tx_active_info_);
   }
   tx_active_remaining_ = 0U;
   tx_active_total_ = 0U;
@@ -1295,7 +1292,7 @@ void MSPM0UART::AbortTx(bool in_isr)
   WriteInfoBlock info;
   while (write_port_->queue_info_->Pop(info) == ErrorCode::OK)
   {
-    write_port_->Finish(in_isr, ErrorCode::FAILED, info, 0U);
+    write_port_->Finish(in_isr, ErrorCode::FAILED, info);
   }
 
   if (write_port_->queue_data_ != nullptr)

--- a/driver/mspm0/mspm0_uart.hpp
+++ b/driver/mspm0/mspm0_uart.hpp
@@ -38,8 +38,8 @@ class MSPM0UART : public UART
   ErrorCode SetConfig(UART::Configuration config) override;
   static UART::Configuration BuildConfigFromSysCfg(UART_Regs* instance,
                                                    uint32_t baudrate);
-  static ErrorCode WriteFun(WritePort& port);
-  static ErrorCode ReadFun(ReadPort& port);
+  static ErrorCode WriteFun(WritePort& port, bool in_isr);
+  static ErrorCode ReadFun(ReadPort& port, bool in_isr);
 
   void Abort(bool in_isr = false);
   static void OnInterrupt(uint8_t index);

--- a/src/driver/usb/CMakeLists.txt
+++ b/src/driver/usb/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.12)
 
 if(NOT TARGET xr)
   message(FATAL_ERROR "Need LibXR to build.")


### PR DESCRIPTION
## Summary by Sourcery

Improve Linux GPIO/UART portability and CMake 3.12+ compatibility while tightening UART callback interfaces.

New Features:
- Allow Linux UART devices to be discovered by USB VID/PID/serial, with deterministic selection when multiple matches exist.

Bug Fixes:
- Harden Linux GPIO against missing kernel GPIO v2 or bias/set-config v1 APIs by compiling out unsupported paths and falling back safely.
- Prevent filesystem canonicalization errors in Linux UART device path resolution from breaking device discovery, falling back to the original TTY path.
- Align UART read/write callback signatures and completion handling across Linux and MSPM0 implementations to avoid mismatches in finished-byte reporting.

Enhancements:
- Centralize common compiler options with feature-detection for -fmacro-prefix-map and apply them consistently to the xr target.
- Improve Linux UART logging when multiple or ambiguous USB TTY devices are present and when serial is required for disambiguation.

Build:
- Raise the minimum CMake version to 3.12 for USB driver builds and document this requirement in both English and Chinese READMEs.
- Link against stdc++fs on older GNU C++ compilers when building the Linux driver to satisfy filesystem dependencies.

Documentation:
- Document the new CMake 3.12+ requirement in both English and Chinese READMEs and clarify VID/PID/serial-based UART discovery.