### PR TITLE
refactor(print): clean naming and test structure

### DIFF
--- a/system/linux/libxr_system.cpp
+++ b/system/linux/libxr_system.cpp
@@ -21,11 +21,11 @@ struct timespec libxr_linux_start_time_spec;  // NOLINT
 static LibXR::LinuxTimebase libxr_linux_timebase;
 
 static LibXR::Semaphore stdo_sem;
-static constexpr size_t kHostStdioQueueBytes = 4096;
+static constexpr size_t host_stdio_queue_bytes = 4096;
 
 void StdiThread(LibXR::ReadPort* read_port)
 {
-  static uint8_t read_buff[kHostStdioQueueBytes];
+  static uint8_t read_buff[host_stdio_queue_bytes];
 
   if (!isatty(STDIN_FILENO))
   {
@@ -64,7 +64,7 @@ void StdiThread(LibXR::ReadPort* read_port)
 void StdoThread(LibXR::WritePort* write_port)
 {
   LibXR::WriteInfoBlock info;
-  static uint8_t write_buff[kHostStdioQueueBytes];
+  static uint8_t write_buff[host_stdio_queue_bytes];
 
   while (true)
   {
@@ -105,7 +105,7 @@ void LibXR::PlatformInit(uint32_t timer_pri, uint32_t timer_stack_depth)
     return LibXR::ErrorCode::PENDING;
   };
 
-  LibXR::STDIO::write_ = new LibXR::WritePort(32, kHostStdioQueueBytes);
+  LibXR::STDIO::write_ = new LibXR::WritePort(32, host_stdio_queue_bytes);
 
   *LibXR::STDIO::write_ = write_fun;
 
@@ -115,7 +115,7 @@ void LibXR::PlatformInit(uint32_t timer_pri, uint32_t timer_stack_depth)
     return LibXR::ErrorCode::PENDING;
   };
 
-  LibXR::STDIO::read_ = new LibXR::ReadPort(kHostStdioQueueBytes);
+  LibXR::STDIO::read_ = new LibXR::ReadPort(host_stdio_queue_bytes);
 
   *LibXR::STDIO::read_ = read_fun;
 

--- a/system/webasm/libxr_system.cpp
+++ b/system/webasm/libxr_system.cpp
@@ -28,7 +28,7 @@ extern "C"
   }
 }
 
-static constexpr size_t kWebAsmStdioQueueBytes = 4096;
+static constexpr size_t webasm_stdio_queue_bytes = 4096;
 
 void LibXR::PlatformInit()
 {
@@ -36,7 +36,7 @@ void LibXR::PlatformInit()
 
   auto write_fun = [](WritePort& port, bool)
   {
-    static uint8_t write_buff[kWebAsmStdioQueueBytes];
+    static uint8_t write_buff[webasm_stdio_queue_bytes];
     WriteInfoBlock info;
     while (true)
     {
@@ -65,13 +65,13 @@ void LibXR::PlatformInit()
     return LibXR::ErrorCode::OK;
   };
 
-  LibXR::STDIO::write_ = new LibXR::WritePort(32, kWebAsmStdioQueueBytes);
+  LibXR::STDIO::write_ = new LibXR::WritePort(32, webasm_stdio_queue_bytes);
 
   *LibXR::STDIO::write_ = write_fun;
 
   auto read_fun = [](ReadPort&, bool) { return LibXR::ErrorCode::EMPTY; };
 
-  LibXR::STDIO::read_ = new LibXR::ReadPort(kWebAsmStdioQueueBytes);
+  LibXR::STDIO::read_ = new LibXR::ReadPort(webasm_stdio_queue_bytes);
 
   *LibXR::STDIO::read_ = read_fun;
 }

--- a/system/webots/libxr_system.cpp
+++ b/system/webots/libxr_system.cpp
@@ -31,7 +31,7 @@ static uint64_t step_interval_ns = 1000000ULL;
 LibXR::condition_var_handle* _libxr_webots_time_notify = nullptr;
 
 static LibXR::Semaphore stdo_sem;
-static constexpr size_t kHostStdioQueueBytes = 4096;
+static constexpr size_t host_stdio_queue_bytes = 4096;
 
 struct LibXR::WebotsRealtimeThreadRegistration
 {
@@ -97,7 +97,7 @@ bool AllWebotsRealtimeThreadsParkedUnlocked(
 
 void StdiThread(LibXR::ReadPort* read_port)
 {
-  static uint8_t read_buff[kHostStdioQueueBytes];
+  static uint8_t read_buff[host_stdio_queue_bytes];
 
   while (true)
   {
@@ -127,7 +127,7 @@ void StdiThread(LibXR::ReadPort* read_port)
 void StdoThread(LibXR::WritePort* write_port)
 {
   LibXR::WriteInfoBlock info;
-  static uint8_t write_buff[kHostStdioQueueBytes];
+  static uint8_t write_buff[host_stdio_queue_bytes];
 
   while (true)
   {
@@ -205,7 +205,7 @@ void LibXR::PlatformInit(webots::Robot* robot, uint32_t timer_pri,
     return LibXR::ErrorCode::PENDING;
   };
 
-  LibXR::STDIO::write_ = new LibXR::WritePort(32, kHostStdioQueueBytes);
+  LibXR::STDIO::write_ = new LibXR::WritePort(32, host_stdio_queue_bytes);
 
   *LibXR::STDIO::write_ = write_fun;
 
@@ -215,7 +215,7 @@ void LibXR::PlatformInit(webots::Robot* robot, uint32_t timer_pri,
     return LibXR::ErrorCode::PENDING;
   };
 
-  LibXR::STDIO::read_ = new LibXR::ReadPort(kHostStdioQueueBytes);
+  LibXR::STDIO::read_ = new LibXR::ReadPort(host_stdio_queue_bytes);
 
   *LibXR::STDIO::read_ = read_fun;
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -11,34 +11,6 @@
 
 const static char* test_name = nullptr;
 
-using LoggerFrontend = LibXR::Detail::LoggerLiteral::Frontend;
-using LoggerResolution = LibXR::Detail::LoggerLiteral::Resolution;
-
-static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "logger {}",
-                                                            int>() ==
-              LoggerResolution::Format);
-static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "logger %d",
-                                                            int>() ==
-              LoggerResolution::Printf);
-static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "{{}}">() ==
-              LoggerResolution::Format);
-static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "%%">() ==
-              LoggerResolution::Printf);
-static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "plain text">() ==
-              LoggerResolution::Format);
-static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "{} %d", int>() ==
-              LoggerResolution::Ambiguous);
-static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "%s {}", const char*>() ==
-              LoggerResolution::Ambiguous);
-static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "{0}%1$d", int>() ==
-              LoggerResolution::Ambiguous);
-static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "{%">() ==
-              LoggerResolution::None);
-static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "{%d}", int>() ==
-              LoggerResolution::Printf);
-static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "{123abc} %d", int>() ==
-              LoggerResolution::Printf);
-
 #define TEST_STEP(_arg)                                \
   do                                                   \
   {                                                    \
@@ -58,14 +30,6 @@ struct TestCase
   void (*function)();
   bool isolated;
 };
-
-static void logger_literal_surface_compile_smoke(const char* name)
-{
-  XR_LOG_INFO("logger smoke [{}]\n", name);
-  XR_LOG_INFO("logger smoke [%s]\n", name);
-  XR_LOG_INFO(XR_FMT("logger smoke explicit [{}]\n"), name);
-  XR_LOG_INFO(XR_PRINTF("logger smoke explicit [%s]\n"), name);
-}
 
 static void run_test_case(const TestCase& test_case)
 {
@@ -94,7 +58,6 @@ static void run_test_case(const TestCase& test_case)
 
 static void run_libxr_tests()
 {
-  logger_literal_surface_compile_smoke("boot");
   XR_LOG_INFO("Running LibXR Tests...\n");
 
   TestCase core_tests[] = {
@@ -114,9 +77,6 @@ static void run_libxr_tests()
       {"crc", test_crc, false},
       {"encoder", test_float_encoder, false},
       {"cycle_value", test_cycle_value, false},
-  };
-
-  TestCase print_tests[] = {
       {"print", test_print, false},
   };
 
@@ -158,7 +118,6 @@ static void run_libxr_tests()
   } test_groups[] = {{core_tests, "core_tests"},
                      {synchronization_tests, "synchronization_tests"},
                      {utility_tests, "utility_tests"},
-                     {print_tests, "print_tests"},
                      {data_structure_tests, "data_structure_tests"},
                      {threading_tests, "threading_tests"},
                      {motion_tests, "motion_tests"},
@@ -169,7 +128,6 @@ static void run_libxr_tests()
       sizeof(core_tests) / sizeof(TestCase),
       sizeof(synchronization_tests) / sizeof(TestCase),
       sizeof(utility_tests) / sizeof(TestCase),
-      sizeof(print_tests) / sizeof(TestCase),
       sizeof(data_structure_tests) / sizeof(TestCase),
       sizeof(threading_tests) / sizeof(TestCase),
       sizeof(motion_tests) / sizeof(TestCase),

--- a/test/test_pool.cpp
+++ b/test/test_pool.cpp
@@ -91,10 +91,7 @@ void test_lock_free_pool()
 
   // ---- 多线程并发完整性测试 ----
   {
-    push_sum = 0;
-    pop_sum = 0;
-    push_cnt = 0;
-    pop_cnt = 0;
+    push_sum = pop_sum = push_cnt = pop_cnt = 0;
     for (int i = 0; i < N; ++i)
     {
       pop_taken[i] = 0;

--- a/test/test_print.cpp
+++ b/test/test_print.cpp
@@ -1,11 +1,11 @@
 #include <array>
 #include <cstddef>
 #include <cstdint>
-#include <cstring>
 #include <cstdio>
 #include <cstdlib>
-#include <limits>
+#include <cstring>
 #include <iostream>
+#include <limits>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -17,6 +17,43 @@ static_assert(LibXR::Format<"{1} {0}">::ArgumentCount() == 2);
 static_assert(LibXR::Format<"{:d} {}">::template Matches<int, const char*>());
 static_assert(LibXR::Format<"{}">::template Matches<int, int>());
 static_assert(!LibXR::Format<"{:d} {}">::template Matches<const char*, int>());
+
+using LoggerFrontend = LibXR::Detail::LoggerLiteral::Frontend;
+using LoggerResolution = LibXR::Detail::LoggerLiteral::Resolution;
+
+static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto,
+                                                            "logger {}", int>() ==
+              LoggerResolution::Format);
+static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto,
+                                                            "logger %d", int>() ==
+              LoggerResolution::Printf);
+static_assert(
+    LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "{{}}">() ==
+    LoggerResolution::Format);
+static_assert(
+    LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "%%">() ==
+    LoggerResolution::Printf);
+static_assert(
+    LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "plain text">() ==
+    LoggerResolution::Format);
+static_assert(
+    LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "{} %d", int>() ==
+    LoggerResolution::Ambiguous);
+static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "%s {}",
+                                                            const char*>() ==
+              LoggerResolution::Ambiguous);
+static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto,
+                                                            "{0}%1$d", int>() ==
+              LoggerResolution::Ambiguous);
+static_assert(
+    LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "{%">() ==
+    LoggerResolution::None);
+static_assert(
+    LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "{%d}", int>() ==
+    LoggerResolution::Printf);
+static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto,
+                                                            "{123abc} %d", int>() ==
+              LoggerResolution::Printf);
 
 namespace
 {
@@ -73,14 +110,32 @@ struct BrokenGenericFormat
     return std::array<LibXR::Print::FormatArgumentInfo, 0>{};
   }
 
-  [[nodiscard]] static constexpr auto ArgumentOrder()
-  {
-    return std::array<size_t, 0>{};
-  }
+  [[nodiscard]] static constexpr auto ArgumentOrder() { return std::array<size_t, 0>{}; }
 
   [[nodiscard]] static constexpr LibXR::Print::FormatProfile Profile()
   {
     return LibXR::Print::FormatProfile::Generic;
+  }
+};
+
+struct StdioWriteScope
+{
+  explicit StdioWriteScope(LibXR::WritePort& write, LibXR::Mutex& mutex,
+                           LibXR::WritePort::Stream* stream = nullptr)
+  {
+    LibXR::STDIO::write_ = &write;
+    LibXR::STDIO::write_mutex_ = &mutex;
+    LibXR::STDIO::write_stream_ = stream;
+  }
+
+  StdioWriteScope(const StdioWriteScope&) = delete;
+  StdioWriteScope& operator=(const StdioWriteScope&) = delete;
+
+  ~StdioWriteScope()
+  {
+    LibXR::STDIO::write_ = nullptr;
+    LibXR::STDIO::write_mutex_ = nullptr;
+    LibXR::STDIO::write_stream_ = nullptr;
   }
 };
 
@@ -91,16 +146,14 @@ bool SameAsSnprintf(Args... args)
   int expected_size = 0;
   if constexpr (sizeof...(Args) == 0)
   {
-    expected_size =
-        std::snprintf(expected.data(), expected.size(), "%s", Source.Data());
+    expected_size = std::snprintf(expected.data(), expected.size(), "%s", Source.Data());
   }
   else
   {
     expected_size =
         std::snprintf(expected.data(), expected.size(), Source.Data(), args...);
   }
-  if (expected_size < 0 ||
-      static_cast<size_t>(expected_size) >= expected.size())
+  if (expected_size < 0 || static_cast<size_t>(expected_size) >= expected.size())
   {
     return false;
   }
@@ -162,9 +215,8 @@ int Fail(const char* message)
   std::exit(1);
   return 0;
 }
-}  // namespace
 
-void test_print()
+void TestPrintfFrontendSemantics()
 {
   if (!SameAsSnprintf<"abc">())
   {
@@ -206,8 +258,8 @@ void test_print()
     Fail("octal integer semantics mismatch");
   }
 
-  if (!SamePrintfAsExpected<"%b|%B|%#b|%#B|%08b">("101|101|0b101|0B101|00000101", 5U,
-                                                  5U, 5U, 5U, 5U))
+  if (!SamePrintfAsExpected<"%b|%B|%#b|%#B|%08b">("101|101|0b101|0B101|00000101", 5U, 5U,
+                                                  5U, 5U, 5U))
   {
     Fail("binary integer semantics mismatch");
   }
@@ -235,8 +287,7 @@ void test_print()
     Fail("string format mismatch");
   }
 
-  if (!SameAsSnprintf<"%s|%.3s|%6.3s|%-6.3s">("abcdef", "abcdef", "abcdef",
-                                              "abcdef"))
+  if (!SameAsSnprintf<"%s|%.3s|%6.3s|%-6.3s">("abcdef", "abcdef", "abcdef", "abcdef"))
   {
     Fail("string semantics mismatch");
   }
@@ -263,9 +314,9 @@ void test_print()
     ptrdiff_t ptrdiff_signed = -11;
     std::make_unsigned_t<ptrdiff_t> ptrdiff_unsigned = 12;
     if (!SameAsSnprintf<"%hhd %hhu %hd %hu %lld %llu %jd %ju %td %tu">(
-            tiny_signed, tiny_unsigned, short_signed, short_unsigned,
-            long_long_signed, long_long_unsigned, max_signed, max_unsigned,
-            ptrdiff_signed, ptrdiff_unsigned))
+            tiny_signed, tiny_unsigned, short_signed, short_unsigned, long_long_signed,
+            long_long_unsigned, max_signed, max_unsigned, ptrdiff_signed,
+            ptrdiff_unsigned))
     {
       Fail("integer length family mismatch");
     }
@@ -306,20 +357,17 @@ void test_print()
     Fail("negative zero float mismatch");
   }
 
-  if (!SameAsSnprintf<"%f|%F|%e">(
-          std::numeric_limits<double>::infinity(),
-          -std::numeric_limits<double>::infinity(),
-          std::numeric_limits<double>::quiet_NaN()))
+  if (!SameAsSnprintf<"%f|%F|%e">(std::numeric_limits<double>::infinity(),
+                                  -std::numeric_limits<double>::infinity(),
+                                  std::numeric_limits<double>::quiet_NaN()))
   {
     Fail("float inf nan mismatch");
   }
 
   {
     int value = 0;
-    if (!SameAsSnprintf<
-            "a%d 0123456789abcdef %u %o %x %X %p %c %s %f %e %g %Lf %Le %Lg">(
-            -1, 2U, 8U, 42U, 42U, &value, 'Q', "xy", 1.5, 1.5, 1.5, 2.25L,
-            2.25L, 2.25L))
+    if (!SameAsSnprintf<"a%d 0123456789abcdef %u %o %x %X %p %c %s %f %e %g %Lf %Le %Lg">(
+            -1, 2U, 8U, 42U, 42U, &value, 'Q', "xy", 1.5, 1.5, 1.5, 2.25L, 2.25L, 2.25L))
     {
       Fail("full supported family mismatch");
     }
@@ -345,6 +393,14 @@ void test_print()
     }
   }
 
+  if (!SamePrintfAsExpected<"[%s]">("[(null)]", static_cast<const char*>(nullptr)))
+  {
+    Fail("printf null string mismatch");
+  }
+}
+
+void TestFormatFrontendSemantics()
+{
   if (!SameFormatAsExpected<"abc">("abc"))
   {
     Fail("format frontend plain text mismatch");
@@ -366,8 +422,8 @@ void test_print()
     Fail("format frontend non-decimal mismatch");
   }
 
-  if (!SameFormatAsExpected<"[{:.3s}] [{:_>6s}] [{:*^7s}]">(
-          "[abc] [___abc] [**abc**]", "abcdef", "abc", "abc"))
+  if (!SameFormatAsExpected<"[{:.3s}] [{:_>6s}] [{:*^7s}]">("[abc] [___abc] [**abc**]",
+                                                            "abcdef", "abc", "abc"))
   {
     Fail("format frontend string field mismatch");
   }
@@ -377,14 +433,13 @@ void test_print()
     Fail("format frontend character mismatch");
   }
 
-  if (!SameFormatAsExpected<"{:.2f}|{:.1E}|{:g}">("1.25|1.2E+01|12", 1.25, 12.0,
-                                                   12.0))
+  if (!SameFormatAsExpected<"{:.2f}|{:.1E}|{:g}">("1.25|1.2E+01|12", 1.25, 12.0, 12.0))
   {
     Fail("format frontend float mismatch");
   }
 
   if (!SameFormatAsExpected<"{:+d}|{: d}|{:08d}|{:#x}">("+7| 7|00000007|0x2a", 7, 7, 7,
-                                                         42U))
+                                                        42U))
   {
     Fail("format frontend integer flag mismatch");
   }
@@ -395,7 +450,7 @@ void test_print()
   }
 
   if (!SameFormatAsExpected<"{:f}|{:E}|{:g}">("-0.000000|-0.000000E+00|-0", -0.0, -0.0,
-                                               -0.0))
+                                              -0.0))
   {
     Fail("format frontend negative zero mismatch");
   }
@@ -427,11 +482,45 @@ void test_print()
     Fail("format frontend null string mismatch");
   }
 
-  if (!SamePrintfAsExpected<"[%s]">("[(null)]", static_cast<const char*>(nullptr)))
   {
-    Fail("printf null string mismatch");
+    constexpr LibXR::Format<"{:c} {:.3s} {:p}"> format{};
+    int value = 7;
+    StringSink sink;
+    auto ec = format.WriteTo(sink, 'A', "abcdef", &value);
+    if (ec != LibXR::ErrorCode::OK || !sink.buffer.starts_with("A abc 0x"))
+    {
+      Fail("format frontend writeto mismatch");
+    }
   }
 
+  {
+    int value = 0;
+    std::string expected = "ptr=" + PointerText(&value);
+    if (!SameFormatAsExpected<"ptr={}">(expected, &value))
+    {
+      Fail("format frontend pointer default mismatch");
+    }
+  }
+
+  {
+    int value = 0;
+    std::string pointer = PointerText(&value);
+    std::string expected = "[";
+    if (pointer.size() < 32)
+    {
+      expected.append(32 - pointer.size(), ' ');
+    }
+    expected += pointer;
+    expected.push_back(']');
+    if (!SameFormatAsExpected<"[{:32}]">(expected, &value))
+    {
+      Fail("format frontend pointer default alignment mismatch");
+    }
+  }
+}
+
+void TestPrintApiWrappers()
+{
   {
     constexpr LibXR::Format<"x={:+05d} {:#x} {}"> format{};
     StringSink sink;
@@ -495,9 +584,8 @@ void test_print()
 
   {
     char buffer[32] = {};
-    size_t written =
-        LibXR::Print::FormatIntoBuffer<"x={:+05d} {:#x} {}">(buffer, sizeof(buffer), 7,
-                                                            42U, "ok");
+    size_t written = LibXR::Print::FormatIntoBuffer<"x={:+05d} {:#x} {}">(
+        buffer, sizeof(buffer), 7, 42U, "ok");
     if (std::string_view(buffer) != "x=+0007 0x2a ok" ||
         written != std::strlen("x=+0007 0x2a ok"))
     {
@@ -585,8 +673,8 @@ void test_print()
 
   {
     char buffer[8] = {'x', 'x', 'x', '\0'};
-    size_t written = LibXR::Print::FormatIntoBuffer(buffer, sizeof(buffer),
-                                                    BrokenGenericFormat{});
+    size_t written =
+        LibXR::Print::FormatIntoBuffer(buffer, sizeof(buffer), BrokenGenericFormat{});
     if (written != 0 || buffer[0] != '\0')
     {
       Fail("format bounded buffer runtime error mismatch");
@@ -601,18 +689,10 @@ void test_print()
       Fail("snprintf runtime error mismatch");
     }
   }
+}
 
-  {
-    constexpr LibXR::Format<"{:c} {:.3s} {:p}"> format{};
-    int value = 7;
-    StringSink sink;
-    auto ec = format.WriteTo(sink, 'A', "abcdef", &value);
-    if (ec != LibXR::ErrorCode::OK || !sink.buffer.starts_with("A abc 0x"))
-    {
-      Fail("format frontend writeto mismatch");
-    }
-  }
-
+void TestStdioPrintWrappers()
+{
   {
     static constexpr char expected[] = "x=+0007 0x2a ok";
 
@@ -620,10 +700,7 @@ void test_print()
     LibXR::ReadPort& read = pipe.GetReadPort();
     LibXR::WritePort& write = pipe.GetWritePort();
     LibXR::Mutex mutex;
-
-    LibXR::STDIO::write_ = &write;
-    LibXR::STDIO::write_mutex_ = &mutex;
-    LibXR::STDIO::write_stream_ = nullptr;
+    StdioWriteScope stdio_scope(write, mutex);
 
     uint8_t rx[sizeof(expected) - 1] = {0};
     LibXR::ReadOperation read_op;
@@ -643,10 +720,6 @@ void test_print()
     {
       Fail("format frontend stdio output mismatch");
     }
-
-    LibXR::STDIO::write_ = nullptr;
-    LibXR::STDIO::write_mutex_ = nullptr;
-    LibXR::STDIO::write_stream_ = nullptr;
   }
 
   {
@@ -658,10 +731,7 @@ void test_print()
     LibXR::Mutex mutex;
     LibXR::WriteOperation stream_op;
     LibXR::WritePort::Stream stream(&write, stream_op);
-
-    LibXR::STDIO::write_ = &write;
-    LibXR::STDIO::write_mutex_ = &mutex;
-    LibXR::STDIO::write_stream_ = &stream;
+    StdioWriteScope stdio_scope(write, mutex, &stream);
 
     uint8_t rx[sizeof(expected) - 1] = {0};
     LibXR::ReadOperation read_op;
@@ -681,10 +751,6 @@ void test_print()
     {
       Fail("format frontend stdio stream output mismatch");
     }
-
-    LibXR::STDIO::write_ = nullptr;
-    LibXR::STDIO::write_mutex_ = nullptr;
-    LibXR::STDIO::write_stream_ = nullptr;
   }
 
   {
@@ -694,10 +760,7 @@ void test_print()
     LibXR::ReadPort& read = pipe.GetReadPort();
     LibXR::WritePort& write = pipe.GetWritePort();
     LibXR::Mutex mutex;
-
-    LibXR::STDIO::write_ = &write;
-    LibXR::STDIO::write_mutex_ = &mutex;
-    LibXR::STDIO::write_stream_ = nullptr;
+    StdioWriteScope stdio_scope(write, mutex);
 
     uint8_t rx[sizeof(expected) - 1] = {0};
     LibXR::ReadOperation read_op;
@@ -717,10 +780,6 @@ void test_print()
     {
       Fail("printf frontend stdio output mismatch");
     }
-
-    LibXR::STDIO::write_ = nullptr;
-    LibXR::STDIO::write_mutex_ = nullptr;
-    LibXR::STDIO::write_stream_ = nullptr;
   }
 
   {
@@ -732,10 +791,7 @@ void test_print()
     LibXR::Mutex mutex;
     LibXR::WriteOperation stream_op;
     LibXR::WritePort::Stream stream(&write, stream_op);
-
-    LibXR::STDIO::write_ = &write;
-    LibXR::STDIO::write_mutex_ = &mutex;
-    LibXR::STDIO::write_stream_ = &stream;
+    StdioWriteScope stdio_scope(write, mutex, &stream);
 
     uint8_t rx[sizeof(expected) - 1] = {0};
     LibXR::ReadOperation read_op;
@@ -755,12 +811,11 @@ void test_print()
     {
       Fail("printf frontend stdio stream output mismatch");
     }
-
-    LibXR::STDIO::write_ = nullptr;
-    LibXR::STDIO::write_mutex_ = nullptr;
-    LibXR::STDIO::write_stream_ = nullptr;
   }
+}
 
+void TestStdioTruncation()
+{
   {
     constexpr size_t pipe_capacity = 64;
     constexpr size_t payload_size = pipe_capacity + 16;
@@ -777,14 +832,12 @@ void test_print()
     LibXR::WritePort& write = pipe.GetWritePort();
     LibXR::Mutex mutex;
     const size_t expected_retained = write.EmptySize();
-
-    LibXR::STDIO::write_ = &write;
-    LibXR::STDIO::write_mutex_ = &mutex;
-    LibXR::STDIO::write_stream_ = nullptr;
+    StdioWriteScope stdio_scope(write, mutex);
 
     std::array<uint8_t, payload_size> rx{};
     LibXR::ReadOperation read_op;
-    if (read(LibXR::RawData{rx.data(), expected_retained}, read_op) != LibXR::ErrorCode::OK)
+    if (read(LibXR::RawData{rx.data(), expected_retained}, read_op) !=
+        LibXR::ErrorCode::OK)
     {
       Fail("stdio pipe-capacity truncation read arm failed");
     }
@@ -800,10 +853,6 @@ void test_print()
     {
       Fail("stdio pipe-capacity truncation payload mismatch");
     }
-
-    LibXR::STDIO::write_ = nullptr;
-    LibXR::STDIO::write_mutex_ = nullptr;
-    LibXR::STDIO::write_stream_ = nullptr;
   }
 
   {
@@ -824,14 +873,12 @@ void test_print()
     LibXR::WriteOperation stream_op;
     LibXR::WritePort::Stream stream(&write, stream_op);
     const size_t expected_retained = write.EmptySize();
-
-    LibXR::STDIO::write_ = &write;
-    LibXR::STDIO::write_mutex_ = &mutex;
-    LibXR::STDIO::write_stream_ = &stream;
+    StdioWriteScope stdio_scope(write, mutex, &stream);
 
     std::array<uint8_t, payload_size> rx{};
     LibXR::ReadOperation read_op;
-    if (read(LibXR::RawData{rx.data(), expected_retained}, read_op) != LibXR::ErrorCode::OK)
+    if (read(LibXR::RawData{rx.data(), expected_retained}, read_op) !=
+        LibXR::ErrorCode::OK)
     {
       Fail("stdio bound-stream truncation read arm failed");
     }
@@ -847,10 +894,6 @@ void test_print()
     {
       Fail("stdio bound-stream truncation payload mismatch");
     }
-
-    LibXR::STDIO::write_ = nullptr;
-    LibXR::STDIO::write_mutex_ = nullptr;
-    LibXR::STDIO::write_stream_ = nullptr;
   }
 
   {
@@ -871,14 +914,12 @@ void test_print()
     LibXR::WriteOperation stream_op;
     LibXR::WritePort::Stream stream(&write, stream_op);
     const size_t expected_retained = write.EmptySize();
-
-    LibXR::STDIO::write_ = &write;
-    LibXR::STDIO::write_mutex_ = &mutex;
-    LibXR::STDIO::write_stream_ = &stream;
+    StdioWriteScope stdio_scope(write, mutex, &stream);
 
     std::array<uint8_t, payload_size> rx{};
     LibXR::ReadOperation read_op;
-    if (read(LibXR::RawData{rx.data(), expected_retained}, read_op) != LibXR::ErrorCode::OK)
+    if (read(LibXR::RawData{rx.data(), expected_retained}, read_op) !=
+        LibXR::ErrorCode::OK)
     {
       Fail("stdio bound-stream small-capacity truncation read arm failed");
     }
@@ -894,34 +935,16 @@ void test_print()
     {
       Fail("stdio bound-stream small-capacity truncation payload mismatch");
     }
-
-    LibXR::STDIO::write_ = nullptr;
-    LibXR::STDIO::write_mutex_ = nullptr;
-    LibXR::STDIO::write_stream_ = nullptr;
   }
+}
 
-  {
-    int value = 0;
-    std::string expected = "ptr=" + PointerText(&value);
-    if (!SameFormatAsExpected<"ptr={}">(expected, &value))
-    {
-      Fail("format frontend pointer default mismatch");
-    }
-  }
+}  // namespace
 
-  {
-    int value = 0;
-    std::string pointer = PointerText(&value);
-    std::string expected = "[";
-    if (pointer.size() < 32)
-    {
-      expected.append(32 - pointer.size(), ' ');
-    }
-    expected += pointer;
-    expected.push_back(']');
-    if (!SameFormatAsExpected<"[{:32}]">(expected, &value))
-    {
-      Fail("format frontend pointer default alignment mismatch");
-    }
-  }
+void test_print()
+{
+  TestPrintfFrontendSemantics();
+  TestFormatFrontendSemantics();
+  TestPrintApiWrappers();
+  TestStdioPrintWrappers();
+  TestStdioTruncation();
 }

--- a/test/test_rw_pipe.cpp
+++ b/test/test_rw_pipe.cpp
@@ -1,6 +1,5 @@
 #include <atomic>
 #include <cstring>
-#include <string_view>
 #include <vector>
 
 #if defined(LIBXR_SYSTEM_POSIX_HOST)
@@ -1106,69 +1105,6 @@ void test_pipe_stream_api()
   ASSERT(std::memcmp(rx, EXPECT, sizeof(EXPECT)) == 0);
 }
 
-void test_pipe_stream_write_string_view()
-{
-  using namespace LibXR;
-
-  Pipe pipe(64);
-  ReadPort& r = pipe.GetReadPort();
-  WritePort& w = pipe.GetWritePort();
-  WriteOperation wop;
-
-  uint8_t rx[5] = {0};
-  ReadOperation rop;
-  ASSERT(r(RawData{rx, sizeof(rx)}, rop) == ErrorCode::OK);
-
-  WritePort::Stream ws(&w, wop);
-  ASSERT(ws.Write(std::string_view("abc")) == ErrorCode::OK);
-  ASSERT(ws.Write(std::string_view("de")) == ErrorCode::OK);
-  ASSERT(ws.Commit() == ErrorCode::OK);
-
-  r.ProcessPendingReads(false);
-  ASSERT(std::memcmp(rx, "abcde", sizeof(rx)) == 0);
-}
-
-void test_pipe_stream_write_full_is_chunk_atomic()
-{
-  using namespace LibXR;
-
-  Pipe pipe(5);
-  ReadPort& r = pipe.GetReadPort();
-  WritePort& w = pipe.GetWritePort();
-  WriteOperation wop;
-
-  static const uint8_t A[] = {0x61, 0x62, 0x63};
-  static const uint8_t B[] = {0x71, 0x72, 0x73};
-  uint8_t rx[sizeof(A)] = {0};
-
-  ReadOperation rop;
-  ASSERT(r(RawData{rx, sizeof(rx)}, rop) == ErrorCode::OK);
-
-  WritePort::Stream ws(&w, wop);
-  ASSERT(ws.Write(ConstRawData{A, sizeof(A)}) == ErrorCode::OK);
-  ASSERT(ws.Write(ConstRawData{B, sizeof(B)}) == ErrorCode::FULL);
-  ASSERT(ws.Commit() == ErrorCode::OK);
-
-  r.ProcessPendingReads(false);
-  ASSERT(std::memcmp(rx, A, sizeof(A)) == 0);
-}
-
-void test_pipe_stream_write_busy_returns_error()
-{
-  using namespace LibXR;
-
-  Pipe pipe(64);
-  WritePort& w = pipe.GetWritePort();
-
-  WriteOperation owner_op;
-  WriteOperation contender_op;
-  WritePort::Stream owner(&w, owner_op);
-  WritePort::Stream contender(&w, contender_op);
-
-  ASSERT(contender.Write(std::string_view("busy")) == ErrorCode::BUSY);
-  owner.Discard();
-}
-
 void test_pipe_stream_block_immediate_path()
 {
   using namespace LibXR;
@@ -1382,9 +1318,6 @@ void test_pipe()
   test_pipe_write_then_read();
   test_pipe_chunked_rw();
   test_pipe_stream_api();
-  test_pipe_stream_write_string_view();
-  test_pipe_stream_write_full_is_chunk_atomic();
-  test_pipe_stream_write_busy_returns_error();
   test_pipe_stream_block_immediate_path();
   test_pipe_stream_commit_releases_lock_for_next_stream();
   test_pipe_stream_commit_allows_persistent_and_external_streams();


### PR DESCRIPTION
## Summary
- rename host stdio queue constants to local snake_case style
- keep print coverage in test_print.cpp but split it into focused helper sections
- remove unrelated test runner/RW pipe/pool churn from the cleanup branch

## Validation
- /home/xiao/runs/libxr_print_cleanup_validate_20260428T233415Z/99_summary.txt
- patch apply on clean origin/master: PASS
- clang-format/cmake-format checks: PASS
- default build: PASS
- LIBXR_TEST_BUILD=True build + ctest: PASS

## Note
This is a corrective follow-up for the merged print/format work. Do not merge until reviewed.

## Summary by Sourcery

Refactor print and stdio handling to clean up naming, focus print tests, and remove unrelated or redundant test code.

Enhancements:
- Rename host stdio queue size constants to consistent local snake_case names across Linux, Webots, and WebAsm platforms.
- Introduce a scoped helper for configuring LibXR STDIO write ports in tests to centralize setup and teardown.
- Restructure print tests into focused helper functions for printf semantics, format semantics, API wrappers, and stdio behavior.

Tests:
- Move logger literal resolution static assertions from the main test harness into print-specific tests to keep concerns localized.
- Simplify the LibXR test runner groups by folding print tests into the core tests set and removing logger smoke logging from startup.
- Remove several RW pipe stream tests that depended on string_view overloads and busy/atomic semantics that are no longer needed or are covered elsewhere.