### PR TITLE
Fix/stm32 asyncblockwait 32bit

### DIFF
--- a/driver/esp/esp_cdc_jtag.cpp
+++ b/driver/esp/esp_cdc_jtag.cpp
@@ -126,7 +126,7 @@ void IRAM_ATTR ESP32CDCJtag::ResetTxState(bool)
 {
   ClearActiveTx();
   ClearPendingTx();
-  tx_busy_.store(false, std::memory_order_release);
+  tx_busy_.Clear();
 }
 
 bool IRAM_ATTR ESP32CDCJtag::DequeueTxToSlot(uint8_t* slot, size_t& size,
@@ -206,12 +206,12 @@ bool IRAM_ATTR ESP32CDCJtag::LoadPendingTxFromQueue(bool in_isr)
 
 bool IRAM_ATTR ESP32CDCJtag::PumpTx(bool)
 {
-  while (tx_busy_.load(std::memory_order_acquire))
+  while (tx_busy_.IsSet())
   {
     if (!tx_active_valid_ || (tx_active_ptr_ == nullptr) ||
         (tx_active_offset_ >= tx_active_size_))
     {
-      tx_busy_.store(false, std::memory_order_release);
+      tx_busy_.Clear();
       return true;
     }
 
@@ -226,7 +226,7 @@ bool IRAM_ATTR ESP32CDCJtag::PumpTx(bool)
     tx_active_offset_ += static_cast<size_t>(written);
     if (tx_active_offset_ >= tx_active_size_)
     {
-      tx_busy_.store(false, std::memory_order_release);
+      tx_busy_.Clear();
       return true;
     }
   }
@@ -270,9 +270,7 @@ bool IRAM_ATTR ESP32CDCJtag::StartActiveTransfer(bool in_isr)
     return false;
   }
 
-  bool expected = false;
-  if (!tx_busy_.compare_exchange_strong(expected, true, std::memory_order_acq_rel,
-                                        std::memory_order_acquire))
+  if (tx_busy_.TestAndSet())
   {
     return true;
   }
@@ -294,7 +292,7 @@ bool IRAM_ATTR ESP32CDCJtag::StartAndReportActive(bool in_isr)
 
   // Keep aligned with STM/CH: once next op is kicked to HW, report it finished.
   write_port_->Finish(in_isr, ErrorCode::OK, tx_active_info_);
-  if (!tx_busy_.load(std::memory_order_acquire) && tx_active_valid_)
+  if (!tx_busy_.IsSet() && tx_active_valid_)
   {
     OnTxTransferDone(in_isr, ErrorCode::OK);
   }
@@ -310,7 +308,7 @@ void IRAM_ATTR ESP32CDCJtag::StopTxTransfer()
 void IRAM_ATTR ESP32CDCJtag::OnTxTransferDone(bool in_isr, ErrorCode result)
 {
   Flag::ScopedRestore tx_flag(in_tx_isr_);
-  tx_busy_.store(false, std::memory_order_release);
+  tx_busy_.Clear();
 
   ClearActiveTx();
 
@@ -348,8 +346,7 @@ void IRAM_ATTR ESP32CDCJtag::OnTxTransferDone(bool in_isr, ErrorCode result)
     (void)LoadPendingTxFromQueue(in_isr);
   }
 
-  if (!tx_busy_.load(std::memory_order_acquire) && !tx_active_valid_ &&
-      !tx_pending_valid_)
+  if (!tx_busy_.IsSet() && !tx_active_valid_ && !tx_pending_valid_)
   {
     StopTxTransfer();
   }
@@ -367,7 +364,7 @@ ErrorCode IRAM_ATTR ESP32CDCJtag::TryStartTx(bool in_isr)
     (void)LoadActiveTxFromQueue(in_isr);
   }
 
-  if (!tx_busy_.load(std::memory_order_acquire) && tx_active_valid_)
+  if (!tx_busy_.IsSet() && tx_active_valid_)
   {
     if (!StartActiveTransfer(in_isr))
     {
@@ -375,7 +372,7 @@ ErrorCode IRAM_ATTR ESP32CDCJtag::TryStartTx(bool in_isr)
       return ErrorCode::FAILED;
     }
 
-    if (!tx_busy_.load(std::memory_order_acquire) && tx_active_valid_)
+    if (!tx_busy_.IsSet() && tx_active_valid_)
     {
       OnTxTransferDone(in_isr, ErrorCode::OK);
     }
@@ -421,9 +418,9 @@ void IRAM_ATTR ESP32CDCJtag::HandleInterrupt()
   usb_serial_jtag_ll_clr_intsts_mask(tx_status);
 
   Flag::ScopedRestore tx_flag(in_tx_isr_);
-  const bool was_busy = tx_busy_.load(std::memory_order_acquire);
+  const bool was_busy = tx_busy_.IsSet();
   (void)PumpTx(true);
-  if (was_busy && !tx_busy_.load(std::memory_order_acquire))
+  if (was_busy && !tx_busy_.IsSet())
   {
     OnTxTransferDone(true, ErrorCode::OK);
   }

--- a/driver/esp/esp_cdc_jtag.hpp
+++ b/driver/esp/esp_cdc_jtag.hpp
@@ -2,7 +2,6 @@
 
 #include "esp_def.hpp"
 
-#include <atomic>
 #include <cstddef>
 #include <cstdint>
 
@@ -78,7 +77,7 @@ class ESP32CDCJtag : public UART
   size_t tx_pending_size_ = 0;
   bool tx_pending_valid_ = false;
   WriteInfoBlock tx_pending_info_ = {};
-  std::atomic<bool> tx_busy_{false};
+  Flag::Atomic tx_busy_{};
   Flag::Plain in_tx_isr_;
 
   ReadPort _read_port;

--- a/driver/esp/esp_spi.cpp
+++ b/driver/esp/esp_spi.cpp
@@ -168,14 +168,9 @@ ESP32SPI::ESP32SPI(spi_host_device_t host, int sclk_pin, int miso_pin, int mosi_
   }
 }
 
-bool ESP32SPI::Acquire()
-{
-  bool expected = false;
-  return busy_.compare_exchange_strong(expected, true, std::memory_order_acq_rel,
-                                       std::memory_order_acquire);
-}
+bool ESP32SPI::Acquire() { return !busy_.TestAndSet(); }
 
-void ESP32SPI::Release() { busy_.store(false, std::memory_order_release); }
+void ESP32SPI::Release() { busy_.Clear(); }
 
 ErrorCode ESP32SPI::InitializeHardware()
 {
@@ -464,7 +459,7 @@ ErrorCode ESP32SPI::SetConfig(SPI::Configuration config)
   {
     return ErrorCode::STATE_ERR;
   }
-  if (busy_.load(std::memory_order_acquire))
+  if (busy_.IsSet())
   {
     return ErrorCode::BUSY;
   }

--- a/driver/esp/esp_spi.hpp
+++ b/driver/esp/esp_spi.hpp
@@ -2,12 +2,12 @@
 
 #include "esp_def.hpp"
 
-#include <atomic>
 #include <cstddef>
 #include <cstdint>
 
 #include "driver/gpio.h"
 #include "esp_intr_alloc.h"
+#include "flag.hpp"
 #include "hal/spi_ll.h"
 #include "hal/spi_types.h"
 #include "soc/soc_caps.h"
@@ -109,7 +109,7 @@ class ESP32SPI : public SPI
   int miso_pin_;
   int mosi_pin_;
   uint32_t source_clock_hz_ = 0;
-  std::atomic<bool> busy_{false};
+  Flag::Atomic busy_{};
   bool initialized_ = false;
   uint32_t dma_enable_min_size_ = 3U;
   bool dma_requested_ = true;

--- a/driver/mspm0/mspm0_uart.cpp
+++ b/driver/mspm0/mspm0_uart.cpp
@@ -22,15 +22,15 @@ static constexpr uint32_t MSPM0_UART_BASE_INTERRUPT_MASK =
 
 namespace
 {
-class AtomicBoolGuard
+class AtomicFlagGuard
 {
  public:
-  explicit AtomicBoolGuard(std::atomic<bool>& flag) : flag_(flag) {}
+  explicit AtomicFlagGuard(Flag::Atomic& flag) : flag_(flag) {}
 
-  ~AtomicBoolGuard() { flag_.store(false, std::memory_order_release); }
+  ~AtomicFlagGuard() { flag_.Clear(); }
 
  private:
-  std::atomic<bool>& flag_;
+  Flag::Atomic& flag_;
 };
 
 class AtomicCounterGuard
@@ -220,13 +220,11 @@ ErrorCode MSPM0UART::SetConfig(UART::Configuration config)
     return ErrorCode::ARG_ERR;
   }
 
-  bool expected_reconfig = false;
-  if (!reconfig_in_progress_.compare_exchange_strong(
-          expected_reconfig, true, std::memory_order_acq_rel, std::memory_order_acquire))
+  if (reconfig_in_progress_.TestAndSet())
   {
     return ErrorCode::BUSY;
   }
-  AtomicBoolGuard reconfig_guard(reconfig_in_progress_);
+  AtomicFlagGuard reconfig_guard(reconfig_in_progress_);
 
   const bool IRQ_WAS_ENABLED = (NVIC_GetEnableIRQ(res_.irqn) != 0U);
   if (IRQ_WAS_ENABLED)
@@ -278,7 +276,7 @@ ErrorCode MSPM0UART::SetConfig(UART::Configuration config)
   // prevent a stale LINC0_MATCH from causing a spurious IRQ during
   // DL_UART_changeConfig.
   CancelByteModeBlockTimeout();
-  byte_mode_drop_detached_rx_.store(false, std::memory_order_release);
+  byte_mode_drop_detached_rx_.Clear();
   byte_mode_drop_detached_rx_epoch_.store(0U, std::memory_order_release);
   active_read_request_epoch_.store(0U, std::memory_order_release);
   DL_UART_disableInterrupt(res_.instance, DL_UART_INTERRUPT_LINC0_MATCH);
@@ -321,7 +319,7 @@ ErrorCode MSPM0UART::SetConfig(UART::Configuration config)
   DL_UART_disableInterrupt(res_.instance,
                            DL_UART_INTERRUPT_TX | GetTimeoutInterruptMask());
 
-  tx_active_valid_.store(false, std::memory_order_release);
+  tx_active_valid_.Clear();
   tx_active_remaining_ = 0;
   tx_active_total_ = 0;
 
@@ -347,7 +345,7 @@ ErrorCode MSPM0UART::WriteFun(WritePort& port, bool)
   auto* uart = CONTAINER_OF(&port, MSPM0UART, _write_port);
   AtomicCounterGuard io_guard(uart->io_handler_inflight_);
 
-  if (uart->reconfig_in_progress_.load(std::memory_order_acquire))
+  if (uart->reconfig_in_progress_.IsSet())
   {
     return ErrorCode::BUSY;
   }
@@ -367,7 +365,7 @@ ErrorCode MSPM0UART::ReadFun(ReadPort& port, bool)
   auto* uart = CONTAINER_OF(&port, MSPM0UART, _read_port);
   AtomicCounterGuard io_guard(uart->io_handler_inflight_);
 
-  if (uart->reconfig_in_progress_.load(std::memory_order_acquire))
+  if (uart->reconfig_in_progress_.IsSet())
   {
     // 在重配窗口内阻止 read 进入 pending：把 busy 标记为 EVENT，让
     // ReadPort::operator() 的 IDLE->PENDING CAS 失败并重试 / During
@@ -394,12 +392,10 @@ ErrorCode MSPM0UART::ReadFun(ReadPort& port, bool)
   {
     const uint32_t DROP_EPOCH =
         uart->byte_mode_drop_detached_rx_epoch_.load(std::memory_order_acquire);
-    if (uart->byte_mode_drop_detached_rx_.load(std::memory_order_acquire) &&
+    if (uart->byte_mode_drop_detached_rx_.IsSet() &&
         !IsInDetachedDropWindow(ACTIVE_READ_EPOCH, DROP_EPOCH))
     {
-      bool expected_drop = true;
-      if (uart->byte_mode_drop_detached_rx_.compare_exchange_strong(
-              expected_drop, false, std::memory_order_acq_rel, std::memory_order_acquire))
+      if (uart->byte_mode_drop_detached_rx_.TestAndClear())
       {
         uart->byte_mode_drop_detached_rx_epoch_.store(0U, std::memory_order_release);
         UNUSED(uart->ConsumeTimedOutReadData(false, false));
@@ -408,7 +404,7 @@ ErrorCode MSPM0UART::ReadFun(ReadPort& port, bool)
   }
   else
   {
-    uart->byte_mode_drop_detached_rx_.store(false, std::memory_order_release);
+    uart->byte_mode_drop_detached_rx_.Clear();
     uart->byte_mode_drop_detached_rx_epoch_.store(0U, std::memory_order_release);
   }
 
@@ -494,7 +490,7 @@ ErrorCode MSPM0UART::ReadFun(ReadPort& port, bool)
 void MSPM0UART::Abort(bool in_isr)
 {
   CancelByteModeBlockTimeout();
-  byte_mode_drop_detached_rx_.store(false, std::memory_order_release);
+  byte_mode_drop_detached_rx_.Clear();
   byte_mode_drop_detached_rx_epoch_.store(0U, std::memory_order_release);
   active_read_request_epoch_.store(0U, std::memory_order_release);
 
@@ -579,8 +575,7 @@ MSPM0UART::RxTimeoutMode MSPM0UART::ResolveRxTimeoutMode() const
 
 bool MSPM0UART::IsTxBusy() const
 {
-  return tx_active_valid_.load(std::memory_order_acquire) ||
-         (write_port_->queue_info_->Size() > 0U) ||
+  return tx_active_valid_.IsSet() || (write_port_->queue_info_->Size() > 0U) ||
          (write_port_->queue_data_->Size() > 0U) || DL_UART_isBusy(res_.instance);
 }
 
@@ -607,8 +602,7 @@ bool MSPM0UART::IsZeroTimeoutPendingBlockRead() const
 
 void MSPM0UART::KickTxIfPending()
 {
-  if ((write_port_->queue_info_->Size() == 0U) &&
-      !tx_active_valid_.load(std::memory_order_acquire))
+  if ((write_port_->queue_info_->Size() == 0U) && !tx_active_valid_.IsSet())
   {
     return;
   }
@@ -649,7 +643,8 @@ void MSPM0UART::RearmLinCompareTimeout()
     return;
   }
 
-  uint16_t lin_compare_window = lin_compare_window_.load(std::memory_order_acquire);
+  uint16_t lin_compare_window =
+      static_cast<uint16_t>(lin_compare_window_.load(std::memory_order_acquire));
   if (lin_compare_window == 0U)
   {
     lin_compare_window = ResolveLinCompareWindow();
@@ -729,7 +724,8 @@ ErrorCode MSPM0UART::ApplyRxTimeoutMode()
 
   if (rx_timeout_mode_.load(std::memory_order_acquire) == RxTimeoutMode::LIN_COMPARE)
   {
-    const uint16_t CURRENT_WINDOW = lin_compare_window_.load(std::memory_order_acquire);
+    const uint16_t CURRENT_WINDOW =
+        static_cast<uint16_t>(lin_compare_window_.load(std::memory_order_acquire));
     const uint16_t RESOLVED_WINDOW =
         (CURRENT_WINDOW > 0U) ? CURRENT_WINDOW : ResolveLinCompareWindow();
     if (RESOLVED_WINDOW != 0U)
@@ -821,7 +817,7 @@ void MSPM0UART::OnByteModeBlockTimeout(MSPM0UART* uart)
   }
 
   AtomicCounterGuard timeout_guard(uart->timeout_cb_inflight_);
-  if (uart->reconfig_in_progress_.load(std::memory_order_acquire))
+  if (uart->reconfig_in_progress_.IsSet())
   {
     return;
   }
@@ -868,14 +864,11 @@ void MSPM0UART::OnByteModeBlockTimeout(MSPM0UART* uart)
     return;
   }
 
-  bool expected_completion = false;
-  if (!uart->read_completion_inflight_.compare_exchange_strong(expected_completion, true,
-                                                               std::memory_order_acq_rel,
-                                                               std::memory_order_acquire))
+  if (uart->read_completion_inflight_.TestAndSet())
   {
     return;
   }
-  AtomicBoolGuard completion_guard(uart->read_completion_inflight_);
+  AtomicFlagGuard completion_guard(uart->read_completion_inflight_);
 
   uart->CompletePendingReadOnTimeout(false);
 }
@@ -889,7 +882,7 @@ void MSPM0UART::HandleInterrupt()
 {
   AtomicCounterGuard io_guard(io_handler_inflight_);
 
-  if (reconfig_in_progress_.load(std::memory_order_acquire))
+  if (reconfig_in_progress_.IsSet())
   {
     const uint32_t TIMEOUT_MASK = GetTimeoutInterruptMask();
     const uint32_t IRQ_MASK = MSPM0_UART_BASE_INTERRUPT_MASK | TIMEOUT_MASK;
@@ -995,12 +988,9 @@ void MSPM0UART::HandleRxInterrupt(uint32_t timeout_mask)
 
   if (pushed)
   {
-    bool expected_completion = false;
-    if (read_completion_inflight_.compare_exchange_strong(expected_completion, true,
-                                                          std::memory_order_acq_rel,
-                                                          std::memory_order_acquire))
+    if (!read_completion_inflight_.TestAndSet())
     {
-      AtomicBoolGuard completion_guard(read_completion_inflight_);
+      AtomicFlagGuard completion_guard(read_completion_inflight_);
       if (IsZeroTimeoutPendingBlockRead())
       {
         ReadPort::BusyState expected = ReadPort::BusyState::PENDING;
@@ -1040,7 +1030,7 @@ void MSPM0UART::DrainRxFIFO(bool& received, bool& pushed)
       IsInDetachedDropWindow(
           active_read_request_epoch_.load(std::memory_order_acquire),
           byte_mode_drop_detached_rx_epoch_.load(std::memory_order_acquire)) &&
-      byte_mode_drop_detached_rx_.load(std::memory_order_acquire);
+      byte_mode_drop_detached_rx_.IsSet();
 
   while (!DL_UART_isRXFIFOEmpty(res_.instance))
   {
@@ -1099,15 +1089,12 @@ void MSPM0UART::HandleRxTimeoutInterrupt(uint32_t pending, uint32_t timeout_mask
     return;
   }
 
-  bool expected_completion = false;
-  if (!read_completion_inflight_.compare_exchange_strong(expected_completion, true,
-                                                         std::memory_order_acq_rel,
-                                                         std::memory_order_acquire))
+  if (read_completion_inflight_.TestAndSet())
   {
     DL_UART_clearInterruptStatus(res_.instance, pending & timeout_mask);
     return;
   }
-  AtomicBoolGuard completion_guard(read_completion_inflight_);
+  AtomicFlagGuard completion_guard(read_completion_inflight_);
 
   if (IsZeroTimeoutPendingBlockRead())
   {
@@ -1199,7 +1186,7 @@ void MSPM0UART::CompletePendingReadOnTimeout(bool in_isr)
         byte_mode_drop_detached_rx_epoch_.store(
             active_read_request_epoch_.load(std::memory_order_acquire),
             std::memory_order_release);
-        byte_mode_drop_detached_rx_.store(true, std::memory_order_release);
+        byte_mode_drop_detached_rx_.Set();
       }
       UNUSED(ConsumeTimedOutReadData(in_isr, false));
       read_port_->read_size_ = 0U;
@@ -1229,7 +1216,7 @@ void MSPM0UART::HandleTxInterrupt(bool in_isr)
   // completes.
   while (true)
   {
-    if (!tx_active_valid_.load(std::memory_order_acquire))
+    if (!tx_active_valid_.IsSet())
     {
       if (write_port_->queue_info_->Pop(tx_active_info_) != ErrorCode::OK)
       {
@@ -1246,7 +1233,7 @@ void MSPM0UART::HandleTxInterrupt(bool in_isr)
 
       tx_active_total_ = tx_active_info_.data.size_;
       tx_active_remaining_ = tx_active_total_;
-      tx_active_valid_.store(true, std::memory_order_release);
+      tx_active_valid_.Set();
     }
 
     while (tx_active_remaining_ > 0 && !DL_UART_isTXFIFOFull(res_.instance))
@@ -1255,7 +1242,7 @@ void MSPM0UART::HandleTxInterrupt(bool in_isr)
       if (write_port_->queue_data_->Pop(tx_byte) != ErrorCode::OK)
       {
         write_port_->Finish(in_isr, ErrorCode::FAILED, tx_active_info_);
-        tx_active_valid_.store(false, std::memory_order_release);
+        tx_active_valid_.Clear();
         tx_active_remaining_ = 0;
         tx_active_total_ = 0;
         DisableTxInterrupt();
@@ -1272,7 +1259,7 @@ void MSPM0UART::HandleTxInterrupt(bool in_isr)
     }
 
     write_port_->Finish(in_isr, ErrorCode::OK, tx_active_info_);
-    tx_active_valid_.store(false, std::memory_order_release);
+    tx_active_valid_.Clear();
     tx_active_remaining_ = 0;
     tx_active_total_ = 0;
   }
@@ -1282,7 +1269,7 @@ void MSPM0UART::AbortTx(bool in_isr)
 {
   DisableTxInterrupt();
 
-  if (tx_active_valid_.exchange(false, std::memory_order_acq_rel))
+  if (tx_active_valid_.TestAndClear())
   {
     write_port_->Finish(in_isr, ErrorCode::FAILED, tx_active_info_);
   }

--- a/driver/mspm0/mspm0_uart.hpp
+++ b/driver/mspm0/mspm0_uart.hpp
@@ -3,6 +3,7 @@
 #include <atomic>
 
 #include "dl_uart_main.h"
+#include "flag.hpp"
 #include "ti_msp_dl_config.h"
 #include "timer.hpp"
 #include "uart.hpp"
@@ -15,7 +16,7 @@ class MSPM0UART : public UART
  public:
   using UART::Write;
 
-  enum class RxTimeoutMode : uint8_t
+  enum class RxTimeoutMode : uint32_t
   {
     LIN_COMPARE,
     BYTE_INTERRUPT
@@ -58,7 +59,7 @@ class MSPM0UART : public UART
   }
   uint16_t GetLinCompareWindow() const
   {
-    return lin_compare_window_.load(std::memory_order_acquire);
+    return static_cast<uint16_t>(lin_compare_window_.load(std::memory_order_acquire));
   }
   uint32_t GetLastTimeoutConsumedSize() const
   {
@@ -251,18 +252,18 @@ class MSPM0UART : public UART
 
   Resources res_;
   WriteInfoBlock tx_active_info_;
-  std::atomic<bool> tx_active_valid_{false};
+  Flag::Atomic tx_active_valid_{};
   size_t tx_active_remaining_ = 0;
   size_t tx_active_total_ = 0;
   std::atomic<RxTimeoutMode> rx_timeout_mode_{RxTimeoutMode::BYTE_INTERRUPT};
-  std::atomic<uint16_t> lin_compare_window_{0U};
+  std::atomic<uint32_t> lin_compare_window_{0U};
   std::atomic<uint32_t> rx_drop_count_{0U};
   std::atomic<uint32_t> rx_timeout_count_{0U};
   std::atomic<uint32_t> last_timeout_consumed_size_{0U};
-  std::atomic<bool> reconfig_in_progress_{false};
+  Flag::Atomic reconfig_in_progress_{};
   std::atomic<uint32_t> io_handler_inflight_{0U};
   std::atomic<uint32_t> timeout_cb_inflight_{0U};
-  std::atomic<bool> read_completion_inflight_{false};
+  Flag::Atomic read_completion_inflight_{};
   std::atomic<uint32_t> read_request_epoch_{0U};
   std::atomic<uint32_t> active_read_request_epoch_{0U};
   Timer::TimerHandle byte_mode_block_timeout_task_ = nullptr;
@@ -270,7 +271,7 @@ class MSPM0UART : public UART
   std::atomic<uint32_t> byte_mode_block_timeout_start_ms_{0U};
   std::atomic<uint32_t> byte_mode_block_timeout_cycle_ms_{0U};
   std::atomic<uint32_t> byte_mode_drop_detached_rx_epoch_{0U};
-  std::atomic<bool> byte_mode_drop_detached_rx_{false};
+  Flag::Atomic byte_mode_drop_detached_rx_{};
 
   static std::atomic<MSPM0UART*> instance_map_[MAX_UART_INSTANCES];
 };

--- a/src/core/libxr_rw.hpp
+++ b/src/core/libxr_rw.hpp
@@ -245,7 +245,9 @@ class Operation
 class AsyncBlockWait
 {
  public:
-  enum class State : uint8_t
+  // Keep the waiter state 32-bit wide so STM32 builds stay within the
+  // project-wide atomic shim boundary.
+  enum class State : uint32_t
   {
     IDLE = 0,
     PENDING = 1,

--- a/src/utils/flag.hpp
+++ b/src/utils/flag.hpp
@@ -99,7 +99,7 @@ class Atomic
   Atomic& operator=(const Atomic&) = delete;
 
  private:
-  std::atomic<uint8_t> value_{
+  std::atomic<uint32_t> value_{
       0u};  ///< 标志值（0=clear, 1=set）/ Flag value (0=clear, 1=set)
 };
 


### PR DESCRIPTION
## Summary by Sourcery

Unify boolean-like atomic flags across UART, SPI, CDC-JTAG, and core async primitives to use the shared Flag::Atomic abstraction and widen relevant atomic and state types to 32-bit for consistency with the project’s atomic shim and STM32 constraints.

Enhancements:
- Replace various std::atomic<bool> flags in MSPM0 UART, ESP SPI, and ESP CDC-JTAG drivers with Flag::Atomic and update call sites to use its Set/Clear/TestAndSet/TestAndClear/IsSet helpers for clearer and safer flag handling.
- Widen several atomic types and enums (including AsyncBlockWait::State, MSPM0 UART RxTimeoutMode, lin_compare_window_, and Flag::Atomic storage) to 32-bit to stay within the project-wide atomic shim boundary and improve cross-platform consistency.
- Introduce and use AtomicFlagGuard in MSPM0 UART to manage Flag::Atomic lifetimes in critical sections instead of manual store operations, simplifying reconfiguration and read-completion in-flight tracking.