### PR TITLE
build(cmake): export cxx20 requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(xr LANGUAGES C CXX ASM)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+target_compile_features(${PROJECT_NAME} PUBLIC cxx_std_20)
 
 if(LIBXR_SHARED_BUILD)
   add_library(${PROJECT_NAME} SHARED)


### PR DESCRIPTION
## Summary
- export the C++20 requirement from the xr target
- keep consumer toolchains aligned with libxr public headers
- avoid relying only on directory-wide CMAKE_CXX_STANDARD

## Testing
- source inspection only on current host
- local compile blocked by host policy: ERROR: compilation is not allowed on this machine (UK server).

## Summary by Sourcery

Build:
- Declare C++20 as a required compile feature on the xr target instead of relying solely on the directory-wide CMAKE_CXX_STANDARD.