### PR TITLE
refactor(core): integrate D-Cache handling across STM32 drivers

### DIFF
--- a/driver/st/stm32_adc.cpp
+++ b/driver/st/stm32_adc.cpp
@@ -1,7 +1,7 @@
 #include "stm32_adc.hpp"
 
-#include "stm32_dcache.hpp"
 #include "libxr_def.hpp"
+#include "stm32_dcache.hpp"
 
 #ifdef HAL_ADC_MODULE_ENABLED
 
@@ -97,9 +97,7 @@ float STM32ADC::ReadChannel(uint8_t channel)
   uint16_t* buffer = reinterpret_cast<uint16_t*>(dma_buffer_.addr_);
   if (use_dma_)
   {
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     STM32_InvalidateDCacheByAddr(buffer, filter_size_ * NUM_CHANNELS * 2);
-#endif
     uint32_t sum = 0;
     for (uint8_t i = 0; i < filter_size_; ++i)
     {

--- a/driver/st/stm32_adc.cpp
+++ b/driver/st/stm32_adc.cpp
@@ -1,5 +1,6 @@
 #include "stm32_adc.hpp"
 
+#include "stm32_dcache.hpp"
 #include "libxr_def.hpp"
 
 #ifdef HAL_ADC_MODULE_ENABLED
@@ -97,7 +98,7 @@ float STM32ADC::ReadChannel(uint8_t channel)
   if (use_dma_)
   {
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    SCB_InvalidateDCache_by_Addr(buffer, filter_size_ * NUM_CHANNELS * 2);
+    STM32_InvalidateDCacheByAddr(buffer, filter_size_ * NUM_CHANNELS * 2);
 #endif
     uint32_t sum = 0;
     for (uint8_t i = 0; i < filter_size_; ++i)

--- a/driver/st/stm32_dcache.hpp
+++ b/driver/st/stm32_dcache.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <type_traits>
+
+#include "main.h"
+
+namespace LibXR
+{
+/**
+ * @brief D-Cache API accepts `void*`
+ * @brief D-Cache API 可直接接受 `void*`
+ */
+template <typename FunctionType>
+concept DCacheFunctionAcceptsVoidPtr =
+    std::is_invocable_v<FunctionType, void*, int32_t>;
+
+/**
+ * @brief D-Cache API accepts `volatile void*`
+ * @brief D-Cache API 可直接接受 `volatile void*`
+ */
+template <typename FunctionType>
+concept DCacheFunctionAcceptsVolatileVoidPtr =
+    std::is_invocable_v<FunctionType, volatile void*, int32_t>;
+
+/**
+ * @brief Calls the CMSIS D-Cache helper with the pointer type accepted by the
+ * current toolchain
+ * @brief 按当前工具链接受的指针类型调用 CMSIS D-Cache 接口
+ */
+template <typename FunctionType>
+requires DCacheFunctionAcceptsVoidPtr<FunctionType>
+inline void STM32_CallDCacheByAddr(FunctionType function, void* addr, int32_t dsize)
+{
+  function(addr, dsize);
+}
+
+template <typename FunctionType>
+requires(!DCacheFunctionAcceptsVoidPtr<FunctionType> &&
+         DCacheFunctionAcceptsVolatileVoidPtr<FunctionType>)
+inline void STM32_CallDCacheByAddr(FunctionType function, void* addr, int32_t dsize)
+{
+  function(reinterpret_cast<volatile void*>(addr), dsize);
+}
+
+template <typename FunctionType>
+requires(!DCacheFunctionAcceptsVoidPtr<FunctionType> &&
+         !DCacheFunctionAcceptsVolatileVoidPtr<FunctionType>)
+inline void STM32_CallDCacheByAddr(FunctionType function, void* addr, int32_t dsize)
+{
+  function(reinterpret_cast<uint32_t*>(addr), dsize);
+}
+
+/**
+ * @brief Cleans D-Cache lines covering the specified memory range
+ * @brief 清理指定内存范围覆盖的 D-Cache cache line
+ */
+inline void STM32_CleanDCacheByAddr(const void* addr, size_t size)
+{
+#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+  auto* raw = const_cast<void*>(addr);
+  const auto dsize = static_cast<int32_t>(size);
+  STM32_CallDCacheByAddr(&SCB_CleanDCache_by_Addr, raw, dsize);
+#else
+  (void)addr;
+  (void)size;
+#endif
+}
+
+/**
+ * @brief Invalidates D-Cache lines covering the specified memory range
+ * @brief 失效指定内存范围覆盖的 D-Cache cache line
+ */
+inline void STM32_InvalidateDCacheByAddr(void* addr, size_t size)
+{
+#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+  const auto dsize = static_cast<int32_t>(size);
+  STM32_CallDCacheByAddr(&SCB_InvalidateDCache_by_Addr, addr, dsize);
+#else
+  (void)addr;
+  (void)size;
+#endif
+}
+}  // namespace LibXR

--- a/driver/st/stm32_dcache.hpp
+++ b/driver/st/stm32_dcache.hpp
@@ -72,11 +72,12 @@ inline void STM32_CleanDCacheByAddr(const void* addr, size_t size)
  * @brief Invalidates D-Cache lines covering the specified memory range
  * @brief 失效指定内存范围覆盖的 D-Cache cache line
  */
-inline void STM32_InvalidateDCacheByAddr(void* addr, size_t size)
+inline void STM32_InvalidateDCacheByAddr(const void* addr, size_t size)
 {
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
+  auto* raw = const_cast<void*>(addr);
   const auto dsize = static_cast<int32_t>(size);
-  STM32_CallDCacheByAddr(&SCB_InvalidateDCache_by_Addr, addr, dsize);
+  STM32_CallDCacheByAddr(&SCB_InvalidateDCache_by_Addr, raw, dsize);
 #else
   (void)addr;
   (void)size;

--- a/driver/st/stm32_i2c.cpp
+++ b/driver/st/stm32_i2c.cpp
@@ -243,9 +243,7 @@ ErrorCode STM32I2C::Write(uint16_t slave_addr, ConstRawData write_data,
       // Arm the BLOCK waiter before HAL exposes completion to IRQ context.
       block_wait_.Start(*op.data.sem_info.sem);
     }
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     STM32_CleanDCacheByAddr(dma_buff_.addr_, write_data.size_);
-#endif
     const HAL_StatusTypeDef st = HAL_I2C_Master_Transmit_DMA(
         i2c_handle_, dev_addr, reinterpret_cast<uint8_t*>(dma_buff_.addr_),
         write_data.size_);
@@ -368,9 +366,7 @@ ErrorCode STM32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
       // Arm the BLOCK waiter before HAL exposes completion to IRQ context.
       block_wait_.Start(*op.data.sem_info.sem);
     }
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     STM32_CleanDCacheByAddr(dma_buff_.addr_, write_data.size_);
-#endif
     const HAL_StatusTypeDef st = HAL_I2C_Mem_Write_DMA(
         i2c_handle_, dev_addr, mem_addr,
         mem_addr_size == MemAddrLength::BYTE_8 ? I2C_MEMADD_SIZE_8BIT
@@ -439,9 +435,7 @@ extern "C" void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef* hi2c)
 #ifdef HAL_I2C_ERROR_NONE
     ec = (hi2c->ErrorCode == HAL_I2C_ERROR_NONE) ? ErrorCode::OK : ErrorCode::FAILED;
 #endif
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     STM32_InvalidateDCacheByAddr(i2c->dma_buff_.addr_, i2c->read_buff_.size_);
-#endif
     if (ec == ErrorCode::OK)
     {
       Memory::FastCopy(i2c->read_buff_.addr_, i2c->dma_buff_.addr_,
@@ -510,9 +504,7 @@ extern "C" void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef* hi2c)
 #ifdef HAL_I2C_ERROR_NONE
     ec = (hi2c->ErrorCode == HAL_I2C_ERROR_NONE) ? ErrorCode::OK : ErrorCode::FAILED;
 #endif
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     STM32_InvalidateDCacheByAddr(i2c->dma_buff_.addr_, i2c->read_buff_.size_);
-#endif
     if (ec == ErrorCode::OK)
     {
       Memory::FastCopy(i2c->read_buff_.addr_, i2c->dma_buff_.addr_,

--- a/driver/st/stm32_i2c.cpp
+++ b/driver/st/stm32_i2c.cpp
@@ -1,5 +1,6 @@
 #include "stm32_i2c.hpp"
 
+#include "stm32_dcache.hpp"
 #ifdef HAL_I2C_MODULE_ENABLED
 
 using namespace LibXR;
@@ -243,8 +244,7 @@ ErrorCode STM32I2C::Write(uint16_t slave_addr, ConstRawData write_data,
       block_wait_.Start(*op.data.sem_info.sem);
     }
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    SCB_CleanDCache_by_Addr(reinterpret_cast<uint32_t*>(dma_buff_.addr_),
-                            write_data.size_);
+    STM32_CleanDCacheByAddr(dma_buff_.addr_, write_data.size_);
 #endif
     const HAL_StatusTypeDef st = HAL_I2C_Master_Transmit_DMA(
         i2c_handle_, dev_addr, reinterpret_cast<uint8_t*>(dma_buff_.addr_),
@@ -369,8 +369,7 @@ ErrorCode STM32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
       block_wait_.Start(*op.data.sem_info.sem);
     }
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    SCB_CleanDCache_by_Addr(reinterpret_cast<uint32_t*>(dma_buff_.addr_),
-                            write_data.size_);
+    STM32_CleanDCacheByAddr(dma_buff_.addr_, write_data.size_);
 #endif
     const HAL_StatusTypeDef st = HAL_I2C_Mem_Write_DMA(
         i2c_handle_, dev_addr, mem_addr,
@@ -441,7 +440,7 @@ extern "C" void HAL_I2C_MasterRxCpltCallback(I2C_HandleTypeDef* hi2c)
     ec = (hi2c->ErrorCode == HAL_I2C_ERROR_NONE) ? ErrorCode::OK : ErrorCode::FAILED;
 #endif
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    SCB_InvalidateDCache_by_Addr(i2c->dma_buff_.addr_, i2c->read_buff_.size_);
+    STM32_InvalidateDCacheByAddr(i2c->dma_buff_.addr_, i2c->read_buff_.size_);
 #endif
     if (ec == ErrorCode::OK)
     {
@@ -512,7 +511,7 @@ extern "C" void HAL_I2C_MemRxCpltCallback(I2C_HandleTypeDef* hi2c)
     ec = (hi2c->ErrorCode == HAL_I2C_ERROR_NONE) ? ErrorCode::OK : ErrorCode::FAILED;
 #endif
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    SCB_InvalidateDCache_by_Addr(i2c->dma_buff_.addr_, i2c->read_buff_.size_);
+    STM32_InvalidateDCacheByAddr(i2c->dma_buff_.addr_, i2c->read_buff_.size_);
 #endif
     if (ec == ErrorCode::OK)
     {

--- a/driver/st/stm32_spi.cpp
+++ b/driver/st/stm32_spi.cpp
@@ -1,7 +1,7 @@
 #include "stm32_spi.hpp"
 
-#include "stm32_dcache.hpp"
 #include "libxr_def.hpp"
+#include "stm32_dcache.hpp"
 
 #ifdef HAL_SPI_MODULE_ENABLED
 
@@ -123,9 +123,7 @@ ErrorCode STM32SPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
         Memory::FastSet(reinterpret_cast<uint8_t*>(tx.addr_) + write_data.size_, 0,
                         need_write - write_data.size_);
       }
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
       STM32_CleanDCacheByAddr(tx.addr_, need_write);
-#endif
       read_buff_ = read_data;
 
       st = HAL_SPI_TransmitReceive_DMA(spi_handle_, static_cast<uint8_t*>(tx.addr_),
@@ -139,9 +137,7 @@ ErrorCode STM32SPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
         Memory::FastSet(reinterpret_cast<uint8_t*>(tx.addr_) + write_data.size_, 0,
                         need_write - write_data.size_);
       }
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
       STM32_CleanDCacheByAddr(tx.addr_, need_write);
-#endif
       read_buff_ = {nullptr, 0};
 
       st = HAL_SPI_Transmit_DMA(spi_handle_, static_cast<uint8_t*>(tx.addr_), need_write);
@@ -189,9 +185,7 @@ ErrorCode STM32SPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
       Memory::FastSet(reinterpret_cast<uint8_t*>(tx.addr_) + write_data.size_, 0,
                       need_write - write_data.size_);
     }
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     STM32_CleanDCacheByAddr(tx.addr_, need_write);
-#endif
     ans = (HAL_SPI_TransmitReceive(spi_handle_, static_cast<uint8_t*>(tx.addr_),
                                    static_cast<uint8_t*>(rx.addr_), need_write,
                                    20) == HAL_OK)
@@ -220,9 +214,7 @@ ErrorCode STM32SPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
   else if (write_data.size_ > 0)
   {
     Memory::FastCopy(tx.addr_, write_data.addr_, write_data.size_);
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     STM32_CleanDCacheByAddr(tx.addr_, need_write);
-#endif
     ans = (HAL_SPI_Transmit(spi_handle_, static_cast<uint8_t*>(tx.addr_),
                             write_data.size_, 20) == HAL_OK)
               ? ErrorCode::OK
@@ -373,9 +365,7 @@ ErrorCode STM32SPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bo
     uint8_t* txb = reinterpret_cast<uint8_t*>(tx.addr_);
     Memory::FastSet(txb, 0, need_read + 1);
     txb[0] = static_cast<uint8_t>(reg | 0x80);
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     STM32_CleanDCacheByAddr(tx.addr_, need_read + 1);
-#endif
     read_buff_ = read_data;
 
     HAL_StatusTypeDef st =
@@ -403,9 +393,7 @@ ErrorCode STM32SPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bo
   uint8_t* txb = reinterpret_cast<uint8_t*>(tx.addr_);
   Memory::FastSet(txb, 0, need_read + 1);
   txb[0] = static_cast<uint8_t>(reg | 0x80);
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
   STM32_CleanDCacheByAddr(tx.addr_, need_read + 1);
-#endif
 
   ErrorCode ans = (HAL_SPI_TransmitReceive(spi_handle_, static_cast<uint8_t*>(tx.addr_),
                                            static_cast<uint8_t*>(rx.addr_), need_read + 1,
@@ -452,9 +440,7 @@ ErrorCode STM32SPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW&
     uint8_t* txb = reinterpret_cast<uint8_t*>(tx.addr_);
     txb[0] = static_cast<uint8_t>(reg & 0x7F);
     Memory::FastCopy(txb + 1, write_data.addr_, need_write);
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     STM32_CleanDCacheByAddr(tx.addr_, need_write + 1);
-#endif
     read_buff_ = {nullptr, 0};
 
     HAL_StatusTypeDef st = HAL_SPI_Transmit_DMA(
@@ -480,9 +466,7 @@ ErrorCode STM32SPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW&
   uint8_t* txb = reinterpret_cast<uint8_t*>(tx.addr_);
   txb[0] = static_cast<uint8_t>(reg & 0x7F);
   Memory::FastCopy(txb + 1, write_data.addr_, need_write);
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
   STM32_CleanDCacheByAddr(tx.addr_, need_write + 1);
-#endif
 
   ErrorCode ans = (HAL_SPI_Transmit(spi_handle_, static_cast<uint8_t*>(tx.addr_),
                                     need_write + 1, 20) == HAL_OK)
@@ -700,10 +684,8 @@ ErrorCode STM32SPI::Transfer(size_t size, OperationRW& op, bool in_isr)
       block_wait_.Start(*op.data.sem_info.sem);
     }
 
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     STM32_CleanDCacheByAddr(tx.addr_, xfer);
     STM32_InvalidateDCacheByAddr(rx.addr_, xfer);
-#endif
 
     HAL_StatusTypeDef st =
         HAL_SPI_TransmitReceive_DMA(spi_handle_, static_cast<uint8_t*>(tx.addr_),
@@ -732,9 +714,7 @@ ErrorCode STM32SPI::Transfer(size_t size, OperationRW& op, bool in_isr)
           ? ErrorCode::OK
           : ErrorCode::BUSY;
 
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
   STM32_InvalidateDCacheByAddr(rx.addr_, xfer);
-#endif
 
   SwitchBuffer();
 
@@ -780,16 +760,12 @@ extern "C" void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef* hspi)
   {
     if (!spi->mem_read_)
     {
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
       STM32_InvalidateDCacheByAddr(rx.addr_, spi->read_buff_.size_);
-#endif
       Memory::FastCopy(spi->read_buff_.addr_, rx.addr_, spi->read_buff_.size_);
     }
     else
     {
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
       STM32_InvalidateDCacheByAddr(rx.addr_, spi->read_buff_.size_ + 1);
-#endif
       uint8_t* rx_dma_buff = reinterpret_cast<uint8_t*>(rx.addr_);
       Memory::FastCopy(spi->read_buff_.addr_, rx_dma_buff + 1, spi->read_buff_.size_);
     }

--- a/driver/st/stm32_spi.cpp
+++ b/driver/st/stm32_spi.cpp
@@ -1,5 +1,6 @@
 #include "stm32_spi.hpp"
 
+#include "stm32_dcache.hpp"
 #include "libxr_def.hpp"
 
 #ifdef HAL_SPI_MODULE_ENABLED
@@ -123,8 +124,7 @@ ErrorCode STM32SPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
                         need_write - write_data.size_);
       }
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-      SCB_CleanDCache_by_Addr(static_cast<uint32_t*>(tx.addr_),
-                              static_cast<int32_t>(need_write));
+      STM32_CleanDCacheByAddr(tx.addr_, need_write);
 #endif
       read_buff_ = read_data;
 
@@ -140,8 +140,7 @@ ErrorCode STM32SPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
                         need_write - write_data.size_);
       }
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-      SCB_CleanDCache_by_Addr(static_cast<uint32_t*>(tx.addr_),
-                              static_cast<int32_t>(need_write));
+      STM32_CleanDCacheByAddr(tx.addr_, need_write);
 #endif
       read_buff_ = {nullptr, 0};
 
@@ -191,8 +190,7 @@ ErrorCode STM32SPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
                       need_write - write_data.size_);
     }
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    SCB_CleanDCache_by_Addr(static_cast<uint32_t*>(tx.addr_),
-                            static_cast<int32_t>(need_write));
+    STM32_CleanDCacheByAddr(tx.addr_, need_write);
 #endif
     ans = (HAL_SPI_TransmitReceive(spi_handle_, static_cast<uint8_t*>(tx.addr_),
                                    static_cast<uint8_t*>(rx.addr_), need_write,
@@ -223,8 +221,7 @@ ErrorCode STM32SPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
   {
     Memory::FastCopy(tx.addr_, write_data.addr_, write_data.size_);
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    SCB_CleanDCache_by_Addr(static_cast<uint32_t*>(tx.addr_),
-                            static_cast<int32_t>(need_write));
+    STM32_CleanDCacheByAddr(tx.addr_, need_write);
 #endif
     ans = (HAL_SPI_Transmit(spi_handle_, static_cast<uint8_t*>(tx.addr_),
                             write_data.size_, 20) == HAL_OK)
@@ -377,8 +374,7 @@ ErrorCode STM32SPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bo
     Memory::FastSet(txb, 0, need_read + 1);
     txb[0] = static_cast<uint8_t>(reg | 0x80);
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    SCB_CleanDCache_by_Addr(static_cast<uint32_t*>(tx.addr_),
-                            static_cast<int32_t>(need_read + 1));
+    STM32_CleanDCacheByAddr(tx.addr_, need_read + 1);
 #endif
     read_buff_ = read_data;
 
@@ -408,8 +404,7 @@ ErrorCode STM32SPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bo
   Memory::FastSet(txb, 0, need_read + 1);
   txb[0] = static_cast<uint8_t>(reg | 0x80);
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-  SCB_CleanDCache_by_Addr(static_cast<uint32_t*>(tx.addr_),
-                          static_cast<int32_t>(need_read + 1));
+  STM32_CleanDCacheByAddr(tx.addr_, need_read + 1);
 #endif
 
   ErrorCode ans = (HAL_SPI_TransmitReceive(spi_handle_, static_cast<uint8_t*>(tx.addr_),
@@ -458,8 +453,7 @@ ErrorCode STM32SPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW&
     txb[0] = static_cast<uint8_t>(reg & 0x7F);
     Memory::FastCopy(txb + 1, write_data.addr_, need_write);
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    SCB_CleanDCache_by_Addr(static_cast<uint32_t*>(tx.addr_),
-                            static_cast<int32_t>(need_write + 1));
+    STM32_CleanDCacheByAddr(tx.addr_, need_write + 1);
 #endif
     read_buff_ = {nullptr, 0};
 
@@ -487,8 +481,7 @@ ErrorCode STM32SPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW&
   txb[0] = static_cast<uint8_t>(reg & 0x7F);
   Memory::FastCopy(txb + 1, write_data.addr_, need_write);
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-  SCB_CleanDCache_by_Addr(static_cast<uint32_t*>(tx.addr_),
-                          static_cast<int32_t>(need_write + 1));
+  STM32_CleanDCacheByAddr(tx.addr_, need_write + 1);
 #endif
 
   ErrorCode ans = (HAL_SPI_Transmit(spi_handle_, static_cast<uint8_t*>(tx.addr_),
@@ -708,9 +701,8 @@ ErrorCode STM32SPI::Transfer(size_t size, OperationRW& op, bool in_isr)
     }
 
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    SCB_CleanDCache_by_Addr(static_cast<uint32_t*>(tx.addr_), static_cast<int32_t>(xfer));
-    SCB_InvalidateDCache_by_Addr(static_cast<uint32_t*>(rx.addr_),
-                                 static_cast<int32_t>(xfer));
+    STM32_CleanDCacheByAddr(tx.addr_, xfer);
+    STM32_InvalidateDCacheByAddr(rx.addr_, xfer);
 #endif
 
     HAL_StatusTypeDef st =
@@ -741,8 +733,7 @@ ErrorCode STM32SPI::Transfer(size_t size, OperationRW& op, bool in_isr)
           : ErrorCode::BUSY;
 
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-  SCB_InvalidateDCache_by_Addr(static_cast<uint32_t*>(rx.addr_),
-                               static_cast<int32_t>(xfer));
+  STM32_InvalidateDCacheByAddr(rx.addr_, xfer);
 #endif
 
   SwitchBuffer();
@@ -790,14 +781,14 @@ extern "C" void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef* hspi)
     if (!spi->mem_read_)
     {
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-      SCB_InvalidateDCache_by_Addr(rx.addr_, spi->read_buff_.size_);
+      STM32_InvalidateDCacheByAddr(rx.addr_, spi->read_buff_.size_);
 #endif
       Memory::FastCopy(spi->read_buff_.addr_, rx.addr_, spi->read_buff_.size_);
     }
     else
     {
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-      SCB_InvalidateDCache_by_Addr(rx.addr_, spi->read_buff_.size_ + 1);
+      STM32_InvalidateDCacheByAddr(rx.addr_, spi->read_buff_.size_ + 1);
 #endif
       uint8_t* rx_dma_buff = reinterpret_cast<uint8_t*>(rx.addr_);
       Memory::FastCopy(spi->read_buff_.addr_, rx_dma_buff + 1, spi->read_buff_.size_);

--- a/driver/st/stm32_uart.cpp
+++ b/driver/st/stm32_uart.cpp
@@ -1,5 +1,6 @@
 #include "stm32_uart.hpp"
 
+#include "stm32_dcache.hpp"
 #ifdef HAL_UART_MODULE_ENABLED
 
 using namespace LibXR;
@@ -247,8 +248,7 @@ ErrorCode STM32UART::WriteFun(WritePort& port, bool)
     port.queue_info_->Pop(uart->write_info_active_);
 
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-    SCB_CleanDCache_by_Addr(
-        reinterpret_cast<uint32_t*>(uart->dma_buff_tx_.ActiveBuffer()), info.data.size_);
+    STM32_CleanDCacheByAddr(uart->dma_buff_tx_.ActiveBuffer(), info.data.size_);
 #endif
 
     uart->dma_buff_tx_.SetActiveLength(info.data.size_);
@@ -376,7 +376,7 @@ static inline void STM32_UART_RX_ISR_Handler(UART_HandleTypeDef* uart_handle)
   size_t last_pos = uart->last_rx_pos_;
 
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-  SCB_InvalidateDCache_by_Addr(rx_buf, dma_size);
+  STM32_InvalidateDCacheByAddr(rx_buf, dma_size);
 #endif
 
   if (curr_pos != last_pos)
@@ -417,8 +417,7 @@ void STM32_UART_ISR_Handler_TX_CPLT(stm32_uart_id_t id)
   uart->dma_buff_tx_.Switch();
 
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-  SCB_CleanDCache_by_Addr(reinterpret_cast<uint32_t*>(uart->dma_buff_tx_.ActiveBuffer()),
-                          pending_len);
+  STM32_CleanDCacheByAddr(uart->dma_buff_tx_.ActiveBuffer(), pending_len);
 #endif
 
   uart->dma_buff_tx_.SetActiveLength(pending_len);

--- a/driver/st/stm32_uart.cpp
+++ b/driver/st/stm32_uart.cpp
@@ -247,9 +247,7 @@ ErrorCode STM32UART::WriteFun(WritePort& port, bool)
 
     port.queue_info_->Pop(uart->write_info_active_);
 
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     STM32_CleanDCacheByAddr(uart->dma_buff_tx_.ActiveBuffer(), info.data.size_);
-#endif
 
     uart->dma_buff_tx_.SetActiveLength(info.data.size_);
     uart->tx_busy_.Set();
@@ -375,9 +373,7 @@ static inline void STM32_UART_RX_ISR_Handler(UART_HandleTypeDef* uart_handle)
       dma_size - __HAL_DMA_GET_COUNTER(uart_handle->hdmarx);  // 当前 DMA 写入位置
   size_t last_pos = uart->last_rx_pos_;
 
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
   STM32_InvalidateDCacheByAddr(rx_buf, dma_size);
-#endif
 
   if (curr_pos != last_pos)
   {
@@ -416,9 +412,7 @@ void STM32_UART_ISR_Handler_TX_CPLT(stm32_uart_id_t id)
 
   uart->dma_buff_tx_.Switch();
 
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
   STM32_CleanDCacheByAddr(uart->dma_buff_tx_.ActiveBuffer(), pending_len);
-#endif
 
   uart->dma_buff_tx_.SetActiveLength(pending_len);
   uart->tx_busy_.Set();

--- a/driver/st/stm32_usb_dev.cpp
+++ b/driver/st/stm32_usb_dev.cpp
@@ -1,5 +1,6 @@
 #include "stm32_usb_dev.hpp"
 
+#include "stm32_dcache.hpp"
 #if defined(HAL_PCD_MODULE_ENABLED)
 
 using namespace LibXR;
@@ -32,8 +33,7 @@ extern "C" void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef* hpcd)
   }
 
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-  SCB_InvalidateDCache_by_Addr(hpcd->Setup,
-                               static_cast<int32_t>(sizeof(USB::SetupPacket)));
+  STM32_InvalidateDCacheByAddr(hpcd->Setup, sizeof(USB::SetupPacket));
 #endif
 
   usb->GetEndpoint0In()->SetState(USB::Endpoint::State::IDLE);

--- a/driver/st/stm32_usb_dev.cpp
+++ b/driver/st/stm32_usb_dev.cpp
@@ -32,9 +32,7 @@ extern "C" void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef* hpcd)
     return;
   }
 
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
   STM32_InvalidateDCacheByAddr(hpcd->Setup, sizeof(USB::SetupPacket));
-#endif
 
   usb->GetEndpoint0In()->SetState(USB::Endpoint::State::IDLE);
   usb->GetEndpoint0Out()->SetState(USB::Endpoint::State::IDLE);

--- a/driver/st/stm32_usb_ep.cpp
+++ b/driver/st/stm32_usb_ep.cpp
@@ -218,12 +218,10 @@ ErrorCode STM32Endpoint::Transfer(size_t size)
   {
     ep->dma_addr = reinterpret_cast<uint32_t>(ep->xfer_buff);
 
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     if (is_in == true)
     {
       STM32_CleanDCacheByAddr(buffer.addr_, size);
     }
-#endif
   }
 #endif
 
@@ -378,9 +376,7 @@ extern "C" void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef* hpcd, uint8_t ep
 
   size_t actual_transfer_size = ep_handle->xfer_count;
 
-#if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
   STM32_InvalidateDCacheByAddr(ep->GetBuffer().addr_, actual_transfer_size);
-#endif
 
   ep->OnTransferCompleteCallback(true, actual_transfer_size);
 }

--- a/driver/st/stm32_usb_ep.cpp
+++ b/driver/st/stm32_usb_ep.cpp
@@ -1,5 +1,6 @@
 #include "stm32_usb_ep.hpp"
 
+#include "stm32_dcache.hpp"
 using namespace LibXR;
 
 #if defined(HAL_PCD_MODULE_ENABLED)
@@ -220,8 +221,7 @@ ErrorCode STM32Endpoint::Transfer(size_t size)
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
     if (is_in == true)
     {
-      SCB_CleanDCache_by_Addr(reinterpret_cast<uint32_t*>(buffer.addr_),
-                              static_cast<int32_t>(size));
+      STM32_CleanDCacheByAddr(buffer.addr_, size);
     }
 #endif
   }
@@ -379,8 +379,7 @@ extern "C" void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef* hpcd, uint8_t ep
   size_t actual_transfer_size = ep_handle->xfer_count;
 
 #if defined(__DCACHE_PRESENT) && (__DCACHE_PRESENT == 1U)
-  SCB_InvalidateDCache_by_Addr(ep->GetBuffer().addr_,
-                               static_cast<int32_t>(actual_transfer_size));
+  STM32_InvalidateDCacheByAddr(ep->GetBuffer().addr_, actual_transfer_size);
 #endif
 
   ep->OnTransferCompleteCallback(true, actual_transfer_size);


### PR DESCRIPTION
## Summary
- add a small STM32 D-Cache adapter that accepts the CMSIS pointer signature exposed by the current STM32 family/toolchain
- route STM32 ADC/I2C/SPI/UART/USB cache maintenance through the shared helper
- keep the cache call sites behaviorally identical while removing F7/H7 signature mismatches

## Validation
- Ubuntu24 host build: `cmake -S . -B build_linux_test -G Ninja -DLIBXR_TEST_BUILD=True`
- Ubuntu24 host test: `./build_linux_test/test`
- `libxr_stm32_test` matrix on Ubuntu24 against `fix/stm32f7-cache`: 12/12 boards passed for `gcc`, `STARM_HYBRID`, `STARM_NEWLIB`, `STARM_PICOLIBC`

## Notes
- the `libxr_stm32_test` pass was run with the known generation-time STM32 consumer `C++20` patch applied after `xr_cubemx_cfg`; that downstream generator issue is outside this branch

## Summary by Sourcery

Unify STM32 D-Cache handling behind a shared adapter and apply it across STM32 peripheral drivers to keep behavior consistent across toolchains.

Enhancements:
- Introduce a generic STM32 D-Cache adapter that normalizes CMSIS D-Cache function pointer signatures across toolchains.
- Refactor STM32 SPI, I2C, UART, USB, and ADC drivers to use the shared D-Cache adapter for all cache clean/invalidate operations while preserving existing behavior.