### PR TITLE
feat(usb): expose WinUSB descriptors for DFU

### DIFF
--- a/driver/ch/ch32_usb_otgfs.cpp
+++ b/driver/ch/ch32_usb_otgfs.cpp
@@ -13,9 +13,9 @@ using namespace LibXR::USB;
 namespace
 {
 
-constexpr uint8_t kOtgFsClearableMask = USBFS_UIF_FIFO_OV | USBFS_UIF_HST_SOF |
-                                        USBFS_UIF_SUSPEND | USBFS_UIF_TRANSFER |
-                                        USBFS_UIF_DETECT | USBFS_UIF_BUS_RST;
+constexpr uint8_t OTG_FS_CLEARABLE_MASK = USBFS_UIF_FIFO_OV | USBFS_UIF_HST_SOF |
+                                          USBFS_UIF_SUSPEND | USBFS_UIF_TRANSFER |
+                                          USBFS_UIF_DETECT | USBFS_UIF_BUS_RST;
 
 static void ClearPendingOtgFsInterrupts()
 {
@@ -24,7 +24,7 @@ static void ClearPendingOtgFsInterrupts()
     const uint16_t INTFGST = *reinterpret_cast<volatile uint16_t*>(
         reinterpret_cast<uintptr_t>(&USBFSD->INT_FG));
     const uint8_t INTFLAG = static_cast<uint8_t>(INTFGST & 0x00FFu);
-    const uint8_t PENDING = static_cast<uint8_t>(INTFLAG & kOtgFsClearableMask);
+    const uint8_t PENDING = static_cast<uint8_t>(INTFLAG & OTG_FS_CLEARABLE_MASK);
     if (PENDING == 0u)
     {
       break;
@@ -74,7 +74,7 @@ extern "C" __attribute__((interrupt("WCH-Interrupt-fast"))) void USBFS_IRQHandle
     const uint8_t INTFLAG = static_cast<uint8_t>(INTFGST & 0x00FFu);
     const uint8_t INTST = static_cast<uint8_t>((INTFGST >> 8) & 0x00FFu);
 
-    const uint8_t PENDING = static_cast<uint8_t>(INTFLAG & kOtgFsClearableMask);
+    const uint8_t PENDING = static_cast<uint8_t>(INTFLAG & OTG_FS_CLEARABLE_MASK);
     if (PENDING == 0)
     {
       break;

--- a/driver/esp/esp_adc.cpp
+++ b/driver/esp/esp_adc.cpp
@@ -38,7 +38,7 @@ namespace LibXR
 namespace
 {
 
-constexpr uint32_t kDefaultLineFittingVrefMv = 1100U;
+constexpr uint32_t DEFAULT_LINE_FITTING_VREF_MV = 1100U;
 
 }  // namespace
 
@@ -92,7 +92,7 @@ ESP32ADC::ESP32ADC(adc_unit_t unit, const adc_channel_t* channels, uint8_t num_c
 
   for (uint8_t i = 0; i < SOC_ADC_MAX_CHANNEL_NUM; ++i)
   {
-    channel_idx_map_[i] = kInvalidChannelIdx;
+    channel_idx_map_[i] = INVALID_CHANNEL_IDX;
     cali_handles_[i] = nullptr;
   }
 
@@ -100,8 +100,8 @@ ESP32ADC::ESP32ADC(adc_unit_t unit, const adc_channel_t* channels, uint8_t num_c
   {
     ASSERT(IsValidChannel(channels[i]));
     const uint8_t ch = static_cast<uint8_t>(channels[i]);
-    ASSERT(channel_idx_map_[ch] == kInvalidChannelIdx);
-    if (!IsValidChannel(channels[i]) || (channel_idx_map_[ch] != kInvalidChannelIdx))
+    ASSERT(channel_idx_map_[ch] == INVALID_CHANNEL_IDX);
+    if (!IsValidChannel(channels[i]) || (channel_idx_map_[ch] != INVALID_CHANNEL_IDX))
     {
       return;
     }
@@ -301,7 +301,7 @@ bool ESP32ADC::InitCalibration()
   config.atten = attenuation_;
   config.bitwidth = bitwidth_;
 #if CONFIG_IDF_TARGET_ESP32
-  config.default_vref = kDefaultLineFittingVrefMv;
+  config.default_vref = DEFAULT_LINE_FITTING_VREF_MV;
 #endif
 
   adc_cali_handle_t handle = nullptr;

--- a/driver/esp/esp_adc.hpp
+++ b/driver/esp/esp_adc.hpp
@@ -99,7 +99,7 @@ class ESP32ADC
   adc_bitwidth_t bitwidth_;
   float reference_voltage_;
   uint16_t max_raw_;
-  static constexpr uint8_t kInvalidChannelIdx = 0xFFU;
+  static constexpr uint8_t INVALID_CHANNEL_IDX = 0xFFU;
 
   Backend backend_ = Backend::NONE;
   adc_oneshot_hal_ctx_t* oneshot_hal_ = nullptr;

--- a/driver/esp/esp_adc_continuous.cpp
+++ b/driver/esp/esp_adc_continuous.cpp
@@ -89,7 +89,7 @@ void ESP32ADC::DrainContinuousFrames(uint32_t timeout_ms)
       }
 
       const uint8_t sample_idx = channel_idx_map_[sample_channel];
-      if ((sample_idx == kInvalidChannelIdx) || (sample_idx >= num_channels_))
+      if ((sample_idx == INVALID_CHANNEL_IDX) || (sample_idx >= num_channels_))
       {
         continue;
       }

--- a/driver/esp/esp_cdc_jtag.cpp
+++ b/driver/esp/esp_cdc_jtag.cpp
@@ -14,9 +14,9 @@
 
 namespace
 {
-constexpr uint32_t kTxIntrMask = USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY;
-constexpr uint32_t kRxIntrMask = USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT;
-constexpr uint32_t kAllIntrMask = kTxIntrMask | kRxIntrMask;
+constexpr uint32_t TX_INTR_MASK = USB_SERIAL_JTAG_INTR_SERIAL_IN_EMPTY;
+constexpr uint32_t RX_INTR_MASK = USB_SERIAL_JTAG_INTR_SERIAL_OUT_RECV_PKT;
+constexpr uint32_t ALL_INTR_MASK = TX_INTR_MASK | RX_INTR_MASK;
 }  // namespace
 
 namespace LibXR
@@ -81,8 +81,8 @@ ErrorCode ESP32CDCJtag::InitHardware()
     return ErrorCode::INIT_ERR;
   }
 
-  usb_serial_jtag_ll_clr_intsts_mask(kAllIntrMask);
-  usb_serial_jtag_ll_ena_intr_mask(kRxIntrMask);
+  usb_serial_jtag_ll_clr_intsts_mask(ALL_INTR_MASK);
+  usb_serial_jtag_ll_ena_intr_mask(RX_INTR_MASK);
 
   hw_inited_ = true;
   return ErrorCode::OK;
@@ -276,7 +276,7 @@ bool IRAM_ATTR ESP32CDCJtag::StartActiveTransfer(bool in_isr)
   }
 
   tx_active_offset_ = 0;
-  usb_serial_jtag_ll_ena_intr_mask(kTxIntrMask);
+  usb_serial_jtag_ll_ena_intr_mask(TX_INTR_MASK);
   (void)PumpTx(in_isr);
   return true;
 }
@@ -302,7 +302,7 @@ bool IRAM_ATTR ESP32CDCJtag::StartAndReportActive(bool in_isr)
 void IRAM_ATTR ESP32CDCJtag::StopTxTransfer()
 {
   usb_serial_jtag_ll_txfifo_flush();
-  usb_serial_jtag_ll_disable_intr_mask(kTxIntrMask);
+  usb_serial_jtag_ll_disable_intr_mask(TX_INTR_MASK);
 }
 
 void IRAM_ATTR ESP32CDCJtag::OnTxTransferDone(bool in_isr, ErrorCode result)
@@ -396,7 +396,7 @@ void IRAM_ATTR ESP32CDCJtag::HandleInterrupt()
 {
   const uint32_t status = usb_serial_jtag_ll_get_intsts_mask();
 
-  const uint32_t rx_status = status & kRxIntrMask;
+  const uint32_t rx_status = status & RX_INTR_MASK;
   if (rx_status != 0U)
   {
     usb_serial_jtag_ll_clr_intsts_mask(rx_status);
@@ -409,7 +409,7 @@ void IRAM_ATTR ESP32CDCJtag::HandleInterrupt()
     }
   }
 
-  const uint32_t tx_status = status & kTxIntrMask;
+  const uint32_t tx_status = status & TX_INTR_MASK;
   if (tx_status == 0U)
   {
     return;

--- a/driver/esp/esp_dac.hpp
+++ b/driver/esp/esp_dac.hpp
@@ -59,12 +59,12 @@ class ESP32DAC : public DAC
       voltage = reference_voltage_;
     }
 
-    constexpr uint32_t kMaxCode = (1U << SOC_DAC_RESOLUTION) - 1U;
-    const float scale = static_cast<float>(kMaxCode) / reference_voltage_;
+    constexpr uint32_t MAX_CODE = (1U << SOC_DAC_RESOLUTION) - 1U;
+    const float scale = static_cast<float>(MAX_CODE) / reference_voltage_;
     uint32_t code = static_cast<uint32_t>((voltage * scale) + 0.5f);
-    if (code > kMaxCode)
+    if (code > MAX_CODE)
     {
-      code = kMaxCode;
+      code = MAX_CODE;
     }
 
     dac_ll_update_output_value(ToChannel(channel_id_), static_cast<uint8_t>(code));

--- a/driver/esp/esp_i2c.cpp
+++ b/driver/esp/esp_i2c.cpp
@@ -15,10 +15,10 @@ namespace LibXR
 namespace
 {
 
-constexpr uint8_t kAckValue = I2C_MASTER_ACK;
-constexpr uint8_t kNackValue = I2C_MASTER_NACK;
-constexpr uint8_t kCheckAck = 1U;
-constexpr uint8_t kNoCheckAck = 0U;
+constexpr uint8_t ACK_VALUE = I2C_MASTER_ACK;
+constexpr uint8_t NACK_VALUE = I2C_MASTER_NACK;
+constexpr uint8_t CHECK_ACK = 1U;
+constexpr uint8_t NO_CHECK_ACK = 0U;
 
 uint64_t ToTimeoutUs(uint32_t timeout_ms)
 {
@@ -153,7 +153,7 @@ ESP32I2C::ESP32I2C(i2c_port_t port_num, int scl_pin, int sda_pin, uint32_t clock
   ASSERT(GPIO_IS_VALID_OUTPUT_GPIO(static_cast<gpio_num_t>(scl_pin_)));
   ASSERT(GPIO_IS_VALID_OUTPUT_GPIO(static_cast<gpio_num_t>(sda_pin_)));
   ASSERT(config_.clock_speed > 0U);
-  ASSERT(kFifoLen > 2U);
+  ASSERT(FIFO_LEN > 2U);
 
   if (InitHardware() != ErrorCode::OK)
   {
@@ -474,7 +474,7 @@ ErrorCode ESP32I2C::KickAsyncTransaction()
       static_cast<uint8_t>((async_slave_addr_ << 1U) | I2C_MASTER_WRITE);
   const uint8_t read_addr =
       static_cast<uint8_t>((async_slave_addr_ << 1U) | I2C_MASTER_READ);
-  const size_t fifo_len = kFifoLen;
+  const size_t fifo_len = FIFO_LEN;
   const size_t write_chunk_cap = (fifo_len > 1U) ? (fifo_len - 1U) : 0U;
   ASSERT(write_chunk_cap > 0U);
 
@@ -494,11 +494,11 @@ ErrorCode ESP32I2C::KickAsyncTransaction()
     {
       if (!async_write_addr_sent_)
       {
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_RESTART, kAckValue, kAckValue,
-                     kNoCheckAck, 0U);
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_RESTART, ACK_VALUE, ACK_VALUE,
+                     NO_CHECK_ACK, 0U);
         i2c_ll_write_txfifo(hal_.dev, &write_addr, 1U);
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, kAckValue, kAckValue,
-                     kCheckAck, 1U);
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, ACK_VALUE, ACK_VALUE,
+                     CHECK_ACK, 1U);
         async_write_addr_sent_ = true;
       }
 
@@ -511,10 +511,10 @@ ErrorCode ESP32I2C::KickAsyncTransaction()
                             static_cast<uint8_t>(chunk));
         async_write_prefix_offset_ += chunk;
 
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, kAckValue, kAckValue,
-                     kCheckAck, static_cast<uint8_t>(chunk));
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, kAckValue, kAckValue,
-                     kNoCheckAck, 0U);
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, ACK_VALUE, ACK_VALUE,
+                     CHECK_ACK, static_cast<uint8_t>(chunk));
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, ACK_VALUE, ACK_VALUE,
+                     NO_CHECK_ACK, 0U);
       }
       else if (async_write_offset_ < async_write_size_)
       {
@@ -524,20 +524,20 @@ ErrorCode ESP32I2C::KickAsyncTransaction()
                             static_cast<uint8_t>(chunk));
         async_write_offset_ += chunk;
 
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, kAckValue, kAckValue,
-                     kCheckAck, static_cast<uint8_t>(chunk));
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, kAckValue, kAckValue,
-                     kNoCheckAck, 0U);
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, ACK_VALUE, ACK_VALUE,
+                     CHECK_ACK, static_cast<uint8_t>(chunk));
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, ACK_VALUE, ACK_VALUE,
+                     NO_CHECK_ACK, 0U);
       }
       else if (async_read_size_ == 0U)
       {
         if (!async_write_stop_sent_)
         {
-          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_STOP, kAckValue, kAckValue,
-                       kNoCheckAck, 0U);
+          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_STOP, ACK_VALUE, ACK_VALUE,
+                       NO_CHECK_ACK, 0U);
 #if SOC_I2C_STOP_INDEPENDENT
-          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, kAckValue, kAckValue,
-                       kNoCheckAck, 0U);
+          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, ACK_VALUE, ACK_VALUE,
+                       NO_CHECK_ACK, 0U);
 #endif
           async_write_stop_sent_ = true;
         }
@@ -563,11 +563,11 @@ ErrorCode ESP32I2C::KickAsyncTransaction()
     {
       if (!async_read_addr_sent_)
       {
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_RESTART, kAckValue, kAckValue,
-                     kNoCheckAck, 0U);
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_RESTART, ACK_VALUE, ACK_VALUE,
+                     NO_CHECK_ACK, 0U);
         i2c_ll_write_txfifo(hal_.dev, &read_addr, 1U);
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, kAckValue, kAckValue,
-                     kCheckAck, 1U);
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, ACK_VALUE, ACK_VALUE,
+                     CHECK_ACK, 1U);
         async_read_addr_sent_ = true;
       }
 
@@ -578,31 +578,31 @@ ErrorCode ESP32I2C::KickAsyncTransaction()
 
         if (!is_last)
         {
-          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, kAckValue, kAckValue,
-                       kNoCheckAck, static_cast<uint8_t>(chunk));
-          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, kAckValue, kAckValue,
-                       kNoCheckAck, 0U);
+          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, ACK_VALUE, ACK_VALUE,
+                       NO_CHECK_ACK, static_cast<uint8_t>(chunk));
+          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, ACK_VALUE, ACK_VALUE,
+                       NO_CHECK_ACK, 0U);
         }
         else if (chunk == 1U)
         {
-          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, kNackValue, kAckValue,
-                       kNoCheckAck, 1U);
+          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, NACK_VALUE, ACK_VALUE,
+                       NO_CHECK_ACK, 1U);
         }
         else
         {
-          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, kAckValue, kAckValue,
-                       kNoCheckAck, static_cast<uint8_t>(chunk - 1U));
-          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, kNackValue, kAckValue,
-                       kNoCheckAck, 1U);
+          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, ACK_VALUE, ACK_VALUE,
+                       NO_CHECK_ACK, static_cast<uint8_t>(chunk - 1U));
+          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, NACK_VALUE, ACK_VALUE,
+                       NO_CHECK_ACK, 1U);
         }
 
         if (is_last)
         {
-          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_STOP, kAckValue, kAckValue,
-                       kNoCheckAck, 0U);
+          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_STOP, ACK_VALUE, ACK_VALUE,
+                       NO_CHECK_ACK, 0U);
 #if SOC_I2C_STOP_INDEPENDENT
-          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, kAckValue, kAckValue,
-                       kNoCheckAck, 0U);
+          WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, ACK_VALUE, ACK_VALUE,
+                       NO_CHECK_ACK, 0U);
 #endif
         }
 
@@ -791,7 +791,7 @@ ErrorCode ESP32I2C::ExecuteTransaction(uint16_t slave_addr, const uint8_t* write
   const uint64_t timeout_us = ToTimeoutUs(timeout_ms_);
   const uint8_t write_addr = static_cast<uint8_t>((slave_addr << 1U) | I2C_MASTER_WRITE);
   const uint8_t read_addr = static_cast<uint8_t>((slave_addr << 1U) | I2C_MASTER_READ);
-  const size_t fifo_len = kFifoLen;
+  const size_t fifo_len = FIFO_LEN;
   const size_t write_chunk_cap = (fifo_len > 1U) ? (fifo_len - 1U) : 0U;
   ASSERT(write_chunk_cap > 0U);
 
@@ -802,11 +802,11 @@ ErrorCode ESP32I2C::ExecuteTransaction(uint16_t slave_addr, const uint8_t* write
 
   if ((write_size > 0U) || (read_size == 0U))
   {
-    WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_RESTART, kAckValue, kAckValue,
-                 kNoCheckAck, 0U);
+    WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_RESTART, ACK_VALUE, ACK_VALUE,
+                 NO_CHECK_ACK, 0U);
 
     i2c_ll_write_txfifo(hal_.dev, &write_addr, 1U);
-    WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, kAckValue, kAckValue, kCheckAck,
+    WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, ACK_VALUE, ACK_VALUE, CHECK_ACK,
                  1U);
 
     size_t write_offset = 0U;
@@ -818,10 +818,10 @@ ErrorCode ESP32I2C::ExecuteTransaction(uint16_t slave_addr, const uint8_t* write
                           static_cast<uint8_t>(chunk));
       write_offset += chunk;
 
-      WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, kAckValue, kAckValue, kCheckAck,
+      WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, ACK_VALUE, ACK_VALUE, CHECK_ACK,
                    static_cast<uint8_t>(chunk));
-      WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, kAckValue, kAckValue, kNoCheckAck,
-                   0U);
+      WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, ACK_VALUE, ACK_VALUE,
+                   NO_CHECK_ACK, 0U);
 
       const ErrorCode ec = start_and_wait(cmd_idx - 1);
       if (ec != ErrorCode::OK)
@@ -836,11 +836,11 @@ ErrorCode ESP32I2C::ExecuteTransaction(uint16_t slave_addr, const uint8_t* write
     {
       if (read_size == 0U)
       {
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_STOP, kAckValue, kAckValue,
-                     kNoCheckAck, 0U);
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_STOP, ACK_VALUE, ACK_VALUE,
+                     NO_CHECK_ACK, 0U);
 #if SOC_I2C_STOP_INDEPENDENT
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, kAckValue, kAckValue,
-                     kNoCheckAck, 0U);
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, ACK_VALUE, ACK_VALUE,
+                     NO_CHECK_ACK, 0U);
 #endif
       }
       const ErrorCode ec = start_and_wait(cmd_idx - 1);
@@ -853,11 +853,11 @@ ErrorCode ESP32I2C::ExecuteTransaction(uint16_t slave_addr, const uint8_t* write
     }
     else if (read_size == 0U)
     {
-      WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_STOP, kAckValue, kAckValue,
-                   kNoCheckAck, 0U);
+      WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_STOP, ACK_VALUE, ACK_VALUE,
+                   NO_CHECK_ACK, 0U);
 #if SOC_I2C_STOP_INDEPENDENT
-      WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, kAckValue, kAckValue, kNoCheckAck,
-                   0U);
+      WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, ACK_VALUE, ACK_VALUE,
+                   NO_CHECK_ACK, 0U);
 #endif
       const ErrorCode ec = start_and_wait(cmd_idx - 1);
       if (ec != ErrorCode::OK)
@@ -871,10 +871,10 @@ ErrorCode ESP32I2C::ExecuteTransaction(uint16_t slave_addr, const uint8_t* write
 
   if (read_size > 0U)
   {
-    WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_RESTART, kAckValue, kAckValue,
-                 kNoCheckAck, 0U);
+    WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_RESTART, ACK_VALUE, ACK_VALUE,
+                 NO_CHECK_ACK, 0U);
     i2c_ll_write_txfifo(hal_.dev, &read_addr, 1U);
-    WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, kAckValue, kAckValue, kCheckAck,
+    WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_WRITE, ACK_VALUE, ACK_VALUE, CHECK_ACK,
                  1U);
 
     size_t read_offset = 0U;
@@ -885,31 +885,31 @@ ErrorCode ESP32I2C::ExecuteTransaction(uint16_t slave_addr, const uint8_t* write
 
       if (!is_last)
       {
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, kAckValue, kAckValue,
-                     kNoCheckAck, static_cast<uint8_t>(chunk));
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, kAckValue, kAckValue,
-                     kNoCheckAck, 0U);
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, ACK_VALUE, ACK_VALUE,
+                     NO_CHECK_ACK, static_cast<uint8_t>(chunk));
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, ACK_VALUE, ACK_VALUE,
+                     NO_CHECK_ACK, 0U);
       }
       else if (chunk == 1U)
       {
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, kNackValue, kAckValue,
-                     kNoCheckAck, 1U);
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, NACK_VALUE, ACK_VALUE,
+                     NO_CHECK_ACK, 1U);
       }
       else
       {
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, kAckValue, kAckValue,
-                     kNoCheckAck, static_cast<uint8_t>(chunk - 1U));
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, kNackValue, kAckValue,
-                     kNoCheckAck, 1U);
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, ACK_VALUE, ACK_VALUE,
+                     NO_CHECK_ACK, static_cast<uint8_t>(chunk - 1U));
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_READ, NACK_VALUE, ACK_VALUE,
+                     NO_CHECK_ACK, 1U);
       }
 
       if (is_last)
       {
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_STOP, kAckValue, kAckValue,
-                     kNoCheckAck, 0U);
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_STOP, ACK_VALUE, ACK_VALUE,
+                     NO_CHECK_ACK, 0U);
 #if SOC_I2C_STOP_INDEPENDENT
-        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, kAckValue, kAckValue,
-                     kNoCheckAck, 0U);
+        WriteCommand(hal_.dev, cmd_idx++, I2C_LL_CMD_END, ACK_VALUE, ACK_VALUE,
+                     NO_CHECK_ACK, 0U);
 #endif
       }
 
@@ -1094,7 +1094,7 @@ ErrorCode ESP32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
   }
 
   const size_t mem_len = MemAddrBytes(mem_addr_size);
-  if (mem_len > kMaxWritePayload)
+  if (mem_len > MAX_WRITE_PAYLOAD)
   {
     return Complete(op, in_isr, ErrorCode::SIZE_ERR);
   }
@@ -1134,8 +1134,8 @@ ErrorCode ESP32I2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
     return ErrorCode::OK;
   }
 
-  std::array<uint8_t, kFifoLen> staging = {};
-  const size_t max_chunk = kMaxWritePayload - mem_len;
+  std::array<uint8_t, FIFO_LEN> staging = {};
+  const size_t max_chunk = MAX_WRITE_PAYLOAD - mem_len;
   auto* src = static_cast<const uint8_t*>(write_data.addr_);
   size_t offset = 0U;
   ErrorCode ans = ErrorCode::OK;
@@ -1186,7 +1186,7 @@ ErrorCode ESP32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read
   }
 
   const size_t mem_len = MemAddrBytes(mem_addr_size);
-  if (mem_len > kMaxWriteReadPrefix)
+  if (mem_len > MAX_WRITE_READ_PREFIX)
   {
     return Complete(op, in_isr, ErrorCode::SIZE_ERR);
   }
@@ -1231,7 +1231,7 @@ ErrorCode ESP32I2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read
 
   while (offset < read_data.size_)
   {
-    const size_t chunk = std::min(read_data.size_ - offset, kMaxReadPayload);
+    const size_t chunk = std::min(read_data.size_ - offset, MAX_READ_PAYLOAD);
     const uint16_t cur_mem = static_cast<uint16_t>(mem_addr + offset);
     EncodeMemAddr(cur_mem, mem_len, mem_raw.data());
 

--- a/driver/esp/esp_i2c.hpp
+++ b/driver/esp/esp_i2c.hpp
@@ -49,11 +49,11 @@ class ESP32I2C : public I2C
   i2c_port_t Port() const { return port_num_; }
 
  private:
-  static constexpr size_t kFifoLen = SOC_I2C_FIFO_LEN;
-  static constexpr size_t kMaxWritePayload = (kFifoLen > 4U) ? (kFifoLen - 4U) : 0U;
-  static constexpr size_t kMaxWriteReadPrefix =
-      (kFifoLen > 5U) ? (kFifoLen - 5U) : 0U;
-  static constexpr size_t kMaxReadPayload = (kFifoLen > 4U) ? (kFifoLen - 4U) : kFifoLen;
+  static constexpr size_t FIFO_LEN = SOC_I2C_FIFO_LEN;
+  static constexpr size_t MAX_WRITE_PAYLOAD = (FIFO_LEN > 4U) ? (FIFO_LEN - 4U) : 0U;
+  static constexpr size_t MAX_WRITE_READ_PREFIX =
+      (FIFO_LEN > 5U) ? (FIFO_LEN - 5U) : 0U;
+  static constexpr size_t MAX_READ_PAYLOAD = (FIFO_LEN > 4U) ? (FIFO_LEN - 4U) : FIFO_LEN;
 
   bool Acquire();
   void Release();

--- a/driver/esp/esp_spi.cpp
+++ b/driver/esp/esp_spi.cpp
@@ -81,9 +81,9 @@ esp_err_t DmaStart(spi_dma_chan_handle_t chan, const void* desc)
 #if SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE || SOC_PSRAM_DMA_CAPABLE
 extern "C" esp_err_t esp_cache_msync(void* addr, size_t size, int flags);
 
-constexpr int kCacheSyncFlagUnaligned = (1 << 1);
-constexpr int kCacheSyncFlagDirC2M = (1 << 2);
-constexpr int kCacheSyncFlagDirM2C = (1 << 3);
+constexpr int CACHE_SYNC_FLAG_UNALIGNED = (1 << 1);
+constexpr int CACHE_SYNC_FLAG_DIR_C2M = (1 << 2);
+constexpr int CACHE_SYNC_FLAG_DIR_M2C = (1 << 3);
 
 bool CacheSyncDmaBuffer(const void* addr, size_t size, bool cache_to_mem)
 {
@@ -99,8 +99,8 @@ bool CacheSyncDmaBuffer(const void* addr, size_t size, bool cache_to_mem)
   }
 #endif
 
-  int flags = cache_to_mem ? kCacheSyncFlagDirC2M : kCacheSyncFlagDirM2C;
-  flags |= kCacheSyncFlagUnaligned;
+  int flags = cache_to_mem ? CACHE_SYNC_FLAG_DIR_C2M : CACHE_SYNC_FLAG_DIR_M2C;
+  flags |= CACHE_SYNC_FLAG_UNALIGNED;
 
   const esp_err_t ret = esp_cache_msync(const_cast<void*>(addr), size, flags);
   // Non-cacheable regions can return ESP_ERR_INVALID_ARG; treat as no-op success.
@@ -337,7 +337,7 @@ ErrorCode ESP32SPI::InitDmaBackend()
   dma_enabled_ = true;
   dma_max_transfer_bytes_ =
       std::min<size_t>({static_cast<size_t>(actual_max_size), dma_rx_raw_.size_,
-                        dma_tx_raw_.size_, kMaxDmaTransferBytes});
+                        dma_tx_raw_.size_, MAX_DMA_TRANSFER_BYTES});
 
   if (dma_max_transfer_bytes_ == 0U)
   {
@@ -583,14 +583,14 @@ ErrorCode ESP32SPI::ReturnAsyncStartResult(ErrorCode ec, bool started)
 
 void ESP32SPI::ConfigureTransferRegisters(size_t size)
 {
-  static constexpr spi_line_mode_t kLineMode = {
+  static constexpr spi_line_mode_t LINE_MODE = {
       .cmd_lines = 1,
       .addr_lines = 1,
       .data_lines = 1,
   };
   const size_t bitlen = size * 8U;
 
-  spi_ll_master_set_line_mode(hw_, kLineMode);
+  spi_ll_master_set_line_mode(hw_, LINE_MODE);
   spi_ll_set_mosi_bitlen(hw_, bitlen);
   spi_ll_set_miso_bitlen(hw_, bitlen);
   spi_ll_set_command_bitlen(hw_, 0);
@@ -700,13 +700,13 @@ ErrorCode ESP32SPI::StartAsyncTransfer(const uint8_t* tx, uint8_t* rx, size_t si
 ErrorCode ESP32SPI::ExecuteChunk(const uint8_t* tx, uint8_t* rx, size_t size,
                                  bool enable_rx)
 {
-  if ((size == 0U) || (size > kMaxPollingTransferBytes))
+  if ((size == 0U) || (size > MAX_POLLING_TRANSFER_BYTES))
   {
     return ErrorCode::SIZE_ERR;
   }
 
-  static constexpr std::array<uint8_t, kMaxPollingTransferBytes> kZero = {};
-  const uint8_t* tx_data = (tx != nullptr) ? tx : kZero.data();
+  static constexpr std::array<uint8_t, MAX_POLLING_TRANSFER_BYTES> ZERO = {};
+  const uint8_t* tx_data = (tx != nullptr) ? tx : ZERO.data();
 
   ConfigureTransferRegisters(size);
   spi_ll_enable_mosi(hw_, 1);
@@ -741,7 +741,7 @@ ErrorCode ESP32SPI::ExecuteTransfer(const uint8_t* tx, uint8_t* rx, size_t size,
   while (offset < size)
   {
     const size_t remain = size - offset;
-    const size_t chunk = std::min(remain, kMaxPollingTransferBytes);
+    const size_t chunk = std::min(remain, MAX_POLLING_TRANSFER_BYTES);
     const uint8_t* tx_chunk = (tx != nullptr) ? (tx + offset) : nullptr;
     uint8_t* rx_chunk = (enable_rx && (rx != nullptr)) ? (rx + offset) : nullptr;
 

--- a/driver/esp/esp_spi.hpp
+++ b/driver/esp/esp_spi.hpp
@@ -53,8 +53,8 @@ class ESP32SPI : public SPI
   RawData GetTxBuffer();
 
  private:
-  static constexpr size_t kMaxPollingTransferBytes = SOC_SPI_MAXIMUM_BUFFER_SIZE;
-  static constexpr size_t kMaxDmaTransferBytes = SPI_LL_DMA_MAX_BIT_LEN / 8U;
+  static constexpr size_t MAX_POLLING_TRANSFER_BYTES = SOC_SPI_MAXIMUM_BUFFER_SIZE;
+  static constexpr size_t MAX_DMA_TRANSFER_BYTES = SPI_LL_DMA_MAX_BIT_LEN / 8U;
 
   bool Acquire();
 

--- a/driver/esp/esp_uart.cpp
+++ b/driver/esp/esp_uart.cpp
@@ -16,12 +16,12 @@
 
 namespace
 {
-constexpr uint32_t kUartRxIntrMask =
+constexpr uint32_t UART_RX_INTR_MASK =
     UART_INTR_RXFIFO_FULL | UART_INTR_RXFIFO_TOUT | UART_INTR_RXFIFO_OVF;
-constexpr uint32_t kUartTxIntrMask = UART_INTR_TXFIFO_EMPTY;
+constexpr uint32_t UART_TX_INTR_MASK = UART_INTR_TXFIFO_EMPTY;
 
-constexpr uint8_t kRxToutThreshold = 2;
-constexpr uint16_t kTxEmptyThreshold = 24;
+constexpr uint8_t RX_TOUT_THRESHOLD = 2;
+constexpr uint16_t TX_EMPTY_THRESHOLD = 24;
 
 bool IsConsoleUartInUse(uart_port_t uart_num)
 {
@@ -149,9 +149,9 @@ void ESP32UART::ConfigureRxInterruptPath()
       rx_full_ceil, std::max<size_t>(rx_full_floor, rx_isr_buffer_size_ / 16)));
 
   uart_hal_set_rxfifo_full_thr(&uart_hal_, full_thr);
-  uart_hal_set_rx_timeout(&uart_hal_, kRxToutThreshold);
-  uart_hal_clr_intsts_mask(&uart_hal_, kUartRxIntrMask);
-  uart_hal_ena_intr_mask(&uart_hal_, kUartRxIntrMask);
+  uart_hal_set_rx_timeout(&uart_hal_, RX_TOUT_THRESHOLD);
+  uart_hal_clr_intsts_mask(&uart_hal_, UART_RX_INTR_MASK);
+  uart_hal_ena_intr_mask(&uart_hal_, UART_RX_INTR_MASK);
 }
 
 ErrorCode ESP32UART::SetConfig(UART::Configuration config)
@@ -196,7 +196,7 @@ ErrorCode ESP32UART::SetConfig(UART::Configuration config)
   uart_hal_set_parity(&uart_hal_, ResolveParity(config.parity));
   uart_hal_set_hw_flow_ctrl(&uart_hal_, UART_HW_FLOWCTRL_DISABLE, 0);
   uart_hal_set_mode(&uart_hal_, UART_MODE_UART);
-  uart_hal_set_txfifo_empty_thr(&uart_hal_, kTxEmptyThreshold);
+  uart_hal_set_txfifo_empty_thr(&uart_hal_, TX_EMPTY_THRESHOLD);
   // Drop stale hardware RX FIFO bytes from the previous baud.
   // Keep software read queue semantics aligned with ST/CH (no read_port reset).
   uart_hal_rxfifo_rst(&uart_hal_);
@@ -223,8 +223,8 @@ ErrorCode ESP32UART::SetConfig(UART::Configuration config)
     else
 #endif
     {
-      uart_hal_clr_intsts_mask(&uart_hal_, kUartTxIntrMask);
-      uart_hal_ena_intr_mask(&uart_hal_, kUartTxIntrMask);
+      uart_hal_clr_intsts_mask(&uart_hal_, UART_TX_INTR_MASK);
+      uart_hal_ena_intr_mask(&uart_hal_, UART_TX_INTR_MASK);
       FillTxFifo(false);
     }
   }
@@ -563,8 +563,8 @@ bool IRAM_ATTR ESP32UART::StartActiveTransfer(bool)
   }
 #endif
 
-  uart_hal_clr_intsts_mask(&uart_hal_, kUartTxIntrMask);
-  uart_hal_ena_intr_mask(&uart_hal_, kUartTxIntrMask);
+  uart_hal_clr_intsts_mask(&uart_hal_, UART_TX_INTR_MASK);
+  uart_hal_ena_intr_mask(&uart_hal_, UART_TX_INTR_MASK);
   FillTxFifo(false);
 
   return true;

--- a/driver/esp/esp_uart_dma.cpp
+++ b/driver/esp/esp_uart_dma.cpp
@@ -17,8 +17,8 @@ namespace
 {
 // RX uses a circular DMA descriptor ring, similar to STM/CH circular RX DMA
 // behavior (continuous receive + software consumer index).
-constexpr uint32_t kDmaRxNodeCount = 8;
-constexpr size_t kDmaMaxBufferSizePerLinkItem = 4095U;
+constexpr uint32_t DMA_RX_NODE_COUNT = 8;
+constexpr size_t DMA_MAX_BUFFER_SIZE_PER_LINK_ITEM = 4095U;
 
 struct GdmaLinkItem
 {
@@ -36,8 +36,8 @@ struct GdmaLinkItem
   GdmaLinkItem* next;
 };
 
-constexpr uint32_t kGdmaOwnerCpu = 0U;
-constexpr uint32_t kGdmaOwnerDma = 1U;
+constexpr uint32_t GDMA_OWNER_CPU = 0U;
+constexpr uint32_t GDMA_OWNER_DMA = 1U;
 
 size_t AlignUp(size_t value, size_t align)
 {
@@ -65,9 +65,9 @@ GdmaLinkItem* LinkItemFromHeadAddr(uintptr_t head_addr)
 #if SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE || SOC_PSRAM_DMA_CAPABLE
 extern "C" esp_err_t esp_cache_msync(void* addr, size_t size, int flags);
 
-constexpr int kCacheSyncFlagUnaligned = (1 << 1);
-constexpr int kCacheSyncFlagDirC2M = (1 << 2);
-constexpr int kCacheSyncFlagDirM2C = (1 << 3);
+constexpr int CACHE_SYNC_FLAG_UNALIGNED = (1 << 1);
+constexpr int CACHE_SYNC_FLAG_DIR_C2M = (1 << 2);
+constexpr int CACHE_SYNC_FLAG_DIR_M2C = (1 << 3);
 
 bool CacheSyncDmaBuffer(const void* addr, size_t size, bool cache_to_mem)
 {
@@ -83,8 +83,8 @@ bool CacheSyncDmaBuffer(const void* addr, size_t size, bool cache_to_mem)
   }
 #endif
 
-  int flags = cache_to_mem ? kCacheSyncFlagDirC2M : kCacheSyncFlagDirM2C;
-  flags |= kCacheSyncFlagUnaligned;
+  int flags = cache_to_mem ? CACHE_SYNC_FLAG_DIR_C2M : CACHE_SYNC_FLAG_DIR_M2C;
+  flags |= CACHE_SYNC_FLAG_UNALIGNED;
 
   const esp_err_t ret = esp_cache_msync(const_cast<void*>(addr), size, flags);
   // Non-cacheable regions can return ESP_ERR_INVALID_ARG; treat as no-op success.
@@ -282,7 +282,7 @@ ErrorCode ESP32UART::InitDmaBackend()
   rx_dma_alignment_ = std::max<size_t>(1, std::max(rx_int_alignment, rx_ext_alignment));
 
   gdma_link_list_config_t rx_link_cfg = {
-      .num_items = kDmaRxNodeCount,
+      .num_items = DMA_RX_NODE_COUNT,
       .item_alignment = 4,
       .flags = {},
   };
@@ -292,10 +292,10 @@ ErrorCode ESP32UART::InitDmaBackend()
   }
 
   // Keep one ring window reasonably large to lower ISR pressure at high baud.
-  const size_t rx_chunk_target =
-      std::min<size_t>(std::max<size_t>(32, rx_isr_buffer_size_ / kDmaRxNodeCount), 512);
+  const size_t rx_chunk_target = std::min<size_t>(
+      std::max<size_t>(32, rx_isr_buffer_size_ / DMA_RX_NODE_COUNT), 512);
   rx_dma_chunk_size_ = std::max<size_t>(AlignUp(rx_chunk_target, 4), 32);
-  rx_dma_node_count_ = kDmaRxNodeCount;
+  rx_dma_node_count_ = DMA_RX_NODE_COUNT;
   const size_t rx_storage_alignment = std::max<size_t>(4, rx_dma_alignment_);
   const size_t rx_storage_bytes =
       AlignUp(rx_dma_chunk_size_ * rx_dma_node_count_, rx_storage_alignment);
@@ -308,8 +308,8 @@ ErrorCode ESP32UART::InitDmaBackend()
     return ErrorCode::NO_MEM;
   }
 
-  std::array<gdma_buffer_mount_config_t, kDmaRxNodeCount> rx_mount = {};
-  for (uint32_t i = 0; i < kDmaRxNodeCount; ++i)
+  std::array<gdma_buffer_mount_config_t, DMA_RX_NODE_COUNT> rx_mount = {};
+  for (uint32_t i = 0; i < DMA_RX_NODE_COUNT; ++i)
   {
     rx_mount[i] = gdma_buffer_mount_config_t{
         .buffer = rx_dma_storage_ + (static_cast<size_t>(i) * rx_dma_chunk_size_),
@@ -324,7 +324,7 @@ ErrorCode ESP32UART::InitDmaBackend()
     };
   }
 
-  if (gdma_link_mount_buffers(rx_dma_link_, 0, rx_mount.data(), kDmaRxNodeCount,
+  if (gdma_link_mount_buffers(rx_dma_link_, 0, rx_mount.data(), DMA_RX_NODE_COUNT,
                               nullptr) != ESP_OK)
   {
     return ErrorCode::INIT_ERR;
@@ -365,7 +365,7 @@ bool IRAM_ATTR ESP32UART::StartDmaTx()
   uint8_t* const active_buffer = tx_active_buffer_;
   const size_t active_len = tx_active_length_;
   if ((active_buffer == nullptr) || (active_len == 0) ||
-      (active_len > kDmaMaxBufferSizePerLinkItem))
+      (active_len > DMA_MAX_BUFFER_SIZE_PER_LINK_ITEM))
   {
     return false;
   }
@@ -401,7 +401,7 @@ bool IRAM_ATTR ESP32UART::StartDmaTx()
   desc->dw0.length = static_cast<uint32_t>(active_len);
   desc->dw0.err_eof = 0U;
   desc->dw0.suc_eof = 1U;
-  desc->dw0.owner = kGdmaOwnerDma;
+  desc->dw0.owner = GDMA_OWNER_DMA;
   desc->next = nullptr;
   std::atomic_thread_fence(std::memory_order_release);
 

--- a/driver/esp/esp_uart_fifo.cpp
+++ b/driver/esp/esp_uart_fifo.cpp
@@ -6,9 +6,9 @@
 
 namespace
 {
-constexpr uint32_t kUartRxIntrMask =
+constexpr uint32_t UART_RX_INTR_MASK =
     UART_INTR_RXFIFO_FULL | UART_INTR_RXFIFO_TOUT | UART_INTR_RXFIFO_OVF;
-constexpr uint32_t kUartTxIntrMask = UART_INTR_TXFIFO_EMPTY;
+constexpr uint32_t UART_TX_INTR_MASK = UART_INTR_TXFIFO_EMPTY;
 }  // namespace
 
 namespace LibXR
@@ -33,12 +33,12 @@ ErrorCode ESP32UART::InstallUartIsr()
 #if CONFIG_IDF_TARGET_ESP32 || CONFIG_IDF_TARGET_ESP32S3
   // Classic ESP32/S3 can enter cache-disabled flash windows while UART IRQ is active.
   // The current WritePort path is not fully IRAM-safe, so keep this IRQ non-IRAM.
-  constexpr int kUartIntrFlags = 0;
+  constexpr int UART_INTR_FLAGS = 0;
 #else
-  constexpr int kUartIntrFlags = ESP_INTR_FLAG_IRAM;
+  constexpr int UART_INTR_FLAGS = ESP_INTR_FLAG_IRAM;
 #endif
 
-  const esp_err_t err = esp_intr_alloc(uart_periph_signal[uart_num_].irq, kUartIntrFlags,
+  const esp_err_t err = esp_intr_alloc(uart_periph_signal[uart_num_].irq, UART_INTR_FLAGS,
                                        UartIsrEntry, this, &uart_intr_handle_);
   if (err != ESP_OK)
   {
@@ -204,12 +204,12 @@ void IRAM_ATTR ESP32UART::HandleUartInterrupt()
 
   while (uart_intr_status != 0)
   {
-    if (uart_intr_status & kUartRxIntrMask)
+    if (uart_intr_status & UART_RX_INTR_MASK)
     {
       HandleRxInterrupt(uart_intr_status);
     }
 
-    if (uart_intr_status & kUartTxIntrMask)
+    if (uart_intr_status & UART_TX_INTR_MASK)
     {
       HandleTxInterrupt(uart_intr_status);
     }

--- a/driver/esp/esp_usb.cpp
+++ b/driver/esp/esp_usb.cpp
@@ -17,9 +17,9 @@ namespace LibXR::ESPUSBDetail
 #if SOC_CACHE_INTERNAL_MEM_VIA_L1CACHE || SOC_PSRAM_DMA_CAPABLE
 extern "C" esp_err_t esp_cache_msync(void* addr, size_t size, int flags);
 
-constexpr int kCacheSyncFlagUnaligned = (1 << 1);
-constexpr int kCacheSyncFlagDirC2M = (1 << 2);
-constexpr int kCacheSyncFlagDirM2C = (1 << 3);
+constexpr int CACHE_SYNC_FLAG_UNALIGNED = (1 << 1);
+constexpr int CACHE_SYNC_FLAG_DIR_C2M = (1 << 2);
+constexpr int CACHE_SYNC_FLAG_DIR_M2C = (1 << 3);
 
 bool CacheSyncDmaBuffer(const void* addr, size_t size, bool cache_to_mem,
                         bool allow_unaligned)
@@ -39,10 +39,10 @@ bool CacheSyncDmaBuffer(const void* addr, size_t size, bool cache_to_mem,
     return true;
   }
 
-  int flags = cache_to_mem ? kCacheSyncFlagDirC2M : kCacheSyncFlagDirM2C;
+  int flags = cache_to_mem ? CACHE_SYNC_FLAG_DIR_C2M : CACHE_SYNC_FLAG_DIR_M2C;
   if (allow_unaligned && cache_to_mem)
   {
-    flags |= kCacheSyncFlagUnaligned;
+    flags |= CACHE_SYNC_FLAG_UNALIGNED;
   }
   return esp_cache_msync(const_cast<void*>(addr), size, flags) == ESP_OK;
 }
@@ -63,7 +63,7 @@ esp_dma_mem_info_t UsbDmaMemInfo()
 {
   esp_dma_mem_info_t info = {};
   info.extra_heap_caps = MALLOC_CAP_INTERNAL;
-  info.dma_alignment_bytes = kWordSize;
+  info.dma_alignment_bytes = WORD_SIZE;
   return info;
 }
 
@@ -107,7 +107,7 @@ bool CanUseDirectOutDmaBuffer(const void* ptr, size_t size)
   }
 
   const uintptr_t addr = reinterpret_cast<uintptr_t>(ptr);
-  return ((addr % kUsbDmaAlignment) == 0U) && (AlignUp(size, kUsbDmaAlignment) == size);
+  return ((addr % USB_DMA_ALIGNMENT) == 0U) && (AlignUp(size, USB_DMA_ALIGNMENT) == size);
 }
 
 uint16_t CalcRxFifoWords(uint16_t largest_packet_size, uint8_t ep_count)
@@ -122,14 +122,14 @@ uint16_t CalcConfiguredRxFifoWords(uint16_t largest_packet_size, uint8_t ep_coun
   uint16_t words = CalcRxFifoWords(largest_packet_size, ep_count);
   if (dma_enabled)
   {
-    words = std::max<uint16_t>(words, kEsp32SxFsDmaMinRxFifoWords);
+    words = std::max<uint16_t>(words, ESP32_SX_FS_DMA_MIN_RX_FIFO_WORDS);
   }
   return words;
 }
 
 uint16_t GetHardwareFifoDepthWords()
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(DWC2_FS_REG_BASE);
   return static_cast<uint16_t>(dev->ghwcfg3_reg.dfifodepth);
 }
 
@@ -171,7 +171,7 @@ uint16_t CalcTxFifoWords(uint16_t packet_size, bool dma_enabled)
   uint16_t words = static_cast<uint16_t>((packet_size + 3U) / 4U);
   if (dma_enabled)
   {
-    words = std::max<uint16_t>(words, kEsp32SxFsMinTxFifoWords);
+    words = std::max<uint16_t>(words, ESP32_SX_FS_MIN_TX_FIFO_WORDS);
   }
   return words;
 }
@@ -180,15 +180,15 @@ volatile uint32_t* GetEndpointFifo(usb_dwc_dev_t* dev, uint8_t ep_num)
 {
   uintptr_t base = reinterpret_cast<uintptr_t>(dev);
   return reinterpret_cast<volatile uint32_t*>(
-      base + kFifoBaseOffset + static_cast<uintptr_t>(ep_num) * kFifoStride);
+      base + FIFO_BASE_OFFSET + static_cast<uintptr_t>(ep_num) * FIFO_STRIDE);
 }
 
 void WriteFifoPacket(volatile uint32_t* fifo, const uint8_t* src, size_t size)
 {
-  for (size_t offset = 0; offset < size; offset += kWordSize)
+  for (size_t offset = 0; offset < size; offset += WORD_SIZE)
   {
     uint32_t word = 0U;
-    const size_t chunk = std::min(kWordSize, size - offset);
+    const size_t chunk = std::min(WORD_SIZE, size - offset);
     std::memcpy(&word, src + offset, chunk);
     fifo[0] = word;
   }
@@ -196,10 +196,10 @@ void WriteFifoPacket(volatile uint32_t* fifo, const uint8_t* src, size_t size)
 
 void ReadFifoPacket(const volatile uint32_t* fifo, uint8_t* dst, size_t size)
 {
-  for (size_t offset = 0; offset < size; offset += kWordSize)
+  for (size_t offset = 0; offset < size; offset += WORD_SIZE)
   {
     const uint32_t word = fifo[0];
-    const size_t chunk = std::min(kWordSize, size - offset);
+    const size_t chunk = std::min(WORD_SIZE, size - offset);
     std::memcpy(dst + offset, &word, chunk);
   }
 }

--- a/driver/esp/esp_usb.hpp
+++ b/driver/esp/esp_usb.hpp
@@ -16,34 +16,34 @@
 namespace LibXR::ESPUSBDetail
 {
 
-inline constexpr uint32_t kDwc2FsRegBase = 0x60080000UL;
-inline constexpr size_t kFifoBaseOffset = 0x1000U;
-inline constexpr size_t kFifoStride = 0x1000U;
+inline constexpr uint32_t DWC2_FS_REG_BASE = 0x60080000UL;
+inline constexpr size_t FIFO_BASE_OFFSET = 0x1000U;
+inline constexpr size_t FIFO_STRIDE = 0x1000U;
 
-inline constexpr uint8_t kRxStatusGlobalOutNak = 1U;
-inline constexpr uint8_t kRxStatusData = 2U;
-inline constexpr uint8_t kRxStatusTransferComplete = 3U;
-inline constexpr uint8_t kRxStatusSetupDone = 4U;
-inline constexpr uint8_t kRxStatusSetupData = 6U;
+inline constexpr uint8_t RX_STATUS_GLOBAL_OUT_NAK = 1U;
+inline constexpr uint8_t RX_STATUS_DATA = 2U;
+inline constexpr uint8_t RX_STATUS_TRANSFER_COMPLETE = 3U;
+inline constexpr uint8_t RX_STATUS_SETUP_DONE = 4U;
+inline constexpr uint8_t RX_STATUS_SETUP_DATA = 6U;
 
-inline constexpr uint8_t kEnumSpeedFull30To60Mhz = 1U;
-inline constexpr uint8_t kEnumSpeedFull48Mhz = 3U;
+inline constexpr uint8_t ENUM_SPEED_FULL_30_TO_60_MHZ = 1U;
+inline constexpr uint8_t ENUM_SPEED_FULL_48_MHZ = 3U;
 
-inline constexpr size_t kWordSize = sizeof(uint32_t);
-inline constexpr uint8_t kFlushAllTxFifo = 0x10U;
-inline constexpr uint32_t kDmaBurstIncr4 = 4U;
-inline constexpr uint32_t kDmaMemoryCaps =
+inline constexpr size_t WORD_SIZE = sizeof(uint32_t);
+inline constexpr uint8_t FLUSH_ALL_TX_FIFO = 0x10U;
+inline constexpr uint32_t DMA_BURST_INCR4 = 4U;
+inline constexpr uint32_t DMA_MEMORY_CAPS =
     MALLOC_CAP_INTERNAL | MALLOC_CAP_DMA | MALLOC_CAP_8BIT;
-inline constexpr uint16_t kEsp32SxFsDmaMinRxFifoWords = 88U;
-inline constexpr uint16_t kEsp32SxFsMinTxFifoWords = 16U;
-inline constexpr uint32_t kDisableOutWaitGuard = 100000U;
+inline constexpr uint16_t ESP32_SX_FS_DMA_MIN_RX_FIFO_WORDS = 88U;
+inline constexpr uint16_t ESP32_SX_FS_MIN_TX_FIFO_WORDS = 16U;
+inline constexpr uint32_t DISABLE_OUT_WAIT_GUARD = 100000U;
 
 #if defined(CONFIG_USB_ALIGN_SIZE)
-inline constexpr size_t kUsbDmaAlignment = CONFIG_USB_ALIGN_SIZE;
+inline constexpr size_t USB_DMA_ALIGNMENT = CONFIG_USB_ALIGN_SIZE;
 #elif defined(CONFIG_CACHE_L1_CACHE_LINE_SIZE)
-inline constexpr size_t kUsbDmaAlignment = CONFIG_CACHE_L1_CACHE_LINE_SIZE;
+inline constexpr size_t USB_DMA_ALIGNMENT = CONFIG_CACHE_L1_CACHE_LINE_SIZE;
 #else
-inline constexpr size_t kUsbDmaAlignment = 64U;
+inline constexpr size_t USB_DMA_ALIGNMENT = 64U;
 #endif
 
 constexpr uint32_t PackTxFifoSizeReg(uint16_t start, uint16_t words)
@@ -102,7 +102,7 @@ void DisableOutEndpointAndWait(volatile DoepCtl& ctl)
     return;
   }
 
-  uint32_t guard = kDisableOutWaitGuard;
+  uint32_t guard = DISABLE_OUT_WAIT_GUARD;
   while (ctl.epena && guard > 0U)
   {
     --guard;

--- a/driver/esp/esp_usb_dev.cpp
+++ b/driver/esp/esp_usb_dev.cpp
@@ -33,7 +33,7 @@ ESP32USBDevice::ESP32USBDevice(
       USB::DeviceCore(*this, USB::USBSpec::USB_2_1, USB::Speed::FULL, packet_size, vid,
                       pid, bcd, lang_list, configs, uid)
 {
-  ASSERT(ep_cfgs.size() > 0U && ep_cfgs.size() <= kEndpointCount);
+  ASSERT(ep_cfgs.size() > 0U && ep_cfgs.size() <= ENDPOINT_COUNT);
 
   auto cfg_it = ep_cfgs.begin();
 
@@ -50,7 +50,7 @@ ESP32USBDevice::ESP32USBDevice(
   for (++cfg_it; cfg_it != ep_cfgs.end();
        ++cfg_it, ep_num = USB::Endpoint::NextEPNumber(ep_num))
   {
-    ASSERT(USB::Endpoint::EPNumberToInt8(ep_num) < kEndpointCount);
+    ASSERT(USB::Endpoint::EPNumberToInt8(ep_num) < ENDPOINT_COUNT);
 
     if (cfg_it->direction_hint == EPConfig::DirectionHint::BothDirections)
     {
@@ -94,7 +94,7 @@ ErrorCode ESP32USBDevice::SetAddress(uint8_t address, USB::DeviceCore::Context c
 {
   if (context == USB::DeviceCore::Context::SETUP_BEFORE_STATUS)
   {
-    auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+    auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
     dev->dcfg_reg.devaddr = address;
   }
   return ErrorCode::OK;
@@ -118,7 +118,7 @@ void ESP32USBDevice::Start(bool)
     USB::DeviceCore::Init(false);
   }
 
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   dev->dctl_reg.sftdiscon = 0;
   dev->gahbcfg_reg.glbllntrmsk = 1;
   if (runtime_.intr_handle != nullptr)
@@ -130,7 +130,7 @@ void ESP32USBDevice::Start(bool)
 
 void ESP32USBDevice::Stop(bool)
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   dev->gahbcfg_reg.glbllntrmsk = 0;
   dev->gintmsk_reg.val = 0;
   if (runtime_.intr_handle != nullptr)
@@ -210,7 +210,7 @@ void ESP32USBDevice::EnsureRomUsbCleaned()
 
 void ESP32USBDevice::InitializeCore()
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
 
   dev->gahbcfg_reg.glbllntrmsk = 0;
 
@@ -250,7 +250,7 @@ void ESP32USBDevice::InitializeCore()
   dev->gintsts_reg.val = 0xFFFFFFFFU;
   dev->gotgint_reg.val = 0xFFFFFFFFU;
   dev->gintmsk_reg.val = 0U;
-  dev->gahbcfg_reg.hbstlen = Detail::kDmaBurstIncr4;
+  dev->gahbcfg_reg.hbstlen = Detail::DMA_BURST_INCR4;
   dev->gahbcfg_reg.dmaen = DmaEnabled() ? 1U : 0U;
   dev->gahbcfg_reg.nptxfemplvl = 1;
   dev->gahbcfg_reg.ptxfemplvl = 1;
@@ -268,7 +268,7 @@ void ESP32USBDevice::InitializeCore()
 
 void ESP32USBDevice::ClearTxFifoRegisters()
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   dev->gnptxfsiz_reg.val = 0U;
   const size_t tx_fifo_reg_count =
       sizeof(dev->dieptxf_regs) / sizeof(dev->dieptxf_regs[0]);
@@ -280,8 +280,8 @@ void ESP32USBDevice::ClearTxFifoRegisters()
 
 void ESP32USBDevice::FlushFifos()
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
-  dev->grstctl_reg.txfnum = Detail::kFlushAllTxFifo;
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
+  dev->grstctl_reg.txfnum = Detail::FLUSH_ALL_TX_FIFO;
   dev->grstctl_reg.txfflsh = 1;
   while (dev->grstctl_reg.txfflsh)
   {
@@ -297,7 +297,7 @@ void ESP32USBDevice::ResetFifoState()
   fifo_state_.depth_words = Detail::GetHardwareFifoDepthWords();
   ASSERT(fifo_state_.depth_words > 0U);
   fifo_state_.rx_words =
-      Detail::CalcConfiguredRxFifoWords(64U, kEndpointCount, DmaEnabled());
+      Detail::CalcConfiguredRxFifoWords(64U, ENDPOINT_COUNT, DmaEnabled());
   fifo_state_.tx_next_words = fifo_state_.rx_words;
   std::memset(fifo_state_.tx_words, 0, sizeof(fifo_state_.tx_words));
   std::memset(fifo_state_.tx_bound, 0, sizeof(fifo_state_.tx_bound));
@@ -309,14 +309,14 @@ void ESP32USBDevice::ResetDeviceState()
   ResetFifoState();
   ResetControlState();
 
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   dev->grxfsiz_reg.rxfdep = fifo_state_.rx_words;
   ClearTxFifoRegisters();
 }
 
 void ESP32USBDevice::ResetEndpointHardwareState()
 {
-  for (uint8_t i = 0; i < kEndpointCount; ++i)
+  for (uint8_t i = 0; i < ENDPOINT_COUNT; ++i)
   {
     if (endpoint_map_.in[i] != nullptr)
     {
@@ -331,14 +331,14 @@ void ESP32USBDevice::ResetEndpointHardwareState()
 
 void ESP32USBDevice::ReloadSetupPacketCount()
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   dev->doeptsiz0_reg.val = 0U;
   if (DmaEnabled())
   {
-    dev->doeptsiz0_reg.xfersize = 3U * kSetupPacketBytes;
+    dev->doeptsiz0_reg.xfersize = 3U * SETUP_PACKET_BYTES;
     dev->doeptsiz0_reg.pktcnt = 1U;
     dev->doeptsiz0_reg.supcnt = 3U;
-    ASSERT(Detail::CacheSyncDmaBuffer(setup_packet_, kSetupDmaBufferBytes, false));
+    ASSERT(Detail::CacheSyncDmaBuffer(setup_packet_, SETUP_DMA_BUFFER_BYTES, false));
     dev->doepdma0_reg.dmaaddr =
         static_cast<uint32_t>(reinterpret_cast<uintptr_t>(setup_packet_));
     dev->doepctl0_reg.cnak = 1;
@@ -352,7 +352,7 @@ void ESP32USBDevice::ReloadSetupPacketCount()
   else
   {
     dev->doeptsiz0_reg.pktcnt = 1U;
-    dev->doeptsiz0_reg.xfersize = 3U * kSetupPacketBytes;
+    dev->doeptsiz0_reg.xfersize = 3U * SETUP_PACKET_BYTES;
     dev->doeptsiz0_reg.supcnt = 3U;
   }
 }
@@ -366,8 +366,8 @@ void ESP32USBDevice::UpdateSetupState(const uint8_t* setup)
 
 void IRAM_ATTR ESP32USBDevice::HandleInterrupt()
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
-  for (uint32_t guard = 0; guard < kInterruptDispatchGuard; ++guard)
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
+  for (uint32_t guard = 0; guard < INTERRUPT_DISPATCH_GUARD; ++guard)
   {
     usb_dwc_gintsts_reg_t pending = {};
     pending.val = dev->gintsts_reg.val & dev->gintmsk_reg.val;
@@ -387,8 +387,8 @@ void IRAM_ATTR ESP32USBDevice::HandleInterrupt()
     {
       dev->gintsts_reg.enumdone = 1;
       const uint32_t enum_speed = dev->dsts_reg.enumspd;
-      if (enum_speed != Detail::kEnumSpeedFull30To60Mhz &&
-          enum_speed != Detail::kEnumSpeedFull48Mhz)
+      if (enum_speed != Detail::ENUM_SPEED_FULL_30_TO_60_MHZ &&
+          enum_speed != Detail::ENUM_SPEED_FULL_48_MHZ)
       {
         ASSERT(false);
       }
@@ -434,9 +434,9 @@ void IRAM_ATTR ESP32USBDevice::HandleInterrupt()
 
 void ESP32USBDevice::HandleBusReset(bool in_isr)
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
 
-  for (uint8_t i = 0; i < kEndpointCount; ++i)
+  for (uint8_t i = 0; i < ENDPOINT_COUNT; ++i)
   {
     if (i == 0U)
     {
@@ -448,7 +448,7 @@ void ESP32USBDevice::HandleBusReset(bool in_isr)
     }
   }
 
-  for (uint8_t i = 0; i < kEndpointCount; ++i)
+  for (uint8_t i = 0; i < ENDPOINT_COUNT; ++i)
   {
     if (i == 0U)
     {
@@ -500,11 +500,11 @@ void ESP32USBDevice::HandleBusReset(bool in_isr)
 
 void ESP32USBDevice::HandleEndpointInterrupt(bool in_isr, bool in_dir)
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   const uint32_t daint = dev->daint_reg.val & dev->daintmsk_reg.val;
   const uint32_t bits = in_dir ? (daint & 0xFFFFU) : ((daint >> 16U) & 0xFFFFU);
 
-  for (uint8_t ep_num = 0; ep_num < kEndpointCount; ++ep_num)
+  for (uint8_t ep_num = 0; ep_num < ENDPOINT_COUNT; ++ep_num)
   {
     if ((bits & (1UL << ep_num)) == 0U)
     {
@@ -531,14 +531,14 @@ void ESP32USBDevice::HandleEndpointInterrupt(bool in_isr, bool in_dir)
 
 void ESP32USBDevice::HandleRxFifoLevel()
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   usb_dwc_grxstsp_reg_t status = {};
   status.val = dev->grxstsp_reg.val;
   const uint8_t ep_num = static_cast<uint8_t>(status.chnum);
 
   if (DmaEnabled())
   {
-    if ((ep_num < kEndpointCount) && (endpoint_map_.out[ep_num] != nullptr))
+    if ((ep_num < ENDPOINT_COUNT) && (endpoint_map_.out[ep_num] != nullptr))
     {
       static_cast<ESP32USBEndpoint*>(endpoint_map_.out[ep_num])
           ->ObserveDmaRxStatus(status.pktsts, status.bcnt);
@@ -548,22 +548,22 @@ void ESP32USBDevice::HandleRxFifoLevel()
 
   switch (status.pktsts)
   {
-    case Detail::kRxStatusGlobalOutNak:
+    case Detail::RX_STATUS_GLOBAL_OUT_NAK:
       break;
 
-    case Detail::kRxStatusSetupData:
+    case Detail::RX_STATUS_SETUP_DATA:
       Detail::ReadFifoPacket(Detail::GetEndpointFifo(dev, 0), setup_packet_,
                              sizeof(setup_packet_));
       UpdateSetupState(setup_packet_);
       break;
 
-    case Detail::kRxStatusSetupDone:
+    case Detail::RX_STATUS_SETUP_DONE:
       ReloadSetupPacketCount();
       break;
 
-    case Detail::kRxStatusData:
+    case Detail::RX_STATUS_DATA:
     {
-      USB::Endpoint* ep = (ep_num < kEndpointCount) ? endpoint_map_.out[ep_num] : nullptr;
+      USB::Endpoint* ep = (ep_num < ENDPOINT_COUNT) ? endpoint_map_.out[ep_num] : nullptr;
       if (ep != nullptr)
       {
         static_cast<ESP32USBEndpoint*>(ep)->HandleRxData(status.bcnt);
@@ -576,7 +576,7 @@ void ESP32USBDevice::HandleRxFifoLevel()
       break;
     }
 
-    case Detail::kRxStatusTransferComplete:
+    case Detail::RX_STATUS_TRANSFER_COMPLETE:
     default:
       break;
   }
@@ -585,7 +585,7 @@ void ESP32USBDevice::HandleRxFifoLevel()
 bool ESP32USBDevice::AllocateTxFifo(uint8_t ep_num, uint16_t packet_size, bool is_bulk,
                                     uint16_t& fifo_words)
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   const uint8_t max_in_ep_num =
       static_cast<uint8_t>(sizeof(dev->dieptxf_regs) / sizeof(dev->dieptxf_regs[0]));
 
@@ -597,7 +597,7 @@ bool ESP32USBDevice::AllocateTxFifo(uint8_t ep_num, uint16_t packet_size, bool i
   }
 
   const uint16_t words = Detail::CalcTxFifoWords(packet_size, DmaEnabled());
-  if (!fifo_state_.tx_bound[ep_num] && (fifo_state_.allocated_in >= kInEndpointLimit))
+  if (!fifo_state_.tx_bound[ep_num] && (fifo_state_.allocated_in >= IN_ENDPOINT_LIMIT))
   {
     return false;
   }
@@ -605,7 +605,7 @@ bool ESP32USBDevice::AllocateTxFifo(uint8_t ep_num, uint16_t packet_size, bool i
   for (uint8_t index = 0U; index <= ep_num; ++index)
   {
     const uint16_t requested_words =
-        (index == ep_num) ? words : Detail::kEsp32SxFsMinTxFifoWords;
+        (index == ep_num) ? words : Detail::ESP32_SX_FS_MIN_TX_FIFO_WORDS;
     if (fifo_state_.tx_words[index] != 0U)
     {
       if (fifo_state_.tx_words[index] < requested_words)
@@ -648,9 +648,9 @@ bool ESP32USBDevice::AllocateTxFifo(uint8_t ep_num, uint16_t packet_size, bool i
 
 bool ESP32USBDevice::EnsureRxFifo(uint16_t packet_size)
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   const uint16_t needed =
-      Detail::CalcConfiguredRxFifoWords(packet_size, kEndpointCount, DmaEnabled());
+      Detail::CalcConfiguredRxFifoWords(packet_size, ENDPOINT_COUNT, DmaEnabled());
   if (needed <= fifo_state_.rx_words)
   {
     return true;

--- a/driver/esp/esp_usb_dev.hpp
+++ b/driver/esp/esp_usb_dev.hpp
@@ -70,11 +70,11 @@ class ESP32USBDevice : public USB::EndpointPool, public USB::DeviceCore
  private:
   friend class ESP32USBEndpoint;
 
-  static constexpr uint8_t kEndpointCount = 7;
-  static constexpr uint8_t kInEndpointLimit = 5;
-  static constexpr uint32_t kInterruptDispatchGuard = 64U;
-  static constexpr size_t kSetupPacketBytes = 8U;
-  static constexpr size_t kSetupDmaBufferBytes = 64U;
+  static constexpr uint8_t ENDPOINT_COUNT = 7;
+  static constexpr uint8_t IN_ENDPOINT_LIMIT = 5;
+  static constexpr uint32_t INTERRUPT_DISPATCH_GUARD = 64U;
+  static constexpr size_t SETUP_PACKET_BYTES = 8U;
+  static constexpr size_t SETUP_DMA_BUFFER_BYTES = 64U;
 
   /**
    * @brief Minimal EP0 setup facts shared with the endpoint layer
@@ -89,8 +89,8 @@ class ESP32USBDevice : public USB::EndpointPool, public USB::DeviceCore
    */
   struct EndpointMap
   {
-    USB::Endpoint* in[kEndpointCount] = {};
-    USB::Endpoint* out[kEndpointCount] = {};
+    USB::Endpoint* in[ENDPOINT_COUNT] = {};
+    USB::Endpoint* out[ENDPOINT_COUNT] = {};
   };
 
   /**
@@ -101,8 +101,8 @@ class ESP32USBDevice : public USB::EndpointPool, public USB::DeviceCore
     uint16_t depth_words = 0U;
     uint16_t rx_words = 0U;
     uint16_t tx_next_words = 0U;
-    uint16_t tx_words[kEndpointCount] = {};
-    bool tx_bound[kEndpointCount] = {};
+    uint16_t tx_words[ENDPOINT_COUNT] = {};
+    bool tx_bound[ENDPOINT_COUNT] = {};
     uint8_t allocated_in = 0U;
   };
 
@@ -150,7 +150,7 @@ class ESP32USBDevice : public USB::EndpointPool, public USB::DeviceCore
   // Runtime resource ownership and global flags.
   RuntimeState runtime_ = {};
   // Shared DMA-visible setup packet buffer.
-  alignas(kSetupDmaBufferBytes) uint8_t setup_packet_[kSetupDmaBufferBytes] = {};
+  alignas(SETUP_DMA_BUFFER_BYTES) uint8_t setup_packet_[SETUP_DMA_BUFFER_BYTES] = {};
   // Functional EP0 setup state that must survive until status completion.
   ControlState control_ = {};
 };

--- a/driver/esp/esp_usb_ep.cpp
+++ b/driver/esp/esp_usb_ep.cpp
@@ -75,7 +75,7 @@ void ESP32USBEndpoint::Configure(const Config& cfg)
 
 void ESP32USBEndpoint::Close()
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   const uint8_t ep_num = EPNumberToInt8(GetNumber());
 
   if (GetDirection() == Direction::IN)
@@ -122,7 +122,7 @@ ErrorCode ESP32USBEndpoint::Stall()
     return ErrorCode::BUSY;
   }
 
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   const uint8_t ep_num = EPNumberToInt8(GetNumber());
 
   if (is_in)
@@ -154,7 +154,7 @@ ErrorCode ESP32USBEndpoint::Stall()
 
 ErrorCode ESP32USBEndpoint::ClearStall()
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   const uint8_t ep_num = EPNumberToInt8(GetNumber());
 
   if (GetDirection() == Direction::IN)
@@ -249,7 +249,7 @@ void ESP32USBEndpoint::HandleInInterrupt(bool in_isr)
 {
   const uint8_t ep_num = EPNumberToInt8(GetNumber());
   usb_dwc_diepint_reg_t intr = {};
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
 
   if (ep_num == 0U)
   {
@@ -315,7 +315,7 @@ void ESP32USBEndpoint::HandleOutInterrupt(bool in_isr)
 {
   const uint8_t ep_num = EPNumberToInt8(GetNumber());
   usb_dwc_doepint_reg_t intr = {};
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
 
   if (ep_num == 0U)
   {
@@ -361,7 +361,7 @@ void ESP32USBEndpoint::HandleOutInterrupt(bool in_isr)
     if (device_.DmaEnabled())
     {
       ASSERT(Detail::CacheSyncDmaBuffer(device_.setup_packet_,
-                                        ESP32USBDevice::kSetupDmaBufferBytes, false));
+                                        ESP32USBDevice::SETUP_DMA_BUFFER_BYTES, false));
     }
     device_.UpdateSetupState(device_.setup_packet_);
     const auto* setup = reinterpret_cast<const USB::SetupPacket*>(device_.setup_packet_);
@@ -405,8 +405,8 @@ void ESP32USBEndpoint::HandleRxData(size_t size)
   if (copy_size > 0U)
   {
     Detail::ReadFifoPacket(
-        Detail::GetEndpointFifo(reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase),
-                                0),
+        Detail::GetEndpointFifo(
+            reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE), 0),
         dst, copy_size);
     transfer_actual_size_ += copy_size;
   }
@@ -419,7 +419,7 @@ void ESP32USBEndpoint::HandleRxData(size_t size)
   uint8_t sink[64] = {};
   size_t remain_drop = drop_size;
   auto* fifo = Detail::GetEndpointFifo(
-      reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase), 0);
+      reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE), 0);
   while (remain_drop > 0U)
   {
     const size_t chunk = std::min(remain_drop, sizeof(sink));
@@ -435,7 +435,7 @@ void ESP32USBEndpoint::ObserveDmaRxStatus(uint8_t pktsts, size_t size)
     return;
   }
 
-  if (pktsts != Detail::kRxStatusData)
+  if (pktsts != Detail::RX_STATUS_DATA)
   {
     return;
   }
@@ -459,7 +459,7 @@ void ESP32USBEndpoint::ResetTransferState()
 
 bool ESP32USBEndpoint::EnsureDmaShadow(size_t size)
 {
-  const size_t need = Detail::AlignUp(size, Detail::kUsbDmaAlignment);
+  const size_t need = Detail::AlignUp(size, Detail::USB_DMA_ALIGNMENT);
   if (need == 0U)
   {
     return true;
@@ -471,7 +471,7 @@ bool ESP32USBEndpoint::EnsureDmaShadow(size_t size)
   }
 
   void* new_buffer =
-      heap_caps_aligned_alloc(Detail::kUsbDmaAlignment, need, Detail::kDmaMemoryCaps);
+      heap_caps_aligned_alloc(Detail::USB_DMA_ALIGNMENT, need, Detail::DMA_MEMORY_CAPS);
   if (new_buffer == nullptr)
   {
     return false;
@@ -528,11 +528,11 @@ bool ESP32USBEndpoint::PrepareTransferBuffer(size_t size)
     ASSERT(transfer_buffer_ != nullptr);
     std::memcpy(transfer_hw_buffer_, transfer_buffer_, size);
     return Detail::CacheSyncDmaBuffer(
-        transfer_hw_buffer_, Detail::AlignUp(size, Detail::kUsbDmaAlignment), true);
+        transfer_hw_buffer_, Detail::AlignUp(size, Detail::USB_DMA_ALIGNMENT), true);
   }
 
   return Detail::CacheSyncDmaBuffer(
-      transfer_hw_buffer_, Detail::AlignUp(size, Detail::kUsbDmaAlignment), false);
+      transfer_hw_buffer_, Detail::AlignUp(size, Detail::USB_DMA_ALIGNMENT), false);
 }
 
 bool ESP32USBEndpoint::FinishOutTransfer(size_t actual_size)
@@ -559,7 +559,7 @@ bool ESP32USBEndpoint::FinishOutTransfer(size_t actual_size)
   ASSERT(transfer_buffer_ != nullptr);
 
   if (!Detail::CacheSyncDmaBuffer(transfer_hw_buffer_,
-                                  Detail::AlignUp(actual_size, Detail::kUsbDmaAlignment),
+                                  Detail::AlignUp(actual_size, Detail::USB_DMA_ALIGNMENT),
                                   false))
   {
     return false;
@@ -571,7 +571,7 @@ bool ESP32USBEndpoint::FinishOutTransfer(size_t actual_size)
 
 size_t ESP32USBEndpoint::GetRemainingTransferSize() const
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   const uint8_t ep_num = EPNumberToInt8(GetNumber());
 
   if (GetDirection() == Direction::IN)
@@ -604,7 +604,7 @@ size_t ESP32USBEndpoint::GetCompletedTransferSize() const
 
 void ESP32USBEndpoint::ActivateHardwareEndpoint()
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   const uint8_t ep_num = EPNumberToInt8(GetNumber());
   auto& cfg = GetConfig();
 
@@ -656,7 +656,7 @@ void ESP32USBEndpoint::ActivateHardwareEndpoint()
 
 void ESP32USBEndpoint::ProgramTransfer(size_t size)
 {
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   const uint8_t ep_num = EPNumberToInt8(GetNumber());
   const uint16_t pkt_count = Detail::PacketCount(size, MaxPacketSize());
 
@@ -734,7 +734,7 @@ void ESP32USBEndpoint::WriteMoreTxData()
     return;
   }
 
-  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::kDwc2FsRegBase);
+  auto* dev = reinterpret_cast<usb_dwc_dev_t*>(Detail::DWC2_FS_REG_BASE);
   const uint8_t ep_num = EPNumberToInt8(GetNumber());
   const volatile uint32_t* fifo = Detail::GetEndpointFifo(dev, ep_num);
 

--- a/driver/esp/esp_watchdog.cpp
+++ b/driver/esp/esp_watchdog.cpp
@@ -11,8 +11,8 @@ namespace LibXR
 namespace
 {
 
-constexpr uint32_t kWdtTickUs = 500;
-constexpr uint32_t kWdtTicksPerMs = 1000 / kWdtTickUs;
+constexpr uint32_t WDT_TICK_US = 500;
+constexpr uint32_t WDT_TICKS_PER_MS = 1000 / WDT_TICK_US;
 
 bool GetMwdtGroupInfo(wdt_inst_t instance, int* group_id, periph_module_t* periph)
 {
@@ -104,7 +104,7 @@ ErrorCode ESP32Watchdog::ApplyConfiguration()
     return ErrorCode::INIT_ERR;
   }
 
-  const uint64_t ticks64 = static_cast<uint64_t>(timeout_ms_) * kWdtTicksPerMs;
+  const uint64_t ticks64 = static_cast<uint64_t>(timeout_ms_) * WDT_TICKS_PER_MS;
   if ((ticks64 == 0) || (ticks64 > UINT32_MAX))
   {
     return ErrorCode::NOT_SUPPORT;

--- a/driver/esp/esp_watchdog.hpp
+++ b/driver/esp/esp_watchdog.hpp
@@ -28,17 +28,17 @@ namespace LibXR
 #endif
 
 #if (LIBXR_ESP_WDT_MWDT1_RESERVED == 0)
-constexpr wdt_inst_t kESP32WatchdogDefaultInstance = WDT_MWDT1;
+constexpr wdt_inst_t ESP32_WATCHDOG_DEFAULT_INSTANCE = WDT_MWDT1;
 #elif (LIBXR_ESP_WDT_MWDT0_RESERVED == 0)
-constexpr wdt_inst_t kESP32WatchdogDefaultInstance = WDT_MWDT0;
+constexpr wdt_inst_t ESP32_WATCHDOG_DEFAULT_INSTANCE = WDT_MWDT0;
 #else
-constexpr wdt_inst_t kESP32WatchdogDefaultInstance = WDT_RWDT;
+constexpr wdt_inst_t ESP32_WATCHDOG_DEFAULT_INSTANCE = WDT_RWDT;
 #endif
 
-static_assert(!(kESP32WatchdogDefaultInstance == WDT_MWDT0 &&
+static_assert(!(ESP32_WATCHDOG_DEFAULT_INSTANCE == WDT_MWDT0 &&
                 LIBXR_ESP_WDT_MWDT0_RESERVED),
               "LibXR ESP32Watchdog selected MWDT0, but MWDT0 is reserved by ESP-IDF.");
-static_assert(!(kESP32WatchdogDefaultInstance == WDT_MWDT1 &&
+static_assert(!(ESP32_WATCHDOG_DEFAULT_INSTANCE == WDT_MWDT1 &&
                 LIBXR_ESP_WDT_MWDT1_RESERVED),
               "LibXR ESP32Watchdog selected MWDT1, but MWDT1 is reserved by ESP-IDF.");
 
@@ -58,7 +58,7 @@ class ESP32Watchdog : public Watchdog
   ErrorCode ApplyConfiguration();
 
   wdt_hal_context_t hal_{};
-  const wdt_inst_t instance_ = kESP32WatchdogDefaultInstance;
+  const wdt_inst_t instance_ = ESP32_WATCHDOG_DEFAULT_INSTANCE;
   bool initialized_ = false;
   bool started_ = false;
 };

--- a/driver/esp/esp_wifi_client.cpp
+++ b/driver/esp/esp_wifi_client.cpp
@@ -13,10 +13,10 @@ namespace LibXR
 {
 namespace
 {
-constexpr uint32_t kWifiConnectTimeoutMs = 15000U;
-constexpr uint32_t kWifiDhcpTimeoutMs = 15000U;
-constexpr uint32_t kWifiDisconnectTimeoutMs = 5000U;
-constexpr uint16_t kMaxScanResults = 20U;
+constexpr uint32_t WIFI_CONNECT_TIMEOUT_MS = 15000U;
+constexpr uint32_t WIFI_DHCP_TIMEOUT_MS = 15000U;
+constexpr uint32_t WIFI_DISCONNECT_TIMEOUT_MS = 5000U;
+constexpr uint16_t MAX_SCAN_RESULTS = 20U;
 
 template <typename Predicate>
 bool WaitForPredicate(Semaphore& semaphore, uint32_t timeout_ms, Predicate&& predicate)
@@ -201,12 +201,13 @@ WifiClient::WifiError ESP32WifiClient::Connect(const Config& config)
     return WifiError::HARDWARE_FAILURE;
   }
 
-  if (!WaitForPredicate(semaphore_, kWifiConnectTimeoutMs, [&]() { return connected_; }))
+  if (!WaitForPredicate(semaphore_, WIFI_CONNECT_TIMEOUT_MS,
+                        [&]() { return connected_; }))
   {
     return WifiError::CONNECTION_TIMEOUT;
   }
 
-  if (!WaitForPredicate(semaphore_, kWifiDhcpTimeoutMs,
+  if (!WaitForPredicate(semaphore_, WIFI_DHCP_TIMEOUT_MS,
                         [&]() { return got_ip_ || !connected_; }))
   {
     return WifiError::DHCP_FAILED;
@@ -228,7 +229,7 @@ WifiClient::WifiError ESP32WifiClient::Disconnect()
     return WifiError::HARDWARE_FAILURE;
   }
 
-  if (!WaitForPredicate(semaphore_, kWifiDisconnectTimeoutMs,
+  if (!WaitForPredicate(semaphore_, WIFI_DISCONNECT_TIMEOUT_MS,
                         [&]() { return !connected_; }))
   {
     return WifiError::UNKNOWN;
@@ -283,12 +284,12 @@ WifiClient::WifiError ESP32WifiClient::Scan(ScanResult* out_list, size_t max_cou
   {
     copy_count = static_cast<uint16_t>(max_count);
   }
-  if (copy_count > kMaxScanResults)
+  if (copy_count > MAX_SCAN_RESULTS)
   {
-    copy_count = kMaxScanResults;
+    copy_count = MAX_SCAN_RESULTS;
   }
 
-  wifi_ap_record_t ap_records[kMaxScanResults] = {};
+  wifi_ap_record_t ap_records[MAX_SCAN_RESULTS] = {};
   if ((copy_count > 0U) &&
       (esp_wifi_scan_get_ap_records(&copy_count, ap_records) != ESP_OK))
   {

--- a/driver/hpm/hpm_gpio.cpp
+++ b/driver/hpm/hpm_gpio.cpp
@@ -11,8 +11,8 @@ using namespace LibXR;
  * 按端口和引脚保存对象指针，供中断入口快速找到具体实例并触发回调。
  * Stores instance pointers by port/pin so IRQ entry can dispatch callbacks quickly.
  */
-HPMGPIO* HPMGPIO::map[HPMGPIO::kPortCount][HPMGPIO::kPinCount] = {};
-GPIO_Type* HPMGPIO::port_controller_map[HPMGPIO::kPortCount] = {};
+HPMGPIO* HPMGPIO::map[HPMGPIO::PORT_COUNT][HPMGPIO::PIN_COUNT] = {};
+GPIO_Type* HPMGPIO::port_controller_map[HPMGPIO::PORT_COUNT] = {};
 
 /**
  * @brief 将 PAD 复用切换为 GPIO 功能 / Route PAD mux to GPIO function.
@@ -52,10 +52,10 @@ HPMGPIO::HPMGPIO(GPIO_Type* gpio, uint32_t port, uint8_t pin, uint32_t irq,
       port_(port),
       pin_(pin),
       irq_(irq),
-      pad_index_(pad_index == kInvalidPadIndex ? ResolvePadIndex(gpio, port, pin)
-                                               : pad_index)
+      pad_index_(pad_index == INVALID_PAD_INDEX ? ResolvePadIndex(gpio, port, pin)
+                                                : pad_index)
 {
-  if (port_ < kPortCount && pin_ < kPinCount)
+  if (port_ < PORT_COUNT && pin_ < PIN_COUNT)
   {
     map[port_][pin_] = this;
     if (port_controller_map[port_] == nullptr)
@@ -77,7 +77,7 @@ HPMGPIO::HPMGPIO(GPIO_Type* gpio, uint32_t port, uint8_t pin, uint32_t irq,
  */
 ErrorCode HPMGPIO::EnableInterrupt()
 {
-  if (irq_ == kInvalidIrq)
+  if (irq_ == INVALID_IRQ)
   {
     return ErrorCode::ARG_ERR;
   }
@@ -95,7 +95,7 @@ ErrorCode HPMGPIO::EnableInterrupt()
  */
 ErrorCode HPMGPIO::DisableInterrupt()
 {
-  if (irq_ == kInvalidIrq)
+  if (irq_ == INVALID_IRQ)
   {
     return ErrorCode::ARG_ERR;
   }
@@ -117,12 +117,12 @@ ErrorCode HPMGPIO::DisableInterrupt()
  */
 ErrorCode HPMGPIO::SetConfig(Configuration config)
 {
-  if (port_ >= kPortCount || pin_ >= kPinCount)
+  if (port_ >= PORT_COUNT || pin_ >= PIN_COUNT)
   {
     return ErrorCode::ARG_ERR;
   }
 
-  if (pad_index_ != kInvalidPadIndex)
+  if (pad_index_ != INVALID_PAD_INDEX)
   {
     // 保持接口自洽：先确保 PAD 复用到 GPIO / Keep API self-contained: force GPIO mux
     // first.
@@ -154,7 +154,7 @@ ErrorCode HPMGPIO::SetConfig(Configuration config)
       return ErrorCode::ARG_ERR;
   }
 
-  if (pad_index_ != kInvalidPadIndex)
+  if (pad_index_ != INVALID_PAD_INDEX)
   {
     uint32_t pad_ctl = HPM_IOC->PAD[pad_index_].PAD_CTL;
 
@@ -199,12 +199,12 @@ ErrorCode HPMGPIO::SetConfig(Configuration config)
  */
 ErrorCode HPMGPIO::SetAnalogHighImpedance()
 {
-  if (port_ >= kPortCount || pin_ >= kPinCount)
+  if (port_ >= PORT_COUNT || pin_ >= PIN_COUNT)
   {
     return ErrorCode::ARG_ERR;
   }
 
-  if (pad_index_ == kInvalidPadIndex)
+  if (pad_index_ == INVALID_PAD_INDEX)
   {
     return ErrorCode::NOT_SUPPORT;
   }
@@ -237,7 +237,7 @@ ErrorCode HPMGPIO::SetAnalogHighImpedance()
  */
 void HPMGPIO::CheckInterrupt(uint32_t port)
 {
-  if (port >= kPortCount)
+  if (port >= PORT_COUNT)
   {
     return;
   }
@@ -254,7 +254,7 @@ void HPMGPIO::CheckInterrupt(uint32_t port)
     return;
   }
 
-  for (uint8_t pin = 0; pin < kPinCount; ++pin)
+  for (uint8_t pin = 0; pin < PIN_COUNT; ++pin)
   {
     if ((flags & (1u << pin)) == 0u)
     {
@@ -276,7 +276,7 @@ uint16_t HPMGPIO::ResolvePadIndex(GPIO_Type* gpio, uint32_t port, uint8_t pin)
 {
   if (gpio != HPM_GPIO0 && gpio != HPM_FGPIO)
   {
-    return kInvalidPadIndex;
+    return INVALID_PAD_INDEX;
   }
 
   switch (port)
@@ -286,11 +286,11 @@ uint16_t HPMGPIO::ResolvePadIndex(GPIO_Type* gpio, uint32_t port, uint8_t pin)
     case GPIO_DI_GPIOB:
       return static_cast<uint16_t>(IOC_PAD_PB00 + pin);
     case GPIO_DI_GPIOX:
-      return pin < 8u ? static_cast<uint16_t>(IOC_PAD_PX00 + pin) : kInvalidPadIndex;
+      return pin < 8u ? static_cast<uint16_t>(IOC_PAD_PX00 + pin) : INVALID_PAD_INDEX;
     case GPIO_DI_GPIOY:
-      return pin < 8u ? static_cast<uint16_t>(IOC_PAD_PY00 + pin) : kInvalidPadIndex;
+      return pin < 8u ? static_cast<uint16_t>(IOC_PAD_PY00 + pin) : INVALID_PAD_INDEX;
     default:
-      return kInvalidPadIndex;
+      return INVALID_PAD_INDEX;
   }
 }
 

--- a/driver/hpm/hpm_gpio.hpp
+++ b/driver/hpm/hpm_gpio.hpp
@@ -29,8 +29,8 @@ class HPMGPIO final : public GPIO
    * @param pad_index IOC PAD 编号，默认值表示自动由 `(gpio, port, pin)` 推导 /
    * IOC PAD index. Use default value to auto-resolve from `(gpio, port, pin)`.
    */
-  HPMGPIO(GPIO_Type* gpio, uint32_t port, uint8_t pin, uint32_t irq = kInvalidIrq,
-          uint16_t pad_index = kInvalidPadIndex);
+  HPMGPIO(GPIO_Type* gpio, uint32_t port, uint8_t pin, uint32_t irq = INVALID_IRQ,
+          uint16_t pad_index = INVALID_PAD_INDEX);
 
   /**
    * @brief 读取引脚电平 / Read current pin level.
@@ -99,10 +99,10 @@ class HPMGPIO final : public GPIO
   static void CheckInterrupt(uint32_t port);
 
  private:
-  static constexpr uint32_t kPortCount = 15;  ///< 支持的端口数量 / Supported port count.
-  static constexpr uint32_t kPinCount = 32;   ///< 每个端口引脚数 / Pins per port.
-  static constexpr uint32_t kInvalidIrq = 0xFFFFFFFFu;    ///< 无效 IRQ 标记 / Invalid IRQ marker.
-  static constexpr uint16_t kInvalidPadIndex = 0xFFFFu;   ///< 无效 PAD 标记 / Invalid PAD marker.
+  static constexpr uint32_t PORT_COUNT = 15;  ///< 支持的端口数量 / Supported port count.
+  static constexpr uint32_t PIN_COUNT = 32;   ///< 每个端口引脚数 / Pins per port.
+  static constexpr uint32_t INVALID_IRQ = 0xFFFFFFFFu;    ///< 无效 IRQ 标记 / Invalid IRQ marker.
+  static constexpr uint16_t INVALID_PAD_INDEX = 0xFFFFu;   ///< 无效 PAD 标记 / Invalid PAD marker.
 
   /**
    * @brief 根据控制器与端口引脚推导 IOC PAD 编号 /
@@ -110,15 +110,15 @@ class HPMGPIO final : public GPIO
    * @param gpio GPIO 控制器基地址 / GPIO controller base address.
    * @param port GPIO 端口号 / GPIO port index.
    * @param pin GPIO 引脚号 / GPIO pin index.
-   * @return 有效 PAD 编号，无法推导时返回 `kInvalidPadIndex` /
-   * Resolved PAD index, or `kInvalidPadIndex` if unavailable.
+   * @return 有效 PAD 编号，无法推导时返回 `INVALID_PAD_INDEX` /
+   * Resolved PAD index, or `INVALID_PAD_INDEX` if unavailable.
    */
   static uint16_t ResolvePadIndex(GPIO_Type* gpio, uint32_t port, uint8_t pin);
 
   ///< 端口-引脚到对象实例的静态映射，用于中断分发 /
   ///< Static port-pin to object map for interrupt dispatch.
-  static HPMGPIO* map[kPortCount][kPinCount];
-  static GPIO_Type* port_controller_map[kPortCount];
+  static HPMGPIO* map[PORT_COUNT][PIN_COUNT];
+  static GPIO_Type* port_controller_map[PORT_COUNT];
 
   GPIO_Type* gpio_;     ///< GPIO 控制器实例 / GPIO controller instance.
   uint32_t port_;       ///< GPIO 端口号 / GPIO port index.

--- a/driver/hpm/hpm_pwm.cpp
+++ b/driver/hpm/hpm_pwm.cpp
@@ -13,7 +13,7 @@ uint8_t HPMPWM::ResolveGptmrReloadCmpIndex(uint8_t duty_cmp_index)
 {
   if (duty_cmp_index >= GPTMR_CH_CMP_COUNT)
   {
-    return kInvalidCmpIndex;
+    return INVALID_CMP_INDEX;
   }
   return static_cast<uint8_t>(duty_cmp_index == 0u ? 1u : 0u);
 }
@@ -155,7 +155,7 @@ ErrorCode HPMPWM::SetConfig(Configuration config)
   }
 
   const uint8_t reload_cmp_index = ResolveGptmrReloadCmpIndex(cmp_index_);
-  if (reload_cmp_index == kInvalidCmpIndex)
+  if (reload_cmp_index == INVALID_CMP_INDEX)
   {
     return ErrorCode::ARG_ERR;
   }

--- a/driver/hpm/hpm_pwm.hpp
+++ b/driver/hpm/hpm_pwm.hpp
@@ -71,7 +71,7 @@ class HPMPWM : public PWM
   ErrorCode Disable() override;
 
  private:
-  static constexpr uint8_t kInvalidCmpIndex = 0xFFu;
+  static constexpr uint8_t INVALID_CMP_INDEX = 0xFFu;
   static uint8_t ResolveGptmrReloadCmpIndex(uint8_t duty_cmp_index);
 
   LibXRHpmPwmType* pwm_;

--- a/driver/linux/linux_gpio.cpp
+++ b/driver/linux/linux_gpio.cpp
@@ -38,7 +38,7 @@
 
 namespace
 {
-constexpr const char* kLinuxGPIOConsumer = "LinuxGPIO";
+constexpr const char* LINUX_GPIO_CONSUMER = "LinuxGPIO";
 
 LibXR::GPIO::Configuration ResolveRequestConfig(LibXR::GPIO::Configuration desired,
                                                 bool interrupt_enabled)
@@ -788,7 +788,7 @@ ErrorCode LinuxGPIO::OpenRequestV2(Configuration config)
   request.num_lines = 1U;
   request.event_buffer_size =
       IsInterruptDirection(config.direction) ? EVENT_BUFFER_CAPACITY : 0U;
-  CopyConsumer(request.consumer, kLinuxGPIOConsumer);
+  CopyConsumer(request.consumer, LINUX_GPIO_CONSUMER);
   request.config.flags = BuildLineFlagsV2(config);
 
   if (ioctl(chip_fd_, GPIO_V2_GET_LINE_IOCTL, &request) < 0)
@@ -860,7 +860,7 @@ ErrorCode LinuxGPIO::OpenRequestV1(Configuration config)
     request.lineoffset = line_offset_;
     request.handleflags = BuildHandleFlagsV1(config);
     request.eventflags = BuildEventFlagsV1(config.direction);
-    CopyConsumer(request.consumer_label, kLinuxGPIOConsumer);
+    CopyConsumer(request.consumer_label, LINUX_GPIO_CONSUMER);
 
     if (ioctl(chip_fd_, GPIO_GET_LINEEVENT_IOCTL, &request) < 0)
     {
@@ -877,7 +877,7 @@ ErrorCode LinuxGPIO::OpenRequestV1(Configuration config)
     request.lineoffsets[0] = line_offset_;
     request.lines = 1U;
     request.flags = BuildHandleFlagsV1(config);
-    CopyConsumer(request.consumer_label, kLinuxGPIOConsumer);
+    CopyConsumer(request.consumer_label, LINUX_GPIO_CONSUMER);
 
     if (ioctl(chip_fd_, GPIO_GET_LINEHANDLE_IOCTL, &request) < 0)
     {

--- a/src/driver/debug/swd_general_gpio.hpp
+++ b/src/driver/debug/swd_general_gpio.hpp
@@ -28,7 +28,7 @@ enum class SwdIoDriveMode : uint8_t
  *       Recommended circuit: 33Ω series resistors on SWCLK/SWDIO, 10k pull-up on SWDIO.
  */
 template <typename SwclkGpioType, typename SwdioGpioType,
-          SwdIoDriveMode kIoDriveMode = SwdIoDriveMode::PUSH_PULL>
+          SwdIoDriveMode IO_DRIVE_MODE = SwdIoDriveMode::PUSH_PULL>
 class SwdGeneralGPIO final : public Swd
 {
   static constexpr uint32_t MIN_HZ = 10'000u;
@@ -368,7 +368,7 @@ class SwdGeneralGPIO final : public Swd
     if (swdio_mode_ != SwdioMode::DRIVE)
     {
       const ErrorCode EC =
-          swdio_.SetConfig({(kIoDriveMode == SwdIoDriveMode::OPEN_DRAIN)
+          swdio_.SetConfig({(IO_DRIVE_MODE == SwdIoDriveMode::OPEN_DRAIN)
                                 ? SwdioGpioType::Direction::OUTPUT_OPEN_DRAIN
                                 : SwdioGpioType::Direction::OUTPUT_PUSH_PULL,
                             SwdioGpioType::Pull::NONE});

--- a/src/driver/usb/device/bos/webusb.hpp
+++ b/src/driver/usb/device/bos/webusb.hpp
@@ -211,19 +211,19 @@ class WebUsbBosCapability final : public LibXR::USB::BosCapability
    */
   static bool ParseLandingPageUrl(const char* input, uint8_t& scheme, const char*& body)
   {
-    static constexpr const char kHttpsPrefix[] = "https://";
-    static constexpr const char kHttpPrefix[] = "http://";
+    static constexpr const char HTTPS_PREFIX[] = "https://";
+    static constexpr const char HTTP_PREFIX[] = "http://";
 
-    if (std::strncmp(input, kHttpsPrefix, sizeof(kHttpsPrefix) - 1u) == 0)
+    if (std::strncmp(input, HTTPS_PREFIX, sizeof(HTTPS_PREFIX) - 1u) == 0)
     {
       scheme = WEBUSB_URL_SCHEME_HTTPS;
-      body = input + sizeof(kHttpsPrefix) - 1u;
+      body = input + sizeof(HTTPS_PREFIX) - 1u;
       return true;
     }
-    if (std::strncmp(input, kHttpPrefix, sizeof(kHttpPrefix) - 1u) == 0)
+    if (std::strncmp(input, HTTP_PREFIX, sizeof(HTTP_PREFIX) - 1u) == 0)
     {
       scheme = WEBUSB_URL_SCHEME_HTTP;
-      body = input + sizeof(kHttpPrefix) - 1u;
+      body = input + sizeof(HTTP_PREFIX) - 1u;
       return true;
     }
 

--- a/src/driver/usb/device/bos/winusb_msos20.hpp
+++ b/src/driver/usb/device/bos/winusb_msos20.hpp
@@ -36,6 +36,8 @@ static constexpr uint8_t MSOS20_PLATFORM_CAPABILITY_UUID[16] = {
 // "{xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx}" + UTF-16 NUL
 static constexpr uint16_t GUID_CHARS_WITH_BRACES = 38;
 static constexpr uint16_t GUID_STR_UTF16_BYTES = (GUID_CHARS_WITH_BRACES + 1) * 2;  // 78
+static constexpr uint16_t GUID_MULTI_SZ_UTF16_BYTES =
+    static_cast<uint16_t>(GUID_STR_UTF16_BYTES + 2u);
 
 // "DeviceInterfaceGUIDs" (UTF-16LE) + NUL terminator
 static constexpr uint8_t PROP_NAME_DEVICE_INTERFACE_GUIDS_UTF16[] = {
@@ -63,6 +65,8 @@ struct MsOs20SubsetHeaderConfiguration
 {
   uint16_t wLength = 0x0008;
   uint16_t wDescriptorType = MS_OS_20_SUBSET_HEADER_CONFIGURATION;
+  // MS OS 2.0 uses a zero-based configuration index here. This is not the
+  // USB configuration descriptor's bConfigurationValue, which normally starts at 1.
   uint8_t bConfigurationValue = 0;
   uint8_t bReserved = 0;
   uint16_t wTotalLength = 0;  // sizeof(this cfg subset)
@@ -122,6 +126,123 @@ struct MsOs20PlatformCapability
   uint8_t bAltEnumCode = 0x00;                 // optional, often 0
 };
 
+template <uint16_t PropertyDataBytes>
+struct DeviceInterfaceGuidsRegProperty
+{
+  static_assert(PropertyDataBytes >= 4u,
+                "REG_MULTI_SZ property data must fit the double-NUL terminator");
+
+  MsOs20FeatureRegPropertyHeader header;
+  uint8_t name[PROP_NAME_DEVICE_INTERFACE_GUIDS_BYTES];
+  uint16_t wPropertyDataLength = 0;
+  uint8_t data[PropertyDataBytes] = {};
+
+  void Init(const char* guid)
+  {
+    *this = DeviceInterfaceGuidsRegProperty<PropertyDataBytes>{};
+    header.wDescriptorType = MS_OS_20_FEATURE_REG_PROPERTY;
+    header.wPropertyDataType = REG_MULTI_SZ;
+    header.wPropertyNameLength = PROP_NAME_DEVICE_INTERFACE_GUIDS_BYTES;
+    Memory::FastCopy(name, PROP_NAME_DEVICE_INTERFACE_GUIDS_UTF16,
+                     PROP_NAME_DEVICE_INTERFACE_GUIDS_BYTES);
+
+    const size_t max_guid_chars =
+        (PropertyDataBytes >= 4u) ? ((PropertyDataBytes - 4u) / 2u) : 0u;
+    size_t guid_len = 0u;
+    if (guid != nullptr)
+    {
+      while (guid[guid_len] != '\0' && guid_len < GUID_CHARS_WITH_BRACES &&
+             guid_len < max_guid_chars)
+      {
+        data[guid_len * 2u] = static_cast<uint8_t>(guid[guid_len]);
+        data[guid_len * 2u + 1u] = 0x00u;
+        ++guid_len;
+      }
+    }
+
+    if (PropertyDataBytes >= 4u)
+    {
+      data[guid_len * 2u] = 0x00u;
+      data[guid_len * 2u + 1u] = 0x00u;
+      data[guid_len * 2u + 2u] = 0x00u;
+      data[guid_len * 2u + 3u] = 0x00u;
+    }
+
+    wPropertyDataLength = static_cast<uint16_t>((guid_len * 2u) + 4u);
+    header.wLength = static_cast<uint16_t>(sizeof(*this));
+  }
+};
+
+template <uint16_t PropertyDataBytes>
+struct DeviceScopedWinUsbMsOs20DescSet
+{
+  MsOs20SetHeader set;
+  MsOs20FeatureCompatibleId compat;
+  DeviceInterfaceGuidsRegProperty<PropertyDataBytes> prop;
+
+  void Init(const char* guid, uint32_t windows_version = 0x06030000)
+  {
+    *this = DeviceScopedWinUsbMsOs20DescSet<PropertyDataBytes>{};
+
+    set.wLength = static_cast<uint16_t>(sizeof(MsOs20SetHeader));
+    set.wDescriptorType = MS_OS_20_SET_HEADER_DESCRIPTOR;
+    set.dwWindowsVersion = windows_version;
+    set.wTotalLength = static_cast<uint16_t>(sizeof(*this));
+
+    compat.wLength = static_cast<uint16_t>(sizeof(MsOs20FeatureCompatibleId));
+    compat.wDescriptorType = MS_OS_20_FEATURE_COMPATIBLE_ID;
+
+    prop.Init(guid);
+  }
+};
+
+template <uint16_t PropertyDataBytes>
+struct FunctionScopedWinUsbMsOs20DescSet
+{
+  MsOs20SetHeader set;
+  MsOs20SubsetHeaderConfiguration cfg;
+  MsOs20SubsetHeaderFunction func;
+  MsOs20FeatureCompatibleId compat;
+  DeviceInterfaceGuidsRegProperty<PropertyDataBytes> prop;
+
+  void Init(uint8_t configuration_index, uint8_t first_interface, const char* guid,
+            uint32_t windows_version = 0x06030000)
+  {
+    *this = FunctionScopedWinUsbMsOs20DescSet<PropertyDataBytes>{};
+
+    set.wLength = static_cast<uint16_t>(sizeof(MsOs20SetHeader));
+    set.wDescriptorType = MS_OS_20_SET_HEADER_DESCRIPTOR;
+    set.dwWindowsVersion = windows_version;
+    set.wTotalLength = static_cast<uint16_t>(sizeof(*this));
+
+    cfg.wLength = static_cast<uint16_t>(sizeof(cfg));
+    cfg.wDescriptorType = MS_OS_20_SUBSET_HEADER_CONFIGURATION;
+    cfg.bConfigurationValue = configuration_index;
+    cfg.bReserved = 0u;
+    cfg.wTotalLength = static_cast<uint16_t>(
+        sizeof(*this) -
+        offsetof(FunctionScopedWinUsbMsOs20DescSet<PropertyDataBytes>, cfg));
+
+    func.wLength = static_cast<uint16_t>(sizeof(func));
+    func.wDescriptorType = MS_OS_20_SUBSET_HEADER_FUNCTION;
+    func.bFirstInterface = first_interface;
+    func.bReserved = 0u;
+    func.wTotalLength = static_cast<uint16_t>(
+        sizeof(*this) -
+        offsetof(FunctionScopedWinUsbMsOs20DescSet<PropertyDataBytes>, func));
+
+    compat.wLength = static_cast<uint16_t>(sizeof(MsOs20FeatureCompatibleId));
+    compat.wDescriptorType = MS_OS_20_FEATURE_COMPATIBLE_ID;
+
+    prop.Init(guid);
+  }
+
+  void SetFirstInterface(uint8_t first_interface)
+  {
+    func.bFirstInterface = first_interface;
+  }
+};
+
 #pragma pack(pop)
 
 // ---- sanity checks ----
@@ -130,11 +251,15 @@ static_assert(sizeof(MsOs20SubsetHeaderConfiguration) == 8, "CfgHeader size mism
 static_assert(sizeof(MsOs20SubsetHeaderFunction) == 8, "FuncHeader size mismatch");
 static_assert(sizeof(MsOs20FeatureCompatibleId) == 20, "CompatibleId size mismatch");
 static_assert(sizeof(MsOs20PlatformCapability) == 28, "PlatformCapability size mismatch");
+static_assert(sizeof(DeviceScopedWinUsbMsOs20DescSet<GUID_MULTI_SZ_UTF16_BYTES>) ==
+                  0x00A2,
+              "Device-scoped WinUSB MS OS 2.0 set size mismatch");
+static_assert(sizeof(FunctionScopedWinUsbMsOs20DescSet<GUID_MULTI_SZ_UTF16_BYTES>) ==
+                  0x00B2,
+              "Function-scoped WinUSB MS OS 2.0 set size mismatch");
 
-// ---- helpers ----
+// ---- platform capability helper ----
 
-// Initialize MsOs20PlatformCapability with given descriptor-set length / vendor code /
-// version.
 inline void init_msos20_platform_capability(MsOs20PlatformCapability& cap,
                                             uint16_t msos_descriptor_set_total_length,
                                             uint8_t vendor_code = 0x20,
@@ -271,24 +396,11 @@ class MsOs20BosCapability final : public LibXR::USB::BosCapability
  private:
   void RefreshPlatformCap()
   {
-    // Keep Platform Capability synchronized with descriptor set length / vendor code.
-    platform_cap_ = MsOs20PlatformCapability{};
-    Memory::FastCopy(platform_cap_.PlatformCapabilityUUID,
-                     MSOS20_PLATFORM_CAPABILITY_UUID,
-                     sizeof(MSOS20_PLATFORM_CAPABILITY_UUID));
-    platform_cap_.dwWindowsVersion = windows_version_;
-    platform_cap_.bMS_VendorCode = vendor_code_;
-    platform_cap_.bAltEnumCode = 0x00;
-
-    if (descriptor_set_.size_ <= 0xFFFF)
-    {
-      platform_cap_.wMSOSDescriptorSetTotalLength =
-          static_cast<uint16_t>(descriptor_set_.size_);
-    }
-    else
-    {
-      platform_cap_.wMSOSDescriptorSetTotalLength = 0;
-    }
+    const uint16_t total_length = (descriptor_set_.size_ <= 0xFFFF)
+                                      ? static_cast<uint16_t>(descriptor_set_.size_)
+                                      : 0u;
+    init_msos20_platform_capability(platform_cap_, total_length, vendor_code_,
+                                    windows_version_);
   }
 
   // Cached MS OS 2.0 descriptor set bytes.

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -370,8 +370,6 @@ class DapLinkV2Class : public DeviceClass
 
   void InitWinUsbDescriptors()
   {
-    static constexpr uint8_t kConfigurationValue = 1u;
-
     winusb_msos20_.set.wLength = static_cast<uint16_t>(sizeof(winusb_msos20_.set));
     winusb_msos20_.set.wDescriptorType =
         LibXR::USB::WinUsbMsOs20::MS_OS_20_SET_HEADER_DESCRIPTOR;
@@ -382,7 +380,8 @@ class DapLinkV2Class : public DeviceClass
     winusb_msos20_.cfg.wDescriptorType =
         LibXR::USB::WinUsbMsOs20::MS_OS_20_SUBSET_HEADER_CONFIGURATION;
 
-    winusb_msos20_.cfg.bConfigurationValue = kConfigurationValue;
+    // MS OS 2.0 configuration subset uses a zero-based configuration index.
+    winusb_msos20_.cfg.bConfigurationValue = 0u;
     winusb_msos20_.cfg.bReserved = 0;
     winusb_msos20_.cfg.wTotalLength = static_cast<uint16_t>(
         sizeof(winusb_msos20_) - offsetof(WinUsbMsOs20DescSet, cfg));

--- a/src/driver/usb/device/dfu/dfu_bootloader.hpp
+++ b/src/driver/usb/device/dfu/dfu_bootloader.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <cstring>
-#include <new>
 
 #include "dfu/dfu_def.hpp"
 
@@ -57,18 +56,12 @@ class DfuBootloaderBackend
     erase_block_count_ = (image_size_limit_ + erase_block_size_ - 1u) / erase_block_size_;
     if (erase_block_count_ > 0u)
     {
-      erased_blocks_ = new (std::nothrow) uint8_t[erase_block_count_];
-      if (erased_blocks_ != nullptr)
-      {
-        std::memset(erased_blocks_, 0, erase_block_count_);
-      }
+      erased_blocks_ = new uint8_t[erase_block_count_];
+      std::memset(erased_blocks_, 0, erase_block_count_);
     }
-    seal_storage_size_ = erase_block_size_;
-    if (seal_storage_size_ < sizeof(SealRecord))
-    {
-      seal_storage_size_ = sizeof(SealRecord);
-    }
-    seal_storage_ = new (std::nothrow) uint8_t[seal_storage_size_];
+    seal_storage_size_ =
+        AlignUp(sizeof(SealRecord), NonZeroWriteSize(flash_.MinWriteSize()));
+    seal_storage_ = new uint8_t[seal_storage_size_];
     transfer_size_ = PayloadLimit();
     if (transfer_size_ == 0u)
     {
@@ -78,7 +71,7 @@ class DfuBootloaderBackend
     {
       transfer_size_ = 4096u;
     }
-    write_buffer_ = new (std::nothrow) uint8_t[transfer_size_];
+    write_buffer_ = new uint8_t[transfer_size_];
     ResetTransferState();
     image_.launch_requested = false;
     image_.ready = false;
@@ -148,11 +141,6 @@ class DfuBootloaderBackend
     if (data.addr_ == nullptr || data.size_ == 0u || data.size_ > transfer_size_)
     {
       return DFUStatusCode::ERR_USBR;
-    }
-    if ((erased_blocks_ == nullptr && erase_block_count_ > 0u) ||
-        write_buffer_ == nullptr)
-    {
-      return DFUStatusCode::ERR_VENDOR;
     }
     if (HasPendingWrite() || HasPendingManifest())
     {
@@ -398,12 +386,27 @@ class DfuBootloaderBackend
     return seal_offset_;
   }
 
+  static size_t NonZeroWriteSize(size_t write_size)
+  {
+    return (write_size == 0u) ? 1u : write_size;
+  }
+
+  static size_t AlignUp(size_t value, size_t align)
+  {
+    if (align <= 1u)
+    {
+      return value;
+    }
+    const size_t rem = value % align;
+    return (rem == 0u) ? value : (value + align - rem);
+  }
+
   // 开启新的下载会话，并使之前缓存的镜像有效性视图失效。
   // Start a fresh download session and invalidate any previously cached image view.
   void StartDownloadSession()
   {
     ResetTransferState();
-    if (erased_blocks_ != nullptr)
+    if (erase_block_count_ > 0u)
     {
       std::memset(erased_blocks_, 0, erase_block_count_);
     }
@@ -557,16 +560,11 @@ class DfuBootloaderBackend
                                                       sizeof(seal)}) == ErrorCode::OK;
   }
 
-  // seal 先写入一个擦除块大小的临时缓冲区，
-  // 因此调用方不需要板级专用 side storage。
-  // The seal is staged in an erase-block-sized scratch buffer, so callers do
-  // not need board-specific side storage.
+  // seal 只需要按最小写入粒度对齐；擦除仍按块执行。
+  // The seal scratch buffer only needs minimum-write alignment; erase still
+  // happens at erase-block granularity.
   bool WriteSeal(size_t image_size, uint32_t crc32)
   {
-    if (seal_storage_ == nullptr)
-    {
-      return false;
-    }
     std::memset(seal_storage_, 0xFF, seal_storage_size_);
     auto* seal = reinterpret_cast<SealRecord*>(seal_storage_);
     seal->magic = kSealMagic;
@@ -814,6 +812,10 @@ class DFUClass : public DfuInterfaceClassBase
 
  public:
   static constexpr const char* DEFAULT_INTERFACE_STRING = "XRUSB DFU";
+  static constexpr const char* DEFAULT_WINUSB_DEVICE_INTERFACE_GUID =
+      DfuInterfaceClassBase::DEFAULT_WINUSB_DEVICE_INTERFACE_GUID;
+  static constexpr uint8_t DEFAULT_WINUSB_VENDOR_CODE =
+      DfuInterfaceClassBase::DEFAULT_WINUSB_VENDOR_CODE;
 
   /**
    * @brief Backend 需要满足的接口契约 / Backend contract requirements
@@ -835,9 +837,12 @@ class DFUClass : public DfuInterfaceClassBase
   explicit DFUClass(
       Backend& backend, const char* interface_string = DEFAULT_INTERFACE_STRING,
       const char* webusb_landing_page_url = nullptr,
-      uint8_t webusb_vendor_code = LibXR::USB::WebUsb::WEBUSB_VENDOR_CODE_DEFAULT)
+      uint8_t webusb_vendor_code = LibXR::USB::WebUsb::WEBUSB_VENDOR_CODE_DEFAULT,
+      const char* winusb_device_interface_guid = DEFAULT_WINUSB_DEVICE_INTERFACE_GUID,
+      uint8_t winusb_vendor_code = DEFAULT_WINUSB_VENDOR_CODE)
       : DfuInterfaceClassBase(interface_string, webusb_landing_page_url,
-                              webusb_vendor_code),
+                              webusb_vendor_code, winusb_device_interface_guid,
+                              winusb_vendor_code),
         backend_(backend)
   {
   }
@@ -846,7 +851,8 @@ class DFUClass : public DfuInterfaceClassBase
   void BindEndpoints(EndpointPool&, uint8_t start_itf_num, bool) override
   {
     // 固件态 DFU 在绑定阶段发布单接口描述符，并校验 backend 能力。
-    // Firmware DFU publishes one interface and validates backend capabilities during bind.
+    // Firmware DFU publishes one interface and validates backend capabilities during
+    // bind.
     interface_num_ = start_itf_num;
     current_alt_setting_ = 0u;
 
@@ -1207,7 +1213,8 @@ class DFUClass : public DfuInterfaceClassBase
   void AdvanceStateForStatusRead()
   {
     // 标准 DFU 状态机是在 GETSTATUS 这个同步点上推进的。
-    // GETSTATUS is the synchronization point that advances the standard DFU state machine.
+    // GETSTATUS is the synchronization point that advances the standard DFU state
+    // machine.
     switch (state_)
     {
       case DFUState::DFU_DNLOAD_SYNC:
@@ -1409,11 +1416,14 @@ class DfuBootloaderClassT : private DfuBootloaderClassStorage,
       JumpCallback jump_to_app, void* jump_app_ctx = nullptr, bool autorun = true,
       const char* interface_string = Base::DEFAULT_INTERFACE_STRING,
       const char* webusb_landing_page_url = nullptr,
-      uint8_t webusb_vendor_code = LibXR::USB::WebUsb::WEBUSB_VENDOR_CODE_DEFAULT)
+      uint8_t webusb_vendor_code = LibXR::USB::WebUsb::WEBUSB_VENDOR_CODE_DEFAULT,
+      const char* winusb_device_interface_guid =
+          Base::DEFAULT_WINUSB_DEVICE_INTERFACE_GUID,
+      uint8_t winusb_vendor_code = Base::DEFAULT_WINUSB_VENDOR_CODE)
       : Storage(flash, image_base, image_limit, seal_offset, jump_to_app, jump_app_ctx,
                 autorun),
         Base(Storage::backend_, interface_string, webusb_landing_page_url,
-             webusb_vendor_code)
+             webusb_vendor_code, winusb_device_interface_guid, winusb_vendor_code)
   {
   }
 

--- a/src/driver/usb/device/dfu/dfu_bootloader.hpp
+++ b/src/driver/usb/device/dfu/dfu_bootloader.hpp
@@ -14,7 +14,7 @@ class DfuBootloaderBackend
 {
  public:
   using JumpCallback = void (*)(void*);
-  static constexpr uint32_t kSealMagic = 0x4C414553u;  // "SEAL"
+  static constexpr uint32_t SEAL_MAGIC = 0x4C414553u;  // "SEAL"
 
 #pragma pack(push, 1)
   /**
@@ -22,7 +22,7 @@ class DfuBootloaderBackend
    */
   struct SealRecord
   {
-    uint32_t magic = kSealMagic;
+    uint32_t magic = SEAL_MAGIC;
     uint32_t image_size = 0u;
     uint32_t crc32 = 0u;
     uint32_t crc32_inv = 0u;
@@ -567,7 +567,7 @@ class DfuBootloaderBackend
   {
     std::memset(seal_storage_, 0xFF, seal_storage_size_);
     auto* seal = reinterpret_cast<SealRecord*>(seal_storage_);
-    seal->magic = kSealMagic;
+    seal->magic = SEAL_MAGIC;
     seal->image_size = static_cast<uint32_t>(image_size);
     seal->crc32 = crc32;
     seal->crc32_inv = ~crc32;
@@ -591,7 +591,7 @@ class DfuBootloaderBackend
     {
       return false;
     }
-    if (seal.magic != kSealMagic)
+    if (seal.magic != SEAL_MAGIC)
     {
       return false;
     }
@@ -743,15 +743,15 @@ class DFUClass : public DfuInterfaceClassBase
   static_assert(MAX_TRANSFER_SIZE <= 0xFFFFu,
                 "DFU transfer size must fit in wTransferSize.");
 
-  static constexpr uint8_t kInterfaceClass = 0xFEu;
-  static constexpr uint8_t kInterfaceSubClass = 0x01u;
-  static constexpr uint8_t kInterfaceProtocol = 0x02u;
-  static constexpr uint16_t kDfuVersion = 0x0110u;
+  static constexpr uint8_t INTERFACE_CLASS = 0xFEu;
+  static constexpr uint8_t INTERFACE_SUB_CLASS = 0x01u;
+  static constexpr uint8_t INTERFACE_PROTOCOL = 0x02u;
+  static constexpr uint16_t DFU_VERSION = 0x0110u;
 
-  static constexpr uint8_t kAttrCanDownload = 0x01u;
-  static constexpr uint8_t kAttrCanUpload = 0x02u;
-  static constexpr uint8_t kAttrManifestationTolerant = 0x04u;
-  static constexpr uint8_t kAttrWillDetach = 0x08u;
+  static constexpr uint8_t ATTR_CAN_DOWNLOAD = 0x01u;
+  static constexpr uint8_t ATTR_CAN_UPLOAD = 0x02u;
+  static constexpr uint8_t ATTR_MANIFESTATION_TOLERANT = 0x04u;
+  static constexpr uint8_t ATTR_WILL_DETACH = 0x08u;
 
  public:
 #pragma pack(push, 1)
@@ -766,7 +766,7 @@ class DFUClass : public DfuInterfaceClassBase
     uint8_t bmAttributes = 0;
     uint16_t wDetachTimeOut = 0;
     uint16_t wTransferSize = 0;
-    uint16_t bcdDFUVersion = kDfuVersion;
+    uint16_t bcdDFUVersion = DFU_VERSION;
   };
 
   /**
@@ -798,9 +798,9 @@ class DFUClass : public DfuInterfaceClassBase
         0,
         0,
         0,
-        kInterfaceClass,
-        kInterfaceSubClass,
-        kInterfaceProtocol,
+        INTERFACE_CLASS,
+        INTERFACE_SUB_CLASS,
+        INTERFACE_PROTOCOL,
         0};
     FunctionalDescriptor func_desc = {};
   };
@@ -868,7 +868,7 @@ class DFUClass : public DfuInterfaceClassBase
     desc_block_.func_desc.bmAttributes = BuildAttributeBitmap(caps_);
     desc_block_.func_desc.wDetachTimeOut = caps_.detach_timeout_ms;
     desc_block_.func_desc.wTransferSize = caps_.transfer_size;
-    desc_block_.func_desc.bcdDFUVersion = kDfuVersion;
+    desc_block_.func_desc.bcdDFUVersion = DFU_VERSION;
 
     SetData(RawData{reinterpret_cast<uint8_t*>(&desc_block_), sizeof(desc_block_)});
 
@@ -903,8 +903,8 @@ class DFUClass : public DfuInterfaceClassBase
   ErrorCode WriteDeviceDescriptor(DeviceDescriptor& header) override
   {
     header.data_.bDeviceClass = DeviceDescriptor::ClassID::APPLICATION_SPECIFIC;
-    header.data_.bDeviceSubClass = kInterfaceSubClass;
-    header.data_.bDeviceProtocol = kInterfaceProtocol;
+    header.data_.bDeviceSubClass = INTERFACE_SUB_CLASS;
+    header.data_.bDeviceProtocol = INTERFACE_PROTOCOL;
     return ErrorCode::OK;
   }
 
@@ -1059,10 +1059,10 @@ class DFUClass : public DfuInterfaceClassBase
   static constexpr uint8_t BuildAttributeBitmap(const DFUCapabilities& caps)
   {
     return static_cast<uint8_t>(
-        (caps.can_download ? kAttrCanDownload : 0u) |
-        (caps.can_upload ? kAttrCanUpload : 0u) |
-        (caps.manifestation_tolerant ? kAttrManifestationTolerant : 0u) |
-        (caps.will_detach ? kAttrWillDetach : 0u));
+        (caps.can_download ? ATTR_CAN_DOWNLOAD : 0u) |
+        (caps.can_upload ? ATTR_CAN_UPLOAD : 0u) |
+        (caps.manifestation_tolerant ? ATTR_MANIFESTATION_TOLERANT : 0u) |
+        (caps.will_detach ? ATTR_WILL_DETACH : 0u));
   }
 
   ErrorCode HandleDetach(ControlTransferResult&)
@@ -1409,7 +1409,7 @@ class DfuBootloaderClassT : private DfuBootloaderClassStorage,
 
  public:
   using JumpCallback = DfuBootloaderBackend::JumpCallback;
-  static constexpr uint8_t kVendorRequestRunApp = 0x5Au;
+  static constexpr uint8_t VENDOR_REQUEST_RUN_APP = 0x5Au;
 
   DfuBootloaderClassT(
       Flash& flash, size_t image_base, size_t image_limit, size_t seal_offset,
@@ -1449,7 +1449,7 @@ class DfuBootloaderClassT : private DfuBootloaderClassStorage,
                             uint16_t,
                             typename Base::ControlTransferResult& result) override
   {
-    if (bRequest != kVendorRequestRunApp)
+    if (bRequest != VENDOR_REQUEST_RUN_APP)
     {
       return ErrorCode::NOT_SUPPORT;
     }

--- a/src/driver/usb/device/dfu/dfu_def.hpp
+++ b/src/driver/usb/device/dfu/dfu_def.hpp
@@ -8,6 +8,7 @@
 #include "flash.hpp"
 #include "timebase.hpp"
 #include "webusb.hpp"
+#include "winusb_msos20.hpp"
 
 namespace LibXR::USB
 {
@@ -85,20 +86,39 @@ struct DFUCapabilities
 class DfuInterfaceClassBase : public DeviceClass
 {
  protected:
-  // DFU 单接口类共享的公共状态：
-  // - 一个接口字符串
-  // - 可选 WebUSB BOS capability
-  // - 一组当前 interface/alt setting 状态
-  // Shared single-interface DFU class state:
+  static constexpr const char* DEFAULT_WINUSB_DEVICE_INTERFACE_GUID =
+      "{4066E5F4-3B02-4B90-9475-12F770A7841B}";
+  static constexpr uint8_t DEFAULT_WINUSB_VENDOR_CODE = 0x20u;
+  enum class WinUsbMsOs20Scope : uint8_t
+  {
+    NONE = 0u,
+    DEVICE = 1u,
+    FUNCTION = 2u,
+  };
+  using DeviceWinUsbMsOs20DescSet =
+      LibXR::USB::WinUsbMsOs20::DeviceScopedWinUsbMsOs20DescSet<
+          LibXR::USB::WinUsbMsOs20::GUID_MULTI_SZ_UTF16_BYTES>;
+  using FunctionWinUsbMsOs20DescSet =
+      LibXR::USB::WinUsbMsOs20::FunctionScopedWinUsbMsOs20DescSet<
+          LibXR::USB::WinUsbMsOs20::GUID_MULTI_SZ_UTF16_BYTES>;
+
+  // Shared single-interface DFU state:
   // - one interface string
   // - optional WebUSB BOS capability
-  // - one active interface/alt-setting pair
+  // - WinUSB BOS capability enabled by default for dedicated DFU bootloaders
+  // - current interface/alt-setting pair
   DfuInterfaceClassBase(
       const char* interface_string, const char* webusb_landing_page_url = nullptr,
-      uint8_t webusb_vendor_code = LibXR::USB::WebUsb::WEBUSB_VENDOR_CODE_DEFAULT)
+      uint8_t webusb_vendor_code = LibXR::USB::WebUsb::WEBUSB_VENDOR_CODE_DEFAULT,
+      const char* winusb_device_interface_guid = DEFAULT_WINUSB_DEVICE_INTERFACE_GUID,
+      uint8_t winusb_vendor_code = DEFAULT_WINUSB_VENDOR_CODE,
+      WinUsbMsOs20Scope winusb_scope = WinUsbMsOs20Scope::DEVICE)
       : interface_string_(interface_string),
+        winusb_scope_(winusb_scope),
         webusb_cap_(webusb_landing_page_url, webusb_vendor_code)
   {
+    InitWinUsbDescriptors(ResolveWinUsbDeviceInterfaceGuid(winusb_device_interface_guid),
+                          winusb_vendor_code);
   }
 
   const char* GetInterfaceString(size_t local_interface_index) const override
@@ -106,10 +126,22 @@ class DfuInterfaceClassBase : public DeviceClass
     return (local_interface_index == 0u) ? interface_string_ : nullptr;
   }
 
-  size_t GetBosCapabilityCount() override { return webusb_cap_.Enabled() ? 1u : 0u; }
+  size_t GetBosCapabilityCount() override
+  {
+    return (HasWinUsbBosCapability() ? 1u : 0u) + (webusb_cap_.Enabled() ? 1u : 0u);
+  }
 
   BosCapability* GetBosCapability(size_t index) override
   {
+    if (HasWinUsbBosCapability())
+    {
+      if (index == 0u)
+      {
+        return &winusb_msos20_cap_;
+      }
+      return (index == 1u && webusb_cap_.Enabled()) ? &webusb_cap_ : nullptr;
+    }
+
     return (index == 0u && webusb_cap_.Enabled()) ? &webusb_cap_ : nullptr;
   }
 
@@ -117,10 +149,57 @@ class DfuInterfaceClassBase : public DeviceClass
   uint8_t current_alt_setting_ = 0u;
   bool inited_ = false;
 
+  void UpdateWinUsbFunctionInterface(uint8_t interface_num,
+                                     uint8_t configuration_index = 0u)
+  {
+    function_winusb_msos20_.SetFirstInterface(interface_num);
+    function_winusb_msos20_.cfg.bConfigurationValue = configuration_index;
+    if (winusb_scope_ == WinUsbMsOs20Scope::FUNCTION)
+    {
+      winusb_msos20_cap_.SetDescriptorSet(GetWinUsbMsOs20DescriptorSet());
+    }
+  }
+
  private:
+  bool HasWinUsbBosCapability() const { return winusb_scope_ != WinUsbMsOs20Scope::NONE; }
+
+  static const char* ResolveWinUsbDeviceInterfaceGuid(const char* guid)
+  {
+    return (guid != nullptr && guid[0] != '\0') ? guid
+                                                : DEFAULT_WINUSB_DEVICE_INTERFACE_GUID;
+  }
+
+  ConstRawData GetWinUsbMsOs20DescriptorSet() const
+  {
+    if (winusb_scope_ == WinUsbMsOs20Scope::FUNCTION)
+    {
+      return ConstRawData{reinterpret_cast<const uint8_t*>(&function_winusb_msos20_),
+                          sizeof(function_winusb_msos20_)};
+    }
+    if (winusb_scope_ == WinUsbMsOs20Scope::DEVICE)
+    {
+      return ConstRawData{reinterpret_cast<const uint8_t*>(&device_winusb_msos20_),
+                          sizeof(device_winusb_msos20_)};
+    }
+    return ConstRawData{nullptr, 0};
+  }
+
+  void InitWinUsbDescriptors(const char* guid, uint8_t vendor_code)
+  {
+    device_winusb_msos20_.Init(guid);
+    function_winusb_msos20_.Init(0u, 0u, guid);
+    winusb_msos20_cap_.SetVendorCode(vendor_code);
+    winusb_msos20_cap_.SetDescriptorSet(GetWinUsbMsOs20DescriptorSet());
+  }
+
   const char* interface_string_ = nullptr;
+  WinUsbMsOs20Scope winusb_scope_ = WinUsbMsOs20Scope::DEVICE;
+  DeviceWinUsbMsOs20DescSet device_winusb_msos20_{};
+  FunctionWinUsbMsOs20DescSet function_winusb_msos20_{};
 
  protected:
+  LibXR::USB::WinUsbMsOs20::MsOs20BosCapability winusb_msos20_cap_{
+      LibXR::ConstRawData{nullptr, 0}, DEFAULT_WINUSB_VENDOR_CODE};
   LibXR::USB::WebUsb::WebUsbBosCapability webusb_cap_;
 };
 

--- a/src/driver/usb/device/dfu/dfu_runtime.hpp
+++ b/src/driver/usb/device/dfu/dfu_runtime.hpp
@@ -26,7 +26,8 @@ class DfuRuntimeClass : public DfuInterfaceClassBase
       const char* webusb_landing_page_url = nullptr,
       uint8_t webusb_vendor_code = LibXR::USB::WebUsb::WEBUSB_VENDOR_CODE_DEFAULT)
       : DfuInterfaceClassBase(interface_string, webusb_landing_page_url,
-                              webusb_vendor_code),
+                              webusb_vendor_code, DEFAULT_WINUSB_DEVICE_INTERFACE_GUID,
+                              DEFAULT_WINUSB_VENDOR_CODE, WinUsbMsOs20Scope::FUNCTION),
         jump_to_bootloader_(jump_to_bootloader),
         jump_ctx_(jump_ctx),
         default_detach_timeout_ms_(detach_timeout_ms)
@@ -109,6 +110,7 @@ class DfuRuntimeClass : public DfuInterfaceClassBase
     // Runtime DFU has no data endpoints; bind only publishes the interface /
     // functional descriptors and resets the detach state machine.
     interface_num_ = start_itf_num;
+    UpdateWinUsbFunctionInterface(interface_num_);
     current_alt_setting_ = 0u;
     detach_pending_ = false;
     detach_timeout_ms_ = default_detach_timeout_ms_;

--- a/src/driver/usb/device/dfu/dfu_runtime.hpp
+++ b/src/driver/usb/device/dfu/dfu_runtime.hpp
@@ -13,7 +13,7 @@ class DfuRuntimeClass : public DfuInterfaceClassBase
  public:
   using JumpCallback = void (*)(void*);
   static constexpr const char* DEFAULT_INTERFACE_STRING = "XRUSB DFU RT";
-  static constexpr uint8_t kAttrWillDetach = 0x08u;
+  static constexpr uint8_t ATTR_WILL_DETACH = 0x08u;
 
   /**
    * @brief 构造 Runtime DFU 类
@@ -118,7 +118,7 @@ class DfuRuntimeClass : public DfuInterfaceClassBase
     desc_block_.interface_desc.bInterfaceNumber = interface_num_;
     desc_block_.interface_desc.iInterface = GetInterfaceStringIndex(0u);
     desc_block_.func_desc.bmAttributes =
-        (jump_to_bootloader_ != nullptr) ? kAttrWillDetach : 0u;
+        (jump_to_bootloader_ != nullptr) ? ATTR_WILL_DETACH : 0u;
     desc_block_.func_desc.wDetachTimeOut =
         (jump_to_bootloader_ != nullptr) ? detach_timeout_ms_ : 0u;
     desc_block_.func_desc.wTransferSize = 0u;

--- a/system/linux/linux_shared_topic_impl.hpp
+++ b/system/linux/linux_shared_topic_impl.hpp
@@ -188,8 +188,8 @@ class LinuxSharedTopic : public Topic
 
       other.topic_ = nullptr;
       other.owned_topic_ = nullptr;
-      other.subscriber_index_ = kInvalidIndex;
-      other.current_slot_index_ = kInvalidIndex;
+      other.subscriber_index_ = INVALID_INDEX;
+      other.current_slot_index_ = INVALID_INDEX;
       other.current_sequence_ = 0;
       return *this;
     }
@@ -201,7 +201,7 @@ class LinuxSharedTopic : public Topic
      */
     bool Valid() const
     {
-      return topic_ != nullptr && subscriber_index_ != kInvalidIndex;
+      return topic_ != nullptr && subscriber_index_ != INVALID_INDEX;
     }
 
     /**
@@ -318,7 +318,7 @@ class LinuxSharedTopic : public Topic
      */
     const TopicData* GetData() const
     {
-      if (!Valid() || current_slot_index_ == kInvalidIndex)
+      if (!Valid() || current_slot_index_ == INVALID_INDEX)
       {
         return nullptr;
       }
@@ -370,14 +370,14 @@ class LinuxSharedTopic : public Topic
      */
     void Release()
     {
-      if (!Valid() || current_slot_index_ == kInvalidIndex)
+      if (!Valid() || current_slot_index_ == INVALID_INDEX)
       {
         return;
       }
 
       topic_->ClearHeldSlot(subscriber_index_, current_slot_index_);
       topic_->ReleaseSlot(current_slot_index_);
-      current_slot_index_ = kInvalidIndex;
+      current_slot_index_ = INVALID_INDEX;
       current_sequence_ = 0;
     }
 
@@ -409,8 +409,8 @@ class LinuxSharedTopic : public Topic
       topic_ = nullptr;
       delete owned_topic_;
       owned_topic_ = nullptr;
-      subscriber_index_ = kInvalidIndex;
-      current_slot_index_ = kInvalidIndex;
+      subscriber_index_ = INVALID_INDEX;
+      current_slot_index_ = INVALID_INDEX;
       current_sequence_ = 0;
     }
 
@@ -444,7 +444,7 @@ class LinuxSharedTopic : public Topic
                                                 std::memory_order_release);
           topic.subscribers_[i].owner_starttime.store(topic.self_identity_.starttime,
                                                       std::memory_order_release);
-          topic.subscribers_[i].held_slot.store(kInvalidIndex, std::memory_order_release);
+          topic.subscribers_[i].held_slot.store(INVALID_INDEX, std::memory_order_release);
           topic.subscribers_[i].mode.store(static_cast<uint32_t>(mode),
                                            std::memory_order_release);
           if (mode == LinuxSharedSubscriberMode::BALANCE_RR)
@@ -464,7 +464,7 @@ class LinuxSharedTopic : public Topic
           }
           topic_ = &topic;
           subscriber_index_ = i;
-          current_slot_index_ = kInvalidIndex;
+          current_slot_index_ = INVALID_INDEX;
           current_sequence_ = 0;
           return ErrorCode::OK;
         }
@@ -475,8 +475,8 @@ class LinuxSharedTopic : public Topic
 
     LinuxSharedTopic* topic_ = nullptr;
     LinuxSharedTopic* owned_topic_ = nullptr;
-    uint32_t subscriber_index_ = kInvalidIndex;
-    uint32_t current_slot_index_ = kInvalidIndex;
+    uint32_t subscriber_index_ = INVALID_INDEX;
+    uint32_t current_slot_index_ = INVALID_INDEX;
     uint64_t current_sequence_ = 0;
   };
 
@@ -527,17 +527,17 @@ class LinuxSharedTopic : public Topic
       subscriber_index_ = other.subscriber_index_;
 
       other.topic_ = nullptr;
-      other.slot_index_ = kInvalidIndex;
+      other.slot_index_ = INVALID_INDEX;
       other.sequence_ = 0;
       other.state_ = SharedDataState::EMPTY;
-      other.subscriber_index_ = kInvalidIndex;
+      other.subscriber_index_ = INVALID_INDEX;
       return *this;
     }
 
     /**
      * @brief 检查句柄是否有效。Checks whether the handle is valid.
      */
-    bool Valid() const { return topic_ != nullptr && slot_index_ != kInvalidIndex; }
+    bool Valid() const { return topic_ != nullptr && slot_index_ != INVALID_INDEX; }
 
     /**
      * @brief 检查句柄是否为空。Checks whether the handle is empty.
@@ -597,10 +597,10 @@ class LinuxSharedTopic : public Topic
         topic_->ReleaseSlot(slot_index_);
       }
       topic_ = nullptr;
-      slot_index_ = kInvalidIndex;
+      slot_index_ = INVALID_INDEX;
       sequence_ = 0;
       state_ = SharedDataState::EMPTY;
-      subscriber_index_ = kInvalidIndex;
+      subscriber_index_ = INVALID_INDEX;
     }
 
    private:
@@ -608,10 +608,10 @@ class LinuxSharedTopic : public Topic
     friend class Subscriber;
 
     LinuxSharedTopic* topic_ = nullptr;
-    uint32_t slot_index_ = kInvalidIndex;
+    uint32_t slot_index_ = INVALID_INDEX;
     uint64_t sequence_ = 0;
     SharedDataState state_ = SharedDataState::EMPTY;
-    uint32_t subscriber_index_ = kInvalidIndex;
+    uint32_t subscriber_index_ = INVALID_INDEX;
   };
 
   /**
@@ -757,7 +757,7 @@ class LinuxSharedTopic : public Topic
 
     data.Reset();
 
-    uint32_t slot_index = kInvalidIndex;
+    uint32_t slot_index = INVALID_INDEX;
     ErrorCode pop_ans = PopFreeSlot(slot_index);
     if (pop_ans != ErrorCode::OK)
     {
@@ -776,7 +776,7 @@ class LinuxSharedTopic : public Topic
     data.slot_index_ = slot_index;
     data.sequence_ = 0;
     data.state_ = SharedDataState::PUBLISHER;
-    data.subscriber_index_ = kInvalidIndex;
+    data.subscriber_index_ = INVALID_INDEX;
     return ErrorCode::OK;
   }
 
@@ -889,7 +889,7 @@ class LinuxSharedTopic : public Topic
 
   struct Descriptor
   {
-    uint32_t slot_index = kInvalidIndex;
+    uint32_t slot_index = INVALID_INDEX;
     uint32_t reserved = 0;
     uint64_t sequence = 0;
   };
@@ -918,10 +918,10 @@ class LinuxSharedTopic : public Topic
     uint64_t starttime = 0;
   };
 
-  static constexpr uint64_t kMagic = 0x4c58524950435348ULL;
-  static constexpr uint32_t kVersion = 1;
-  static constexpr uint32_t kInitReady = 1;
-  static constexpr uint32_t kInvalidIndex = UINT32_MAX;
+  static constexpr uint64_t MAGIC = 0x4c58524950435348ULL;
+  static constexpr uint32_t VERSION = 1;
+  static constexpr uint32_t INIT_READY = 1;
+  static constexpr uint32_t INVALID_INDEX = UINT32_MAX;
 
   static uint32_t ResolveDomainKey(const char* domain_name)
   {
@@ -1170,10 +1170,10 @@ class LinuxSharedTopic : public Topic
     header_->topic_name_len = static_cast<uint32_t>(topic_name_.size());
     SetupPointers();
 
-    header_->magic = kMagic;
+    header_->magic = MAGIC;
     header_->name_key = name_key_;
     header_->domain_crc32 = domain_crc32_;
-    header_->version = kVersion;
+    header_->version = VERSION;
     header_->data_size = sizeof(TopicData);
     header_->slot_count = slot_count_;
     header_->subscriber_capacity = subscriber_capacity_;
@@ -1207,8 +1207,8 @@ class LinuxSharedTopic : public Topic
       subscribers_[i].dropped_messages.store(0, std::memory_order_release);
       subscribers_[i].owner_pid.store(0, std::memory_order_release);
       subscribers_[i].owner_starttime.store(0, std::memory_order_release);
-      subscribers_[i].held_slot.store(kInvalidIndex, std::memory_order_release);
-      balanced_members_[i].store(kInvalidIndex, std::memory_order_release);
+      subscribers_[i].held_slot.store(INVALID_INDEX, std::memory_order_release);
+      balanced_members_[i].store(INVALID_INDEX, std::memory_order_release);
     }
 
     balanced_group_->rr_cursor.store(0, std::memory_order_release);
@@ -1218,7 +1218,7 @@ class LinuxSharedTopic : public Topic
       descriptors_[i] = Descriptor{};
     }
 
-    header_->init_state.store(kInitReady, std::memory_order_release);
+    header_->init_state.store(INIT_READY, std::memory_order_release);
     return ErrorCode::OK;
   }
 
@@ -1241,12 +1241,12 @@ class LinuxSharedTopic : public Topic
     base_ = static_cast<uint8_t*>(mapping_);
     header_ = reinterpret_cast<SharedHeader*>(base_);
 
-    while (header_->init_state.load(std::memory_order_acquire) != kInitReady)
+    while (header_->init_state.load(std::memory_order_acquire) != INIT_READY)
     {
       usleep(1000);
     }
 
-    if (header_->magic != kMagic || header_->version != kVersion ||
+    if (header_->magic != MAGIC || header_->version != VERSION ||
         header_->data_size != sizeof(TopicData))
     {
       return ErrorCode::CHECK_ERR;
@@ -1295,7 +1295,7 @@ class LinuxSharedTopic : public Topic
         bool identity_match = false;
         const size_t mapping_size = static_cast<size_t>(st.st_size);
         const size_t topic_name_bytes = topic_name_.size() + 1U;
-        if (header->magic == kMagic && header->version == kVersion &&
+        if (header->magic == MAGIC && header->version == VERSION &&
             header->domain_crc32 == domain_crc32_ &&
             header->topic_name_len == topic_name_.size())
         {
@@ -1318,7 +1318,7 @@ class LinuxSharedTopic : public Topic
         {
           reclaim = false;
         }
-        else if (init_state != kInitReady)
+        else if (init_state != INIT_READY)
         {
           reclaim = !ProcessAlive(publisher_identity);
         }
@@ -1457,14 +1457,14 @@ class LinuxSharedTopic : public Topic
   {
     uint32_t expected = slot_index;
     subscribers_[subscriber_index].held_slot.compare_exchange_strong(
-        expected, kInvalidIndex, std::memory_order_acq_rel, std::memory_order_relaxed);
+        expected, INVALID_INDEX, std::memory_order_acq_rel, std::memory_order_relaxed);
   }
 
   ErrorCode RegisterBalancedSubscriber(uint32_t subscriber_index)
   {
     for (uint32_t i = 0; i < subscriber_capacity_; ++i)
     {
-      uint32_t expected = kInvalidIndex;
+      uint32_t expected = INVALID_INDEX;
       if (balanced_members_[i].compare_exchange_strong(expected, subscriber_index,
                                                        std::memory_order_acq_rel,
                                                        std::memory_order_relaxed))
@@ -1480,7 +1480,7 @@ class LinuxSharedTopic : public Topic
     for (uint32_t i = 0; i < subscriber_capacity_; ++i)
     {
       uint32_t expected = subscriber_index;
-      if (balanced_members_[i].compare_exchange_strong(expected, kInvalidIndex,
+      if (balanced_members_[i].compare_exchange_strong(expected, INVALID_INDEX,
                                                        std::memory_order_acq_rel,
                                                        std::memory_order_relaxed))
       {
@@ -1496,7 +1496,7 @@ class LinuxSharedTopic : public Topic
     {
       const uint32_t member_index =
           balanced_members_[(base + offset) % subscriber_capacity_].load(std::memory_order_acquire);
-      if (member_index == kInvalidIndex)
+      if (member_index == INVALID_INDEX)
       {
         continue;
       }
@@ -1613,8 +1613,8 @@ class LinuxSharedTopic : public Topic
       subscribers_[i].owner_starttime.store(0, std::memory_order_release);
 
       const uint32_t held_slot =
-          subscribers_[i].held_slot.exchange(kInvalidIndex, std::memory_order_acq_rel);
-      if (held_slot != kInvalidIndex)
+          subscribers_[i].held_slot.exchange(INVALID_INDEX, std::memory_order_acq_rel);
+      if (held_slot != INVALID_INDEX)
       {
         ReleaseSlot(held_slot);
       }
@@ -1770,7 +1770,7 @@ class LinuxSharedTopic : public Topic
     }
 
     uint32_t active_count = 0;
-    uint32_t balanced_target = kInvalidIndex;
+    uint32_t balanced_target = INVALID_INDEX;
     bool has_balanced_subscriber = false;
     for (uint32_t i = 0; i < subscriber_capacity_; ++i)
     {
@@ -1859,13 +1859,13 @@ class LinuxSharedTopic : public Topic
       PushDescriptor(i, descriptor);
     }
 
-    if (balanced_target != kInvalidIndex)
+    if (balanced_target != INVALID_INDEX)
     {
       PushDescriptor(balanced_target, descriptor);
     }
 
     data.topic_ = nullptr;
-    data.slot_index_ = kInvalidIndex;
+    data.slot_index_ = INVALID_INDEX;
     return ErrorCode::OK;
   }
 

--- a/test/test_linux_shm_topic.cpp
+++ b/test/test_linux_shm_topic.cpp
@@ -11,8 +11,8 @@
 namespace
 {
 
-constexpr uint32_t kShortWaitMs = 100;
-constexpr uint32_t kLongWaitMs = 2000;
+constexpr uint32_t SHORT_WAIT_MS = 100;
+constexpr uint32_t LONG_WAIT_MS = 2000;
 
 struct IPCFrame
 {
@@ -114,7 +114,7 @@ void test_linux_shm_topic()
     SharedData data2;
     ASSERT(publisher.CreateData(data2) == LibXR::ErrorCode::FULL);
 
-    ASSERT(subscriber.Wait(kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(subscriber.GetData() != nullptr);
     AssertFrame(*subscriber.GetData(), 100);
     ASSERT(subscriber.GetPendingNum() == 1);
@@ -124,12 +124,12 @@ void test_linux_shm_topic()
     FillFrame(*data2.GetData(), 102);
     ASSERT(publisher.Publish(data2) == LibXR::ErrorCode::OK);
 
-    ASSERT(subscriber.Wait(kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(subscriber.GetData() != nullptr);
     AssertFrame(*subscriber.GetData(), 101);
     subscriber.Release();
 
-    ASSERT(subscriber.Wait(kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(subscriber.GetData() != nullptr);
     AssertFrame(*subscriber.GetData(), 102);
     ASSERT(subscriber.GetPendingNum() == 0);
@@ -208,12 +208,12 @@ void test_linux_shm_topic()
     ASSERT(publisher.GetPublishFailedNum() == 1);
 
     SharedData recv_data;
-    ASSERT(subscriber.Wait(recv_data, kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber.Wait(recv_data, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(recv_data.GetSequence() == 1);
     AssertFrame(*recv_data.GetData(), 201);
     recv_data.Reset();
 
-    ASSERT(subscriber.Wait(recv_data, kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber.Wait(recv_data, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(recv_data.GetSequence() == 2);
     AssertFrame(*recv_data.GetData(), 202);
     recv_data.Reset();
@@ -249,12 +249,12 @@ void test_linux_shm_topic()
     ASSERT(publisher.GetPublishFailedNum() == 0);
 
     SharedData recv_data;
-    ASSERT(subscriber.Wait(recv_data, kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber.Wait(recv_data, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(recv_data.GetSequence() == 2);
     AssertFrame(*recv_data.GetData(), 212);
     recv_data.Reset();
 
-    ASSERT(subscriber.Wait(recv_data, kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber.Wait(recv_data, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(recv_data.GetSequence() == 3);
     AssertFrame(*recv_data.GetData(), 213);
     recv_data.Reset();
@@ -283,8 +283,8 @@ void test_linux_shm_topic()
     FillFrame(frame, 301);
     ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
 
-    ASSERT(subscriber_a.Wait(kShortWaitMs) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_a.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     AssertFrame(*subscriber_a.GetData(), 301);
     AssertFrame(*subscriber_b.GetData(), 301);
 
@@ -298,8 +298,8 @@ void test_linux_shm_topic()
     FillFrame(*blocked_data.GetData(), 302);
     ASSERT(publisher.Publish(blocked_data) == LibXR::ErrorCode::OK);
 
-    ASSERT(subscriber_a.Wait(kShortWaitMs) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_a.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     AssertFrame(*subscriber_a.GetData(), 302);
     AssertFrame(*subscriber_b.GetData(), 302);
     subscriber_a.Release();
@@ -341,8 +341,8 @@ void test_linux_shm_topic()
 
     SharedData recv_a;
     SharedData recv_b;
-    ASSERT(subscriber_a.Wait(recv_a, kShortWaitMs) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(recv_b, kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_a.Wait(recv_a, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(recv_b, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(recv_a.GetData()->seq == 331);
     ASSERT(recv_b.GetData()->seq == 441);
     recv_a.Reset();
@@ -385,10 +385,10 @@ void test_linux_shm_topic()
     SharedData recv_b1;
     SharedData recv_b2;
 
-    ASSERT(subscriber_a.Wait(recv_a1, kShortWaitMs) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(recv_b1, kShortWaitMs) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_a.Wait(recv_a2, kShortWaitMs) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(recv_b2, kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_a.Wait(recv_a1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(recv_b1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_a.Wait(recv_a2, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(recv_b2, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
 
     ASSERT(recv_a1.GetData()->seq == 351);
     ASSERT(recv_b1.GetData()->seq == 352);
@@ -431,7 +431,7 @@ void test_linux_shm_topic()
       }
 
       SharedData data;
-      if (subscriber.Wait(data, kLongWaitMs) != LibXR::ErrorCode::OK)
+      if (subscriber.Wait(data, LONG_WAIT_MS) != LibXR::ErrorCode::OK)
       {
         _exit(41);
       }
@@ -478,8 +478,8 @@ void test_linux_shm_topic()
 
     SharedData recv_alive1;
     SharedData recv_alive2;
-    ASSERT(subscriber_alive.Wait(recv_alive1, kLongWaitMs) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_alive.Wait(recv_alive2, kLongWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_alive.Wait(recv_alive1, LONG_WAIT_MS) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_alive.Wait(recv_alive2, LONG_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(recv_alive1.GetData()->seq == 362);
     ASSERT(recv_alive2.GetData()->seq == 363);
 
@@ -518,7 +518,7 @@ void test_linux_shm_topic()
     ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::OK);
 
     SharedData recv_b0;
-    ASSERT(subscriber_b.Wait(recv_b0, kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(recv_b0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(recv_b0.GetData()->seq == 372);
     recv_b0.Reset();
 
@@ -528,9 +528,9 @@ void test_linux_shm_topic()
     SharedData recv_a;
     SharedData recv_b1;
     SharedData recv_c;
-    ASSERT(subscriber_a.Wait(recv_a, kShortWaitMs) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_b.Wait(recv_b1, kShortWaitMs) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_c.Wait(recv_c, kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_a.Wait(recv_a, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_b.Wait(recv_b1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_c.Wait(recv_c, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
 
     ASSERT(recv_a.GetData()->seq == 371);
     ASSERT(recv_b1.GetData()->seq == 374);
@@ -570,9 +570,9 @@ void test_linux_shm_topic()
     SharedData bc0;
     SharedData bc1;
     SharedData bc2;
-    ASSERT(subscriber_broadcast.Wait(bc0, kShortWaitMs) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_broadcast.Wait(bc1, kShortWaitMs) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_broadcast.Wait(bc2, kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_broadcast.Wait(bc0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_broadcast.Wait(bc1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_broadcast.Wait(bc2, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(bc0.GetData()->seq == 381);
     ASSERT(bc1.GetData()->seq == 382);
     ASSERT(bc2.GetData()->seq == 383);
@@ -580,9 +580,9 @@ void test_linux_shm_topic()
     SharedData rr_a0;
     SharedData rr_b0;
     SharedData rr_a1;
-    ASSERT(subscriber_rr_a.Wait(rr_a0, kShortWaitMs) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_rr_b.Wait(rr_b0, kShortWaitMs) == LibXR::ErrorCode::OK);
-    ASSERT(subscriber_rr_a.Wait(rr_a1, kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_rr_a.Wait(rr_a0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_rr_b.Wait(rr_b0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_rr_a.Wait(rr_a1, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(rr_a0.GetData()->seq == 381);
     ASSERT(rr_b0.GetData()->seq == 382);
     ASSERT(rr_a1.GetData()->seq == 383);
@@ -616,11 +616,11 @@ void test_linux_shm_topic()
     ASSERT(publisher.Publish(frame) == LibXR::ErrorCode::FULL);
 
     SharedData bc0;
-    ASSERT(subscriber_broadcast.Wait(bc0, kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_broadcast.Wait(bc0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(bc0.GetData()->seq == 391);
 
     SharedData rr0;
-    ASSERT(subscriber_rr.Wait(rr0, kShortWaitMs) == LibXR::ErrorCode::OK);
+    ASSERT(subscriber_rr.Wait(rr0, SHORT_WAIT_MS) == LibXR::ErrorCode::OK);
     ASSERT(rr0.GetData()->seq == 391);
   }
 
@@ -659,7 +659,7 @@ void test_linux_shm_topic()
       }
 
       SharedData recv_data;
-      if (subscriber.Wait(recv_data, kLongWaitMs) != LibXR::ErrorCode::OK)
+      if (subscriber.Wait(recv_data, LONG_WAIT_MS) != LibXR::ErrorCode::OK)
       {
         _exit(11);
       }
@@ -740,7 +740,7 @@ void test_linux_shm_topic()
       for (uint32_t seq = 1; seq <= 32; ++seq)
       {
         SharedData recv_data;
-        if (subscriber.Wait(recv_data, kLongWaitMs) != LibXR::ErrorCode::OK)
+        if (subscriber.Wait(recv_data, LONG_WAIT_MS) != LibXR::ErrorCode::OK)
         {
           _exit(3);
         }

--- a/test/test_print.cpp
+++ b/test/test_print.cpp
@@ -405,9 +405,9 @@ void TestPrintfFrontendSemantics()
   {
     enum PlainHex : unsigned
     {
-      kPlainHex = 42U
+      PLAIN_HEX = 42U
     };
-    if (!SameAsSnprintf<"%#x|%u">(kPlainHex, kPlainHex))
+    if (!SameAsSnprintf<"%#x|%u">(PLAIN_HEX, PLAIN_HEX))
     {
       Fail("printf enum mismatch");
     }

--- a/test/test_rw_pipe.cpp
+++ b/test/test_rw_pipe.cpp
@@ -15,8 +15,8 @@
 namespace LibXRTest
 {
 
-inline constexpr uint32_t kAsyncTimeoutMs = 200;
-inline constexpr uint32_t kShortWaitMs = 100;
+inline constexpr uint32_t ASYNC_TIMEOUT_MS = 200;
+inline constexpr uint32_t SHORT_WAIT_MS = 100;
 
 enum class TestMode : uint8_t
 {
@@ -26,9 +26,9 @@ enum class TestMode : uint8_t
   BLOCK
 };
 
-inline constexpr TestMode kAllModes[] = {TestMode::NONE, TestMode::POLLING,
+inline constexpr TestMode ALL_MODES[] = {TestMode::NONE, TestMode::POLLING,
                                          TestMode::CALLBACK, TestMode::BLOCK};
-inline constexpr TestMode kAsyncModes[] = {TestMode::NONE, TestMode::POLLING,
+inline constexpr TestMode ASYNC_MODES[] = {TestMode::NONE, TestMode::POLLING,
                                            TestMode::CALLBACK};
 
 struct CompletionProbe
@@ -52,7 +52,7 @@ struct ModeHarness
   using CallbackType = typename Op::Callback;
   using PollingStatus = typename Op::OperationPollingStatus;
 
-  explicit ModeHarness(TestMode mode, uint32_t timeout = kAsyncTimeoutMs)
+  explicit ModeHarness(TestMode mode, uint32_t timeout = ASYNC_TIMEOUT_MS)
       : mode(mode),
         callback(CallbackType::Create(OnCallback, this)),
         sem(0),
@@ -95,7 +95,7 @@ struct ModeHarness
                                       : PollingStatus::ERROR));
         return;
       case TestMode::CALLBACK:
-        ASSERT(probe.sem.Wait(kAsyncTimeoutMs) == LibXR::ErrorCode::OK);
+        ASSERT(probe.sem.Wait(ASYNC_TIMEOUT_MS) == LibXR::ErrorCode::OK);
         ASSERT(probe.count.load(std::memory_order_acquire) == 1);
         ASSERT(static_cast<LibXR::ErrorCode>(
                    probe.last.load(std::memory_order_acquire)) == expected);
@@ -152,7 +152,7 @@ inline void JoinThreadIfNeeded(LibXR::Thread& thread)
 #endif
 }
 
-inline void ExpectWaitOk(LibXR::Semaphore& sem, uint32_t timeout = kAsyncTimeoutMs)
+inline void ExpectWaitOk(LibXR::Semaphore& sem, uint32_t timeout = ASYNC_TIMEOUT_MS)
 {
   ASSERT(sem.Wait(timeout) == LibXR::ErrorCode::OK);
 }
@@ -163,9 +163,9 @@ namespace
 {
 using LibXRTest::ExpectWaitOk;
 using LibXRTest::JoinThreadIfNeeded;
-using LibXRTest::kAsyncModes;
-using LibXRTest::kAsyncTimeoutMs;
-using LibXRTest::kShortWaitMs;
+using LibXRTest::ASYNC_MODES;
+using LibXRTest::ASYNC_TIMEOUT_MS;
+using LibXRTest::SHORT_WAIT_MS;
 using LibXRTest::ReadHarness;
 using LibXRTest::TestMode;
 using LibXRTest::WriteHarness;
@@ -459,7 +459,7 @@ void VerifyStreamBlockPendingCompletion(LibXR::ErrorCode finish_result,
 
   static const uint8_t TX[] = {0x41, 0x42, 0x43, 0x44};
   Semaphore sem;
-  WriteOperation op(sem, kShortWaitMs);
+  WriteOperation op(sem, SHORT_WAIT_MS);
   Semaphore done;
   Thread finisher;
   StartWriteFinisher(
@@ -476,7 +476,7 @@ void VerifyStreamBlockPendingCompletion(LibXR::ErrorCode finish_result,
     }
   }
 
-  ExpectWaitOk(done, kShortWaitMs);
+  ExpectWaitOk(done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher);
   ASSERT(sem.Value() == 0);
   ASSERT(w.busy_.load(std::memory_order_acquire) == WritePort::BusyState::IDLE);
@@ -510,7 +510,7 @@ void VerifyStreamBlockTimeout()
 
 void test_rw_pending_mode_matrix()
 {
-  for (auto mode : kAsyncModes)
+  for (auto mode : ASYNC_MODES)
   {
     VerifyPendingReadMode(mode, LibXR::ErrorCode::FAILED);
     VerifyPendingWriteMode(mode, LibXR::ErrorCode::FAILED);
@@ -521,7 +521,7 @@ void test_rw_edge_cases()
 {
   using namespace LibXR;
 
-  for (auto mode : kAsyncModes)
+  for (auto mode : ASYNC_MODES)
   {
     VerifyZeroWriteMode(mode);
     VerifyZeroReadMode(mode);
@@ -674,7 +674,7 @@ void test_rw_read_port_reset_detaches_block_waiter()
   ReadOperation blocked_op(blocked_sem, 0);
   ASSERT(r(RawData{blocked_rx, sizeof(blocked_rx)}, blocked_op) == ErrorCode::BUSY);
 
-  ExpectWaitOk(done, kShortWaitMs);
+  ExpectWaitOk(done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(reader);
   ASSERT(ctx.result == ErrorCode::TIMEOUT);
   ASSERT(stale_rx[0] == 0xA5);
@@ -717,7 +717,7 @@ void test_rw_write_port_reset_detaches_block_waiter()
   WriteOperation blocked_op(blocked_sem, 0);
   ASSERT(w(ConstRawData{TX2, sizeof(TX2)}, blocked_op) == ErrorCode::BUSY);
 
-  ExpectWaitOk(done, kShortWaitMs);
+  ExpectWaitOk(done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(writer);
   ASSERT(ctx.result == ErrorCode::TIMEOUT);
   ASSERT(w.busy_.load(std::memory_order_acquire) == WritePort::BusyState::IDLE);
@@ -729,7 +729,7 @@ void test_rw_write_port_reset_detaches_block_waiter()
   Semaphore sem;
   WriteOperation op(sem, 100);
   ASSERT(w(ConstRawData{TX2, sizeof(TX2)}, op) == ErrorCode::OK);
-  ExpectWaitOk(finish_done, kShortWaitMs);
+  ExpectWaitOk(finish_done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher);
 }
 
@@ -762,7 +762,7 @@ void test_rw_write_port_reset_late_finish_before_timeout_wake()
   WriteInfoBlock completed{ConstRawData{TX1, sizeof(TX1)}, op1};
   w.Finish(false, ErrorCode::OK, completed);
 
-  ExpectWaitOk(done, kShortWaitMs);
+  ExpectWaitOk(done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(writer);
   ASSERT(ctx.result == ErrorCode::TIMEOUT);
   ASSERT(sem1.Value() == 0);
@@ -788,7 +788,7 @@ void test_rw_read_port_block_pending_result_propagates()
 
   auto ec = r(RawData{rx, sizeof(rx)}, op);
   ASSERT(ec == ErrorCode::FAILED);
-  ExpectWaitOk(done, kShortWaitMs);
+  ExpectWaitOk(done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher);
 }
 
@@ -808,7 +808,7 @@ void test_rw_write_port_block_pending_result_propagates()
 
   auto ec = w(ConstRawData{TX, sizeof(TX)}, op);
   ASSERT(ec == ErrorCode::FAILED);
-  ExpectWaitOk(done, kShortWaitMs);
+  ExpectWaitOk(done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher);
 }
 
@@ -829,7 +829,7 @@ void test_rw_write_port_block_reused_waiter_discards_stale_signal()
 
   auto ec = w(ConstRawData{TX1, sizeof(TX1)}, op);
   ASSERT(ec == ErrorCode::FAILED);
-  ExpectWaitOk(done1, kShortWaitMs);
+  ExpectWaitOk(done1, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher1);
   ASSERT(sem.Value() == 0);
 
@@ -841,7 +841,7 @@ void test_rw_write_port_block_reused_waiter_discards_stale_signal()
 
   ec = w(ConstRawData{TX2, sizeof(TX2)}, op);
   ASSERT(ec == ErrorCode::OK);
-  ExpectWaitOk(done2, kShortWaitMs);
+  ExpectWaitOk(done2, SHORT_WAIT_MS);
   JoinThreadIfNeeded(finisher2);
   ASSERT(sem.Value() == 0);
 }
@@ -866,14 +866,14 @@ void test_rw()
 
 namespace
 {
-constexpr size_t kPipeCapacity = 64;
-constexpr size_t kMixedStressIterations = 64;
-constexpr size_t kBlockStressIterations = 8;
+constexpr size_t PIPE_CAPACITY = 64;
+constexpr size_t MIXED_STRESS_ITERATIONS = 64;
+constexpr size_t BLOCK_STRESS_ITERATIONS = 8;
 
 using LibXRTest::ExpectWaitOk;
 using LibXRTest::JoinThreadIfNeeded;
-using LibXRTest::kAsyncModes;
-using LibXRTest::kShortWaitMs;
+using LibXRTest::ASYNC_MODES;
+using LibXRTest::SHORT_WAIT_MS;
 using LibXRTest::ReadHarness;
 using LibXRTest::TestMode;
 using LibXRTest::WriteHarness;
@@ -931,7 +931,7 @@ void VerifyPendingReadThenWrite(TestMode read_mode, TestMode write_mode, size_t 
 {
   using namespace LibXR;
 
-  Pipe pipe((size > 0) ? size : kPipeCapacity);
+  Pipe pipe((size > 0) ? size : PIPE_CAPACITY);
   ReadPort& r = pipe.GetReadPort();
   WritePort& w = pipe.GetWritePort();
 
@@ -976,7 +976,7 @@ void VerifyWriteThenRead(TestMode write_mode, TestMode read_mode, size_t size,
 {
   using namespace LibXR;
 
-  Pipe pipe((size > 0) ? size : kPipeCapacity);
+  Pipe pipe((size > 0) ? size : PIPE_CAPACITY);
   ReadPort& r = pipe.GetReadPort();
   WritePort& w = pipe.GetWritePort();
 
@@ -1201,9 +1201,9 @@ void test_pipe_mode_matrix()
 {
   uint8_t seed = 0x21;
 
-  for (auto read_mode : kAsyncModes)
+  for (auto read_mode : ASYNC_MODES)
   {
-    for (auto write_mode : kAsyncModes)
+    for (auto write_mode : ASYNC_MODES)
     {
       VerifyPendingReadThenWrite(read_mode, write_mode, 7, seed++);
       VerifyWriteThenRead(write_mode, read_mode, 7, seed++);
@@ -1215,14 +1215,14 @@ void test_pipe_reuse_stress()
 {
   using namespace LibXR;
 
-  Pipe pipe(kPipeCapacity);
+  Pipe pipe(PIPE_CAPACITY);
   ReadPort& r = pipe.GetReadPort();
   WritePort& w = pipe.GetWritePort();
 
   ReadHarness read(TestMode::CALLBACK);
   WriteHarness write(TestMode::POLLING);
 
-  for (size_t iter = 0; iter < kMixedStressIterations; ++iter)
+  for (size_t iter = 0; iter < MIXED_STRESS_ITERATIONS; ++iter)
   {
     const size_t size = 1 + (iter % 31);
     std::vector<uint8_t> tx(size);
@@ -1257,14 +1257,14 @@ void test_pipe_block_reuse_stress()
 {
   using namespace LibXR;
 
-  Pipe pipe(kPipeCapacity);
+  Pipe pipe(PIPE_CAPACITY);
   ReadPort& r = pipe.GetReadPort();
   WritePort& w = pipe.GetWritePort();
 
   ReadHarness read(TestMode::BLOCK);
   WriteHarness write(TestMode::BLOCK);
 
-  for (size_t iter = 0; iter < kBlockStressIterations; ++iter)
+  for (size_t iter = 0; iter < BLOCK_STRESS_ITERATIONS; ++iter)
   {
     const size_t size = 1 + (iter % 15);
     std::vector<uint8_t> tx(size);
@@ -1302,12 +1302,12 @@ void test_pipe_block_reuse_stress()
 
 void test_pipe_edge_cases()
 {
-  for (auto read_mode : kAsyncModes)
+  for (auto read_mode : ASYNC_MODES)
   {
-    for (auto write_mode : kAsyncModes)
+    for (auto write_mode : ASYNC_MODES)
     {
       VerifyPendingReadThenWrite(read_mode, write_mode, 1, 0x61);
-      VerifyWriteThenRead(write_mode, read_mode, kPipeCapacity, 0x91);
+      VerifyWriteThenRead(write_mode, read_mode, PIPE_CAPACITY, 0x91);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add reusable MS OS 2.0 WinUSB descriptor-set helpers for device-scoped and function-scoped descriptors.
- Expose WinUSB descriptors for DFU bootloader and runtime DFU without requiring a Windows INF workaround.
- Use the MS OS 2.0 zero-based configuration index in function-scoped descriptors; apply the same correction to DAPLink v2.
- Keep DFU bootloader app launch explicit and write only the aligned seal record instead of a full erase block.
- Normalize first-party `kXxx` constant names to the project `UPPER_SNAKE_CASE` convention, excluding third-party Eigen and non-source assets.

## Validation

- OpenCR / STM32F746ZG real hardware on Windows with J-Link EDU Mini `801053237`:
  - full bootloader download, manifest/seal, manual `RUN_APP`, runtime WinUSB, `DETACH`, return to bootloader, upload/compare passed
  - runtime DFU `MI_02` bound to `WINUSB`, `ProblemCode=0`
  - run dirs:
    - `C:\Users\a2592\codex\runs\opencr_dfu_patched_runtime_chain_20260429T003023Z`
    - `C:\Users\a2592\codex\runs\opencr_bcd102_pnp_20260429T003512Z`
    - `C:\Users\a2592\codex\runs\opencr_dfu_runtime_chain_stress_20260429T010939Z`
- Ubuntu24 validation for DFU descriptor changes:
  - run dir: `/tmp/libxr_dfu_pr131_unit_stress_20260429T010214Z`
  - `clang-format 21.1.8`: PASS
  - default CMake/Ninja build: PASS
  - `LIBXR_TEST_BUILD=True` CMake/Ninja build: PASS
  - `build_test/test` repeated `5/5`: PASS
  - `gdb` breakpoint proof for `test_usb_descriptor_policy()`: PASS
- Ubuntu24 validation after naming cleanup:
  - run dir: `/tmp/libxr_kxxx_naming_20260429T014452Z`
  - first-party `kXxx` residual scan excluding `lib/Eigen` and non-source SVG: PASS
  - `tools/format_driver_src.sh --check` with clang-format `21.1.8`: PASS
  - default CMake build: PASS
  - `LIBXR_TEST_BUILD=True` build: PASS
  - `build_test/test`: PASS
- Local checks:
  - `git diff --check`: PASS
  - first-party `kXxx` residual scan excluding `lib/Eigen`, `.git`, SVG/drawio: PASS
