### PR TITLE
refactor(core): merge libxr_def cleanup and callback concepts

### DIFF
--- a/driver/ch/ch32_uart.cpp
+++ b/driver/ch/ch32_uart.cpp
@@ -239,7 +239,7 @@ ErrorCode CH32UART::SetConfig(UART::Configuration config)
 // Write callback (DMA-based transfer).
 ErrorCode CH32UART::WriteFun(WritePort& port, bool)
 {
-  CH32UART* uart = CONTAINER_OF(&port, CH32UART, _write_port);
+  auto* uart = LibXR::ContainerOf(&port, &CH32UART::_write_port);
 
   if (uart->in_tx_isr.IsSet())
   {

--- a/driver/esp/esp_cdc_jtag.cpp
+++ b/driver/esp/esp_cdc_jtag.cpp
@@ -99,7 +99,7 @@ void IRAM_ATTR ESP32CDCJtag::IsrEntry(void* arg)
 
 ErrorCode IRAM_ATTR ESP32CDCJtag::WriteFun(WritePort& port, bool in_isr)
 {
-  auto* cdc = CONTAINER_OF(&port, ESP32CDCJtag, _write_port);
+  auto* cdc = LibXR::ContainerOf(&port, &ESP32CDCJtag::_write_port);
   return cdc->TryStartTx(in_isr);
 }
 

--- a/driver/esp/esp_uart.cpp
+++ b/driver/esp/esp_uart.cpp
@@ -246,7 +246,7 @@ ErrorCode ESP32UART::SetLoopback(bool enable)
 
 ErrorCode IRAM_ATTR ESP32UART::WriteFun(WritePort& port, bool in_isr)
 {
-  auto* uart = CONTAINER_OF(&port, ESP32UART, _write_port);
+  auto* uart = LibXR::ContainerOf(&port, &ESP32UART::_write_port);
   return uart->TryStartTx(in_isr);
 }
 

--- a/driver/linux/linux_uart.hpp
+++ b/driver/linux/linux_uart.hpp
@@ -390,7 +390,7 @@ class LinuxUART : public UART
 
   static ErrorCode WriteFun(WritePort& port, bool)
   {
-    auto uart = CONTAINER_OF(&port, LinuxUART, _write_port);
+    auto* uart = LibXR::ContainerOf(&port, &LinuxUART::_write_port);
     uart->write_sem_.Post();
     return ErrorCode::OK;
   }

--- a/driver/mspm0/mspm0_uart.cpp
+++ b/driver/mspm0/mspm0_uart.cpp
@@ -176,7 +176,7 @@ ErrorCode MSPM0UART::SetConfig(UART::Configuration config)
 
 ErrorCode MSPM0UART::WriteFun(WritePort& port, bool)
 {
-  auto* uart = CONTAINER_OF(&port, MSPM0UART, _write_port);
+  auto* uart = LibXR::ContainerOf(&port, &MSPM0UART::_write_port);
   DL_UART_enableInterrupt(uart->res_.instance, DL_UART_INTERRUPT_TX);
   uart->res_.instance->CPU_INT.ISET = DL_UART_INTERRUPT_TX;
   return ErrorCode::PENDING;
@@ -184,7 +184,7 @@ ErrorCode MSPM0UART::WriteFun(WritePort& port, bool)
 
 ErrorCode MSPM0UART::ReadFun(ReadPort& port, bool)
 {
-  auto* uart = CONTAINER_OF(&port, MSPM0UART, _read_port);
+  auto* uart = LibXR::ContainerOf(&port, &MSPM0UART::_read_port);
   const uint32_t TIMEOUT_MASK = uart->GetTimeoutInterruptMask();
   if (TIMEOUT_MASK != 0U)
   {

--- a/driver/st/stm32_adc.hpp
+++ b/driver/st/stm32_adc.hpp
@@ -268,7 +268,7 @@ class STM32ADC
   float ReadChannel(uint8_t channel);
 
  private:
-  alignas(LIBXR_CACHE_LINE_SIZE) std::atomic<uint32_t> locked_ = 0U;
+  alignas(LibXR::CACHE_LINE_SIZE) std::atomic<uint32_t> locked_ = 0U;
   ADC_HandleTypeDef* hadc_;
   const uint8_t NUM_CHANNELS;
   uint8_t filter_size_;

--- a/driver/st/stm32_uart.cpp
+++ b/driver/st/stm32_uart.cpp
@@ -194,7 +194,7 @@ stm32_uart_id_t stm32_uart_get_id(USART_TypeDef* addr)
 
 ErrorCode STM32UART::WriteFun(WritePort& port, bool)
 {
-  STM32UART* uart = CONTAINER_OF(&port, STM32UART, _write_port);
+  auto* uart = LibXR::ContainerOf(&port, &STM32UART::_write_port);
 
   if (uart->in_tx_isr.IsSet())
   {

--- a/src/core/libxr_cb.hpp
+++ b/src/core/libxr_cb.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <cstring>
 #include <tuple>
 #include <type_traits>
@@ -9,6 +10,16 @@
 
 namespace LibXR
 {
+
+/**
+ * @brief 可转换为精确回调函数指针的可调用对象
+ * @brief Callable convertible to the exact callback function pointer
+ */
+template <typename CallableType, typename BoundArgType, typename... CallbackArgs>
+concept CallbackFunctionCompatible = requires(CallableType callable)
+{
+  static_cast<void (*)(bool, BoundArgType, CallbackArgs...)>(callable);
+};
 
 template <typename... Args>
 struct CallbackBlockHeader
@@ -37,11 +48,6 @@ class CallbackBlock : public CallbackBlockHeader<Args...>
   /**
    * @brief 构造回调块，绑定回调函数与参数 / Construct a callback block with bound
    * function and argument
-   *
-   * 工厂层已经把 `fun` 收窄到了当前块真实需要的函数指针类型，因此这里不再保留
-   * 额外的模板参数做二次推导。
-   * The factory has already narrowed `fun` to the exact function-pointer type required
-   * by this block, so there is no need to keep another template parameter here.
    *
    * @param fun 需要调用的回调函数 / Callback function to be invoked
    * @param arg 绑定的参数值 / Bound argument value
@@ -83,10 +89,6 @@ class GuardedCallbackBlock : public CallbackBlock<ArgType, Args...>
  public:
   /**
    * @brief 带防重入保护的回调块 / Callback block with reentry guard
-   *
-   * 与 `CallbackBlock` 一样，这里直接接收精确的函数指针类型。
-   * Same as `CallbackBlock`, this constructor takes the exact callback function-pointer
-   * type directly.
    */
   GuardedCallbackBlock(typename CallbackBlock<ArgType, Args...>::FunctionType fun,
                        ArgType&& arg)
@@ -146,54 +148,40 @@ class Callback
    * @brief 创建回调对象并绑定回调函数与参数 / Create a callback instance with bound
    * function and argument
    *
-   * @tparam ArgType 绑定参数类型 / Bound argument type
+   * @tparam BoundArgType 绑定参数类型 / Bound argument type
+   * @tparam CallableType 回调可调用对象类型 / Callback callable type
    * @param fun 需要绑定的回调函数 / Callback function to bind
    * @param arg 绑定的参数值 / Bound argument value
    * @return Callback 实例 / Created Callback instance
-   *
-   * `fun` 的类型被显式写成当前 `CallbackBlock` 的真实函数指针类型，
-   * 同时再用 `std::type_identity_t` 阻止它参与额外推导；这样 `ArgType`
-   * 只从 `arg` 推导，避免把“看起来能转”的别的函数指针类型错误地吸进来。
-   * `fun` is written as the exact callback-function pointer type required by the current
-   * `CallbackBlock`, and wrapped in `std::type_identity_t` so it does not participate in
-   * extra deduction. This keeps `ArgType` deduced only from `arg`, and avoids accepting
-   * unrelated-but-convertible function pointer types by accident.
-   *
-   * 因此调用方需要传入可转换到该精确函数指针类型的对象，例如普通函数、静态成员函数，
-   * 或无捕获 lambda。
-   * Callers therefore need an object convertible to that exact function-pointer type,
-   * such as a free function, static member function, or non-capturing lambda.
-   *
-   * @note 该写法依赖 `std::type_identity_t`，要求编译环境提供 C++20 标准库。
-   *       This form relies on `std::type_identity_t`, which requires a C++20 standard
-   *       library.
-   *
-   * @note 包含动态内存分配 / Contains dynamic memory allocation
    */
-  template <typename ArgType>
-  [[nodiscard]] static Callback Create(
-      std::type_identity_t<typename CallbackBlock<ArgType, Args...>::FunctionType> fun,
-      ArgType arg)
+  template <typename BoundArgType, typename CallableType>
+  requires CallbackFunctionCompatible<CallableType, BoundArgType, Args...>
+  [[nodiscard]] static Callback Create(CallableType fun, BoundArgType arg)
   {
-    auto cb_block = new CallbackBlock<ArgType, Args...>(fun, std::move(arg));
+    using FunctionType = typename CallbackBlock<BoundArgType, Args...>::FunctionType;
+    auto cb_block =
+        new CallbackBlock<BoundArgType, Args...>(static_cast<FunctionType>(fun),
+                                                 std::move(arg));
     return Callback(cb_block);
   }
 
   /**
    * @brief 创建带防重入保护的回调 / Create a guarded callback
    *
-   * 参数约束与 `Create` 完全一致，只是底层块换成了带重入压平逻辑的
-   * `GuardedCallbackBlock`。
-   * The parameter constraint is identical to `Create`; the only difference is that the
-   * underlying block becomes `GuardedCallbackBlock`, which flattens reentrant callback
-   * chains.
+   * @tparam BoundArgType 绑定参数类型 / Bound argument type
+   * @tparam CallableType 回调可调用对象类型 / Callback callable type
+   * @param fun 需要绑定的回调函数 / Callback function to bind
+   * @param arg 绑定的参数值 / Bound argument value
+   * @return Callback 实例 / Created Callback instance
    */
-  template <typename ArgType>
-  [[nodiscard]] static Callback CreateGuarded(
-      std::type_identity_t<typename CallbackBlock<ArgType, Args...>::FunctionType> fun,
-      ArgType arg)
+  template <typename BoundArgType, typename CallableType>
+  requires CallbackFunctionCompatible<CallableType, BoundArgType, Args...>
+  [[nodiscard]] static Callback CreateGuarded(CallableType fun, BoundArgType arg)
   {
-    auto cb_block = new GuardedCallbackBlock<ArgType, Args...>(fun, std::move(arg));
+    using FunctionType = typename CallbackBlock<BoundArgType, Args...>::FunctionType;
+    auto cb_block =
+        new GuardedCallbackBlock<BoundArgType, Args...>(static_cast<FunctionType>(fun),
+                                                        std::move(arg));
     return Callback(cb_block);
   }
 
@@ -252,7 +240,6 @@ class Callback
    * create callback instances
    *
    * @param cb_block 回调块对象指针 / Pointer to the callback block
-   * @param cb_fun 回调执行函数指针 / Callback invocation function pointer
    */
   explicit Callback(CallbackBlockHeader<Args...>* cb_block)
       : cb_block_((cb_block != nullptr) ? cb_block : &empty_cb_block_)

--- a/src/core/libxr_def.hpp
+++ b/src/core/libxr_def.hpp
@@ -1,23 +1,10 @@
 #pragma once
 
+#include <concepts>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
-
-#ifndef M_2PI
-#define M_2PI (2.0 * M_PI)
-#endif
-
-#ifndef M_1G
-/// \brief 标准重力加速度（m/s²）
-/// \brief Standard gravitational acceleration (m/s²)
-constexpr double M_1G = 9.80665;
-#endif
 
 #ifndef DEF2STR
 #define XR_TO_STR(_arg) #_arg
@@ -30,31 +17,81 @@ constexpr double M_1G = 9.80665;
 #define UNUSED(_x) ((void)(_x))
 #endif
 
-#ifndef OFFSET_OF
-/// \brief 计算结构体成员在结构体中的偏移量
-/// \brief Computes the offset of a member within a struct
-#define OFFSET_OF(type, member) ((size_t)&((type*)0)->member)
-#endif
-
-#ifndef MEMBER_SIZE_OF
-/// \brief 获取结构体成员的大小
-/// \brief Retrieves the size of a member within a struct
-#define MEMBER_SIZE_OF(type, member) (sizeof(decltype(((type*)0)->member)))
-#endif
-
-#ifndef CONTAINER_OF
-/// \brief 通过成员指针获取包含该成员的结构体指针
-/// \brief Retrieve the pointer to the containing structure from a member pointer
-#define CONTAINER_OF(ptr, type, member) \
-  ((type*)((char*)(ptr) - OFFSET_OF(type, member)))  // NOLINT
-#endif
-
-/// \brief 缓存行大小
-static constexpr size_t LIBXR_CACHE_LINE_SIZE = (sizeof(void*) == 8) ? 64 : 32;
-static constexpr size_t LIBXR_ALIGN_SIZE = (sizeof(void*));
-
 namespace LibXR
 {
+/// \brief PI 常量 / PI constant
+inline constexpr double PI = 3.14159265358979323846;
+
+/// \brief 2PI 常量 / 2PI constant
+inline constexpr double TWO_PI = 2.0 * PI;
+
+/// \brief 标准重力加速度（m/s²） / Standard gravitational acceleration (m/s²)
+inline constexpr double STANDARD_GRAVITY = 9.80665;
+
+/// \brief 缓存行大小 / Cache line size
+inline constexpr size_t CACHE_LINE_SIZE = (sizeof(void*) == 8) ? 64 : 32;
+
+/// \brief 平台自然对齐大小 / Native platform alignment size
+inline constexpr size_t ALIGN_SIZE = sizeof(void*);
+
+/**
+ * @brief 指向非静态数据成员的成员指针
+ * @brief Pointer to a non-static data member
+ */
+template <typename OwnerType, typename MemberType>
+concept MemberObjectPointer = std::is_member_object_pointer_v<MemberType OwnerType::*>;
+
+/**
+ * @brief 具有公共类型且可比较大小的类型对
+ * @brief Type pair with a common type and ordering
+ */
+template <typename LeftType, typename RightType>
+concept CommonOrdered = std::common_with<LeftType, RightType> &&
+                        requires(const LeftType& left, const RightType& right)
+{
+  { left < right } -> std::convertible_to<bool>;
+  { left > right } -> std::convertible_to<bool>;
+};
+
+/**
+ * @brief 计算成员在宿主对象中的偏移量
+ * @brief Computes the offset of a member within the owning object
+ * @param member 指向成员的成员指针，如 `&Type::member` | Member pointer such as `&Type::member`
+ * @return 成员偏移量 | Member offset
+ */
+template <typename OwnerType, typename MemberType>
+requires MemberObjectPointer<OwnerType, MemberType>
+[[nodiscard]] inline size_t OffsetOf(MemberType OwnerType::*member) noexcept
+{
+  return reinterpret_cast<size_t>(
+      &(reinterpret_cast<const volatile OwnerType*>(0)->*member));
+}
+
+/**
+ * @brief 通过成员指针恢复其所属对象指针
+ * @brief Recover the owning object pointer from a member pointer
+ * @param ptr 指向成员的指针 | Pointer to the member
+ * @param member 指向成员的成员指针，如 `&Type::member` | Member pointer such as `&Type::member`
+ * @return 所属对象指针 | Pointer to the owning object
+ */
+template <typename OwnerType, typename MemberType>
+requires MemberObjectPointer<OwnerType, MemberType>
+[[nodiscard]] inline OwnerType* ContainerOf(MemberType* ptr,
+                                            MemberType OwnerType::*member) noexcept
+{
+  return reinterpret_cast<OwnerType*>(reinterpret_cast<std::byte*>(ptr) -
+                                      OffsetOf(member));
+}
+
+template <typename OwnerType, typename MemberType>
+requires MemberObjectPointer<OwnerType, MemberType>
+[[nodiscard]] inline const OwnerType* ContainerOf(const MemberType* ptr,
+                                                  MemberType OwnerType::*member) noexcept
+{
+  return reinterpret_cast<const OwnerType*>(reinterpret_cast<const std::byte*>(ptr) -
+                                            OffsetOf(member));
+}
+
 /**
  * @enum ErrorCode
  * @brief 定义错误码枚举
@@ -159,14 +196,15 @@ namespace LibXR
 /**
  * @brief 计算两个数的最大值
  * @brief Computes the maximum of two numbers
- * @tparam T1 第一个数的类型 | Type of the first number
- * @tparam T2 第二个数的类型 | Type of the second number
+ * @tparam LeftType 第一个数的类型 | Type of the first number
+ * @tparam RightType 第二个数的类型 | Type of the second number
  * @param a 第一个数 | First number
  * @param b 第二个数 | Second number
  * @return 两数中的较大值 | The larger of the two numbers
  */
-template <typename T1, typename T2>
-constexpr auto max(T1 a, T2 b) -> typename std::common_type<T1, T2>::type
+template <typename LeftType, typename RightType>
+requires CommonOrdered<LeftType, RightType>
+constexpr auto max(LeftType a, RightType b) -> std::common_type_t<LeftType, RightType>
 {
   return (a > b) ? a : b;
 }
@@ -174,14 +212,15 @@ constexpr auto max(T1 a, T2 b) -> typename std::common_type<T1, T2>::type
 /**
  * @brief 计算两个数的最小值
  * @brief Computes the minimum of two numbers
- * @tparam T1 第一个数的类型 | Type of the first number
- * @tparam T2 第二个数的类型 | Type of the second number
+ * @tparam LeftType 第一个数的类型 | Type of the first number
+ * @tparam RightType 第二个数的类型 | Type of the second number
  * @param a 第一个数 | First number
  * @param b 第二个数 | Second number
  * @return 两数中的较小值 | The smaller of the two numbers
  */
-template <typename T1, typename T2>
-constexpr auto min(T1 a, T2 b) -> typename std::common_type<T1, T2>::type
+template <typename LeftType, typename RightType>
+requires CommonOrdered<LeftType, RightType>
+constexpr auto min(LeftType a, RightType b) -> std::common_type_t<LeftType, RightType>
 {
   return (a < b) ? a : b;
 }

--- a/src/core/libxr_mem.cpp
+++ b/src/core/libxr_mem.cpp
@@ -7,8 +7,8 @@ void LibXR::Memory::FastCopy(void* dst, const void* src, size_t size)
   uint8_t* d = static_cast<uint8_t*>(dst);
   const uint8_t* s = static_cast<const uint8_t*>(src);
 
-  uintptr_t d_offset = reinterpret_cast<uintptr_t>(d) & (LIBXR_ALIGN_SIZE - 1);
-  uintptr_t s_offset = reinterpret_cast<uintptr_t>(s) & (LIBXR_ALIGN_SIZE - 1);
+  uintptr_t d_offset = reinterpret_cast<uintptr_t>(d) & (LibXR::ALIGN_SIZE - 1);
+  uintptr_t s_offset = reinterpret_cast<uintptr_t>(s) & (LibXR::ALIGN_SIZE - 1);
 
   /**
    * If source and destination have the same alignment offset,
@@ -19,7 +19,7 @@ void LibXR::Memory::FastCopy(void* dst, const void* src, size_t size)
     /// Handle unaligned head bytes before reaching alignment.
     if (d_offset)
     {
-      size_t head = LIBXR_ALIGN_SIZE - d_offset;
+      size_t head = LibXR::ALIGN_SIZE - d_offset;
       if (head > size)
       {
         head = size;
@@ -31,7 +31,7 @@ void LibXR::Memory::FastCopy(void* dst, const void* src, size_t size)
       }
     }
 
-    if constexpr (LIBXR_ALIGN_SIZE == 8)
+    if constexpr (LibXR::ALIGN_SIZE == 8)
     {
       /// Burst copy 8 bytes per cycle (64-bit), using 8x unrolled loop.
       auto* dw = reinterpret_cast<uint64_t*>(d);
@@ -98,7 +98,7 @@ void LibXR::Memory::FastCopy(void* dst, const void* src, size_t size)
   {
     uintptr_t addr_diff = reinterpret_cast<uintptr_t>(s) - reinterpret_cast<uintptr_t>(d);
 
-    if constexpr (LIBXR_ALIGN_SIZE == 8)
+    if constexpr (LibXR::ALIGN_SIZE == 8)
     {
       /// If address difference is a multiple of 4, use 4-byte copying.
       if ((addr_diff & 3) == 0 && size > 0)
@@ -221,12 +221,12 @@ void LibXR::Memory::FastSet(void* dst, uint8_t value, size_t size)
 
   uint8_t* d = static_cast<uint8_t*>(dst);
 
-  uintptr_t d_offset = reinterpret_cast<uintptr_t>(d) & (LIBXR_ALIGN_SIZE - 1);
+  uintptr_t d_offset = reinterpret_cast<uintptr_t>(d) & (LibXR::ALIGN_SIZE - 1);
 
   // 先处理头部到对齐
   if (d_offset)
   {
-    size_t head = LIBXR_ALIGN_SIZE - d_offset;
+    size_t head = LibXR::ALIGN_SIZE - d_offset;
     if (head > size)
     {
       head = size;
@@ -238,7 +238,7 @@ void LibXR::Memory::FastSet(void* dst, uint8_t value, size_t size)
     }
   }
 
-  if constexpr (LIBXR_ALIGN_SIZE == 8)
+  if constexpr (LibXR::ALIGN_SIZE == 8)
   {
     // 8-byte pattern
     uint64_t pat = value;
@@ -330,13 +330,13 @@ int LibXR::Memory::FastCmp(const void* a, const void* b, size_t size)
     return 0;
   };
 
-  uintptr_t p_off = reinterpret_cast<uintptr_t>(p) & (LIBXR_ALIGN_SIZE - 1);
-  uintptr_t q_off = reinterpret_cast<uintptr_t>(q) & (LIBXR_ALIGN_SIZE - 1);
+  uintptr_t p_off = reinterpret_cast<uintptr_t>(p) & (LibXR::ALIGN_SIZE - 1);
+  uintptr_t q_off = reinterpret_cast<uintptr_t>(q) & (LibXR::ALIGN_SIZE - 1);
 
-  // 若同相位：先补齐到 LIBXR_ALIGN_SIZE 对齐再做宽比较
+  // 若同相位：先补齐到 LibXR::ALIGN_SIZE 对齐再做宽比较
   if ((p_off == q_off) && (p_off != 0))
   {
-    size_t head = LIBXR_ALIGN_SIZE - p_off;
+    size_t head = LibXR::ALIGN_SIZE - p_off;
     if (head > size)
     {
       head = size;
@@ -353,7 +353,7 @@ int LibXR::Memory::FastCmp(const void* a, const void* b, size_t size)
     }
   }
 
-  if constexpr (LIBXR_ALIGN_SIZE == 8)
+  if constexpr (LibXR::ALIGN_SIZE == 8)
   {
     // 8-byte compare（仅在两者均 8 对齐时才安全/快）
     if ((((reinterpret_cast<uintptr_t>(p) | reinterpret_cast<uintptr_t>(q)) & 7u) == 0u))

--- a/src/core/libxr_pipe.hpp
+++ b/src/core/libxr_pipe.hpp
@@ -106,7 +106,7 @@ class Pipe
    */
   static ErrorCode WriteFun(WritePort& port, bool in_isr)
   {
-    Pipe* pipe = CONTAINER_OF(&port, Pipe, write_port_);
+    auto* pipe = LibXR::ContainerOf(&port, &Pipe::write_port_);
     WriteInfoBlock info;
     if (port.queue_info_->Pop(info) != ErrorCode::OK)
     {

--- a/src/core/libxr_rw.cpp
+++ b/src/core/libxr_rw.cpp
@@ -9,7 +9,7 @@ template class LibXR::LockFreeQueue<WriteInfoBlock>;
 template class LibXR::LockFreeQueue<uint8_t>;
 
 ReadPort::ReadPort(size_t buffer_size)
-    : queue_data_(buffer_size > 0 ? new (std::align_val_t(LIBXR_CACHE_LINE_SIZE))
+    : queue_data_(buffer_size > 0 ? new (std::align_val_t(LibXR::CACHE_LINE_SIZE))
                                         LockFreeQueue<uint8_t>(buffer_size)
                                   : nullptr)
 {
@@ -263,9 +263,9 @@ void ReadPort::Reset()
 }
 
 WritePort::WritePort(size_t queue_size, size_t buffer_size)
-    : queue_info_(new (std::align_val_t(LIBXR_CACHE_LINE_SIZE))
+    : queue_info_(new (std::align_val_t(LibXR::CACHE_LINE_SIZE))
                       LockFreeQueue<WriteInfoBlock>(queue_size)),
-      queue_data_(buffer_size > 0 ? new (std::align_val_t(LIBXR_CACHE_LINE_SIZE))
+      queue_data_(buffer_size > 0 ? new (std::align_val_t(LibXR::CACHE_LINE_SIZE))
                                         LockFreeQueue<uint8_t>(buffer_size)
                                   : nullptr)
 {

--- a/src/driver/can.cpp
+++ b/src/driver/can.cpp
@@ -10,7 +10,7 @@ void CAN::Register(Callback cb, Type type, FilterMode mode, uint32_t start_id_ma
 {
   ASSERT(type < Type::TYPE_NUM);
 
-  auto node = new (std::align_val_t(LIBXR_CACHE_LINE_SIZE))
+  auto node = new (std::align_val_t(LibXR::CACHE_LINE_SIZE))
       LockFreeList::Node<Filter>(Filter{mode, start_id_mask, end_id_mask, type, cb});
   subscriber_list_[static_cast<uint8_t>(type)].Add(*node);
 }
@@ -46,7 +46,7 @@ void FDCAN::Register(CallbackFD cb, Type type, FilterMode mode, uint32_t start_i
 {
   ASSERT(type < Type::REMOTE_STANDARD);
 
-  auto node = new (std::align_val_t(LIBXR_CACHE_LINE_SIZE))
+  auto node = new (std::align_val_t(LibXR::CACHE_LINE_SIZE))
       LockFreeList::Node<Filter>(Filter{mode, start_id_mask, end_id_mask, type, cb});
   subscriber_list_fd_[static_cast<uint8_t>(type)].Add(*node);
 }

--- a/src/driver/usb/device/cdc/cdc_uart.hpp
+++ b/src/driver/usb/device/cdc/cdc_uart.hpp
@@ -423,7 +423,7 @@ class CDCUart : public CDCBase, public LibXR::UART
   {
     UNUSED(in_isr);
 
-    CDCUart* cdc = CONTAINER_OF(&port, CDCUart, write_port_cdc_);
+    auto* cdc = LibXR::ContainerOf(&port, &CDCUart::write_port_cdc_);
 
     /**
      * @note

--- a/src/middleware/app_framework.hpp
+++ b/src/middleware/app_framework.hpp
@@ -95,7 +95,7 @@ class HardwareContainer
   {
     for (const auto& alias : entry.aliases)
     {
-      auto node = new (std::align_val_t(LIBXR_CACHE_LINE_SIZE))
+      auto node = new (std::align_val_t(LibXR::CACHE_LINE_SIZE))
           LibXR::LockFreeList::Node<AliasEntry>{alias, static_cast<void*>(&entry.object),
                                                 TypeID::GetID<T>()};
       alias_list_.Add(*node);
@@ -144,7 +144,7 @@ class ApplicationManager
    */
   void Register(Application& app)
   {
-    auto node = new (std::align_val_t(LIBXR_CACHE_LINE_SIZE))
+    auto node = new (std::align_val_t(LibXR::CACHE_LINE_SIZE))
         LibXR::LockFreeList::Node<Application*>(&app);
     app_list_.Add(*node);
   }

--- a/src/middleware/database.cpp
+++ b/src/middleware/database.cpp
@@ -186,7 +186,7 @@ size_t DatabaseRawSequential::GetLastKey(BlockType block)
     return 0;
   }
 
-  size_t offset = OFFSET_OF(FlashInfo, key);
+  size_t offset = LibXR::OffsetOf(&FlashInfo::key);
   while (HasLastKey(offset))
   {
     offset = GetNextKey(offset);
@@ -245,7 +245,7 @@ ErrorCode DatabaseRawSequential::AddKey(const char* name, const void* data, size
   const uint32_t NAME_LEN = strlen(name) + 1;
   size_t last_key_offset = GetLastKey(BlockType::MAIN);
   size_t key_buf_offset =
-      last_key_offset ? GetNextKey(last_key_offset) : OFFSET_OF(FlashInfo, key);
+      last_key_offset ? GetNextKey(last_key_offset) : LibXR::OffsetOf(&FlashInfo::key);
 
   size_t end_pos_offset = key_buf_offset + sizeof(KeyInfo) + NAME_LEN + size;
   if (end_pos_offset > max_buffer_size_ - 1)
@@ -318,7 +318,7 @@ size_t DatabaseRawSequential::SearchKey(const char* name)
     return 0;
   }
 
-  size_t key_offset = OFFSET_OF(FlashInfo, key);
+  size_t key_offset = LibXR::OffsetOf(&FlashInfo::key);
   while (true)
   {
     if (KeyNameCompare(key_offset, name) == 0)

--- a/src/middleware/database.hpp
+++ b/src/middleware/database.hpp
@@ -507,7 +507,7 @@ class DatabaseRaw : public Database
       tmp_key.SetNameLength(0);
       tmp_key.SetDataSize(0);
       Write(0, flash_info);
-      key_buf_offset = GetNextKey(OFFSET_OF(FlashInfo, key));
+      key_buf_offset = GetNextKey(LibXR::OffsetOf(&FlashInfo::key));
     }
     else
     {
@@ -745,7 +745,7 @@ class DatabaseRaw : public Database
     }
 
     KeyInfo key;
-    size_t key_offset = OFFSET_OF(FlashInfo, key);
+    size_t key_offset = LibXR::OffsetOf(&FlashInfo::key);
     if (block != BlockType::MAIN)
     {
       key_offset += block_size_;
@@ -831,7 +831,7 @@ class DatabaseRaw : public Database
     }
 
     KeyInfo key;
-    size_t key_offset = OFFSET_OF(FlashInfo, key);
+    size_t key_offset = LibXR::OffsetOf(&FlashInfo::key);
     flash_.Read(key_offset, key);
 
     size_t ans = 0, need_cycle = 0;
@@ -1013,7 +1013,7 @@ class DatabaseRaw : public Database
     }
 
     KeyInfo key;
-    size_t key_offset = OFFSET_OF(FlashInfo, key);
+    size_t key_offset = LibXR::OffsetOf(&FlashInfo::key);
     flash_.Read(key_offset, key);
     size_t need_cycle = 0;
     while (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key))
@@ -1074,7 +1074,7 @@ class DatabaseRaw : public Database
     }
 
     KeyInfo key;
-    size_t key_offset = OFFSET_OF(FlashInfo, key);
+    size_t key_offset = LibXR::OffsetOf(&FlashInfo::key);
     flash_.Read(key_offset, key);
 
     if (!IsBlockEmpty(BlockType::BACKUP))
@@ -1082,7 +1082,7 @@ class DatabaseRaw : public Database
       InitBlock(BlockType::BACKUP);
     }
 
-    size_t write_buff_offset = OFFSET_OF(FlashInfo, key) + block_size_;
+    size_t write_buff_offset = LibXR::OffsetOf(&FlashInfo::key) + block_size_;
 
     auto new_key = KeyInfo{};
     BlockBoolUtil<MinWriteSize>::SetFlag(new_key.uninit, false);

--- a/src/middleware/message.cpp
+++ b/src/middleware/message.cpp
@@ -122,7 +122,7 @@ void LibXR::Topic::RegisterCallback(Callback& cb)
   CallbackBlock block;
   block.cb = cb;
   block.type = SuberType::CALLBACK;
-  auto node = new (std::align_val_t(LIBXR_CACHE_LINE_SIZE))
+  auto node = new (std::align_val_t(LibXR::CACHE_LINE_SIZE))
       LockFreeList::Node<CallbackBlock>(block);
   block_->data_.subers.Add(*node);
 }

--- a/src/structure/lockfree_pool.hpp
+++ b/src/structure/lockfree_pool.hpp
@@ -38,7 +38,7 @@ class LockFreePool
   // NOLINTEND
 
   /// @brief 单个槽结构体 / Individual slot structure (cache line aligned)
-  union alignas(LIBXR_CACHE_LINE_SIZE) Slot
+  union alignas(LibXR::CACHE_LINE_SIZE) Slot
   {
     struct
     {
@@ -46,7 +46,7 @@ class LockFreePool
       Data data;                     ///< 槽内数据 / Stored data
     } slot;
 
-    uint8_t pad[LIBXR_CACHE_LINE_SIZE];  ///< 缓存行填充 / Cache line padding
+    uint8_t pad[LibXR::CACHE_LINE_SIZE];  ///< 缓存行填充 / Cache line padding
 
     Slot()
     {
@@ -65,7 +65,7 @@ class LockFreePool
    */
   LockFreePool(uint32_t slot_count)
       : SLOT_COUNT(slot_count),
-        slots_(new (std::align_val_t(LIBXR_CACHE_LINE_SIZE)) Slot[slot_count])
+        slots_(new (std::align_val_t(LibXR::CACHE_LINE_SIZE)) Slot[slot_count])
   {
     for (uint32_t index = 0; index < SLOT_COUNT; index++)
     {

--- a/src/structure/lockfree_queue.hpp
+++ b/src/structure/lockfree_queue.hpp
@@ -26,7 +26,7 @@ namespace LibXR
  * @tparam Data 队列存储的数据类型 / The type of data stored in the queue.
  */
 template <typename Data>
-class alignas(LIBXR_CACHE_LINE_SIZE) LockFreeQueue
+class alignas(LibXR::CACHE_LINE_SIZE) LockFreeQueue
 {
   inline constexpr size_t AlignUp(size_t size, size_t align)
   {
@@ -47,7 +47,7 @@ class alignas(LIBXR_CACHE_LINE_SIZE) LockFreeQueue
   LockFreeQueue(size_t length)
       : head_(0),
         tail_(0),
-        LENGTH(AlignUp(length, LIBXR_ALIGN_SIZE) - 1),
+        LENGTH(AlignUp(length, LibXR::ALIGN_SIZE) - 1),
         queue_handle_(new Data[LENGTH + 1])
   {
   }
@@ -514,8 +514,8 @@ class alignas(LIBXR_CACHE_LINE_SIZE) LockFreeQueue
   size_t MaxSize() const { return LENGTH; }
 
  private:
-  alignas(LIBXR_CACHE_LINE_SIZE) std::atomic<uint32_t> head_;
-  alignas(LIBXR_CACHE_LINE_SIZE) std::atomic<uint32_t> tail_;
+  alignas(LibXR::CACHE_LINE_SIZE) std::atomic<uint32_t> head_;
+  alignas(LibXR::CACHE_LINE_SIZE) std::atomic<uint32_t> tail_;
   const size_t LENGTH;
   Data* queue_handle_;
 

--- a/src/utils/cycle_value.hpp
+++ b/src/utils/cycle_value.hpp
@@ -49,10 +49,10 @@ class CycleValue
    */
   static constexpr Scalar Calculate(Scalar value)
   {
-    value = std::fmod(value, M_2PI);
+    value = std::fmod(value, LibXR::TWO_PI);
     if (value < 0)
     {
-      value += M_2PI;
+      value += LibXR::TWO_PI;
     }
     return value;
   }
@@ -75,14 +75,14 @@ class CycleValue
    */
   CycleValue(const CycleValue& value) : value_(value.value_)
   {
-    while (value_ >= M_2PI)
+    while (value_ >= LibXR::TWO_PI)
     {
-      value_ -= M_2PI;
+      value_ -= LibXR::TWO_PI;
     }
 
     while (value_ < 0)
     {
-      value_ += M_2PI;
+      value_ += LibXR::TWO_PI;
     }
   }
 
@@ -126,14 +126,14 @@ class CycleValue
   CycleValue& operator+=(const CycleValue& value)
   {
     Scalar ans = value.value_ + value_;
-    while (ans >= M_2PI)
+    while (ans >= LibXR::TWO_PI)
     {
-      ans -= M_2PI;
+      ans -= LibXR::TWO_PI;
     }
 
     while (ans < 0)
     {
-      ans += M_2PI;
+      ans += LibXR::TWO_PI;
     }
 
     value_ = ans;
@@ -154,14 +154,14 @@ class CycleValue
   {
     Scalar value = Calculate(raw_value);
     Scalar ans = value_ - value;
-    while (ans >= M_PI)
+    while (ans >= LibXR::PI)
     {
-      ans -= M_2PI;
+      ans -= LibXR::TWO_PI;
     }
 
-    while (ans < -M_PI)
+    while (ans < -LibXR::PI)
     {
-      ans += M_2PI;
+      ans += LibXR::TWO_PI;
     }
 
     return ans;
@@ -170,14 +170,14 @@ class CycleValue
   Scalar operator-(const CycleValue& value) const
   {
     Scalar ans = value_ - value.value_;
-    while (ans >= M_PI)
+    while (ans >= LibXR::PI)
     {
-      ans -= M_2PI;
+      ans -= LibXR::TWO_PI;
     }
 
-    while (ans < -M_PI)
+    while (ans < -LibXR::PI)
     {
-      ans += M_2PI;
+      ans += LibXR::TWO_PI;
     }
 
     return ans;
@@ -201,14 +201,14 @@ class CycleValue
   CycleValue& operator-=(const CycleValue& value)
   {
     Scalar ans = value_ - value.value_;
-    while (ans >= M_2PI)
+    while (ans >= LibXR::TWO_PI)
     {
-      ans -= M_2PI;
+      ans -= LibXR::TWO_PI;
     }
 
     while (ans < 0)
     {
-      ans += M_2PI;
+      ans += LibXR::TWO_PI;
     }
 
     value_ = ans;
@@ -222,7 +222,7 @@ class CycleValue
    * @return 返回取反后的 `CycleValue`。
    *         Returns the negated `CycleValue`.
    */
-  CycleValue operator-() const { return CycleValue(M_2PI - value_); }
+  CycleValue operator-() const { return CycleValue(LibXR::TWO_PI - value_); }
 
   /**
    * @brief 类型转换操作符，将 `CycleValue` 转换为 `Scalar`。

--- a/src/utils/kinematic.hpp
+++ b/src/utils/kinematic.hpp
@@ -122,13 +122,13 @@ class Joint
    */
   void SetState(Scalar state)
   {
-    if (state > M_PI)
+    if (state > LibXR::PI)
     {
-      state -= 2 * M_PI;
+      state -= 2 * LibXR::PI;
     }
-    if (state < -M_PI)
+    if (state < -LibXR::PI)
     {
-      state += 2 * M_PI;
+      state += 2 * LibXR::PI;
     }
     runtime_.state_angle.angle() = state;
     runtime_.state_angle.axis() = param_.axis;
@@ -145,13 +145,13 @@ class Joint
    */
   void SetTarget(Scalar target)
   {
-    if (target > M_PI)
+    if (target > LibXR::PI)
     {
-      target -= 2 * M_PI;
+      target -= 2 * LibXR::PI;
     }
-    if (target < -M_PI)
+    if (target < -LibXR::PI)
     {
-      target += 2 * M_PI;
+      target += 2 * LibXR::PI;
     }
     runtime_.target_angle.angle() = target;
     runtime_.target_angle.axis() = param_.axis;

--- a/test/test_cb.cpp
+++ b/test/test_cb.cpp
@@ -85,6 +85,24 @@ struct GuardedCreationProbe
     self->depth--;
   }
 };
+
+struct LambdaCreationProbe
+{
+  LibXR::Callback<int> cb;
+  int seen_value = 0;
+  bool seen_in_isr = false;
+
+  LambdaCreationProbe()
+      : cb(LibXR::Callback<int>::Create(
+            [](bool in_isr, LambdaCreationProbe* self, int value)
+            {
+              self->seen_value = value;
+              self->seen_in_isr = in_isr;
+            },
+            this))
+  {
+  }
+};
 }  // namespace
 
 void test_cb()
@@ -153,5 +171,12 @@ void test_cb()
     ASSERT(probe.seen_in_isr[0] == false);
     ASSERT(probe.seen_in_isr[1] == false);
     ASSERT(probe.max_depth == 1);
+  }
+
+  {
+    LambdaCreationProbe probe;
+    probe.cb.Run(true, 7);
+    ASSERT(probe.seen_value == 7);
+    ASSERT(probe.seen_in_isr == true);
   }
 }

--- a/test/test_crc.cpp
+++ b/test/test_crc.cpp
@@ -9,21 +9,21 @@ void test_crc()
     double a;
     char b;
     uint8_t crc;
-  } test_crc8 = {.a = M_PI, .b = 'X', .crc = 0};
+  } test_crc8 = {.a = LibXR::PI, .b = 'X', .crc = 0};
 
   struct __attribute__((packed))
   {
     double a;
     char b;
     uint16_t crc;
-  } test_crc16 = {.a = M_PI * 2, .b = 'X', .crc = 0};
+  } test_crc16 = {.a = LibXR::PI * 2, .b = 'X', .crc = 0};
 
   struct __attribute__((packed))
   {
     double a;
     char b;
     uint32_t crc;
-  } test_crc32 = {.a = M_PI * 3, .b = 'X', .crc = 0};
+  } test_crc32 = {.a = LibXR::PI * 3, .b = 'X', .crc = 0};
 
   test_crc8.crc = LibXR::CRC8::Calculate(&test_crc8, sizeof(test_crc8) - sizeof(uint8_t));
   test_crc16.crc =

--- a/test/test_cycle_value.cpp
+++ b/test/test_cycle_value.cpp
@@ -6,18 +6,18 @@
 void test_cycle_value()
 {
   using LibXR::CycleValue;
-  CycleValue<> val(4 * M_PI + M_PI / 2);
-  ASSERT(equal(static_cast<double>(val), M_PI / 2));
+  CycleValue<> val(4 * LibXR::PI + LibXR::PI / 2);
+  ASSERT(equal(static_cast<double>(val), LibXR::PI / 2));
 
-  val += M_PI;
-  ASSERT(equal(static_cast<double>(val), 3 * M_PI / 2));
+  val += LibXR::PI;
+  ASSERT(equal(static_cast<double>(val), 3 * LibXR::PI / 2));
 
-  ASSERT(equal(static_cast<double>(CycleValue<>(val - 0.0)), 3 * M_PI / 2));
+  ASSERT(equal(static_cast<double>(CycleValue<>(val - 0.0)), 3 * LibXR::PI / 2));
 
-  val -= M_PI;
-  ASSERT(equal(static_cast<double>(val), M_PI / 2));
+  val -= LibXR::PI;
+  ASSERT(equal(static_cast<double>(val), LibXR::PI / 2));
 
   auto neg = -val;
-  ASSERT(equal(static_cast<double>(neg), M_2PI - M_PI / 2));
+  ASSERT(equal(static_cast<double>(neg), LibXR::TWO_PI - LibXR::PI / 2));
   UNUSED(neg);
 }

--- a/test/test_encoder.cpp
+++ b/test/test_encoder.cpp
@@ -54,7 +54,7 @@ void test_float_encoder()
 
   // 3. Euler angle test: [-π, π]
   {
-    FloatEncoder<BITS> encoder(-M_PI, M_PI);
+    FloatEncoder<BITS> encoder(-LibXR::PI, LibXR::PI);
 
     struct __attribute__((packed))
     {
@@ -63,7 +63,7 @@ void test_float_encoder()
       float decoded;
     } eulr;
 
-    eulr.input = M_PI / 2.0f;
+    eulr.input = LibXR::PI / 2.0f;
     eulr.encoded = encoder.Encode(eulr.input);
     eulr.decoded = encoder.Decode(eulr.encoded);
 

--- a/test/test_inertia.cpp
+++ b/test/test_inertia.cpp
@@ -85,7 +85,7 @@ void test_inertia()
   /* Original behaviour check */
   auto inertia_new = Inertia(0.1, 1., 1., 1., 0., 0., 0.)
                          .Translate(pos)
-                         .Rotate(LibXR::EulerAngle(0., 0., M_PI / 4).ToQuaternion());
+                         .Rotate(LibXR::EulerAngle(0., 0., LibXR::PI / 4).ToQuaternion());
 
   ASSERT(equal(inertia_new(0, 0), 1.1) && equal(inertia_new(0, 1), 0.) &&
          equal(inertia_new(0, 2), 0.) && equal(inertia_new(1, 0), 0.) &&
@@ -95,7 +95,7 @@ void test_inertia()
 
   inertia_new = Inertia(0.1, 1., 1., 1., 0., 0., 0.)
                     .Translate(pos)
-                    .Rotate(LibXR::EulerAngle(0., 0., M_PI / 4).ToRotationMatrix());
+                    .Rotate(LibXR::EulerAngle(0., 0., LibXR::PI / 4).ToRotationMatrix());
 
   ASSERT(equal(inertia_new(0, 0), 1.1) && equal(inertia_new(0, 1), 0.) &&
          equal(inertia_new(0, 2), 0.) && equal(inertia_new(1, 0), 0.) &&

--- a/test/test_kinematic.cpp
+++ b/test/test_kinematic.cpp
@@ -42,7 +42,7 @@ void test_kinematic()
                                          t_joint2endpoint);
 
   joint_endpoint.SetState(0.);
-  joint_midpoint.SetState(M_PI / 2);
+  joint_midpoint.SetState(LibXR::PI / 2);
 
   LibXR::Quaternion target_quat(0.7071068, 0., -0.7071068, 0.);
   LibXR::Position target_pos(0., 0., 4.);

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -6,7 +6,7 @@ void test_transform()
 {
   LibXR::Position pos(1., 8., 0.3);
   LibXR::Position pos_new;
-  LibXR::EulerAngle eulr = {M_PI / 12, M_PI / 6, M_PI / 4}, eulr_new;
+  LibXR::EulerAngle eulr = {LibXR::PI / 12, LibXR::PI / 6, LibXR::PI / 4}, eulr_new;
   LibXR::RotationMatrix rot, rot_new;
   LibXR::Quaternion quat, quat_new;
 


### PR DESCRIPTION
## Summary
- move `libxr_def.hpp` helper constants and utilities into `LibXR`, including `PI`, `TWO_PI`, `CACHE_LINE_SIZE`, `ALIGN_SIZE`, `OffsetOf`, and `ContainerOf`
- update all related call sites in `driver/`, `src/`, and `test/` to the new `LibXR` helper surface
- constrain `Callback::Create` and `CreateGuarded` with a C++20 concept instead of the previous `std::type_identity_t` signature trick
- constrain `LibXR::OffsetOf` / `ContainerOf` and `LibXR::max` / `min` with C++20 concepts
- add a non-capturing lambda callback test to lock in the intended callable form
