### PR TITLE
refactor(print): express core format contracts as concepts

### DIFF
--- a/src/core/print/format_compile.hpp
+++ b/src/core/print/format_compile.hpp
@@ -8,6 +8,7 @@
 #include <limits>
 
 #include "format_protocol.hpp"
+#include "print_contract.hpp"
 
 namespace LibXR::Print
 {
@@ -41,13 +42,7 @@ template <typename Frontend>
 class FormatCompiler
 {
  private:
-  static constexpr bool source_contract =
-      requires {
-        typename Frontend::ErrorType;
-        { Frontend::SourceData() } -> std::convertible_to<const char*>;
-        { Frontend::SourceSize() } -> std::convertible_to<size_t>;
-      };
-  static_assert(source_contract,
+  static_assert(SourceFrontend<Frontend>,
                 "LibXR::Print::FormatCompiler: frontend must expose ErrorType, "
                 "SourceData(), and SourceSize()");
 
@@ -405,11 +400,7 @@ class FormatCompiler
     }
   };
 
-  static constexpr bool walk_contract =
-      requires(ScratchBuilder& visitor) {
-        { Frontend::Walk(visitor) } -> std::same_as<Error>;
-      };
-  static_assert(walk_contract,
+  static_assert(WalkableFrontend<Frontend, ScratchBuilder>,
                 "LibXR::Print::FormatCompiler: frontend Walk(visitor) must accept "
                 "the shared builder and return ErrorType");
 

--- a/src/core/print/format_surface.hpp
+++ b/src/core/print/format_surface.hpp
@@ -160,7 +160,7 @@ class Format
   }
 
   /// Writes this format into one sink and returns only the sink status. / 将当前格式写入一个输出端，并且只返回 sink 状态
-  template <typename Sink, typename... Args>
+  template <Print::OutputSink Sink, typename... Args>
   [[nodiscard]] ErrorCode WriteTo(Sink& sink, Args&&... args) const
   {
     using Built = Compiled<std::remove_cvref_t<Args>...>;
@@ -177,7 +177,7 @@ namespace LibXR::Print
  *        concrete Args... type list and then executing the shared runtime writer.
  * @brief 写入一份 brace 风格格式包装器：先将其绑定到具体 Args... 类型列表，再执行共享运行期 writer。
  */
-template <Text Source, typename Sink, typename... Args>
+template <Text Source, OutputSink Sink, typename... Args>
 [[nodiscard]] inline ErrorCode Write(Sink& sink, const LibXR::Format<Source>&,
                                      Args&&... args)
 {

--- a/src/core/print/print_api.hpp
+++ b/src/core/print/print_api.hpp
@@ -39,12 +39,13 @@ namespace LibXR::Print
  * @brief 将编译后的格式写入输出端。
  * @return Returns the sink write status only. / 仅返回 sink 写入状态。
  */
-[[nodiscard]] inline ErrorCode Write(auto& sink, const auto& format, auto&&... args)
+template <typename Sink, typename Format, typename... Args>
+requires OutputSink<Sink> && CompiledFormat<std::remove_cvref_t<Format>>
+[[nodiscard]] inline ErrorCode Write(Sink& sink, const Format& format, Args&&... args)
 {
-  using Sink = std::remove_cvref_t<decltype(sink)>;
-  using Built = std::remove_cvref_t<decltype(format)>;
+  using Built = std::remove_cvref_t<Format>;
   return Writer::template RunArgumentOrder<Sink, Built, Built::ArgumentOrder()>(
-      sink, format, std::forward<decltype(args)>(args)...);
+      sink, format, std::forward<Args>(args)...);
 }
 
 /**
@@ -52,9 +53,10 @@ namespace LibXR::Print
  * @brief 面向用户的便捷包装：将一份编译格式写入一个输出端。
  * @return Returns the sink write status only. / 仅返回 sink 写入状态。
  */
-[[nodiscard]] inline ErrorCode FormatTo(auto& sink, const auto& format, auto&&... args)
+template <OutputSink Sink, typename Format, typename... Args>
+[[nodiscard]] inline ErrorCode FormatTo(Sink& sink, const Format& format, Args&&... args)
 {
-  return Write(sink, format, std::forward<decltype(args)>(args)...);
+  return Write(sink, format, std::forward<Args>(args)...);
 }
 
 /**
@@ -62,7 +64,7 @@ namespace LibXR::Print
  * @brief 将一条 brace 风格字面量直接写入一个输出端。
  * @return Returns the sink write status only. / 仅返回 sink 写入状态。
  */
-template <Text Source, typename Sink, typename... Args>
+template <Text Source, OutputSink Sink, typename... Args>
 [[nodiscard]] inline ErrorCode FormatTo(Sink& sink, Args&&... args)
 {
   constexpr LibXR::Format<Source> format{};
@@ -74,7 +76,7 @@ template <Text Source, typename Sink, typename... Args>
  * @brief 将一条 printf 风格字面量直接写入一个输出端。
  * @return Returns the sink write status only. / 仅返回 sink 写入状态。
  */
-template <Text Source, typename Sink, typename... Args>
+template <Text Source, OutputSink Sink, typename... Args>
 [[nodiscard]] inline ErrorCode PrintfTo(Sink& sink, Args&&... args)
 {
   constexpr auto format = Printf::Build<Source>();

--- a/src/core/print/print_contract.hpp
+++ b/src/core/print/print_contract.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <concepts>
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <type_traits>
+
+#include "format_protocol.hpp"
+#include "libxr_def.hpp"
+
+namespace LibXR::Print
+{
+
+/**
+ * @brief 接收编译格式输出的写入端。
+ * @brief Output endpoint accepted by compiled format writers.
+ */
+template <typename Sink>
+concept OutputSink = requires(Sink& output, std::string_view text)
+{
+  { output.Write(text) } -> std::convertible_to<ErrorCode>;
+};
+
+/**
+ * @brief 可由共享后端读取源码信息的格式前端。
+ * @brief Format frontend exposing source metadata to the shared backend.
+ */
+template <typename Frontend>
+concept SourceFrontend = requires
+{
+  typename Frontend::ErrorType;
+  { Frontend::SourceData() } -> std::convertible_to<const char*>;
+  { Frontend::SourceSize() } -> std::convertible_to<size_t>;
+};
+
+/**
+ * @brief 可向指定 visitor 发射格式事件的前端。
+ * @brief Frontend that can emit format events into the supplied visitor.
+ */
+template <typename Frontend, typename Visitor>
+concept WalkableFrontend =
+    SourceFrontend<Frontend> && requires(Visitor& visitor)
+{
+  { Frontend::Walk(visitor) } -> std::same_as<typename Frontend::ErrorType>;
+};
+
+/**
+ * @brief Writer 可执行的编译后格式对象。
+ * @brief Compiled format object executable by Writer.
+ */
+template <typename Format>
+concept CompiledFormat = requires
+{
+  typename std::remove_cvref_t<decltype(Format::Codes())>::value_type;
+  typename std::remove_cvref_t<decltype(Format::ArgumentList())>::value_type;
+  { Format::Codes().data() } -> std::convertible_to<const uint8_t*>;
+  { Format::Codes().size() } -> std::convertible_to<size_t>;
+  { Format::ArgumentList().size() } -> std::convertible_to<size_t>;
+  { Format::ArgumentOrder().size() } -> std::convertible_to<size_t>;
+  { Format::Profile() } -> std::convertible_to<FormatProfile>;
+} && std::same_as<typename std::remove_cvref_t<decltype(Format::Codes())>::value_type,
+                  uint8_t> &&
+    std::same_as<
+        typename std::remove_cvref_t<decltype(Format::ArgumentList())>::value_type,
+        FormatArgumentInfo>;
+
+}  // namespace LibXR::Print

--- a/src/core/print/writer.hpp
+++ b/src/core/print/writer.hpp
@@ -17,6 +17,7 @@
 #include "format_argument.hpp"
 #include "format_protocol.hpp"
 #include "libxr_def.hpp"
+#include "print_contract.hpp"
 
 namespace LibXR::Print
 {
@@ -39,11 +40,10 @@ class Writer
    * 同时保持运行期字节码流本身仍然严格按源串顺序执行。
    */
   template <typename Sink, typename Format, auto ArgumentOrder, typename... Args>
+  requires OutputSink<Sink> && CompiledFormat<std::remove_cvref_t<Format>>
   [[nodiscard]] static ErrorCode RunArgumentOrder(Sink& sink, const Format&, Args&&... args)
   {
     using Built = std::remove_cvref_t<Format>;
-    CheckSinkContract<Sink>();
-    CheckFormatContract<Built>();
     static_assert(ArgumentOrder.size() == Built::ArgumentList().size(),
                   "LibXR::Print::Writer: argument reorder list must match the "
                   "compiled field count");
@@ -56,50 +56,6 @@ class Writer
   }
 
  private:
-  /**
-   * @brief Shared sink contract used by both direct-order and reordered writes.
-   * @brief direct-order 与 reordered 两条写入路径共用的输出端契约检查。
-   */
-  template <typename Sink>
-  static consteval void CheckSinkContract()
-  {
-    constexpr bool sink_contract =
-        requires(Sink& output, std::string_view text) {
-          { output.Write(text) } -> std::convertible_to<ErrorCode>;
-        };
-    static_assert(sink_contract,
-                  "LibXR::Print::Writer: sink must provide "
-                  "Write(std::string_view) -> ErrorCode");
-  }
-
-  /**
-   * @brief Shared compiled-format contract used by every runtime entrypoint.
-   * @brief 所有运行期入口共用的编译格式契约检查。
-   */
-  template <typename Built>
-  static consteval void CheckFormatContract()
-  {
-    constexpr bool format_contract =
-        requires {
-          typename std::remove_cvref_t<decltype(Built::Codes())>::value_type;
-          typename std::remove_cvref_t<decltype(Built::ArgumentList())>::value_type;
-          { Built::Codes().data() } -> std::convertible_to<const uint8_t*>;
-          { Built::Codes().size() } -> std::convertible_to<size_t>;
-          { Built::ArgumentList().size() } -> std::convertible_to<size_t>;
-          { Built::Profile() } -> std::convertible_to<FormatProfile>;
-        } && requires {
-          requires(std::same_as<
-                   typename std::remove_cvref_t<decltype(Built::Codes())>::value_type,
-                   uint8_t>);
-          requires(std::same_as<typename std::remove_cvref_t<
-                                    decltype(Built::ArgumentList())>::value_type,
-                                FormatArgumentInfo>);
-        };
-    static_assert(format_contract,
-                  "LibXR::Print::Writer: format must expose Codes() bytes and "
-                  "ArgumentList() metadata plus Profile()");
-  }
-
   /**
    * @brief Emits the stack argument byte blob for one compiled argument list.
    * @brief 为某个已编译参数列表生成栈上参数字节块。
@@ -1113,17 +1069,17 @@ class Writer
   class CodeReader;
   class ArgumentReader;
 
-  template <typename Sink, FormatProfile Profile>
+  template <OutputSink Sink, FormatProfile Profile>
   class Executor;
 
-  template <typename Sink, FormatProfile Profile>
+  template <OutputSink Sink, FormatProfile Profile>
   [[nodiscard]] __attribute__((noinline)) static ErrorCode Execute(
       Sink& sink, const uint8_t* codes, const uint8_t* args)
   {
     return Executor<Sink, Profile>(sink, codes, args).Run();
   }
 
-  template <typename Sink, auto ArgumentInfoList, auto ArgumentOrder,
+  template <OutputSink Sink, auto ArgumentInfoList, auto ArgumentOrder,
             FormatProfile Profile, typename... Args>
   [[nodiscard]] __attribute__((noinline)) static ErrorCode RunTaggedArgumentOrder(
       Sink& sink, const uint8_t* codes, Args&&... args)
@@ -1240,7 +1196,7 @@ class Writer::ArgumentReader
  * @brief Per-sink bytecode executor specialized by the compiled format profile.
  * @brief 按编译格式 profile 特化的按输出端类型区分字节码执行器。
  */
-template <typename Sink, FormatProfile Profile>
+template <OutputSink Sink, FormatProfile Profile>
 class Writer::Executor
 {
  public:


### PR DESCRIPTION
## Summary
- add explicit print contract concepts for sinks, frontends, and compiled formats
- constrain print writer/public sink entrypoints with the new concepts
- replace local FormatCompiler requires checks with named frontend concepts

## Validation
- Ubuntu24: default CMake/Ninja build PASS
- Ubuntu24: LIBXR_TEST_BUILD=True build PASS
- Ubuntu24: test binary PASS
- Ubuntu24: tools/format_driver_src.sh --check PASS

Validation run dir: /tmp/libxr_core_print_concepts_20260430_v3

## Summary by Sourcery

Introduce named print contract concepts for sinks, frontends, and compiled formats and apply them across the core print APIs and writer.

Enhancements:
- Define reusable OutputSink, SourceFrontend, WalkableFrontend, and CompiledFormat concepts centralizing print contracts in a new header.
- Constrain public print/format API templates and Writer internals with the new concepts instead of ad-hoc requires/static_assert checks.
- Tighten format compilation constraints by expressing frontend source and walk contracts via dedicated concepts.
- Update format wrapper helpers to require OutputSink for sink parameters.