### PR TITLE
fix(linux): tolerate drop-old subscriber race

### DIFF
--- a/system/linux/linux_shared_topic_impl.hpp
+++ b/system/linux/linux_shared_topic_impl.hpp
@@ -1896,7 +1896,13 @@ class LinuxSharedTopic : public Topic
 
         if (mode == LinuxSharedSubscriberMode::BROADCAST_DROP_OLD)
         {
-          if (DropDescriptor(i) != ErrorCode::OK)
+          const ErrorCode drop_ans = DropDescriptor(i);
+          if (drop_ans == ErrorCode::EMPTY && QueueHasSpace(i))
+          {
+            // 消费者可能在 QueueHasSpace() 和 DropDescriptor() 之间弹走旧描述符。
+            // 此时队列已经有空位，发布者继续写入即可，不能把竞态误报成 FULL。
+          }
+          else if (drop_ans != ErrorCode::OK)
           {
             header_->publish_failures.fetch_add(1, std::memory_order_relaxed);
             data.Reset();


### PR DESCRIPTION
## 问题
LinuxSharedTopic 的 BROADCAST_DROP_OLD 发布路径存在竞态：发布者看到订阅者队列满后，消费者可能先弹走旧描述符；此时 DropDescriptor() 返回 EMPTY，但队列已经有空位，旧逻辑仍把这次发布误报为 FULL。

## 修改
- DropDescriptor() 返回 EMPTY 后重新检查 QueueHasSpace()。
- 如果队列已经有空位，认为这是消费者并发弹出造成的良性竞态，继续发布。
- 其他失败路径保持原来的 FULL 语义。

## 验证
- 与 CameraFrameSync 启动压测联测：/home/xiao/runs/cfs_latency_dropold_fix_20260504T000356Z
- raw_probe_start_attached: detected=144 published=200 startup_ok=1
- 无 image publish failed，无 SYNCED -> OBSERVING
- RAW_PROBE publish-before 到 detector Wait return p99 7.133us

## Summary by Sourcery

Bug Fixes:
- Avoid misreporting full queues when a consumer concurrently frees space between queue space check and descriptor drop in BROADCAST_DROP_OLD mode.