### PR TITLE
webots: add flow-rate step barrier

### DIFF
--- a/system/linux/linux_shared_topic_impl.hpp
+++ b/system/linux/linux_shared_topic_impl.hpp
@@ -11,6 +11,7 @@
 #include <cstdio>
 #include <cstring>
 #include <fstream>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <type_traits>
@@ -1189,7 +1190,7 @@ class LinuxSharedTopic : public Topic
     {
       slots_[i].refcount.store(0, std::memory_order_release);
       slots_[i].sequence.store(0, std::memory_order_release);
-      std::memset(&payloads_[i], 0, sizeof(TopicData));
+      std::construct_at(&payloads_[i], TopicData{});
       free_slots_[i].slot_index = i;
       free_slots_[i].sequence.store(static_cast<uint64_t>(i) + 1U,
                                     std::memory_order_release);

--- a/system/webots/libxr_system.cpp
+++ b/system/webots/libxr_system.cpp
@@ -1,5 +1,8 @@
 #include "libxr_system.hpp"
 
+#include <cerrno>
+#include <cmath>
+#include <list>
 #include <poll.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
@@ -21,11 +24,75 @@
 #include "webots_timebase.hpp"
 
 uint64_t _libxr_webots_time_count = 0;
+uint32_t _libxr_webots_poll_period_ms = 1;
 webots::Robot* _libxr_webots_robot_handle = nullptr;  // NOLINT
-static float time_step = 0.0f;
+static uint32_t basic_time_step_ms = 1;
+static uint64_t step_interval_ns = 1000000ULL;
 LibXR::condition_var_handle* _libxr_webots_time_notify = nullptr;
 
 static LibXR::Semaphore stdo_sem;
+
+struct LibXR::WebotsRealtimeThreadRegistration
+{
+  bool started{false};
+  bool parked{false};
+  bool parked_on_step_wait{false};
+  uint64_t parked_epoch{0};
+};
+
+namespace
+{
+// 注册项地址会绑定到线程 TLS，容器不能在插入/删除其他项时搬动已有元素。
+std::list<LibXR::WebotsRealtimeThreadRegistration> g_webots_realtime_threads;
+pthread_mutex_t g_webots_realtime_threads_mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t g_webots_realtime_threads_cond = PTHREAD_COND_INITIALIZER;
+uint64_t g_webots_step_epoch = 0;
+thread_local LibXR::WebotsRealtimeThreadRegistration* g_current_realtime_thread = nullptr;
+
+void RemoveWebotsRealtimeThreadUnlocked(LibXR::WebotsRealtimeThreadRegistration* registration)
+{
+  for (auto it = g_webots_realtime_threads.begin(); it != g_webots_realtime_threads.end();
+       ++it)
+  {
+    if (&(*it) == registration)
+    {
+      g_webots_realtime_threads.erase(it);
+      return;
+    }
+  }
+}
+
+bool AllWebotsRealtimeThreadsParkedUnlocked(
+    const LibXR::WebotsRealtimeThreadRegistration* excluded)
+{
+  for (const auto& registration : g_webots_realtime_threads)
+  {
+    if (!registration.started)
+    {
+      continue;
+    }
+
+    if (&registration == excluded)
+    {
+      continue;
+    }
+
+    if (!registration.parked)
+    {
+      return false;
+    }
+
+    // Thread::Sleep 会被 Webots step 唤醒，必须等它处理完本 step 后重新挂起。
+    // Semaphore/topic 等非 step 阻塞不会被 step 唤醒；线程已经挂起即可推进仿真。
+    if (registration.parked_on_step_wait &&
+        registration.parked_epoch != g_webots_step_epoch)
+    {
+      return false;
+    }
+  }
+  return true;
+}
+}  // namespace
 
 void StdiThread(LibXR::ReadPort* read_port)
 {
@@ -89,8 +156,44 @@ void StdoThread(LibXR::WritePort* write_port)
   }
 }
 
+namespace
+{
+uint64_t MonotonicNowNanoseconds()
+{
+  timespec ts = {};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<uint64_t>(ts.tv_sec) * 1000000000ULL +
+         static_cast<uint64_t>(ts.tv_nsec);
+}
+
+timespec NanosecondsToTimespec(uint64_t nanoseconds)
+{
+  timespec ts = {};
+  ts.tv_sec = static_cast<time_t>(nanoseconds / 1000000000ULL);
+  ts.tv_nsec = static_cast<long>(nanoseconds % 1000000000ULL);
+  return ts;
+}
+
+void SleepUntilNanoseconds(uint64_t deadline_ns)
+{
+  const timespec ts = NanosecondsToTimespec(deadline_ns);
+  while (true)
+  {
+    const int ans = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &ts, nullptr);
+    if (ans == 0)
+    {
+      return;
+    }
+    if (ans != EINTR)
+    {
+      return;
+    }
+  }
+}
+}  // namespace
+
 void LibXR::PlatformInit(webots::Robot* robot, uint32_t timer_pri,
-                         uint32_t timer_stack_depth)
+                         uint32_t timer_stack_depth, double sim_flow_rate)
 {
   LibXR::Timer::priority_ = static_cast<LibXR::Thread::Priority>(timer_pri);
   LibXR::Timer::stack_depth_ = timer_stack_depth;
@@ -128,6 +231,7 @@ void LibXR::PlatformInit(webots::Robot* robot, uint32_t timer_pri,
 
   stdo_thread.Create<LibXR::WritePort*>(LibXR::STDIO::write_, StdoThread, "STDIO.write_",
                                         1024, LibXR::Thread::Priority::MEDIUM);
+
   if (robot == nullptr)
   {
     _libxr_webots_robot_handle = new webots::Robot();
@@ -137,13 +241,32 @@ void LibXR::PlatformInit(webots::Robot* robot, uint32_t timer_pri,
     _libxr_webots_robot_handle = robot;
   }
 
-  time_step = _libxr_webots_robot_handle->getBasicTimeStep();
-
   if (_libxr_webots_robot_handle == nullptr)
   {
-    printf("webots robot handle is null.\n");
-    exit(-1);
+    std::fprintf(stderr, "webots robot handle is null.\n");
+    std::exit(EXIT_FAILURE);
   }
+
+  const double basic_time_step = _libxr_webots_robot_handle->getBasicTimeStep();
+  if (basic_time_step <= 0.0)
+  {
+    std::fprintf(stderr, "webots basicTimeStep is invalid: %.3f.\n", basic_time_step);
+    std::exit(EXIT_FAILURE);
+  }
+
+  if (sim_flow_rate <= 0.0)
+  {
+    std::fprintf(stderr, "webots sim_flow_rate %.6f is invalid, fallback to 1.0.\n",
+                 sim_flow_rate);
+    sim_flow_rate = 1.0;
+  }
+
+  basic_time_step_ms =
+      static_cast<uint32_t>(LibXR::max(1LL, std::llround(basic_time_step)));
+  _libxr_webots_poll_period_ms = static_cast<uint32_t>(
+      LibXR::max(1LL, std::llround(basic_time_step / sim_flow_rate)));
+  step_interval_ns = static_cast<uint64_t>(
+      LibXR::max(1LL, std::llround(basic_time_step * 1000000.0 / sim_flow_rate)));
 
   _libxr_webots_time_notify = new condition_var_handle;
   pthread_mutex_init(&_libxr_webots_time_notify->mutex, nullptr);
@@ -151,23 +274,118 @@ void LibXR::PlatformInit(webots::Robot* robot, uint32_t timer_pri,
 
   auto webots_timebase_thread_fun = [](void*)
   {
-    poll(nullptr, 0, 100);
+    uint64_t next_deadline_ns = MonotonicNowNanoseconds() + step_interval_ns;
 
     while (true)
     {
-      poll(nullptr, 0, 1);
-      _libxr_webots_robot_handle->step(time_step);
-      _libxr_webots_time_count++;
+      SleepUntilNanoseconds(next_deadline_ns);
+      next_deadline_ns += step_interval_ns;
+
+      if (_libxr_webots_robot_handle->step(static_cast<int>(basic_time_step_ms)) < 0)
+      {
+        std::exit(EXIT_SUCCESS);
+      }
+
+      _libxr_webots_time_count += basic_time_step_ms;
+      LibXR::WebotsAdvanceStepEpoch();
       pthread_mutex_lock(&_libxr_webots_time_notify->mutex);
       pthread_cond_broadcast(&_libxr_webots_time_notify->cond);
       pthread_mutex_unlock(&_libxr_webots_time_notify->mutex);
+      LibXR::WebotsWaitUntilRealtimeThreadsParked();
     }
   };
 
   LibXR::Thread webots_timebase_thread;
   webots_timebase_thread.Create<void*>(
-      reinterpret_cast<void*>(0), webots_timebase_thread_fun, "webots_timebase_thread",
+      reinterpret_cast<void*>(0), webots_timebase_thread_fun, "webots_timebase",
       1024, Thread::Priority::REALTIME);
 
   static LibXR::WebotsTimebase timebase;
+}
+
+LibXR::WebotsRealtimeThreadRegistration* LibXR::WebotsRegisterRealtimeThread()
+{
+  pthread_mutex_lock(&g_webots_realtime_threads_mutex);
+  g_webots_realtime_threads.emplace_back();
+  auto* registration = &g_webots_realtime_threads.back();
+  pthread_mutex_unlock(&g_webots_realtime_threads_mutex);
+  pthread_cond_broadcast(&g_webots_realtime_threads_cond);
+  return registration;
+}
+
+void LibXR::WebotsBindCurrentRealtimeThread(WebotsRealtimeThreadRegistration* registration)
+{
+  if (registration == nullptr)
+  {
+    return;
+  }
+
+  pthread_mutex_lock(&g_webots_realtime_threads_mutex);
+  registration->started = true;
+  registration->parked = false;
+  g_current_realtime_thread = registration;
+  pthread_mutex_unlock(&g_webots_realtime_threads_mutex);
+  pthread_cond_broadcast(&g_webots_realtime_threads_cond);
+}
+
+void LibXR::WebotsReleaseRealtimeThread(WebotsRealtimeThreadRegistration* registration)
+{
+  if (registration == nullptr)
+  {
+    return;
+  }
+
+  pthread_mutex_lock(&g_webots_realtime_threads_mutex);
+  if (g_current_realtime_thread == registration)
+  {
+    g_current_realtime_thread = nullptr;
+  }
+  RemoveWebotsRealtimeThreadUnlocked(registration);
+  pthread_mutex_unlock(&g_webots_realtime_threads_mutex);
+  pthread_cond_broadcast(&g_webots_realtime_threads_cond);
+}
+
+void LibXR::WebotsMarkCurrentRealtimeThreadRunning()
+{
+  if (g_current_realtime_thread == nullptr)
+  {
+    return;
+  }
+
+  pthread_mutex_lock(&g_webots_realtime_threads_mutex);
+  g_current_realtime_thread->parked = false;
+  g_current_realtime_thread->parked_on_step_wait = false;
+  pthread_mutex_unlock(&g_webots_realtime_threads_mutex);
+}
+
+void LibXR::WebotsMarkCurrentRealtimeThreadParked(bool waiting_for_step)
+{
+  if (g_current_realtime_thread == nullptr)
+  {
+    return;
+  }
+
+  pthread_mutex_lock(&g_webots_realtime_threads_mutex);
+  g_current_realtime_thread->parked = true;
+  g_current_realtime_thread->parked_on_step_wait = waiting_for_step;
+  g_current_realtime_thread->parked_epoch = g_webots_step_epoch;
+  pthread_mutex_unlock(&g_webots_realtime_threads_mutex);
+  pthread_cond_broadcast(&g_webots_realtime_threads_cond);
+}
+
+void LibXR::WebotsAdvanceStepEpoch()
+{
+  pthread_mutex_lock(&g_webots_realtime_threads_mutex);
+  ++g_webots_step_epoch;
+  pthread_mutex_unlock(&g_webots_realtime_threads_mutex);
+}
+
+void LibXR::WebotsWaitUntilRealtimeThreadsParked()
+{
+  pthread_mutex_lock(&g_webots_realtime_threads_mutex);
+  while (!AllWebotsRealtimeThreadsParkedUnlocked(g_current_realtime_thread))
+  {
+    pthread_cond_wait(&g_webots_realtime_threads_cond, &g_webots_realtime_threads_mutex);
+  }
+  pthread_mutex_unlock(&g_webots_realtime_threads_mutex);
 }

--- a/system/webots/libxr_system.hpp
+++ b/system/webots/libxr_system.hpp
@@ -8,7 +8,7 @@
 
 /**
  * @brief  Webots 仿真时间计数变量
- *         Webots simulation time counter variable
+ *         Webots simulation time counter variable in milliseconds
  */
 extern uint64_t _libxr_webots_time_count;  // NOLINT
 
@@ -20,6 +20,8 @@ extern webots::Robot *_libxr_webots_robot_handle;  // NOLINT
 
 namespace LibXR
 {
+
+struct WebotsRealtimeThreadRegistration;
 
 /**
  * @brief  互斥锁句柄类型定义
@@ -60,6 +62,8 @@ typedef struct
  *                    Timer task priority (default: 2)
  * @param  timer_stack_depth  定时器任务的栈深度（默认值 65536）
  *                            Timer task stack depth (default: 65536)
+ * @param  sim_flow_rate  仿真流速倍率（默认值 1.0）
+ *                        Simulation flow-rate multiplier (default: 1.0)
  *
  * @details
  * 此函数用于初始化 Webots 仿真环境，设置 `_libxr_webots_robot_handle` 变量，
@@ -70,6 +74,46 @@ typedef struct
  * time counter `_libxr_webots_time_count`.
  */
 void PlatformInit(webots::Robot *robot = nullptr, uint32_t timer_pri = 2,
-                  uint32_t timer_stack_depth = 65536);  // NOLINT
+                  uint32_t timer_stack_depth = 65536,
+                  double sim_flow_rate = 1.0);  // NOLINT
+
+/**
+ * @brief  为 REALTIME 线程预留一条注册项
+ * @return  注册项句柄，在线程创建成功后由线程自身完成绑定
+ */
+WebotsRealtimeThreadRegistration *WebotsRegisterRealtimeThread();
+
+/**
+ * @brief  将当前线程绑定到已注册的 REALTIME 项
+ * @param  registration 线程创建阶段预留的注册项
+ */
+void WebotsBindCurrentRealtimeThread(WebotsRealtimeThreadRegistration *registration);
+
+/**
+ * @brief  释放一条 REALTIME 线程注册项
+ * @param  registration 需要释放的注册项
+ */
+void WebotsReleaseRealtimeThread(WebotsRealtimeThreadRegistration *registration);
+
+/**
+ * @brief  标记当前 REALTIME 线程进入运行态
+ */
+void WebotsMarkCurrentRealtimeThreadRunning();
+
+/**
+ * @brief  标记当前 REALTIME 线程已挂起
+ * @param  waiting_for_step 当前挂起是否会被 Webots step 唤醒
+ */
+void WebotsMarkCurrentRealtimeThreadParked(bool waiting_for_step = false);
+
+/**
+ * @brief  推进 Webots step epoch
+ */
+void WebotsAdvanceStepEpoch();
+
+/**
+ * @brief  等待除当前线程外的所有 REALTIME 线程挂起
+ */
+void WebotsWaitUntilRealtimeThreadsParked();
 
 }  // namespace LibXR

--- a/system/webots/monotonic_time.hpp
+++ b/system/webots/monotonic_time.hpp
@@ -7,6 +7,11 @@
 #include "libxr_def.hpp"
 #include "libxr_system.hpp"
 
+/**
+ * @brief Webots 等待轮询片长（毫秒） / Webots timed-wait polling slice in milliseconds
+ */
+extern uint32_t _libxr_webots_poll_period_ms;  // NOLINT
+
 namespace LibXR
 {
 namespace MonotonicTime
@@ -29,8 +34,13 @@ inline uint32_t RemainingMilliseconds(uint64_t deadline_ms)
 
 inline uint32_t WaitSliceMilliseconds(uint32_t remaining_ms)
 {
-  UNUSED(remaining_ms);
-  return 1;
+  if (remaining_ms == 0)
+  {
+    return 0;
+  }
+
+  const uint32_t poll_ms = _libxr_webots_poll_period_ms != 0 ? _libxr_webots_poll_period_ms : 1U;
+  return remaining_ms < poll_ms ? remaining_ms : poll_ms;
 }
 
 inline timespec RealtimeDeadlineFromNow(uint32_t milliseconds)

--- a/system/webots/semaphore.cpp
+++ b/system/webots/semaphore.cpp
@@ -43,7 +43,10 @@ ErrorCode Semaphore::Wait(uint32_t timeout)
         MonotonicTime::RealtimeDeadlineFromNow(MonotonicTime::WaitSliceMilliseconds(
             MonotonicTime::RemainingMilliseconds(deadline_ms)));
 
-    if (!sem_timedwait(semaphore_handle_, &ts))
+    WebotsMarkCurrentRealtimeThreadParked(false);
+    const int wait_ans = sem_timedwait(semaphore_handle_, &ts);
+    WebotsMarkCurrentRealtimeThreadRunning();
+    if (!wait_ans)
     {
       return ErrorCode::OK;
     }

--- a/system/webots/thread.cpp
+++ b/system/webots/thread.cpp
@@ -19,11 +19,13 @@ static ErrorCode ConditionVarWait(uint32_t timeout)
   while (MonotonicTime::RemainingMilliseconds(deadline_ms) > 0)
   {
     pthread_mutex_lock(&_libxr_webots_time_notify->mutex);
+    WebotsMarkCurrentRealtimeThreadParked(true);
     const timespec ts =
         MonotonicTime::RealtimeDeadlineFromNow(MonotonicTime::WaitSliceMilliseconds(
             MonotonicTime::RemainingMilliseconds(deadline_ms)));
     auto ans = pthread_cond_timedwait(&_libxr_webots_time_notify->cond,
                                       &_libxr_webots_time_notify->mutex, &ts);
+    WebotsMarkCurrentRealtimeThreadRunning();
     pthread_mutex_unlock(&_libxr_webots_time_notify->mutex);
     if (ans == 0)
     {

--- a/system/webots/thread.hpp
+++ b/system/webots/thread.hpp
@@ -4,6 +4,7 @@
 #include "libxr_time.hpp"
 #include "logger.hpp"
 
+#include <algorithm>
 #include <cstring>
 
 namespace LibXR
@@ -67,6 +68,13 @@ class Thread
   void Create(ArgType arg, void (*function)(ArgType arg), const char *name,
               size_t stack_depth, Thread::Priority priority)
   {
+    const bool is_realtime = priority == Thread::Priority::REALTIME;
+    WebotsRealtimeThreadRegistration *realtime_registration = nullptr;
+    if (is_realtime)
+    {
+      realtime_registration = WebotsRegisterRealtimeThread();
+    }
+
     pthread_attr_t attr;
     pthread_attr_init(&attr);
     ConfigureAttributes(attr, stack_depth, priority);
@@ -85,14 +93,18 @@ class Thread
        * @param  arg 线程参数 Thread argument
        * @param  name 线程名称 Thread name
        */
-      ThreadBlock(decltype(function) fun, ArgType arg, const char *name)
+      ThreadBlock(decltype(function) fun, ArgType arg, const char *name, bool is_realtime,
+                  WebotsRealtimeThreadRegistration *realtime_registration)
           : fun_(fun),
-            arg_(arg)
+            arg_(arg),
+            is_realtime_(is_realtime),
+            realtime_registration_(realtime_registration)
       {
         std::memset(name_, 0, sizeof(name_));
         if (name != nullptr)
         {
-          std::strncpy(name_, name, sizeof(name_) - 1);
+          const size_t copy_len = std::min(std::strlen(name), sizeof(name_) - 1U);
+          std::memcpy(name_, name, copy_len);
         }
       }
 
@@ -106,17 +118,28 @@ class Thread
       static void *Port(void *arg)
       {
         ThreadBlock *block = static_cast<ThreadBlock *>(arg);
+        if (block->is_realtime_)
+        {
+          WebotsBindCurrentRealtimeThread(block->realtime_registration_);
+        }
         block->fun_(block->arg_);
+        if (block->is_realtime_)
+        {
+          WebotsReleaseRealtimeThread(block->realtime_registration_);
+        }
         delete block;
         return static_cast<void *>(nullptr);
       }
 
       decltype(function) fun_;  ///< 线程执行的函数 Function executed by the thread
       ArgType arg_;             ///< 线程函数的参数 Argument passed to the thread function
+      bool is_realtime_{false};
+      WebotsRealtimeThreadRegistration *realtime_registration_{nullptr};
       char name_[16];           ///< 线程名称 Thread name
     };
 
-    auto block = new ThreadBlock(function, arg, name);
+    auto block =
+        new ThreadBlock(function, arg, name, is_realtime, realtime_registration);
 
     // 创建线程
     int ans = pthread_create(&this->thread_handle_, &attr, ThreadBlock::Port, block);
@@ -134,7 +157,12 @@ class Thread
       if (ans != 0)
       {
         XR_LOG_ERROR("Failed to create thread: %s (%s)", name, strerror(ans));
+        if (is_realtime)
+        {
+          WebotsReleaseRealtimeThread(realtime_registration);
+        }
         delete block;
+        return;
       }
     }
   }


### PR DESCRIPTION
## 摘要
- Webots 平台初始化保留单一 `PlatformInit`，仿真流速作为默认参数。
- REALTIME 传感器线程按 step 挂起/唤醒，并在推进下一 step 前确认其它 REALTIME 线程已重新 park。
- 非 step 阻塞等待不强制每个 epoch 重新 park，避免 topic/semaphore 等待路径引入额外唤醒复杂度。

## 验证
- Ubuntu24 `/tmp/build_webots_rt_barrier.sh`：PASS。
- Webots camera/sync 矩阵 `flow=0.1 / 1.0`、`latest_imu / raw_probe`：PASS。
- 无残留 Webots/Xvfb/controller 进程。

## 边界
- 只覆盖 Webots timing/barrier 语义，不包含 detector/tracker 重构。

## Summary by Sourcery

Add configurable Webots simulation flow-rate and introduce a step-aware barrier that coordinates REALTIME threads with the simulator timebase.

New Features:
- Allow configuring Webots simulation flow-rate via an additional PlatformInit parameter to scale basicTimeStep and polling periods.
- Introduce a registration and tracking mechanism for REALTIME threads so the Webots timebase can wait until all are parked before advancing simulation steps.

Bug Fixes:
- Prevent improper reuse of shared topic payload memory by constructing payload objects instead of zeroing raw memory.

Enhancements:
- Replace fixed 1 ms polling with a flow-rate-aware polling slice for timed waits to align blocking behavior with simulation pacing.
- Improve Webots timebase scheduling by using monotonic clock nanosleep with absolute deadlines for more stable step timing.
- Add explicit tracking of REALTIME thread run/park states around condition variable and semaphore waits to avoid unintended wake-up semantics.
- Tighten validation and error reporting for Webots robot handle, basicTimeStep, and simulation flow-rate configuration.