### PR TITLE
ci: retry doxygen binary download

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -32,11 +32,22 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Doxygen
+      - name: Install documentation dependencies
         run: sudo apt-get update && sudo apt-get install -y graphviz wget
 
       - name: Install Doxygen
-        run: wget https://www.doxygen.nl/files/doxygen-1.12.0.linux.bin.tar.gz && tar xzf doxygen-1.12.0.linux.bin.tar.gz && sudo ln -s $(pwd)/doxygen-1.12.0/bin/* /usr/bin
+        run: |
+          wget \
+            --tries=5 \
+            --waitretry=10 \
+            --retry-connrefused \
+            --retry-on-http-error=403,429,500,502,503,504 \
+            --timeout=30 \
+            --continue \
+            https://www.doxygen.nl/files/doxygen-1.12.0.linux.bin.tar.gz
+          echo "3c42c3f3fb206732b503862d9c9c11978920a8214f223a3950bbf2520be5f647  doxygen-1.12.0.linux.bin.tar.gz" | sha256sum -c -
+          tar xzf doxygen-1.12.0.linux.bin.tar.gz
+          sudo ln -sf "$(pwd)"/doxygen-1.12.0/bin/* /usr/bin
 
       - name: Check Doxygen Version
         run: doxygen --version


### PR DESCRIPTION
## 摘要
- Doxygen 二进制下载改为显式 `wget` 重试。
- 覆盖连接拒绝、`403/429/5xx` HTTP 返回码，避免 doxygen.nl/Cloudflare 偶发拒绝直接打红主线。
- 顺手区分依赖安装 step 和 Doxygen 安装 step 的名称，便于日志定位。

## 验证
- `git diff --check` PASS。
- 本地 `wget --help` 确认支持 `--retry-on-http-error`、`--waitretry`、`--retry-connrefused`。
- 当前 master 上失败的 Doxygen run 重跑后已通过；此 PR 是防复发修复。

## Summary by Sourcery

Improve reliability of the Doxygen installation in the CI workflow by adding resilient download behavior and clarifying installation steps.

CI:
- Split documentation dependency installation and Doxygen installation into separate, clearly named workflow steps in the Doxygen GitHub Actions job.
- Make the Doxygen binary download in CI more robust by using wget with retries, backoff, connection-refused handling, and HTTP error retries.