### PR TITLE
fix(usb): harden device startup lifecycle across backends

### DIFF
--- a/driver/ch/ch32_usb_devfs.cpp
+++ b/driver/ch/ch32_usb_devfs.cpp
@@ -360,9 +360,8 @@ static void usbdev_fs_irqhandler()
           LibXR::CH32EndpointDevFs::ClearEpCtrRx(0);
 
           out0->CopyRxDataToBuffer(sizeof(LibXR::USB::SetupPacket));
-          usb->OnSetupPacket(
-              true,
-              reinterpret_cast<const LibXR::USB::SetupPacket*>(out0->GetBuffer().addr_));
+          usb->OnSetupPacket(true, reinterpret_cast<const LibXR::USB::SetupPacket*>(
+                                       out0->GetBuffer().addr_));
 
           continue;
         }

--- a/driver/ch/ch32_usb_devfs.cpp
+++ b/driver/ch/ch32_usb_devfs.cpp
@@ -252,6 +252,12 @@ static void drain_usbdev_fs_pending_irqs()
     {
       LibXR::CH32EndpointDevFs::ClearEpCtrTx(EP_ID);
     }
+
+    // We only drain the bits that are latched right now. If the host produces a
+    // new event after that point, hardware will assert the IRQ again and the next
+    // handler entry will observe it.
+    // 这里只清掉当前已经锁存的 pending 位；如果主机随后又产生了新事件，
+    // 硬件会重新拉起 IRQ，下一次进入 handler 时再处理。
   }
 }
 

--- a/driver/ch/ch32_usb_devfs.cpp
+++ b/driver/ch/ch32_usb_devfs.cpp
@@ -210,8 +210,60 @@ static LibXR::RawData select_buffer_dev_fs(USB::Endpoint::EPNumber ep_num,
   return LibXR::RawData(reinterpret_cast<uint8_t*>(buffer.addr_) + HALF, HALF);
 }
 
+static void drain_usbdev_fs_pending_irqs()
+{
+  while (true)
+  {
+    const uint16_t ISTR = *usbdev_istr();
+
+    if (ISTR & USB_ISTR_RESET)
+    {
+      usbdev_clear_istr(USB_ISTR_RESET);
+      continue;
+    }
+
+    if (ISTR & USB_ISTR_SUSP)
+    {
+      usbdev_clear_istr(USB_ISTR_SUSP);
+      continue;
+    }
+
+    if (ISTR & USB_ISTR_WKUP)
+    {
+      usbdev_clear_istr(USB_ISTR_WKUP);
+      continue;
+    }
+
+    if ((ISTR & USB_ISTR_CTR) == 0)
+    {
+      break;
+    }
+
+    const uint8_t EP_ID = static_cast<uint8_t>(ISTR & USB_ISTR_EP_ID);
+
+    uint16_t epr = *usbdev_ep_reg(EP_ID);
+    if (epr & USB_EP_CTR_RX)
+    {
+      LibXR::CH32EndpointDevFs::ClearEpCtrRx(EP_ID);
+    }
+
+    epr = *usbdev_ep_reg(EP_ID);
+    if (epr & USB_EP_CTR_TX)
+    {
+      LibXR::CH32EndpointDevFs::ClearEpCtrTx(EP_ID);
+    }
+  }
+}
+
 static void usbdev_fs_irqhandler()
 {
+  auto* usb = LibXR::CH32USBDeviceFS::self_;
+  if (usb == nullptr || !usb->IsInited())
+  {
+    drain_usbdev_fs_pending_irqs();
+    return;
+  }
+
   auto& map = LibXR::CH32EndpointDevFs::map_dev_fs_;
 
   constexpr uint8_t OUT_IDX = static_cast<uint8_t>(LibXR::USB::Endpoint::Direction::OUT);
@@ -238,8 +290,8 @@ static void usbdev_fs_irqhandler()
 
       LibXR::CH32EndpointDevFs::ResetPMAAllocator();
 
-      LibXR::CH32USBDeviceFS::self_->Deinit(true);
-      LibXR::CH32USBDeviceFS::self_->Init(true);
+      usb->Deinit(true);
+      usb->Init(true);
 
       out0->SetState(LibXR::USB::Endpoint::State::IDLE);
       in0->SetState(LibXR::USB::Endpoint::State::IDLE);
@@ -257,8 +309,8 @@ static void usbdev_fs_irqhandler()
     {
       usbdev_clear_istr(USB_ISTR_SUSP);
 
-      LibXR::CH32USBDeviceFS::self_->Deinit(true);
-      LibXR::CH32USBDeviceFS::self_->Init(true);
+      usb->Deinit(true);
+      usb->Init(true);
 
       out0->SetState(LibXR::USB::Endpoint::State::IDLE);
       in0->SetState(LibXR::USB::Endpoint::State::IDLE);
@@ -302,7 +354,7 @@ static void usbdev_fs_irqhandler()
           LibXR::CH32EndpointDevFs::ClearEpCtrRx(0);
 
           out0->CopyRxDataToBuffer(sizeof(LibXR::USB::SetupPacket));
-          LibXR::CH32USBDeviceFS::self_->OnSetupPacket(
+          usb->OnSetupPacket(
               true,
               reinterpret_cast<const LibXR::USB::SetupPacket*>(out0->GetBuffer().addr_));
 
@@ -378,8 +430,6 @@ CH32USBDeviceFS::CH32USBDeviceFS(
       USB::DeviceCore(*this, USB::USBSpec::USB_2_1, USB::Speed::FULL, packet_size, vid,
                       pid, bcd, LANG_LIST, CONFIGS, uid)
 {
-  self_ = this;
-
   ASSERT(EP_CFGS.size() > 0 && EP_CFGS.size() <= CH32EndpointDevFs::EP_DEV_FS_MAX_SIZE);
 
   auto cfgs_itr = EP_CFGS.begin();
@@ -444,9 +494,6 @@ LibXR::ErrorCode CH32USBDeviceFS::SetAddress(uint8_t address,
 
 void CH32USBDeviceFS::Start(bool)
 {
-  LibXR::CH32UsbCanShared::usb_inited.store(true, std::memory_order_release);
-  LibXR::CH32UsbCanShared::register_usb_irq(&usb_irq_thunk);
-
   // FSDEV 使用共享 USB 48 MHz 时钟；如果这个时钟来自 USBHS PHY PLL，
   // 则必须先打开 USBHS 依赖时钟，再打开 USBDEV 本体时钟。
   // FSDEV uses the shared USB 48 MHz clock; when that clock comes from the
@@ -519,12 +566,17 @@ void CH32USBDeviceFS::Start(bool)
     }
     (void)out->Transfer(out->MaxTransferSize());
   }
+
+  self_ = this;
+  LibXR::CH32UsbCanShared::usb_inited.store(true, std::memory_order_release);
+  LibXR::CH32UsbCanShared::register_usb_irq(&usb_irq_thunk);
 }
 
 void CH32USBDeviceFS::Stop(bool)
 {
   LibXR::CH32UsbCanShared::register_usb_irq(nullptr);
   LibXR::CH32UsbCanShared::usb_inited.store(false, std::memory_order_release);
+  self_ = nullptr;
 
 #if defined(EXTEN_USBD_PU_EN)
   EXTEN->EXTEN_CTR &= ~EXTEN_USBD_PU_EN;

--- a/driver/ch/ch32_usb_otgfs.cpp
+++ b/driver/ch/ch32_usb_otgfs.cpp
@@ -30,6 +30,12 @@ static void ClearPendingOtgFsInterrupts()
       break;
     }
     USBFSD->INT_FG = PENDING;
+
+    // This loop only drains the pending bits visible in the current INT_FG
+    // snapshot. Any later host event will relatch a fresh interrupt and be
+    // handled by the next IRQ entry.
+    // 这个循环只清当前 INT_FG 快照里可见的 pending 位；主机后续的新事件
+    // 会重新锁存成新的中断，并在下一次 IRQ 进入时处理。
   }
 }
 

--- a/driver/ch/ch32_usb_otgfs.cpp
+++ b/driver/ch/ch32_usb_otgfs.cpp
@@ -10,17 +10,45 @@ using namespace LibXR::USB;
 
 #if defined(USBFSD)
 
+namespace
+{
+
+constexpr uint8_t kOtgFsClearableMask = USBFS_UIF_FIFO_OV | USBFS_UIF_HST_SOF |
+                                        USBFS_UIF_SUSPEND | USBFS_UIF_TRANSFER |
+                                        USBFS_UIF_DETECT | USBFS_UIF_BUS_RST;
+
+static void ClearPendingOtgFsInterrupts()
+{
+  while (true)
+  {
+    const uint16_t INTFGST = *reinterpret_cast<volatile uint16_t*>(
+        reinterpret_cast<uintptr_t>(&USBFSD->INT_FG));
+    const uint8_t INTFLAG = static_cast<uint8_t>(INTFGST & 0x00FFu);
+    const uint8_t PENDING = static_cast<uint8_t>(INTFLAG & kOtgFsClearableMask);
+    if (PENDING == 0u)
+    {
+      break;
+    }
+    USBFSD->INT_FG = PENDING;
+  }
+}
+
+}  // namespace
+
 // NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" __attribute__((interrupt("WCH-Interrupt-fast"))) void USBFS_IRQHandler(void)
 {
+  auto* usb = LibXR::CH32USBOtgFS::self_;
+  if (usb == nullptr || !usb->IsInited())
+  {
+    ClearPendingOtgFsInterrupts();
+    return;
+  }
+
   auto& map = LibXR::CH32EndpointOtgFs::map_otg_fs_;
 
   constexpr uint8_t OUT_IDX = static_cast<uint8_t>(LibXR::USB::Endpoint::Direction::OUT);
   constexpr uint8_t IN_IDX = static_cast<uint8_t>(LibXR::USB::Endpoint::Direction::IN);
-
-  constexpr uint8_t CLEARABLE_MASK = USBFS_UIF_FIFO_OV | USBFS_UIF_HST_SOF |
-                                     USBFS_UIF_SUSPEND | USBFS_UIF_TRANSFER |
-                                     USBFS_UIF_DETECT | USBFS_UIF_BUS_RST;
   auto* out0 = map[0][OUT_IDX];
   auto* in0 = map[0][IN_IDX];
   ASSERT(out0 != nullptr);
@@ -40,7 +68,7 @@ extern "C" __attribute__((interrupt("WCH-Interrupt-fast"))) void USBFS_IRQHandle
     const uint8_t INTFLAG = static_cast<uint8_t>(INTFGST & 0x00FFu);
     const uint8_t INTST = static_cast<uint8_t>((INTFGST >> 8) & 0x00FFu);
 
-    const uint8_t PENDING = static_cast<uint8_t>(INTFLAG & CLEARABLE_MASK);
+    const uint8_t PENDING = static_cast<uint8_t>(INTFLAG & kOtgFsClearableMask);
     if (PENDING == 0)
     {
       break;
@@ -54,8 +82,8 @@ extern "C" __attribute__((interrupt("WCH-Interrupt-fast"))) void USBFS_IRQHandle
     {
       USBFSD->DEV_ADDR = 0;
 
-      LibXR::CH32USBOtgFS::self_->Deinit(true);
-      LibXR::CH32USBOtgFS::self_->Init(true);
+      usb->Deinit(true);
+      usb->Init(true);
 
       out0->SetState(LibXR::USB::Endpoint::State::IDLE);
       in0->SetState(LibXR::USB::Endpoint::State::IDLE);
@@ -72,8 +100,8 @@ extern "C" __attribute__((interrupt("WCH-Interrupt-fast"))) void USBFS_IRQHandle
     // suspend 走与 reset 相同的 EP0 恢复路径；resume 由后续主机时序体现。
     if (PENDING & USBFS_UIF_SUSPEND)
     {
-      LibXR::CH32USBOtgFS::self_->Deinit(true);
-      LibXR::CH32USBOtgFS::self_->Init(true);
+      usb->Deinit(true);
+      usb->Init(true);
 
       out0->SetState(LibXR::USB::Endpoint::State::IDLE);
       in0->SetState(LibXR::USB::Endpoint::State::IDLE);
@@ -109,7 +137,7 @@ extern "C" __attribute__((interrupt("WCH-Interrupt-fast"))) void USBFS_IRQHandle
           out0->tog_ = true;
           in0->tog_ = true;
 
-          LibXR::CH32USBOtgFS::self_->OnSetupPacket(
+          usb->OnSetupPacket(
               true, reinterpret_cast<const SetupPacket*>(out0->GetBuffer().addr_));
           break;
         }
@@ -161,7 +189,6 @@ CH32USBOtgFS::CH32USBOtgFS(
       USB::DeviceCore(*this, USB::USBSpec::USB_2_1, USB::Speed::FULL, packet_size, vid,
                       pid, bcd, LANG_LIST, CONFIGS, uid)
 {
-  self_ = this;
   ASSERT(EP_CFGS.size() > 0 && EP_CFGS.size() <= CH32EndpointOtgFs::EP_OTG_FS_MAX_SIZE);
 
   auto cfgs_itr = EP_CFGS.begin();
@@ -232,6 +259,7 @@ void CH32USBOtgFS::Start(bool)
   USBFSD->BASE_CTRL = USBFS_UC_DEV_PU_EN | USBFS_UC_INT_BUSY | USBFS_UC_DMA_EN;
   USBFSD->UDEV_CTRL = USBFS_UD_PD_DIS | USBFS_UD_PORT_EN;
   NVIC_EnableIRQ(USBFS_IRQn);
+  self_ = this;
 }
 
 void CH32USBOtgFS::Stop(bool)
@@ -239,6 +267,7 @@ void CH32USBOtgFS::Stop(bool)
   USBFSH->BASE_CTRL = USBFS_UC_RESET_SIE | USBFS_UC_CLR_ALL;
   USBFSD->BASE_CTRL = 0x00;
   NVIC_DisableIRQ(USBFS_IRQn);
+  self_ = nullptr;
 }
 
 #endif  // defined(USBFSD)

--- a/driver/ch/ch32_usb_otghs.cpp
+++ b/driver/ch/ch32_usb_otghs.cpp
@@ -197,6 +197,12 @@ static void ClearPendingOtgHsInterrupts()
       break;
     }
     USBHSD->INT_FG = INTFLAG;
+
+    // This loop drains only the bits already latched in INT_FG. If hardware
+    // observes another bus event later, it will assert a new IRQ and the next
+    // handler entry will clear it.
+    // 这个循环只清理 INT_FG 里已经锁存的位；如果之后又出现新的总线事件，
+    // 硬件会重新触发 IRQ，由下一次进入 handler 时再清。
   }
 }
 

--- a/driver/ch/ch32_usb_otghs.cpp
+++ b/driver/ch/ch32_usb_otghs.cpp
@@ -185,11 +185,33 @@ static void HandleTransferToken(OtgHsEndpointMap& map, uint8_t int_st)
   }
 }
 
+static void ClearPendingOtgHsInterrupts()
+{
+  while (true)
+  {
+    const uint16_t INTFGST = *reinterpret_cast<volatile uint16_t*>(
+        reinterpret_cast<uintptr_t>(&USBHSD->INT_FG));
+    const uint8_t INTFLAG = static_cast<uint8_t>(INTFGST & 0x00FFu);
+    if (INTFLAG == 0u)
+    {
+      break;
+    }
+    USBHSD->INT_FG = INTFLAG;
+  }
+}
+
 }  // namespace
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" __attribute__((interrupt("WCH-Interrupt-fast"))) void USBHS_IRQHandler(void)
 {
+  auto* usb = LibXR::CH32USBOtgHS::self_;
+  if (usb == nullptr || !usb->IsInited())
+  {
+    ClearPendingOtgHsInterrupts();
+    return;
+  }
+
   auto& map = LibXR::CH32EndpointOtgHs::map_otg_hs_;
 
   // Handle order matters: recover bus-level events first, then settle EP0 setup
@@ -216,16 +238,16 @@ extern "C" __attribute__((interrupt("WCH-Interrupt-fast"))) void USBHS_IRQHandle
     if (INTFLAG & USBHS_UIF_BUS_RST)
     {
       USBHSD->DEV_AD = 0;
-      LibXR::CH32USBOtgHS::self_->Deinit(true);
-      LibXR::CH32USBOtgHS::self_->Init(true);
+      usb->Deinit(true);
+      usb->Init(true);
       ResetEp0State(map);
       clear_mask |= USBHS_UIF_BUS_RST;
     }
 
     if (INTFLAG & USBHS_UIF_SUSPEND)
     {
-      LibXR::CH32USBOtgHS::self_->Deinit(true);
-      LibXR::CH32USBOtgHS::self_->Init(true);
+      usb->Deinit(true);
+      usb->Init(true);
       ResetEp0State(map);
       clear_mask |= USBHS_UIF_SUSPEND;
     }
@@ -247,7 +269,7 @@ extern "C" __attribute__((interrupt("WCH-Interrupt-fast"))) void USBHS_IRQHandle
       ASSERT(out0 != nullptr);
       const auto* setup =
           reinterpret_cast<const LibXR::USB::SetupPacket*>(out0->GetBuffer().addr_);
-      LibXR::CH32USBOtgHS::self_->OnSetupPacket(true, setup);
+      usb->OnSetupPacket(true, setup);
       clear_mask |= USBHS_UIF_SETUP_ACT;
     }
 
@@ -276,7 +298,6 @@ CH32USBOtgHS::CH32USBOtgHS(
                       USB::DeviceDescriptor::PacketSize0::SIZE_64, vid, pid, bcd,
                       LANG_LIST, CONFIGS, uid)
 {
-  self_ = this;
   ASSERT(EP_CFGS.size() > 0 && EP_CFGS.size() <= CH32EndpointOtgHs::EP_OTG_HS_MAX_SIZE);
 
   auto cfgs_itr = EP_CFGS.begin();
@@ -345,6 +366,7 @@ void CH32USBOtgHS::Start(bool)
       USBHS_UIE_SETUP_ACT | USBHS_UIE_TRANSFER | USBHS_UIE_DETECT | USBHS_UIE_SUSPEND;
   USBHSD->CONTROL |= USBHS_UC_DEV_PU_EN;
   NVIC_EnableIRQ(USBHS_IRQn);
+  self_ = this;
 }
 
 void CH32USBOtgHS::Stop(bool)
@@ -352,6 +374,7 @@ void CH32USBOtgHS::Stop(bool)
   USBHSD->CONTROL = USBHS_UC_CLR_ALL | USBHS_UC_RESET_SIE;
   USBHSD->CONTROL = 0;
   NVIC_DisableIRQ(USBHS_IRQn);
+  self_ = nullptr;
 }
 
 #endif  // defined(USBHSD)

--- a/driver/esp/esp_usb_dev.cpp
+++ b/driver/esp/esp_usb_dev.cpp
@@ -86,13 +86,11 @@ void ESP32USBDevice::Init(bool in_isr)
 {
   ResetFifoState();
   USB::DeviceCore::Init(in_isr);
-  runtime_.core_inited = true;
 }
 
 void ESP32USBDevice::Deinit(bool in_isr)
 {
   USB::DeviceCore::Deinit(in_isr);
-  runtime_.core_inited = false;
 }
 
 ErrorCode ESP32USBDevice::SetAddress(uint8_t address, USB::DeviceCore::Context context)
@@ -117,7 +115,7 @@ void ESP32USBDevice::Start(bool)
   ASSERT(EnsureInterruptReady());
 
   InitializeCore();
-  if (runtime_.core_inited)
+  if (IsInited())
   {
     USB::DeviceCore::Deinit(false);
     USB::DeviceCore::Init(false);
@@ -494,7 +492,7 @@ void ESP32USBDevice::HandleBusReset(bool in_isr)
 
   dev->dcfg_reg.devaddr = 0U;
 
-  if (runtime_.core_inited)
+  if (IsInited())
   {
     Deinit(in_isr);
     Init(in_isr);

--- a/driver/esp/esp_usb_dev.cpp
+++ b/driver/esp/esp_usb_dev.cpp
@@ -88,10 +88,7 @@ void ESP32USBDevice::Init(bool in_isr)
   USB::DeviceCore::Init(in_isr);
 }
 
-void ESP32USBDevice::Deinit(bool in_isr)
-{
-  USB::DeviceCore::Deinit(in_isr);
-}
+void ESP32USBDevice::Deinit(bool in_isr) { USB::DeviceCore::Deinit(in_isr); }
 
 ErrorCode ESP32USBDevice::SetAddress(uint8_t address, USB::DeviceCore::Context context)
 {

--- a/driver/esp/esp_usb_dev.hpp
+++ b/driver/esp/esp_usb_dev.hpp
@@ -116,7 +116,6 @@ class ESP32USBDevice : public USB::EndpointPool, public USB::DeviceCore
     bool phy_ready = false;
     bool irq_ready = false;
     bool started = false;
-    bool core_inited = false;
     bool rom_usb_cleaned = false;
   };
 

--- a/driver/st/stm32_usb_dev.cpp
+++ b/driver/st/stm32_usb_dev.cpp
@@ -23,7 +23,10 @@ extern "C" void HAL_PCD_SetupStageCallback(PCD_HandleTypeDef* hpcd)
 {
   auto id = STM32USBDeviceGetID(hpcd);
 
-  ASSERT(id < STM32_USB_DEV_ID_NUM);
+  if (id >= STM32_USB_DEV_ID_NUM)
+  {
+    return;
+  }
 
   auto usb = STM32USBDevice::map_[id];
 
@@ -47,7 +50,10 @@ extern "C" void HAL_PCD_ResetCallback(PCD_HandleTypeDef* hpcd)
 {
   auto id = STM32USBDeviceGetID(hpcd);
 
-  ASSERT(id < STM32_USB_DEV_ID_NUM);
+  if (id >= STM32_USB_DEV_ID_NUM)
+  {
+    return;
+  }
 
   auto usb = STM32USBDevice::map_[id];
 
@@ -64,7 +70,10 @@ extern "C" void HAL_PCD_SuspendCallback(PCD_HandleTypeDef* hpcd)
 {
   auto id = STM32USBDeviceGetID(hpcd);
 
-  ASSERT(id < STM32_USB_DEV_ID_NUM);
+  if (id >= STM32_USB_DEV_ID_NUM)
+  {
+    return;
+  }
 
   auto usb = STM32USBDevice::map_[id];
 
@@ -79,7 +88,10 @@ extern "C" void HAL_PCD_ResumeCallback(PCD_HandleTypeDef* hpcd)
 {
   auto id = STM32USBDeviceGetID(hpcd);
 
-  ASSERT(id < STM32_USB_DEV_ID_NUM);
+  if (id >= STM32_USB_DEV_ID_NUM)
+  {
+    return;
+  }
 
   auto usb = STM32USBDevice::map_[id];
 

--- a/driver/st/stm32_usb_dev.hpp
+++ b/driver/st/stm32_usb_dev.hpp
@@ -39,15 +39,25 @@ class STM32USBDevice : public LibXR::USB::EndpointPool, public LibXR::USB::Devic
         hpcd_(hpcd),
         id_(id)
   {
-    map_[id] = this;
   }
 
   void Init(bool in_isr) override { LibXR::USB::DeviceCore::Init(in_isr); }
 
   void Deinit(bool in_isr) override { LibXR::USB::DeviceCore::Deinit(in_isr); }
 
-  void Start(bool) override { HAL_PCD_Start(hpcd_); }
-  void Stop(bool) override { HAL_PCD_Stop(hpcd_); }
+  void Start(bool) override
+  {
+    map_[id_] = this;
+    HAL_PCD_Start(hpcd_);
+  }
+  void Stop(bool) override
+  {
+    HAL_PCD_Stop(hpcd_);
+    if (map_[id_] == this)
+    {
+      map_[id_] = nullptr;
+    }
+  }
 
   PCD_HandleTypeDef* hpcd_;
   stm32_usb_dev_id_t id_;

--- a/driver/st/stm32_usb_ep.cpp
+++ b/driver/st/stm32_usb_ep.cpp
@@ -347,7 +347,10 @@ extern "C" void HAL_PCD_DataInStageCallback(PCD_HandleTypeDef* hpcd, uint8_t epn
 {
   auto id = STM32USBDeviceGetID(hpcd);
 
-  ASSERT(id < STM32_USB_DEV_ID_NUM);
+  if (id >= STM32_USB_DEV_ID_NUM || STM32USBDevice::map_[id] == nullptr)
+  {
+    return;
+  }
 
   auto ep = GetEndpoint(hpcd, epnum, true);
 
@@ -363,7 +366,10 @@ extern "C" void HAL_PCD_DataOutStageCallback(PCD_HandleTypeDef* hpcd, uint8_t ep
 {
   auto id = STM32USBDeviceGetID(hpcd);
 
-  ASSERT(id < STM32_USB_DEV_ID_NUM);
+  if (id >= STM32_USB_DEV_ID_NUM || STM32USBDevice::map_[id] == nullptr)
+  {
+    return;
+  }
 
   auto ep = GetEndpoint(hpcd, epnum, false);
 
@@ -388,7 +394,10 @@ extern "C" void HAL_PCD_ISOINIncompleteCallback(PCD_HandleTypeDef* hpcd, uint8_t
 {
   auto id = STM32USBDeviceGetID(hpcd);
 
-  ASSERT(id < STM32_USB_DEV_ID_NUM);
+  if (id >= STM32_USB_DEV_ID_NUM || STM32USBDevice::map_[id] == nullptr)
+  {
+    return;
+  }
 
   auto ep = GetEndpoint(hpcd, epnum, true);
 
@@ -404,7 +413,10 @@ extern "C" void HAL_PCD_ISOOUTIncompleteCallback(PCD_HandleTypeDef* hpcd, uint8_
 {
   auto id = STM32USBDeviceGetID(hpcd);
 
-  ASSERT(id < STM32_USB_DEV_ID_NUM);
+  if (id >= STM32_USB_DEV_ID_NUM || STM32USBDevice::map_[id] == nullptr)
+  {
+    return;
+  }
 
   auto ep = GetEndpoint(hpcd, epnum, false);
 

--- a/src/driver/usb/device/cdc/cdc_base.hpp
+++ b/src/driver/usb/device/cdc/cdc_base.hpp
@@ -228,6 +228,7 @@ class CDCBase : public DeviceClass
    */
   void SetOnSetControlLineStateCallback(LibXR::Callback<bool, bool> cb)
   {
+    has_control_line_state_cb_ = !cb.Empty();
     on_set_control_line_state_cb_ = cb;
   }
 
@@ -237,6 +238,7 @@ class CDCBase : public DeviceClass
    */
   void SetOnSetLineCodingCallback(LibXR::Callback<LibXR::UART::Configuration> cb)
   {
+    has_line_coding_cb_ = !cb.Empty();
     on_set_line_coding_cb_ = cb;
   }
 
@@ -532,7 +534,10 @@ class CDCBase : public DeviceClass
         control_line_state_ = wValue;
         result.write_zlp = true;
         SendSerialState();
-        on_set_control_line_state_cb_.Run(in_isr, IsDtrSet(), IsRtsSet());
+        if (has_control_line_state_cb_)
+        {
+          on_set_control_line_state_cb_.Run(in_isr, IsDtrSet(), IsRtsSet());
+        }
         return ErrorCode::OK;
 
       case ClassRequest::SEND_BREAK:
@@ -587,7 +592,10 @@ class CDCBase : public DeviceClass
             cfg.parity = LibXR::UART::Parity::NO_PARITY;
         }
         cfg.data_bits = line_coding_.bDataBits;
-        on_set_line_coding_cb_.Run(in_isr, cfg);
+        if (has_line_coding_cb_)
+        {
+          on_set_line_coding_cb_.Run(in_isr, cfg);
+        }
       }
         return ErrorCode::OK;
       default:
@@ -699,7 +707,9 @@ class CDCBase : public DeviceClass
 
   // 状态标志。
   // State flags.
-  bool inited_ = false;  ///< 初始化标志 / Initialization flag
+  bool inited_ = false;                 ///< 初始化标志 / Initialization flag
+  bool has_control_line_state_cb_ = false;  ///< Control-line callback registered
+  bool has_line_coding_cb_ = false;         ///< Line-coding callback registered
 
   // 接口信息。
   // Interface metadata.

--- a/src/driver/usb/device/dev_core.hpp
+++ b/src/driver/usb/device/dev_core.hpp
@@ -97,6 +97,8 @@ class DeviceCore
    */
   void OnSetupPacket(bool in_isr, const SetupPacket* setup);
 
+  [[nodiscard]] bool IsInited() const { return state_.inited; }
+
  protected:
   /**
    * @brief 设置设备地址（由子类实现）

--- a/src/driver/usb/device/dev_core.hpp
+++ b/src/driver/usb/device/dev_core.hpp
@@ -97,6 +97,12 @@ class DeviceCore
    */
   void OnSetupPacket(bool in_isr, const SetupPacket* setup);
 
+  /**
+   * @brief 查询设备核心是否已经完成初始化 / Query whether the device core is
+   *        initialized
+   * @return true：已初始化；false：未初始化 / true: initialized; false: not
+   *         initialized
+   */
   [[nodiscard]] bool IsInited() const { return state_.inited; }
 
  protected:


### PR DESCRIPTION
## Summary
- add `DeviceCore::IsInited()` and reuse the base lifecycle state instead of backend-local duplicate flags
- delay STM32 and CH32 USB device publication/binding until `Start()` and clear it in `Stop()`
- drain or clear early pending IRQs on CH32 FSDEV/OTGFS/OTGHS when interrupts arrive before device init completes
- turn STM32 invalid-id and null-device callback paths into safe early returns instead of asserts
- guard CDC control-line and line-coding callback invocation when no callback has been registered
- remove the duplicate `runtime_.core_inited` state from the ESP32-S3 backend

## Validation
- OpenCR manual-jump retest on Windows remained clean after syncing the patch set
- STM32F103 CMSIS-DAP retest passed
- CH32V305 DFU -> RUN_APP -> echo retest passed
- ESP32-S3 `USB_DEV_ONLY(17)` DTR/TX/RX retest passed

## Summary by Sourcery

Harden USB device initialization and interrupt handling across CH32, STM32, and ESP32 backends while avoiding unsafe callbacks when devices or handlers are not fully registered.

Bug Fixes:
- Prevent CH32 FSDEV/OTGFS/OTGHS IRQ handlers from dereferencing uninitialized device instances by draining and clearing pending interrupts until the core is initialized.
- Avoid STM32 USB callbacks accessing invalid or null device entries by turning assertion-based checks into safe early returns.
- Guard CDC control-line and line-coding callbacks so they are only invoked when a handler has actually been registered, preventing null or empty-callback invocations.
- Ensure STM32 USB device mapping and CH32/ESP32 device startup use the shared DeviceCore initialization state, eliminating races and duplicate state tracking that could cause inconsistent startup behavior.

Enhancements:
- Delay CH32 and STM32 USB device self-registration and interrupt binding until Start(), and clear registrations in Stop(), aligning device visibility with the active lifecycle.
- Expose a DeviceCore::IsInited() accessor and use it in USB backends instead of backend-local flags, simplifying lifecycle checks and centralizing initialization state management.
- Remove the redundant core_inited flag from the ESP32 USB backend in favor of the shared DeviceCore state.