### PR TITLE
fix(print): avoid tautological static assert

### DIFF
--- a/src/core/print/writer.hpp
+++ b/src/core/print/writer.hpp
@@ -62,6 +62,8 @@ class Writer
    */
   static constexpr uint8_t unspecified_precision = 0xFF;
   static constexpr size_t float_buffer_capacity = 512;
+  template <FormatPackKind K>
+  static constexpr bool dependent_false_v = false;
   /// Largest finite float32 value whose integer part still fits in uint32_t. / 整数部分仍可放入 uint32_t 的最大 float32 值上界
   static constexpr float f32_u32_overflow_limit = 4294967296.0f;
   /// Decimal scales used by the narrow float32 fixed-precision fast path. / 窄 float32 定点快路径使用的十进制缩放表
@@ -273,7 +275,7 @@ class Writer
     }
     else
     {
-      static_assert(pack != pack,
+      static_assert(dependent_false_v<pack>,
                     "LibXR::Print::Writer::PackValue: unsupported packed argument kind");
     }
   }


### PR DESCRIPTION
## 问题
`src/core/print/writer.hpp` 用 `static_assert(pack != pack, ...)` 表达不可达模板分支。GCC/Clang 会把它识别为自比较，开启 `-Wtautological-compare` 时产生 warning；在 `-Werror` 构建里会失败。

## 修改
- 在 `Writer` 内新增 `dependent_false_v<FormatPackKind>`。
- 将 `static_assert(pack != pack, ...)` 改为 `static_assert(dependent_false_v<pack>, ...)`。
- 语义不变，只消除恒假自比较 warning。

## 验证
Ubuntu24: `/home/xiao/runs/libxr_print_warning_fix_20260504T003857Z`
- 最小 `print_api` 编译：`-Wall -Wextra -Wtautological-compare -Werror` PASS
- libxr CMake configure/build PASS
- ctest: 仓库当前 build 未发现测试用例

## Summary by Sourcery

Bug Fixes:
- Eliminate a -Wtautological-compare warning in Writer::PackValue by using a dependent-false static assertion instead of a self-comparison.