### PR TITLE
fix(app_framework): enforce alias type checks

### DIFF
--- a/src/middleware/app_framework.hpp
+++ b/src/middleware/app_framework.hpp
@@ -43,10 +43,11 @@ class HardwareContainer
   T* Find(const char* alias) const
   {
     T* result = nullptr;
+    const auto wanted_id = TypeID::GetID<T>();
     alias_list_.Foreach<AliasEntry>(
         [&](AliasEntry& entry)
         {
-          if (std::strcmp(entry.name, alias) == 0)
+          if (std::strcmp(entry.name, alias) == 0 && entry.id == wanted_id)
           {
             result = static_cast<T*>(entry.object);
             return ErrorCode::FAILED;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -106,6 +106,7 @@ static void run_libxr_tests()
   };
 
   TestCase system_tests[] = {{"ramfs", test_ramfs, false},
+                             {"app_framework", test_app_framework, false},
                              {"event", test_event, false},
                              {"message", test_message, false},
                              {"database", test_database, false},

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -17,6 +17,7 @@ void test_terminal();
 void test_thread();
 void test_timebase();
 void test_timer();
+void test_app_framework();
 void test_database();
 void test_transform();
 void test_double_buffer();

--- a/test/test_app_framework.cpp
+++ b/test/test_app_framework.cpp
@@ -1,0 +1,75 @@
+#include "libxr.hpp"
+#include "test.hpp"
+
+namespace
+{
+
+struct DeviceA
+{
+  int value = 1;
+};
+
+struct DeviceB
+{
+  int value = 2;
+};
+
+struct DeviceC
+{
+  int value = 3;
+};
+
+class CountingApp : public LibXR::Application
+{
+ public:
+  CountingApp(int id, int* log, size_t* index) : id_(id), log_(log), index_(index) {}
+
+  void OnMonitor() override { log_[(*index_)++] = id_; }
+
+ private:
+  int id_;
+  int* log_;
+  size_t* index_;
+};
+
+}  // namespace
+
+void test_app_framework()
+{
+  DeviceA dev_a;
+  DeviceB dev_b;
+  DeviceC dev_c;
+
+  LibXR::HardwareContainer hw(
+      LibXR::Entry<DeviceA>{dev_a, {"a", "shared"}},
+      LibXR::Entry<DeviceB>{dev_b, {"b", "shared"}},
+      LibXR::Entry<DeviceC>{dev_c, {"c-only"}});
+
+  ASSERT(hw.Find<DeviceA>("a") == &dev_a);
+  ASSERT(hw.Find<DeviceB>("b") == &dev_b);
+  ASSERT(hw.Find<DeviceC>("c-only") == &dev_c);
+
+  ASSERT(hw.Find<DeviceA>("shared") == &dev_a);
+  ASSERT(hw.Find<DeviceB>("shared") == &dev_b);
+  ASSERT(hw.Find<DeviceC>("shared") == nullptr);
+
+  ASSERT(hw.Find<DeviceA>("missing") == nullptr);
+  ASSERT(hw.Find<DeviceB>({"missing", "shared"}) == &dev_b);
+  ASSERT(hw.Find<DeviceC>({"missing", "shared"}) == nullptr);
+
+  int monitor_log[4] = {0, 0, 0, 0};
+  size_t monitor_index = 0;
+  CountingApp app1(1, monitor_log, &monitor_index);
+  CountingApp app2(2, monitor_log, &monitor_index);
+
+  LibXR::ApplicationManager manager;
+  ASSERT(manager.Size() == 0);
+  manager.Register(app1);
+  manager.Register(app2);
+  ASSERT(manager.Size() == 2);
+
+  manager.MonitorAll();
+  ASSERT(monitor_index == 2);
+  ASSERT(monitor_log[0] == 1);
+  ASSERT(monitor_log[1] == 2);
+}


### PR DESCRIPTION
## Summary
- make `HardwareContainer::Find<T>()` require both alias-name match and stored `TypeID` match before returning an object
- add direct `app_framework` tests for exact alias lookup, shared alias type filtering, fallback alias lists, and `ApplicationManager` monitor order
- wire the new direct test into the main union test harness

## Validation
- Ubuntu24 `/tmp/libxr_appfw_typeid_verify_20260522T091514Z`: `cmake=PASS`, `build=PASS`, `test_rc=0`

## Summary by Sourcery

Enforce type-safe hardware alias lookups and add direct tests for the app framework, including application monitoring order, integrated into the main test harness.

Bug Fixes:
- Ensure HardwareContainer::Find<T>() only returns objects whose stored TypeID matches the requested template type in addition to alias-name matching.

Tests:
- Add app framework tests covering exact alias resolution, shared alias type filtering, fallback alias list behavior, and ApplicationManager monitor invocation order.
- Register the new app framework test in the central test runner and header declarations.