### PR TITLE
fix(print): reject logger argument drops

### DIFF
--- a/src/core/print/format_surface.hpp
+++ b/src/core/print/format_surface.hpp
@@ -64,6 +64,10 @@ class Format
     using Frontend = Compiler<Args...>;
     inline static constexpr auto result = Print::FormatCompiler<Frontend>::Compile();
 
+    static_assert(source_analysis.error != SourceError::None ||
+                      sizeof...(Args) == source_analysis.required_argument_count,
+                  "LibXR::Format: call-site argument count does not match the "
+                  "referenced replacement fields");
     static_assert(result.compile_error != Error::NumberOverflow,
                   "LibXR::Format: index, width, or precision is too large");
     static_assert(result.compile_error != Error::UnexpectedEnd,
@@ -134,7 +138,7 @@ class Format
     }
   };
 
-  /// Returns the minimum number of call-site arguments referenced by this source. / 返回当前源串至少会引用的调用点参数个数
+  /// Returns the required call-site argument count addressed by this source. / 返回当前源串会寻址的调用点参数个数
   [[nodiscard]] static constexpr size_t ArgumentCount()
   {
     return source_analysis.required_argument_count;
@@ -144,8 +148,15 @@ class Format
   template <typename... Args>
   [[nodiscard]] static consteval bool Matches()
   {
-    using Frontend = Compiler<std::remove_cvref_t<Args>...>;
-    return Print::FormatCompiler<Frontend>::Compile().compile_error == Error::None;
+    if constexpr (sizeof...(Args) != source_analysis.required_argument_count)
+    {
+      return false;
+    }
+    else
+    {
+      using Frontend = Compiler<std::remove_cvref_t<Args>...>;
+      return Print::FormatCompiler<Frontend>::Compile().compile_error == Error::None;
+    }
   }
 
   /// Writes this format into one sink and returns only the sink status. / 将当前格式写入一个输出端，并且只返回 sink 状态

--- a/src/core/print/printf_frontend_detail.hpp
+++ b/src/core/print/printf_frontend_detail.hpp
@@ -620,6 +620,12 @@ namespace Lowering
                  ? FormatArgumentRule::LongDouble
                  : FormatArgumentRule::Float;
     case ValueKind::None:
+    case ValueKind::Signed:
+    case ValueKind::Unsigned:
+    case ValueKind::Binary:
+    case ValueKind::Octal:
+    case ValueKind::HexLower:
+    case ValueKind::HexUpper:
       break;
   }
 

--- a/src/middleware/logger.hpp
+++ b/src/middleware/logger.hpp
@@ -94,6 +94,12 @@ template <Print::Text Source>
  * @brief Returns whether one argument list is accepted by the brace frontend,
  *        guarded by source-level validity first.
  * @brief 判断一组参数是否能被 brace 前端接受；会先做源级合法性保护。
+ *
+ * Logger auto-detection must not treat extra call-site arguments as harmless
+ * for brace literals, otherwise unsupported printf-like sources can fall back
+ * to brace plain text and silently drop their arguments.
+ * logger 自动检测不能把多余实参当作 brace 字面量的无害输入，否则不受支持的
+ * printf 风格源串可能回退成 brace 纯文本并静默丢弃实参。
  */
 template <Print::Text Source, typename... Args>
 [[nodiscard]] consteval bool FormatMatches()

--- a/test/test_print.cpp
+++ b/test/test_print.cpp
@@ -15,7 +15,9 @@
 static_assert(LibXR::Format<"abc">::ArgumentCount() == 0);
 static_assert(LibXR::Format<"{1} {0}">::ArgumentCount() == 2);
 static_assert(LibXR::Format<"{:d} {}">::template Matches<int, const char*>());
-static_assert(LibXR::Format<"{}">::template Matches<int, int>());
+static_assert(LibXR::Format<"{}">::template Matches<int>());
+static_assert(!LibXR::Format<"{}">::template Matches<int, int>());
+static_assert(!LibXR::Format<"abc">::template Matches<int>());
 static_assert(!LibXR::Format<"{:d} {}">::template Matches<const char*, int>());
 
 using LoggerFrontend = LibXR::Detail::LoggerLiteral::Frontend;
@@ -27,6 +29,9 @@ static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto
 static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto,
                                                             "logger %d", int>() ==
               LoggerResolution::Printf);
+static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto,
+                                                            "value=%u", unsigned>() ==
+              LoggerResolution::Printf);
 static_assert(
     LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "{{}}">() ==
     LoggerResolution::Format);
@@ -36,6 +41,21 @@ static_assert(
 static_assert(
     LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "plain text">() ==
     LoggerResolution::Format);
+static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto,
+                                                            "plain text", int>() ==
+              LoggerResolution::None);
+static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto,
+                                                            "logger {}", int, int>() ==
+              LoggerResolution::None);
+#if LIBXR_PRINT_INTEGER_ENABLE_64BIT
+static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<
+                  LoggerFrontend::Auto, "frame=%llu", unsigned long long>() ==
+              LoggerResolution::Printf);
+#else
+static_assert(LibXR::Detail::LoggerLiteral::ResolveFrontend<
+                  LoggerFrontend::Auto, "frame=%llu", unsigned long long>() ==
+              LoggerResolution::None);
+#endif
 static_assert(
     LibXR::Detail::LoggerLiteral::ResolveFrontend<LoggerFrontend::Auto, "{} %d", int>() ==
     LoggerResolution::Ambiguous);


### PR DESCRIPTION
## Summary
- make brace-format matching reject extra call-site arguments instead of silently ignoring them
- keep logger auto-detection from falling back to brace plain text for unsupported printf-style literals with arguments
- make printf LowerRule warning-clean under -Wswitch/-Werror=switch

## Validation
- Ubuntu24: default configure/build PASS
- Ubuntu24: LIBXR_TEST_BUILD=True configure/build/ctest PASS
- Ubuntu24: LIBXR_TEST_BUILD=True with -Wswitch -Werror=switch build PASS
- Ubuntu24: default and 64-bit logger frontend probes PASS
- Ubuntu24: tools/format_driver_src.sh --check PASS
- Ubuntu24: tools/format_cmake_files.sh --check PASS
- Ubuntu24: test/test_print.cpp clang-format 21.1.8 check PASS

Artifact: /home/xiao/runs/libxr_print_logger_autodetect_fix_20260429T000616Z/99_final_summary.txt

## Summary by Sourcery

Enforce stricter argument count validation for brace-style format strings and logger frontend auto-detection, and align printf lowering with compiler switch warnings.

Bug Fixes:
- Reject extra or missing call-site arguments for brace-format strings instead of accepting mismatched argument lists.
- Prevent logger frontend auto-detection from treating unsupported printf-style literals with arguments as brace plain text, avoiding silent argument drops.
- Suppress -Wswitch/-Werror=switch warnings in the printf lowering logic by handling previously unhandled value kinds.

Tests:
- Extend print and logger-related static assertions to cover argument count mismatches and logger auto-detection behavior across 32-bit and 64-bit configurations.