### PR TITLE
[codex] fix STM32 USB non-DMA cache handling

### DIFF
--- a/driver/st/stm32_usb.hpp
+++ b/driver/st/stm32_usb.hpp
@@ -27,4 +27,14 @@ typedef enum : uint8_t
   STM32_USB_DEV_ID_NUM
 } stm32_usb_dev_id_t;
 
+static inline bool STM32USBUsesDma(PCD_HandleTypeDef* hpcd)
+{
+#if defined(USB_OTG_FS) || defined(USB_OTG_HS)
+  return hpcd->Init.dma_enable == 1U;
+#else
+  UNUSED(hpcd);
+  return false;
+#endif
+}
+
 #endif

--- a/driver/st/stm32_usb_dev.cpp
+++ b/driver/st/stm32_usb_dev.cpp
@@ -32,7 +32,10 @@ extern "C" void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef* hpcd)
     return;
   }
 
-  STM32_InvalidateDCacheByAddr(hpcd->Setup, sizeof(USB::SetupPacket));
+  if (STM32USBUsesDma(hpcd))
+  {
+    STM32_InvalidateDCacheByAddr(hpcd->Setup, sizeof(USB::SetupPacket));
+  }
 
   usb->GetEndpoint0In()->SetState(USB::Endpoint::State::IDLE);
   usb->GetEndpoint0Out()->SetState(USB::Endpoint::State::IDLE);

--- a/driver/st/stm32_usb_ep.cpp
+++ b/driver/st/stm32_usb_ep.cpp
@@ -376,7 +376,10 @@ extern "C" void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef* hpcd, uint8_t ep
 
   size_t actual_transfer_size = ep_handle->xfer_count;
 
-  STM32_InvalidateDCacheByAddr(ep->GetBuffer().addr_, actual_transfer_size);
+  if (STM32USBUsesDma(hpcd))
+  {
+    STM32_InvalidateDCacheByAddr(ep->GetBuffer().addr_, actual_transfer_size);
+  }
 
   ep->OnTransferCompleteCallback(true, actual_transfer_size);
 }


### PR DESCRIPTION
## Summary

This fixes STM32 USB device cache maintenance when the PCD is running without USB DMA enabled.

The STM32 USB device callbacks currently invalidate D-Cache for the setup packet and OUT endpoint buffers unconditionally. That is only correct when the USB peripheral DMA engine writes those buffers directly. In the common OTG FS non-DMA path, HAL/USB core code copies packet data from the USB FIFO into RAM using the CPU, so invalidating those addresses can discard CPU-written setup or OUT data before the device stack consumes it.

On STM32F746/OpenCR1.0 this showed up as intermittent or complete USB enumeration failure at the device descriptor stage: Windows reported `Unknown USB Device (Device Descriptor Request Failed)` even though the firmware reached `HAL_PCD_Start` and kept running.

## Changes

- Adds a small `STM32USBUsesDma()` helper in the STM32 USB device and endpoint driver files.
- Keeps D-Cache invalidation for OTG FS/HS only when `hpcd->Init.dma_enable == 1U`.
- Returns `false` for non-OTG USB device implementations where the HAL PCD init struct may not expose `dma_enable`.

## Validation

Validated in an STM32F746/OpenCR1.0 CubeMX + FreeRTOS project with D-Cache enabled and `USB_OTG_FS.Init.dma_enable = DISABLE`.

- Before this change: Windows reported `VID_0000&PID_0002` / device descriptor request failed.
- After this change: Windows enumerated the LibXR CDC device successfully as `VID_1D50&PID_6199`, with the CDC interface bound to `usbser` as `COM93`, both with `CM_PROB_NONE`.
- Rebuilt the OpenCR1.0 firmware successfully with STM32Cube CMake and ST ARM Clang.

## Summary by Sourcery

Guard STM32 USB device D-Cache invalidation so it only occurs when the USB peripheral is actually using DMA, avoiding corruption of CPU-written USB buffers on non-DMA configurations.

Bug Fixes:
- Prevent loss of setup and OUT endpoint data on STM32 USB devices running without OTG FS/HS DMA by skipping unnecessary D-Cache invalidation.

Enhancements:
- Introduce a shared STM32USBUsesDma helper to centralize detection of DMA usage for STM32 USB PCD handles.