### PR TITLE
fix(webots): initialize timebase before logging

### DIFF
--- a/system/webots/libxr_system.cpp
+++ b/system/webots/libxr_system.cpp
@@ -196,6 +196,9 @@ void SleepUntilNanoseconds(uint64_t deadline_ns)
 void LibXR::PlatformInit(webots::Robot* robot, uint32_t timer_pri,
                          uint32_t timer_stack_depth, double sim_flow_rate)
 {
+  // Thread/STDIO 初始化路径可能触发 XR_LOG，日志时间戳依赖全局 Timebase。
+  static LibXR::WebotsTimebase timebase;
+
   LibXR::Timer::priority_ = static_cast<LibXR::Thread::Priority>(timer_pri);
   LibXR::Timer::stack_depth_ = timer_stack_depth;
   auto write_fun = [](WritePort& port, bool)
@@ -298,8 +301,6 @@ void LibXR::PlatformInit(webots::Robot* robot, uint32_t timer_pri,
   webots_timebase_thread.Create<void*>(
       reinterpret_cast<void*>(0), webots_timebase_thread_fun, "webots_timebase",
       1024, Thread::Priority::REALTIME);
-
-  static LibXR::WebotsTimebase timebase;
 }
 
 LibXR::WebotsRealtimeThreadRegistration* LibXR::WebotsRegisterRealtimeThread()


### PR DESCRIPTION
## Summary
- construct the Webots timebase at the start of `PlatformInit()`
- avoid startup logging paths touching the global timebase before it exists

## Why
`Thread::Create()` / STDIO initialization can emit XR logs during Webots startup. Those log timestamps depend on the global `Timebase`; constructing `WebotsTimebase` at the end of `PlatformInit()` leaves a null-timebase startup crash window.

## Validation
- `git diff --check origin/master...HEAD`

## Summary by Sourcery

Bug Fixes:
- Prevent a startup crash window where XR logging could access an uninitialized global timebase by constructing the Webots timebase earlier in PlatformInit().