### PR TITLE
fix(transform): keep quaternion array order wxyz

### DIFF
--- a/src/utils/transform.hpp
+++ b/src/utils/transform.hpp
@@ -909,7 +909,10 @@ class Quaternion : public Eigen::Quaternion<Scalar>
                                              std::is_same<T, float>::value ||
                                              std::is_same<T, double>::value,
                                          int> = 0>
-  Quaternion(const T (&data)[4]) : Eigen::Quaternion<Scalar>(data)
+  Quaternion(const T (&data)[4])
+      : Eigen::Quaternion<Scalar>(
+            static_cast<Scalar>(data[0]), static_cast<Scalar>(data[1]),
+            static_cast<Scalar>(data[2]), static_cast<Scalar>(data[3]))
   {
   }
 

--- a/test/test_transform.cpp
+++ b/test/test_transform.cpp
@@ -9,6 +9,12 @@ void test_transform()
   LibXR::EulerAngle eulr = {LibXR::PI / 12, LibXR::PI / 6, LibXR::PI / 4}, eulr_new;
   LibXR::RotationMatrix rot, rot_new;
   LibXR::Quaternion quat, quat_new;
+  double quat_wxyz[4] = {0.1, 0.2, 0.3, 0.4};
+  LibXR::Quaternion quat_from_array(quat_wxyz);
+  ASSERT(equal(quat_from_array.w(), quat_wxyz[0]) &&
+         equal(quat_from_array.x(), quat_wxyz[1]) &&
+         equal(quat_from_array.y(), quat_wxyz[2]) &&
+         equal(quat_from_array.z(), quat_wxyz[3]));
 
   /* Position */
   rot = eulr.ToRotationMatrix();


### PR DESCRIPTION
## Summary
- fix LibXR::Quaternion C-array constructor to follow the documented w,x,y,z order
- add transform coverage with a non-symmetric wxyz array so Eigen's xyzw storage order cannot mask regressions

## Validation
- Ubuntu24 clean clone + patch: /tmp/libxr_quaternion_wxyz_validate_final_20260503T1458Z
- default CMake/Ninja build PASS
- LIBXR_TEST_BUILD=True build PASS
- full unit test PASS
- format_driver_src.sh --check PASS with /home/xiao/work/.venv-clang-format/bin/clang-format
- touched-file clang-format PASS