### PR TITLE
fix(dfu): preserve payload when seal shares erase block

### DIFF
--- a/src/driver/usb/device/dfu/dfu_bootloader.hpp
+++ b/src/driver/usb/device/dfu/dfu_bootloader.hpp
@@ -560,9 +560,9 @@ class DfuBootloaderBackend
                                                       sizeof(seal)}) == ErrorCode::OK;
   }
 
-  // seal 只需要按最小写入粒度对齐；擦除仍按块执行。
-  // The seal scratch buffer only needs minimum-write alignment; erase still
-  // happens at erase-block granularity.
+  // Seal may share the last erase block with payload. Reuse the per-session
+  // erase map so manifest does not wipe a block that was already erased and
+  // partially programmed by DNLOAD payload chunks.
   bool WriteSeal(size_t image_size, uint32_t crc32)
   {
     std::memset(seal_storage_, 0xFF, seal_storage_size_);
@@ -572,7 +572,7 @@ class DfuBootloaderBackend
     seal->crc32 = crc32;
     seal->crc32_inv = ~crc32;
 
-    if (flash_.Erase(image_offset_ + seal_offset_, erase_block_size_) != ErrorCode::OK)
+    if (!EnsureBlocksErased(seal_offset_, seal_storage_size_))
     {
       return false;
     }


### PR DESCRIPTION
## Summary
- Reuse the DFU download-session erase map when writing the seal record.
- Prevent manifest from erasing an already-programmed payload block when the seal lives in the final bytes of the same erase block.
- Keep separate-block seal behavior intact: an untouched seal block is still erased before programming the seal.

## Validation
- Ubuntu24 host fake-Flash DFU smoke: same-block payload+seal PASS, separate-block seal PASS.
- Ubuntu24 libxr CMake build/unit tests PASS.
- Ubuntu24 clang-format check PASS.
- Ubuntu24 diff check PASS.
- OpenCR F746 prior real-hardware evidence after this fix: DFU download/manifest/upload compare/RUN_APP PASS, 5-cycle stress PASS.
- F103 hardware smoke on Ubuntu24: rebuild/flash/enumerate/MBS payload verification PASS.

## Notes
- CH32V305 was not visible on Ubuntu24 during the unattended pass; dfu-util only listed the laptop camera DFU runtime.
- ESP32-S3 on lab3b enumerated as cafe:4024 with 3 IN + 3 OUT bulk endpoints; ESP-IDF checkout on Ubuntu24 is incomplete, so no reflash was attempted.

## Summary by Sourcery

Bug Fixes:
- Avoid erasing an already-programmed payload block when writing the seal in the same erase block by using the per-session erase tracking instead of unconditionally erasing the seal block.