### PR TITLE
refactor(cb): narrow callback factory typing for the C++20 baseline

### DIFF
--- a/src/core/libxr_cb.hpp
+++ b/src/core/libxr_cb.hpp
@@ -38,6 +38,11 @@ class CallbackBlock : public CallbackBlockHeader<Args...>
    * @brief 构造回调块，绑定回调函数与参数 / Construct a callback block with bound
    * function and argument
    *
+   * 工厂层已经把 `fun` 收窄到了当前块真实需要的函数指针类型，因此这里不再保留
+   * 额外的模板参数做二次推导。
+   * The factory has already narrowed `fun` to the exact function-pointer type required
+   * by this block, so there is no need to keep another template parameter here.
+   *
    * @param fun 需要调用的回调函数 / Callback function to be invoked
    * @param arg 绑定的参数值 / Bound argument value
    */
@@ -78,6 +83,10 @@ class GuardedCallbackBlock : public CallbackBlock<ArgType, Args...>
  public:
   /**
    * @brief 带防重入保护的回调块 / Callback block with reentry guard
+   *
+   * 与 `CallbackBlock` 一样，这里直接接收精确的函数指针类型。
+   * Same as `CallbackBlock`, this constructor takes the exact callback function-pointer
+   * type directly.
    */
   GuardedCallbackBlock(typename CallbackBlock<ArgType, Args...>::FunctionType fun,
                        ArgType&& arg)
@@ -107,6 +116,9 @@ class GuardedCallbackBlock : public CallbackBlock<ArgType, Args...>
       return;
     }
 
+    // 重入时只保留最新一组参数，把递归调用压平成串行重放。
+    // On reentry, keep only the latest argument pack so recursive callback chains are
+    // flattened into serialized replay.
     cb->pending_args_ = std::tuple<std::decay_t<Args>...>{std::forward<Args>(args)...};
     cb->pending_ = true;
   }
@@ -139,6 +151,23 @@ class Callback
    * @param arg 绑定的参数值 / Bound argument value
    * @return Callback 实例 / Created Callback instance
    *
+   * `fun` 的类型被显式写成当前 `CallbackBlock` 的真实函数指针类型，
+   * 同时再用 `std::type_identity_t` 阻止它参与额外推导；这样 `ArgType`
+   * 只从 `arg` 推导，避免把“看起来能转”的别的函数指针类型错误地吸进来。
+   * `fun` is written as the exact callback-function pointer type required by the current
+   * `CallbackBlock`, and wrapped in `std::type_identity_t` so it does not participate in
+   * extra deduction. This keeps `ArgType` deduced only from `arg`, and avoids accepting
+   * unrelated-but-convertible function pointer types by accident.
+   *
+   * 因此调用方需要传入可转换到该精确函数指针类型的对象，例如普通函数、静态成员函数，
+   * 或无捕获 lambda。
+   * Callers therefore need an object convertible to that exact function-pointer type,
+   * such as a free function, static member function, or non-capturing lambda.
+   *
+   * @note 该写法依赖 `std::type_identity_t`，要求编译环境提供 C++20 标准库。
+   *       This form relies on `std::type_identity_t`, which requires a C++20 standard
+   *       library.
+   *
    * @note 包含动态内存分配 / Contains dynamic memory allocation
    */
   template <typename ArgType>
@@ -152,6 +181,12 @@ class Callback
 
   /**
    * @brief 创建带防重入保护的回调 / Create a guarded callback
+   *
+   * 参数约束与 `Create` 完全一致，只是底层块换成了带重入压平逻辑的
+   * `GuardedCallbackBlock`。
+   * The parameter constraint is identical to `Create`; the only difference is that the
+   * underlying block becomes `GuardedCallbackBlock`, which flattens reentrant callback
+   * chains.
    */
   template <typename ArgType>
   [[nodiscard]] static Callback CreateGuarded(

--- a/src/core/libxr_cb.hpp
+++ b/src/core/libxr_cb.hpp
@@ -2,6 +2,7 @@
 
 #include <cstring>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 
 #include "libxr_def.hpp"
@@ -37,16 +38,11 @@ class CallbackBlock : public CallbackBlockHeader<Args...>
    * @brief 构造回调块，绑定回调函数与参数 / Construct a callback block with bound
    * function and argument
    *
-   * @tparam FunType 函数类型 / Function type
-   * @tparam ArgT 绑定参数类型 / Bound argument type
    * @param fun 需要调用的回调函数 / Callback function to be invoked
    * @param arg 绑定的参数值 / Bound argument value
    */
-  template <typename FunType, typename ArgT>
-  CallbackBlock(FunType&& fun, ArgT&& arg)
-      : CallbackBlockHeader<Args...>{&InvokeThunk},
-        fun_(std::forward<FunType>(fun)),
-        arg_(std::forward<ArgT>(arg))
+  CallbackBlock(FunctionType fun, ArgType&& arg)
+      : CallbackBlockHeader<Args...>{&InvokeThunk}, fun_(fun), arg_(std::move(arg))
   {
   }
 
@@ -72,8 +68,8 @@ class CallbackBlock : public CallbackBlockHeader<Args...>
     fun_(in_isr, arg_, std::forward<Args>(args)...);
   }
 
-  void (*fun_)(bool, ArgType, Args...);  ///< 绑定的回调函数 / Bound callback function
-  ArgType arg_;                          ///< 绑定的参数 / Bound argument
+  FunctionType fun_;  ///< 绑定的回调函数 / Bound callback function
+  ArgType arg_;       ///< 绑定的参数 / Bound argument
 };
 
 template <typename ArgType, typename... Args>
@@ -83,10 +79,9 @@ class GuardedCallbackBlock : public CallbackBlock<ArgType, Args...>
   /**
    * @brief 带防重入保护的回调块 / Callback block with reentry guard
    */
-  template <typename FunType, typename ArgT>
-  GuardedCallbackBlock(FunType&& fun, ArgT&& arg)
-      : CallbackBlock<ArgType, Args...>(std::forward<FunType>(fun),
-                                        std::forward<ArgT>(arg))
+  GuardedCallbackBlock(typename CallbackBlock<ArgType, Args...>::FunctionType fun,
+                       ArgType&& arg)
+      : CallbackBlock<ArgType, Args...>(fun, std::move(arg))
   {
     this->run_fun_ = &InvokeThunk;
   }
@@ -139,7 +134,6 @@ class Callback
    * @brief 创建回调对象并绑定回调函数与参数 / Create a callback instance with bound
    * function and argument
    *
-   * @tparam FunType 回调函数类型 / Callback function type
    * @tparam ArgType 绑定参数类型 / Bound argument type
    * @param fun 需要绑定的回调函数 / Callback function to bind
    * @param arg 绑定的参数值 / Bound argument value
@@ -147,22 +141,24 @@ class Callback
    *
    * @note 包含动态内存分配 / Contains dynamic memory allocation
    */
-  template <typename FunType, typename ArgType>
-  [[nodiscard]] static Callback Create(FunType fun, ArgType arg)
+  template <typename ArgType>
+  [[nodiscard]] static Callback Create(
+      std::type_identity_t<typename CallbackBlock<ArgType, Args...>::FunctionType> fun,
+      ArgType arg)
   {
-    void (*fun_ptr)(bool, ArgType, Args...) = fun;
-    auto cb_block = new CallbackBlock<ArgType, Args...>(fun_ptr, arg);
+    auto cb_block = new CallbackBlock<ArgType, Args...>(fun, std::move(arg));
     return Callback(cb_block);
   }
 
   /**
    * @brief 创建带防重入保护的回调 / Create a guarded callback
    */
-  template <typename FunType, typename ArgType>
-  [[nodiscard]] static Callback CreateGuarded(FunType fun, ArgType arg)
+  template <typename ArgType>
+  [[nodiscard]] static Callback CreateGuarded(
+      std::type_identity_t<typename CallbackBlock<ArgType, Args...>::FunctionType> fun,
+      ArgType arg)
   {
-    void (*fun_ptr)(bool, ArgType, Args...) = fun;
-    auto cb_block = new GuardedCallbackBlock<ArgType, Args...>(fun_ptr, arg);
+    auto cb_block = new GuardedCallbackBlock<ArgType, Args...>(fun, std::move(arg));
     return Callback(cb_block);
   }
 


### PR DESCRIPTION
## Summary
- narrow `Callback::Create` and `CreateGuarded` to the exact callback function-pointer type
- keep the validated comment clarifications in `libxr_cb.hpp`

## Validation
- non-STM32 C++20 matrix: no flash/RAM deltas on the measured targets
- host and ARM callback probes: identical `.text` hashes, symbol sizes, and stack usage
- runtime probe: only sub-nanosecond noise-level differences

## Boundary
- this change requires a C++20 standard library because it uses `std::type_identity_t`
- existing non-C++20 consumer projects will need follow-up before they build again

## Summary by Sourcery

Refine callback construction to use the exact callback function-pointer type exposed by the factory, aligning the callback blocks and guarded callbacks with stricter, C++20-based type deduction semantics.

Bug Fixes:
- Prevent unintended construction of callbacks from unrelated but implicitly convertible function pointer types by constraining factory and block interfaces to the exact callback signature.

Enhancements:
- Simplify CallbackBlock and GuardedCallbackBlock constructors to take the concrete FunctionType and pass arguments by move, reducing redundant template deduction layers.
- Document the reentry-flattening behavior of guarded callbacks and clarify the stricter function-type requirements and C++20 standard library dependency in the callback API comments.