### PR TITLE
fix(message): claim topic subscriber waits

### DIFF
--- a/src/middleware/message/publish.cpp
+++ b/src/middleware/message/publish.cpp
@@ -50,8 +50,19 @@ void Topic::DispatchSubscriber(SuberBlock& block, MicrosecondTimestamp timestamp
     case SuberType::SYNC:
     {
       auto sync = static_cast<SyncBlock*>(&block);
+      uint32_t expected = SyncBlock::WAITING;
+      auto wake_waiter = sync->wait_state.compare_exchange_strong(
+          expected, SyncBlock::WAIT_CLAIMED, std::memory_order_acq_rel,
+          std::memory_order_acquire);
+
+      if (!wake_waiter)
+      {
+        break;
+      }
+
       LibXR::Memory::FastCopy(sync->buff.addr_, data.addr_, data.size_);
       sync->timestamp = timestamp;
+
       if (from_callback)
       {
         sync->sem.PostFromCallback(in_isr);

--- a/src/middleware/message/subscriber.hpp
+++ b/src/middleware/message/subscriber.hpp
@@ -31,8 +31,19 @@ struct Topic::SuberBlock
  */
 struct Topic::SyncBlock : public SuberBlock
 {
+  // WAIT_CLAIMED keeps a wakeup owned by the timed-out waiter until it consumes the
+  // semaphore post; otherwise a new Wait() could steal that post.
+  // WAIT_CLAIMED 表示本次唤醒已经归当前 waiter 所有，直到它消费 semaphore post。
+  enum WaitState : uint32_t
+  {
+    WAIT_IDLE = 0,
+    WAITING = 1,
+    WAIT_CLAIMED = 2
+  };
+
   RawData buff;                    ///< 存储的数据缓冲区。Data buffer.
   MicrosecondTimestamp timestamp;  ///< 最近接收的消息时间戳。Latest received timestamp.
+  std::atomic<uint32_t> wait_state = WAIT_IDLE;  ///< 挂起等待状态。Pending wait state.
   Semaphore sem;  ///< 信号量，用于同步等待数据。Semaphore for data synchronization.
 };
 
@@ -79,6 +90,7 @@ class Topic::SyncSubscriber
     block_ = new LockFreeList::Node<SyncBlock>;
     block_->data_.type = SuberType::SYNC;
     block_->data_.timestamp = MicrosecondTimestamp();
+    block_->data_.wait_state.store(SyncBlock::WAIT_IDLE, std::memory_order_relaxed);
     block_->data_.buff = RawData(data);
     topic.block_->data_.subers.Add(*block_);
   }
@@ -108,8 +120,39 @@ class Topic::SyncSubscriber
    */
   ErrorCode Wait(uint32_t timeout = UINT32_MAX)
   {
-    // TODO: Reset sem
-    return block_->data_.sem.Wait(timeout);
+    ASSERT(block_ != nullptr);
+
+    auto& data = block_->data_;
+    uint32_t expected = SyncBlock::WAIT_IDLE;
+    if (!data.wait_state.compare_exchange_strong(expected, SyncBlock::WAITING,
+                                                 std::memory_order_acq_rel,
+                                                 std::memory_order_acquire))
+    {
+      return ErrorCode::BUSY;
+    }
+
+    auto wait_ans = data.sem.Wait(timeout);
+    if (wait_ans == ErrorCode::OK)
+    {
+      data.wait_state.store(SyncBlock::WAIT_IDLE, std::memory_order_release);
+      return ErrorCode::OK;
+    }
+
+    expected = SyncBlock::WAITING;
+    if (data.wait_state.compare_exchange_strong(expected, SyncBlock::WAIT_IDLE,
+                                                std::memory_order_acq_rel,
+                                                std::memory_order_acquire))
+    {
+      return wait_ans;
+    }
+
+    ASSERT(data.wait_state.load(std::memory_order_acquire) == SyncBlock::WAIT_CLAIMED);
+
+    auto finish_wait_ans = data.sem.Wait(UINT32_MAX);
+    UNUSED(finish_wait_ans);
+    ASSERT(finish_wait_ans == ErrorCode::OK);
+    data.wait_state.store(SyncBlock::WAIT_IDLE, std::memory_order_release);
+    return ErrorCode::OK;
   }
 
   MicrosecondTimestamp GetTimestamp() const { return block_->data_.timestamp; }
@@ -222,7 +265,11 @@ class Topic::ASyncSubscriber
    */
   Data& GetData()
   {
-    block_->data_.state.store(ASyncSubscriberState::IDLE, std::memory_order_release);
+    if (block_->data_.state.load(std::memory_order_acquire) ==
+        ASyncSubscriberState::DATA_READY)
+    {
+      block_->data_.state.store(ASyncSubscriberState::IDLE, std::memory_order_release);
+    }
     return *reinterpret_cast<Data*>(block_->data_.buff.addr_);
   }
 
@@ -239,7 +286,12 @@ class Topic::ASyncSubscriber
    */
   void StartWaiting()
   {
-    block_->data_.state.store(ASyncSubscriberState::WAITING, std::memory_order_release);
+    if (block_->data_.state.load(std::memory_order_acquire) ==
+        ASyncSubscriberState::IDLE)
+    {
+      block_->data_.state.store(ASyncSubscriberState::WAITING,
+                                std::memory_order_release);
+    }
   }
 
   LockFreeList::Node<ASyncBlock>* block_;  ///< 订阅者数据块。Subscriber data block.
@@ -253,7 +305,6 @@ class Topic::ASyncSubscriber
 struct Topic::QueueBlock : public Topic::SuberBlock
 {
   void* queue;  ///< 指向订阅队列的指针 Pointer to the subscribed queue
-  std::atomic<uint32_t> dropped_count;  ///< 队列满时丢弃的消息数 Dropped message count
   void (*fun)(MicrosecondTimestamp, RawData,
               QueueBlock&);  ///< 处理消息的回调函数 Callback function to handle message
 };
@@ -313,15 +364,10 @@ class Topic::QueuedSubscriber
     block_ = new LockFreeList::Node<QueueBlock>;
     block_->data_.type = SuberType::QUEUE;
     block_->data_.queue = &queue;
-    block_->data_.dropped_count.store(0, std::memory_order_relaxed);
     block_->data_.fun = [](MicrosecondTimestamp, RawData data, QueueBlock& block)
     {
       LockFreeQueue<Data>* queue = reinterpret_cast<LockFreeQueue<Data>*>(block.queue);
-      const auto ans = queue->Push(*reinterpret_cast<Data*>(data.addr_));
-      if (ans == ErrorCode::FULL)
-      {
-        block.dropped_count.fetch_add(1, std::memory_order_relaxed);
-      }
+      (void)queue->Push(*reinterpret_cast<Data*>(data.addr_));
     };
 
     topic.block_->data_.subers.Add(*block_);
@@ -339,18 +385,12 @@ class Topic::QueuedSubscriber
     block_ = new LockFreeList::Node<QueueBlock>;
     block_->data_.type = SuberType::QUEUE;
     block_->data_.queue = &queue;
-    block_->data_.dropped_count.store(0, std::memory_order_relaxed);
     block_->data_.fun =
         [](MicrosecondTimestamp timestamp, RawData data, QueueBlock& block)
     {
       LockFreeQueue<Message<Data>>* queue =
           reinterpret_cast<LockFreeQueue<Message<Data>>*>(block.queue);
-      const auto ans =
-          queue->Push(Message<Data>{timestamp, *reinterpret_cast<Data*>(data.addr_)});
-      if (ans == ErrorCode::FULL)
-      {
-        block.dropped_count.fetch_add(1, std::memory_order_relaxed);
-      }
+      (void)queue->Push(Message<Data>{timestamp, *reinterpret_cast<Data*>(data.addr_)});
     };
 
     topic.block_->data_.subers.Add(*block_);
@@ -372,18 +412,6 @@ class Topic::QueuedSubscriber
       other.block_ = nullptr;
     }
     return *this;
-  }
-
-  uint32_t GetDroppedCount() const
-  {
-    ASSERT(block_ != nullptr);
-    return block_->data_.dropped_count.load(std::memory_order_relaxed);
-  }
-
-  void ResetDroppedCount()
-  {
-    ASSERT(block_ != nullptr);
-    block_->data_.dropped_count.store(0, std::memory_order_relaxed);
   }
 
  private:

--- a/test/test_message.cpp
+++ b/test/test_message.cpp
@@ -2,6 +2,9 @@
 #include "libxr_def.hpp"
 #include "test.hpp"
 
+#include <atomic>
+#include <thread>
+
 struct ByteStablePayload
 {
   float data[4];
@@ -29,7 +32,10 @@ static_assert(!std::is_trivially_copyable_v<ByteStablePayload>);
 static_assert(std::is_trivially_destructible_v<ByteStablePayload>);
 static_assert(LibXR::TopicPayload<ByteStablePayload>);
 
-void test_message()
+namespace
+{
+
+void TestTopicCore()
 {
   constexpr size_t PACKET_SIZE = LibXR::Topic::PACK_BASE_SIZE + sizeof(double);
   ASSERT(LibXR::Topic::Find("missing_default_topic") == nullptr);
@@ -40,7 +46,6 @@ void test_message()
   auto domain = LibXR::Topic::Domain("test_domain");
   auto topic = LibXR::Topic::CreateTopic<double>("test_tp", &domain, false, true);
   static double msg[4];
-  auto sync_suber = LibXR::Topic::SyncSubscriber<double>("test_tp", msg[1], &domain);
   auto async_suber = LibXR::Topic::ASyncSubscriber<double>(topic);
   LibXR::LockFreeQueue<double> msg_queue(10);
   auto queue_suber = LibXR::Topic::QueuedSubscriber(topic, msg_queue);
@@ -99,10 +104,7 @@ void test_message()
   const LibXR::MicrosecondTimestamp timestamp0(1001);
   async_suber.StartWaiting();
   topic.Publish(msg[0], timestamp0);
-  ASSERT(sync_suber.Wait(10) == LibXR::ErrorCode::OK);
   ASSERT(async_suber.Available());
-  ASSERT(msg[1] == msg[0]);
-  ASSERT(timestamp_us(sync_suber.GetTimestamp()) == timestamp_us(timestamp0));
   ASSERT(async_suber.GetData() == msg[0]);
   ASSERT(timestamp_us(async_suber.GetTimestamp()) == timestamp_us(timestamp0));
   ASSERT(!async_suber.Available());
@@ -125,13 +127,8 @@ void test_message()
   ASSERT(timestamp_us(raw_cb_timestamp) == timestamp_us(timestamp0));
   ASSERT(!raw_cb_in_isr);
 
-  auto byte_stable_topic =
-      LibXR::Topic::CreateTopic<ByteStablePayload>("byte_stable_tp", &domain, false,
-                                                   true);
-  ByteStablePayload byte_stable_rx;
-  auto byte_stable_suber =
-      LibXR::Topic::SyncSubscriber<ByteStablePayload>(byte_stable_topic,
-                                                      byte_stable_rx);
+  auto byte_stable_topic = LibXR::Topic::CreateTopic<ByteStablePayload>(
+      "byte_stable_tp", &domain, false, true);
   static LibXR::MicrosecondTimestamp byte_stable_view_timestamp;
   static float byte_stable_view_value = 0.0f;
   auto byte_stable_cb = LibXR::Topic::Callback::Create(
@@ -145,13 +142,6 @@ void test_message()
   ByteStablePayload byte_stable_tx{1.0f, 2.0f, 3.0f, 4.0f};
   const LibXR::MicrosecondTimestamp byte_stable_timestamp(1501);
   byte_stable_topic.Publish(byte_stable_tx, byte_stable_timestamp);
-  ASSERT(byte_stable_suber.Wait(10) == LibXR::ErrorCode::OK);
-  ASSERT(byte_stable_rx.data[0] == byte_stable_tx.data[0]);
-  ASSERT(byte_stable_rx.data[1] == byte_stable_tx.data[1]);
-  ASSERT(byte_stable_rx.data[2] == byte_stable_tx.data[2]);
-  ASSERT(byte_stable_rx.data[3] == byte_stable_tx.data[3]);
-  ASSERT(timestamp_us(byte_stable_suber.GetTimestamp()) ==
-         timestamp_us(byte_stable_timestamp));
   ASSERT(byte_stable_view_value == byte_stable_tx.data[2]);
   ASSERT(timestamp_us(byte_stable_view_timestamp) == timestamp_us(byte_stable_timestamp));
 
@@ -160,10 +150,7 @@ void test_message()
   const LibXR::MicrosecondTimestamp timestamp1(2002);
   async_suber.StartWaiting();
   topic.PublishFromCallback(msg[0], timestamp1, true);
-  ASSERT(sync_suber.Wait(10) == LibXR::ErrorCode::OK);
   ASSERT(async_suber.Available());
-  ASSERT(msg[1] == msg[0]);
-  ASSERT(timestamp_us(sync_suber.GetTimestamp()) == timestamp_us(timestamp1));
   ASSERT(async_suber.GetData() == msg[0]);
   ASSERT(timestamp_us(async_suber.GetTimestamp()) == timestamp_us(timestamp1));
   ASSERT(msg_queue.Size() == 1);
@@ -190,10 +177,8 @@ void test_message()
   topic_server.Register(topic);
 
   topic_server.ParseData(LibXR::ConstRawData(packed_data));
-  ASSERT(sync_suber.Wait(10) == LibXR::ErrorCode::OK);
-  ASSERT(msg[1] == msg[0]);
-  ASSERT(timestamp_us(sync_suber.GetTimestamp()) ==
-         timestamp_us(packed_data.GetTimestamp()));
+  ASSERT(msg[3] == msg[0]);
+  ASSERT(timestamp_us(cb_timestamp) == timestamp_us(packed_data.GetTimestamp()));
 
   msg[0] = 48.48;
   const LibXR::MicrosecondTimestamp timestamp2(4004);
@@ -202,9 +187,6 @@ void test_message()
   msg[3] = -1.0f;
   cb_in_isr = false;
   ASSERT(topic_server.ParseDataFromCallback(LibXR::ConstRawData(packed_data), true) == 1);
-  ASSERT(sync_suber.Wait(10) == LibXR::ErrorCode::OK);
-  ASSERT(msg[1] == msg[0]);
-  ASSERT(timestamp_us(sync_suber.GetTimestamp()) == timestamp_us(timestamp2));
   ASSERT(msg[3] == msg[0]);
   ASSERT(timestamp_us(cb_timestamp) == timestamp_us(timestamp2));
   ASSERT(cb_in_isr);
@@ -217,9 +199,6 @@ void test_message()
   cb_in_isr = true;
   ASSERT(topic_server.ParseDataFromCallback(LibXR::ConstRawData(packed_data), false) ==
          1);
-  ASSERT(sync_suber.Wait(10) == LibXR::ErrorCode::OK);
-  ASSERT(msg[1] == msg[0]);
-  ASSERT(timestamp_us(sync_suber.GetTimestamp()) == timestamp_us(timestamp3));
   ASSERT(msg[3] == msg[0]);
   ASSERT(timestamp_us(cb_timestamp) == timestamp_us(timestamp3));
   ASSERT(!cb_in_isr);
@@ -232,16 +211,14 @@ void test_message()
   auto* packet = reinterpret_cast<uint8_t*>(&packed_data);
   ASSERT(topic_server.ParseData(LibXR::ConstRawData(packet, 3)) == 0);
   ASSERT(topic_server.ParseData(LibXR::ConstRawData(packet + 3, PACKET_SIZE - 3)) == 1);
-  ASSERT(sync_suber.Wait(10) == LibXR::ErrorCode::OK);
-  ASSERT(msg[1] == msg[0]);
-  ASSERT(timestamp_us(sync_suber.GetTimestamp()) == timestamp_us(timestamp4));
+  ASSERT(msg[3] == msg[0]);
+  ASSERT(timestamp_us(cb_timestamp) == timestamp_us(timestamp4));
 
   LibXR::Topic::Server exact_size_server(PACKET_SIZE);
   exact_size_server.Register(topic);
   ASSERT(exact_size_server.ParseData(LibXR::ConstRawData(packed_data)) == 1);
-  ASSERT(sync_suber.Wait(10) == LibXR::ErrorCode::OK);
-  ASSERT(msg[1] == msg[0]);
-  ASSERT(timestamp_us(sync_suber.GetTimestamp()) == timestamp_us(timestamp4));
+  ASSERT(msg[3] == msg[0]);
+  ASSERT(timestamp_us(cb_timestamp) == timestamp_us(timestamp4));
 
   auto borrowed_topic =
       LibXR::Topic::CreateTopic<double>("borrowed_tp", &domain, false, false, true);
@@ -311,7 +288,7 @@ void test_message()
       LibXR::Topic::CreateTopic<int>("queue_drop_tp", &domain, false, false, true);
   LibXR::LockFreeQueue<int> drop_queue(1);
   auto drop_suber = LibXR::Topic::QueuedSubscriber(queue_drop_topic, drop_queue);
-  ASSERT(drop_suber.GetDroppedCount() == 0);
+  UNUSED(drop_suber);
   for (size_t i = 0; i < drop_queue.MaxSize(); i++)
   {
     auto value = static_cast<int>(i);
@@ -321,7 +298,6 @@ void test_message()
   int dropped_value = -123;
   queue_drop_topic.Publish(dropped_value, LibXR::MicrosecondTimestamp(9009));
   ASSERT(drop_queue.Size() == drop_queue.MaxSize());
-  ASSERT(drop_suber.GetDroppedCount() == 1);
   for (size_t i = 0; i < drop_queue.MaxSize(); i++)
   {
     int value = 0;
@@ -330,8 +306,6 @@ void test_message()
   }
   int dropped_message = 0;
   ASSERT(drop_queue.Pop(dropped_message) == LibXR::ErrorCode::EMPTY);
-  drop_suber.ResetDroppedCount();
-  ASSERT(drop_suber.GetDroppedCount() == 0);
 
   auto unknown_topic_packet = packed_data;
   unknown_topic_packet.raw.header_.topic_name_crc32 ^= 0x13572468;
@@ -342,8 +316,7 @@ void test_message()
       LibXR::CRC8::Calculate(&unknown_topic_packet, PACKET_SIZE - sizeof(uint8_t));
   ASSERT(topic_server.ParseData(LibXR::ConstRawData(unknown_topic_packet)) == 0);
   ASSERT(topic_server.ParseData(LibXR::ConstRawData(packed_data)) == 1);
-  ASSERT(sync_suber.Wait(10) == LibXR::ErrorCode::OK);
-  ASSERT(msg[1] == msg[0]);
+  ASSERT(msg[3] == msg[0]);
 
   auto legacy_prefix_packet = packed_data;
   legacy_prefix_packet.raw.header_.prefix = 0xA5;
@@ -354,22 +327,19 @@ void test_message()
       LibXR::CRC8::Calculate(&legacy_prefix_packet, PACKET_SIZE - sizeof(uint8_t));
   ASSERT(topic_server.ParseData(LibXR::ConstRawData(legacy_prefix_packet)) == 0);
   ASSERT(topic_server.ParseData(LibXR::ConstRawData(packed_data)) == 1);
-  ASSERT(sync_suber.Wait(10) == LibXR::ErrorCode::OK);
-  ASSERT(msg[1] == msg[0]);
+  ASSERT(msg[3] == msg[0]);
 
   auto bad_header_packet = packed_data;
   bad_header_packet.raw.header_.pack_header_crc8 ^= 0x5A;
   ASSERT(topic_server.ParseData(LibXR::ConstRawData(bad_header_packet)) == 0);
   ASSERT(topic_server.ParseData(LibXR::ConstRawData(packed_data)) == 1);
-  ASSERT(sync_suber.Wait(10) == LibXR::ErrorCode::OK);
-  ASSERT(msg[1] == msg[0]);
+  ASSERT(msg[3] == msg[0]);
 
   auto bad_payload_packet = packed_data;
   bad_payload_packet.crc8_ ^= 0xA5;
   ASSERT(topic_server.ParseData(LibXR::ConstRawData(bad_payload_packet)) == 0);
   ASSERT(topic_server.ParseData(LibXR::ConstRawData(packed_data)) == 1);
-  ASSERT(sync_suber.Wait(10) == LibXR::ErrorCode::OK);
-  ASSERT(msg[1] == msg[0]);
+  ASSERT(msg[3] == msg[0]);
 
   for (int i = 0; i < 1000; i++)
   {
@@ -378,9 +348,8 @@ void test_message()
     topic.Publish(msg[0], timestamp);
     topic.DumpData(packed_data);
     topic_server.ParseData(LibXR::ConstRawData(packed_data));
-    ASSERT(sync_suber.Wait(10) == LibXR::ErrorCode::OK);
-    ASSERT(msg[1] == msg[0]);
-    ASSERT(timestamp_us(sync_suber.GetTimestamp()) == timestamp_us(timestamp));
+    ASSERT(msg[3] == msg[0]);
+    ASSERT(timestamp_us(cb_timestamp) == timestamp_us(timestamp));
   }
 
   for (int i = 0; i < 1000; i++)
@@ -398,8 +367,109 @@ void test_message()
       auto tmp = reinterpret_cast<uint8_t*>(&packed_data);
       topic_server.ParseData(LibXR::ConstRawData(tmp[j]));
     }
-    ASSERT(sync_suber.Wait(10) == LibXR::ErrorCode::OK);
-    ASSERT(msg[1] == msg[0]);
-    ASSERT(timestamp_us(sync_suber.GetTimestamp()) == timestamp_us(timestamp));
+    ASSERT(msg[3] == msg[0]);
+    ASSERT(timestamp_us(cb_timestamp) == timestamp_us(timestamp));
   }
+}
+
+void TestASyncSubscriberFreshWait()
+{
+  auto domain = LibXR::Topic::Domain("message_async_wait_domain");
+  auto topic =
+      LibXR::Topic::CreateTopic<int>("message_async_wait_tp", &domain, false, true);
+  auto suber = LibXR::Topic::ASyncSubscriber<int>(topic);
+
+  int value = 41;
+  topic.Publish(value, LibXR::MicrosecondTimestamp(7041));
+  ASSERT(!suber.Available());
+
+  suber.StartWaiting();
+  value = 42;
+  topic.Publish(value, LibXR::MicrosecondTimestamp(7042));
+  ASSERT(suber.Available());
+  suber.StartWaiting();
+  ASSERT(suber.Available());
+  ASSERT(suber.GetData() == value);
+  ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7042);
+  ASSERT(!suber.Available());
+
+  suber.StartWaiting();
+  UNUSED(suber.GetData());
+  value = 43;
+  topic.PublishFromCallback(value, LibXR::MicrosecondTimestamp(7043), false);
+  ASSERT(suber.Available());
+  ASSERT(suber.GetData() == value);
+  ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7043);
+  ASSERT(!suber.Available());
+}
+
+void TestSyncSubscriberFreshWait()
+{
+  auto domain = LibXR::Topic::Domain("message_sync_wait_domain");
+  auto topic =
+      LibXR::Topic::CreateTopic<int>("message_sync_wait_tp", &domain, false, true);
+  int rx = -1;
+  auto suber = LibXR::Topic::SyncSubscriber<int>(topic, rx);
+
+  for (int i = 0; i < 5; i++)
+  {
+    auto value = i + 1;
+    topic.Publish(value, LibXR::MicrosecondTimestamp(7100 + i));
+  }
+  ASSERT(rx == -1);
+  ASSERT(suber.Wait(0) == LibXR::ErrorCode::TIMEOUT);
+  ASSERT(suber.Wait(1) == LibXR::ErrorCode::TIMEOUT);
+
+  auto wait_and_publish = [&](auto publish)
+  {
+    LibXR::ErrorCode wait_result = LibXR::ErrorCode::FAILED;
+    std::thread wait_thread([&]() { wait_result = suber.Wait(200); });
+
+    for (uint32_t i = 0;
+         i < 1000000 &&
+         suber.block_->data_.wait_state.load(std::memory_order_acquire) !=
+             LibXR::Topic::SyncBlock::WAITING;
+         i++)
+    {
+      std::this_thread::yield();
+    }
+
+    ASSERT(suber.block_->data_.wait_state.load(std::memory_order_acquire) ==
+           LibXR::Topic::SyncBlock::WAITING);
+    ASSERT(suber.Wait(0) == LibXR::ErrorCode::BUSY);
+    publish();
+    wait_thread.join();
+    ASSERT(wait_result == LibXR::ErrorCode::OK);
+  };
+
+  int value = 6;
+  wait_and_publish(
+      [&]()
+      { topic.PublishFromCallback(value, LibXR::MicrosecondTimestamp(7106), false); });
+  ASSERT(rx == value);
+  ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7106);
+  ASSERT(suber.Wait(0) == LibXR::ErrorCode::TIMEOUT);
+
+  ASSERT(suber.Wait(1) == LibXR::ErrorCode::TIMEOUT);
+  value = 7;
+  topic.Publish(value, LibXR::MicrosecondTimestamp(7107));
+  ASSERT(rx == 6);
+  ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7106);
+  ASSERT(suber.Wait(0) == LibXR::ErrorCode::TIMEOUT);
+
+  value = 8;
+  wait_and_publish(
+      [&]() { topic.Publish(value, LibXR::MicrosecondTimestamp(7108)); });
+  ASSERT(rx == value);
+  ASSERT(static_cast<uint64_t>(suber.GetTimestamp()) == 7108);
+  ASSERT(suber.Wait(0) == LibXR::ErrorCode::TIMEOUT);
+}
+
+}  // namespace
+
+void test_message()
+{
+  TestTopicCore();
+  TestASyncSubscriberFreshWait();
+  TestSyncSubscriberFreshWait();
 }


### PR DESCRIPTION
## Summary
- Make `SyncSubscriber::Wait()` a fresh wait request instead of consuming stale semaphore posts.
- Claim a pending sync wait before copying subscriber data or posting the semaphore.
- Preserve async unread data and armed waits by making async state transitions conditional.
- Remove queued subscriber dropped-count tracking from this cleanup.

## Validation
- `git diff --check`
- `tools/format_driver_src.sh --check`
- CMake configure/build with `LIBXR_TEST_BUILD=True`
- Full unit test binary
- Focused message-only unit test run
- Additional standalone edge and stress probes were run outside the committed test tree.