### PR TITLE
refactor(core): collect FastCmp mismatch handling

### DIFF
--- a/src/core/libxr_mem.cpp
+++ b/src/core/libxr_mem.cpp
@@ -311,24 +311,14 @@ int LibXR::Memory::FastCmp(const void* a, const void* b, size_t size)
 {
   const uint8_t* p = static_cast<const uint8_t*>(a);
   const uint8_t* q = static_cast<const uint8_t*>(b);
+  const uint8_t* mismatch_p = nullptr;
+  const uint8_t* mismatch_q = nullptr;
+  size_t mismatch_size = 0;
 
   if ((size == 0) || (p == q))
   {
     return 0;
   }
-
-  auto byte_cmp = [](const uint8_t* x, const uint8_t* y, size_t n) -> int
-  {
-    for (size_t i = 0; i < n; ++i)
-    {
-      int diff = static_cast<int>(x[i]) - static_cast<int>(y[i]);
-      if (diff != 0)
-      {
-        return diff;
-      }
-    }
-    return 0;
-  };
 
   uintptr_t p_off = reinterpret_cast<uintptr_t>(p) & (LibXR::ALIGN_SIZE - 1);
   uintptr_t q_off = reinterpret_cast<uintptr_t>(q) & (LibXR::ALIGN_SIZE - 1);
@@ -365,43 +355,59 @@ int LibXR::Memory::FastCmp(const void* a, const void* b, size_t size)
       {
         if (pw[0] != qw[0])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 0),
-                          reinterpret_cast<const uint8_t*>(qw + 0), 8);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 0);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 0);
+          mismatch_size = 8;
+          goto compare_fixed_bytes;
         }
         if (pw[1] != qw[1])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 1),
-                          reinterpret_cast<const uint8_t*>(qw + 1), 8);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 1);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 1);
+          mismatch_size = 8;
+          goto compare_fixed_bytes;
         }
         if (pw[2] != qw[2])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 2),
-                          reinterpret_cast<const uint8_t*>(qw + 2), 8);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 2);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 2);
+          mismatch_size = 8;
+          goto compare_fixed_bytes;
         }
         if (pw[3] != qw[3])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 3),
-                          reinterpret_cast<const uint8_t*>(qw + 3), 8);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 3);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 3);
+          mismatch_size = 8;
+          goto compare_fixed_bytes;
         }
         if (pw[4] != qw[4])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 4),
-                          reinterpret_cast<const uint8_t*>(qw + 4), 8);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 4);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 4);
+          mismatch_size = 8;
+          goto compare_fixed_bytes;
         }
         if (pw[5] != qw[5])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 5),
-                          reinterpret_cast<const uint8_t*>(qw + 5), 8);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 5);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 5);
+          mismatch_size = 8;
+          goto compare_fixed_bytes;
         }
         if (pw[6] != qw[6])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 6),
-                          reinterpret_cast<const uint8_t*>(qw + 6), 8);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 6);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 6);
+          mismatch_size = 8;
+          goto compare_fixed_bytes;
         }
         if (pw[7] != qw[7])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 7),
-                          reinterpret_cast<const uint8_t*>(qw + 7), 8);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 7);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 7);
+          mismatch_size = 8;
+          goto compare_fixed_bytes;
         }
 
         pw += 8;
@@ -413,8 +419,10 @@ int LibXR::Memory::FastCmp(const void* a, const void* b, size_t size)
       {
         if (*pw != *qw)
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw),
-                          reinterpret_cast<const uint8_t*>(qw), 8);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw);
+          mismatch_size = 8;
+          goto compare_fixed_bytes;
         }
         ++pw;
         ++qw;
@@ -437,43 +445,59 @@ int LibXR::Memory::FastCmp(const void* a, const void* b, size_t size)
       {
         if (pw[0] != qw[0])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 0),
-                          reinterpret_cast<const uint8_t*>(qw + 0), 4);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 0);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 0);
+          mismatch_size = 4;
+          goto compare_fixed_bytes;
         }
         if (pw[1] != qw[1])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 1),
-                          reinterpret_cast<const uint8_t*>(qw + 1), 4);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 1);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 1);
+          mismatch_size = 4;
+          goto compare_fixed_bytes;
         }
         if (pw[2] != qw[2])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 2),
-                          reinterpret_cast<const uint8_t*>(qw + 2), 4);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 2);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 2);
+          mismatch_size = 4;
+          goto compare_fixed_bytes;
         }
         if (pw[3] != qw[3])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 3),
-                          reinterpret_cast<const uint8_t*>(qw + 3), 4);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 3);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 3);
+          mismatch_size = 4;
+          goto compare_fixed_bytes;
         }
         if (pw[4] != qw[4])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 4),
-                          reinterpret_cast<const uint8_t*>(qw + 4), 4);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 4);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 4);
+          mismatch_size = 4;
+          goto compare_fixed_bytes;
         }
         if (pw[5] != qw[5])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 5),
-                          reinterpret_cast<const uint8_t*>(qw + 5), 4);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 5);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 5);
+          mismatch_size = 4;
+          goto compare_fixed_bytes;
         }
         if (pw[6] != qw[6])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 6),
-                          reinterpret_cast<const uint8_t*>(qw + 6), 4);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 6);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 6);
+          mismatch_size = 4;
+          goto compare_fixed_bytes;
         }
         if (pw[7] != qw[7])
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw + 7),
-                          reinterpret_cast<const uint8_t*>(qw + 7), 4);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw + 7);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw + 7);
+          mismatch_size = 4;
+          goto compare_fixed_bytes;
         }
 
         pw += 8;
@@ -485,8 +509,10 @@ int LibXR::Memory::FastCmp(const void* a, const void* b, size_t size)
       {
         if (*pw != *qw)
         {
-          return byte_cmp(reinterpret_cast<const uint8_t*>(pw),
-                          reinterpret_cast<const uint8_t*>(qw), 4);
+          mismatch_p = reinterpret_cast<const uint8_t*>(pw);
+          mismatch_q = reinterpret_cast<const uint8_t*>(qw);
+          mismatch_size = 4;
+          goto compare_fixed_bytes;
         }
         ++pw;
         ++qw;
@@ -496,6 +522,67 @@ int LibXR::Memory::FastCmp(const void* a, const void* b, size_t size)
       p = reinterpret_cast<const uint8_t*>(pw);
       q = reinterpret_cast<const uint8_t*>(qw);
     }
+  }
+
+compare_fixed_bytes:
+  if (mismatch_size == 8)
+  {
+    int diff = static_cast<int>(mismatch_p[0]) - static_cast<int>(mismatch_q[0]);
+    if (diff != 0)
+    {
+      return diff;
+    }
+    diff = static_cast<int>(mismatch_p[1]) - static_cast<int>(mismatch_q[1]);
+    if (diff != 0)
+    {
+      return diff;
+    }
+    diff = static_cast<int>(mismatch_p[2]) - static_cast<int>(mismatch_q[2]);
+    if (diff != 0)
+    {
+      return diff;
+    }
+    diff = static_cast<int>(mismatch_p[3]) - static_cast<int>(mismatch_q[3]);
+    if (diff != 0)
+    {
+      return diff;
+    }
+    diff = static_cast<int>(mismatch_p[4]) - static_cast<int>(mismatch_q[4]);
+    if (diff != 0)
+    {
+      return diff;
+    }
+    diff = static_cast<int>(mismatch_p[5]) - static_cast<int>(mismatch_q[5]);
+    if (diff != 0)
+    {
+      return diff;
+    }
+    diff = static_cast<int>(mismatch_p[6]) - static_cast<int>(mismatch_q[6]);
+    if (diff != 0)
+    {
+      return diff;
+    }
+    return static_cast<int>(mismatch_p[7]) - static_cast<int>(mismatch_q[7]);
+  }
+
+  if (mismatch_size == 4)
+  {
+    int diff = static_cast<int>(mismatch_p[0]) - static_cast<int>(mismatch_q[0]);
+    if (diff != 0)
+    {
+      return diff;
+    }
+    diff = static_cast<int>(mismatch_p[1]) - static_cast<int>(mismatch_q[1]);
+    if (diff != 0)
+    {
+      return diff;
+    }
+    diff = static_cast<int>(mismatch_p[2]) - static_cast<int>(mismatch_q[2]);
+    if (diff != 0)
+    {
+      return diff;
+    }
+    return static_cast<int>(mismatch_p[3]) - static_cast<int>(mismatch_q[3]);
   }
 
   // tail byte compare（包括：未满足宽比较对齐条件的情况）


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Replace the inline byte comparison lambda with a shared mismatch handling path for 4- and 8-byte chunk comparisons in FastCmp.