### PR TITLE
fix(freertos): keep sleep until in timebase domain

### DIFF
--- a/system/freertos/libxr_system.cpp
+++ b/system/freertos/libxr_system.cpp
@@ -18,11 +18,7 @@ extern "C" __attribute__((weak)) void vApplicationStackOverflowHook(TaskHandle_t
   ASSERT(false);
 }
 
-// NOLINTNEXTLINE
-extern "C" __attribute__((weak)) BaseType_t xTaskCatchUpTicks(TickType_t)
-{
-  return pdFALSE;
-}
+uint32_t LibXR::libxr_freertos_timebase_tick_offset = 0;
 
 void LibXR::PlatformInit(uint32_t timer_pri, uint32_t timer_stack_depth)
 {
@@ -35,13 +31,10 @@ void LibXR::PlatformInit(uint32_t timer_pri, uint32_t timer_stack_depth)
   LibXR::Timer::priority_ = static_cast<LibXR::Thread::Priority>(timer_pri);
   LibXR::Timer::stack_depth_ = timer_stack_depth;
 
-  int64_t time_need_to_catch_up = static_cast<int64_t>(Timebase::GetMilliseconds()) -
-                                  static_cast<int64_t>(xTaskGetTickCount());
+  uint32_t rtos_tick = static_cast<uint32_t>(xTaskGetTickCount());
+  uint32_t timebase_tick = static_cast<uint32_t>(Timebase::GetMilliseconds());
 
-  if (time_need_to_catch_up > 0)
-  {
-    xTaskCatchUpTicks(time_need_to_catch_up);
-  }
+  libxr_freertos_timebase_tick_offset = rtos_tick - timebase_tick;
 }
 
 #ifndef ESP_PLATFORM

--- a/system/freertos/libxr_system.hpp
+++ b/system/freertos/libxr_system.hpp
@@ -10,6 +10,11 @@ typedef SemaphoreHandle_t libxr_mutex_handle;
 typedef SemaphoreHandle_t libxr_semaphore_handle;
 typedef TaskHandle_t libxr_thread_handle;
 
+static_assert(sizeof(TickType_t) >= sizeof(uint32_t),
+              "FreeRTOS TickType_t must hold LibXR millisecond timestamps");
+
+extern uint32_t libxr_freertos_timebase_tick_offset;
+
 /**
  * @brief  平台初始化函数
  *         Platform initialization function

--- a/system/freertos/thread.cpp
+++ b/system/freertos/thread.cpp
@@ -5,14 +5,3 @@
 using namespace LibXR;
 
 Thread Thread::Current(void) { return Thread(xTaskGetCurrentTaskHandle()); }
-
-void Thread::Sleep(uint32_t milliseconds) { vTaskDelay(milliseconds); }
-
-void Thread::SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep)
-{
-  vTaskDelayUntil(reinterpret_cast<uint32_t*>(&last_waskup_time), time_to_sleep);
-}
-
-uint32_t Thread::GetTime() { return xTaskGetTickCount(); }
-
-void Thread::Yield() { portYIELD(); }  // NOLINT

--- a/system/freertos/thread.hpp
+++ b/system/freertos/thread.hpp
@@ -2,6 +2,7 @@
 
 #include "libxr_system.hpp"
 #include "libxr_time.hpp"
+#include "timebase.hpp"
 
 #define LIBXR_PRIORITY_STEP ((configMAX_PRIORITIES - 1) / 5)
 
@@ -110,14 +111,20 @@ class Thread
    *         Gets the current system time in milliseconds
    * @return 当前时间（毫秒） Current time in milliseconds
    */
-  static uint32_t GetTime();
+  static uint32_t GetTime()
+  {
+    return static_cast<uint32_t>(Timebase::GetMilliseconds());
+  }
 
   /**
    * @brief  让线程进入休眠状态
    *         Puts the thread to sleep
    * @param  milliseconds 休眠时间（毫秒） Sleep duration in milliseconds
    */
-  static void Sleep(uint32_t milliseconds);
+  static void Sleep(uint32_t milliseconds)
+  {
+    vTaskDelay(static_cast<TickType_t>(milliseconds));
+  }
 
   /**
    * @brief  让线程休眠直到指定时间点
@@ -125,13 +132,30 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep)
+  {
+    ASSERT(time_to_sleep > 0U);
+
+    uint32_t current_tick = static_cast<uint32_t>(xTaskGetTickCount());
+    uint32_t previous_wake_time =
+        static_cast<uint32_t>(last_waskup_time) + libxr_freertos_timebase_tick_offset;
+
+    if ((previous_wake_time - current_tick) < (UINT32_MAX / 2U))
+    {
+      previous_wake_time = current_tick;
+    }
+
+    TickType_t wake_time = static_cast<TickType_t>(previous_wake_time);
+    vTaskDelayUntil(&wake_time, static_cast<TickType_t>(time_to_sleep));
+    last_waskup_time = MillisecondTimestamp(static_cast<uint32_t>(wake_time) -
+                                            libxr_freertos_timebase_tick_offset);
+  }
 
   /**
    * @brief  让出 CPU 以执行其他线程
    *         Yields CPU execution to allow other threads to run
    */
-  static void Yield();
+  static void Yield() { portYIELD(); }  // NOLINT
 
   /**
    * @brief  线程对象转换为 FreeRTOS 线程句柄


### PR DESCRIPTION
## Summary
- keep the FreeRTOS Thread time API in the LibXR/Timebase millisecond domain
- map Timebase timestamps to FreeRTOS ticks only inside SleepUntil
- clamp a mapped previous wake time that is ahead of the current RTOS tick before calling vTaskDelayUntil
- remove the xTaskCatchUpTicks dependency and the raw reinterpret_cast wrapper

## Validation
- Ubuntu24 clean clone: git diff --check, CMake configure/build, ./build/test passed
- OpenCR hardware probe: 2000 iterations of SleepUntil(..., 2) passed
- OpenCR metrics: first/min/max_delta_rtos=2, zero_delta_count=0, under_period_after_first=0, wakeup_advanced=4000