### PR TITLE
perf(cb): trim callback dispatch overhead

### DIFF
--- a/src/core/libxr_cb.hpp
+++ b/src/core/libxr_cb.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <concepts>
 #include <cstring>
 #include <tuple>
 #include <type_traits>
@@ -9,6 +10,16 @@
 
 namespace LibXR
 {
+
+/**
+ * @brief 可转换为精确回调函数指针的可调用对象
+ * @brief Callable convertible to the exact callback function pointer
+ */
+template <typename CallableType, typename BoundArgType, typename... CallbackArgs>
+concept CallbackFunctionCompatible = requires(CallableType callable)
+{
+  static_cast<void (*)(bool, BoundArgType, CallbackArgs...)>(callable);
+};
 
 template <typename... Args>
 struct CallbackBlockHeader
@@ -37,11 +48,6 @@ class CallbackBlock : public CallbackBlockHeader<Args...>
   /**
    * @brief 构造回调块，绑定回调函数与参数 / Construct a callback block with bound
    * function and argument
-   *
-   * 工厂层已经把 `fun` 收窄到了当前块真实需要的函数指针类型，因此这里不再保留
-   * 额外的模板参数做二次推导。
-   * The factory has already narrowed `fun` to the exact function-pointer type required
-   * by this block, so there is no need to keep another template parameter here.
    *
    * @param fun 需要调用的回调函数 / Callback function to be invoked
    * @param arg 绑定的参数值 / Bound argument value
@@ -83,10 +89,6 @@ class GuardedCallbackBlock : public CallbackBlock<ArgType, Args...>
  public:
   /**
    * @brief 带防重入保护的回调块 / Callback block with reentry guard
-   *
-   * 与 `CallbackBlock` 一样，这里直接接收精确的函数指针类型。
-   * Same as `CallbackBlock`, this constructor takes the exact callback function-pointer
-   * type directly.
    */
   GuardedCallbackBlock(typename CallbackBlock<ArgType, Args...>::FunctionType fun,
                        ArgType&& arg)
@@ -148,54 +150,40 @@ class Callback
    * @brief 创建回调对象并绑定回调函数与参数 / Create a callback instance with bound
    * function and argument
    *
-   * @tparam ArgType 绑定参数类型 / Bound argument type
+   * @tparam BoundArgType 绑定参数类型 / Bound argument type
+   * @tparam CallableType 回调可调用对象类型 / Callback callable type
    * @param fun 需要绑定的回调函数 / Callback function to bind
    * @param arg 绑定的参数值 / Bound argument value
    * @return Callback 实例 / Created Callback instance
-   *
-   * `fun` 的类型被显式写成当前 `CallbackBlock` 的真实函数指针类型，
-   * 同时再用 `std::type_identity_t` 阻止它参与额外推导；这样 `ArgType`
-   * 只从 `arg` 推导，避免把“看起来能转”的别的函数指针类型错误地吸进来。
-   * `fun` is written as the exact callback-function pointer type required by the current
-   * `CallbackBlock`, and wrapped in `std::type_identity_t` so it does not participate in
-   * extra deduction. This keeps `ArgType` deduced only from `arg`, and avoids accepting
-   * unrelated-but-convertible function pointer types by accident.
-   *
-   * 因此调用方需要传入可转换到该精确函数指针类型的对象，例如普通函数、静态成员函数，
-   * 或无捕获 lambda。
-   * Callers therefore need an object convertible to that exact function-pointer type,
-   * such as a free function, static member function, or non-capturing lambda.
-   *
-   * @note 该写法依赖 `std::type_identity_t`，要求编译环境提供 C++20 标准库。
-   *       This form relies on `std::type_identity_t`, which requires a C++20 standard
-   *       library.
-   *
-   * @note 包含动态内存分配 / Contains dynamic memory allocation
    */
-  template <typename ArgType>
-  [[nodiscard]] static Callback Create(
-      std::type_identity_t<typename CallbackBlock<ArgType, Args...>::FunctionType> fun,
-      ArgType arg)
+  template <typename BoundArgType, typename CallableType>
+  requires CallbackFunctionCompatible<CallableType, BoundArgType, Args...>
+  [[nodiscard]] static Callback Create(CallableType fun, BoundArgType arg)
   {
-    auto cb_block = new CallbackBlock<ArgType, Args...>(fun, std::move(arg));
+    using FunctionType = typename CallbackBlock<BoundArgType, Args...>::FunctionType;
+    auto cb_block =
+        new CallbackBlock<BoundArgType, Args...>(static_cast<FunctionType>(fun),
+                                                 std::move(arg));
     return Callback(cb_block);
   }
 
   /**
    * @brief 创建带防重入保护的回调 / Create a guarded callback
    *
-   * 参数约束与 `Create` 完全一致，只是底层块换成了带重入压平逻辑的
-   * `GuardedCallbackBlock`。
-   * The parameter constraint is identical to `Create`; the only difference is that the
-   * underlying block becomes `GuardedCallbackBlock`, which flattens reentrant callback
-   * chains.
+   * @tparam BoundArgType 绑定参数类型 / Bound argument type
+   * @tparam CallableType 回调可调用对象类型 / Callback callable type
+   * @param fun 需要绑定的回调函数 / Callback function to bind
+   * @param arg 绑定的参数值 / Bound argument value
+   * @return Callback 实例 / Created Callback instance
    */
-  template <typename ArgType>
-  [[nodiscard]] static Callback CreateGuarded(
-      std::type_identity_t<typename CallbackBlock<ArgType, Args...>::FunctionType> fun,
-      ArgType arg)
+  template <typename BoundArgType, typename CallableType>
+  requires CallbackFunctionCompatible<CallableType, BoundArgType, Args...>
+  [[nodiscard]] static Callback CreateGuarded(CallableType fun, BoundArgType arg)
   {
-    auto cb_block = new GuardedCallbackBlock<ArgType, Args...>(fun, std::move(arg));
+    using FunctionType = typename CallbackBlock<BoundArgType, Args...>::FunctionType;
+    auto cb_block =
+        new GuardedCallbackBlock<BoundArgType, Args...>(static_cast<FunctionType>(fun),
+                                                        std::move(arg));
     return Callback(cb_block);
   }
 
@@ -254,7 +242,6 @@ class Callback
    * create callback instances
    *
    * @param cb_block 回调块对象指针 / Pointer to the callback block
-   * @param cb_fun 回调执行函数指针 / Callback invocation function pointer
    */
   explicit Callback(CallbackBlockHeader<Args...>* cb_block)
       : cb_block_((cb_block != nullptr) ? cb_block : &empty_cb_block_)

--- a/src/core/libxr_cb.hpp
+++ b/src/core/libxr_cb.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <concepts>
 #include <cstring>
 #include <tuple>
 #include <type_traits>
@@ -10,16 +9,6 @@
 
 namespace LibXR
 {
-
-/**
- * @brief 可转换为精确回调函数指针的可调用对象
- * @brief Callable convertible to the exact callback function pointer
- */
-template <typename CallableType, typename BoundArgType, typename... CallbackArgs>
-concept CallbackFunctionCompatible = requires(CallableType callable)
-{
-  static_cast<void (*)(bool, BoundArgType, CallbackArgs...)>(callable);
-};
 
 template <typename... Args>
 struct CallbackBlockHeader
@@ -49,11 +38,18 @@ class CallbackBlock : public CallbackBlockHeader<Args...>
    * @brief 构造回调块，绑定回调函数与参数 / Construct a callback block with bound
    * function and argument
    *
+   * 工厂层已经把 `fun` 收窄到了当前块真实需要的函数指针类型，因此这里不再保留
+   * 额外的模板参数做二次推导。
+   * The factory has already narrowed `fun` to the exact function-pointer type required
+   * by this block, so there is no need to keep another template parameter here.
+   *
    * @param fun 需要调用的回调函数 / Callback function to be invoked
    * @param arg 绑定的参数值 / Bound argument value
    */
   CallbackBlock(FunctionType fun, ArgType&& arg)
-      : CallbackBlockHeader<Args...>{&InvokeThunk}, fun_(fun), arg_(std::move(arg))
+      : CallbackBlockHeader<Args...>{fun != nullptr ? &InvokeThunk : &InvokeThunkNull},
+        fun_(fun),
+        arg_(std::move(arg))
   {
   }
 
@@ -69,13 +65,11 @@ class CallbackBlock : public CallbackBlockHeader<Args...>
     cb->Invoke(in_isr, std::forward<Args>(args)...);
   }
 
+  static void InvokeThunkNull(void*, bool, Args...) {}
+
  protected:
   void Invoke(bool in_isr, Args... args)
   {
-    if (!fun_)
-    {
-      return;
-    }
     fun_(in_isr, arg_, std::forward<Args>(args)...);
   }
 
@@ -89,12 +83,16 @@ class GuardedCallbackBlock : public CallbackBlock<ArgType, Args...>
  public:
   /**
    * @brief 带防重入保护的回调块 / Callback block with reentry guard
+   *
+   * 与 `CallbackBlock` 一样，这里直接接收精确的函数指针类型。
+   * Same as `CallbackBlock`, this constructor takes the exact callback function-pointer
+   * type directly.
    */
   GuardedCallbackBlock(typename CallbackBlock<ArgType, Args...>::FunctionType fun,
                        ArgType&& arg)
       : CallbackBlock<ArgType, Args...>(fun, std::move(arg))
   {
-    this->run_fun_ = &InvokeThunk;
+    this->run_fun_ = fun != nullptr ? &InvokeThunk : &InvokeThunkNull;
   }
 
   static void InvokeThunk(void* cb_block, bool in_isr, Args... args)
@@ -111,7 +109,7 @@ class GuardedCallbackBlock : public CallbackBlock<ArgType, Args...>
         std::apply([&](auto&... a) { cb->Invoke(in_isr, a...); }, cur_args);
         if (cb->pending_)
         {
-          cur_args = cb->pending_args_;
+          cur_args = std::move(cb->pending_args_);
         }
       } while (cb->pending_);
       cb->running_ = false;
@@ -124,6 +122,8 @@ class GuardedCallbackBlock : public CallbackBlock<ArgType, Args...>
     cb->pending_args_ = std::tuple<std::decay_t<Args>...>{std::forward<Args>(args)...};
     cb->pending_ = true;
   }
+
+  static void InvokeThunkNull(void*, bool, Args...) {}
 
  private:
   bool running_ = false;
@@ -148,40 +148,54 @@ class Callback
    * @brief 创建回调对象并绑定回调函数与参数 / Create a callback instance with bound
    * function and argument
    *
-   * @tparam BoundArgType 绑定参数类型 / Bound argument type
-   * @tparam CallableType 回调可调用对象类型 / Callback callable type
+   * @tparam ArgType 绑定参数类型 / Bound argument type
    * @param fun 需要绑定的回调函数 / Callback function to bind
    * @param arg 绑定的参数值 / Bound argument value
    * @return Callback 实例 / Created Callback instance
+   *
+   * `fun` 的类型被显式写成当前 `CallbackBlock` 的真实函数指针类型，
+   * 同时再用 `std::type_identity_t` 阻止它参与额外推导；这样 `ArgType`
+   * 只从 `arg` 推导，避免把“看起来能转”的别的函数指针类型错误地吸进来。
+   * `fun` is written as the exact callback-function pointer type required by the current
+   * `CallbackBlock`, and wrapped in `std::type_identity_t` so it does not participate in
+   * extra deduction. This keeps `ArgType` deduced only from `arg`, and avoids accepting
+   * unrelated-but-convertible function pointer types by accident.
+   *
+   * 因此调用方需要传入可转换到该精确函数指针类型的对象，例如普通函数、静态成员函数，
+   * 或无捕获 lambda。
+   * Callers therefore need an object convertible to that exact function-pointer type,
+   * such as a free function, static member function, or non-capturing lambda.
+   *
+   * @note 该写法依赖 `std::type_identity_t`，要求编译环境提供 C++20 标准库。
+   *       This form relies on `std::type_identity_t`, which requires a C++20 standard
+   *       library.
+   *
+   * @note 包含动态内存分配 / Contains dynamic memory allocation
    */
-  template <typename BoundArgType, typename CallableType>
-  requires CallbackFunctionCompatible<CallableType, BoundArgType, Args...>
-  [[nodiscard]] static Callback Create(CallableType fun, BoundArgType arg)
+  template <typename ArgType>
+  [[nodiscard]] static Callback Create(
+      std::type_identity_t<typename CallbackBlock<ArgType, Args...>::FunctionType> fun,
+      ArgType arg)
   {
-    using FunctionType = typename CallbackBlock<BoundArgType, Args...>::FunctionType;
-    auto cb_block =
-        new CallbackBlock<BoundArgType, Args...>(static_cast<FunctionType>(fun),
-                                                 std::move(arg));
+    auto cb_block = new CallbackBlock<ArgType, Args...>(fun, std::move(arg));
     return Callback(cb_block);
   }
 
   /**
    * @brief 创建带防重入保护的回调 / Create a guarded callback
    *
-   * @tparam BoundArgType 绑定参数类型 / Bound argument type
-   * @tparam CallableType 回调可调用对象类型 / Callback callable type
-   * @param fun 需要绑定的回调函数 / Callback function to bind
-   * @param arg 绑定的参数值 / Bound argument value
-   * @return Callback 实例 / Created Callback instance
+   * 参数约束与 `Create` 完全一致，只是底层块换成了带重入压平逻辑的
+   * `GuardedCallbackBlock`。
+   * The parameter constraint is identical to `Create`; the only difference is that the
+   * underlying block becomes `GuardedCallbackBlock`, which flattens reentrant callback
+   * chains.
    */
-  template <typename BoundArgType, typename CallableType>
-  requires CallbackFunctionCompatible<CallableType, BoundArgType, Args...>
-  [[nodiscard]] static Callback CreateGuarded(CallableType fun, BoundArgType arg)
+  template <typename ArgType>
+  [[nodiscard]] static Callback CreateGuarded(
+      std::type_identity_t<typename CallbackBlock<ArgType, Args...>::FunctionType> fun,
+      ArgType arg)
   {
-    using FunctionType = typename CallbackBlock<BoundArgType, Args...>::FunctionType;
-    auto cb_block =
-        new GuardedCallbackBlock<BoundArgType, Args...>(static_cast<FunctionType>(fun),
-                                                        std::move(arg));
+    auto cb_block = new GuardedCallbackBlock<ArgType, Args...>(fun, std::move(arg));
     return Callback(cb_block);
   }
 
@@ -240,6 +254,7 @@ class Callback
    * create callback instances
    *
    * @param cb_block 回调块对象指针 / Pointer to the callback block
+   * @param cb_fun 回调执行函数指针 / Callback invocation function pointer
    */
   explicit Callback(CallbackBlockHeader<Args...>* cb_block)
       : cb_block_((cb_block != nullptr) ? cb_block : &empty_cb_block_)

--- a/src/core/libxr_cb.hpp
+++ b/src/core/libxr_cb.hpp
@@ -53,10 +53,9 @@ class CallbackBlock : public CallbackBlockHeader<Args...>
    * @param arg 绑定的参数值 / Bound argument value
    */
   CallbackBlock(FunctionType fun, ArgType&& arg)
-      : CallbackBlockHeader<Args...>{fun != nullptr ? &InvokeThunk : &InvokeThunkNull},
-        fun_(fun),
-        arg_(std::move(arg))
+      : CallbackBlockHeader<Args...>{&InvokeThunk}, fun_(fun), arg_(std::move(arg))
   {
+    ASSERT(fun_ != nullptr);
   }
 
   /**
@@ -70,8 +69,6 @@ class CallbackBlock : public CallbackBlockHeader<Args...>
     auto* cb = static_cast<CallbackBlock<ArgType, Args...>*>(cb_block);
     cb->Invoke(in_isr, std::forward<Args>(args)...);
   }
-
-  static void InvokeThunkNull(void*, bool, Args...) {}
 
  protected:
   void Invoke(bool in_isr, Args... args)
@@ -94,7 +91,7 @@ class GuardedCallbackBlock : public CallbackBlock<ArgType, Args...>
                        ArgType&& arg)
       : CallbackBlock<ArgType, Args...>(fun, std::move(arg))
   {
-    this->run_fun_ = fun != nullptr ? &InvokeThunk : &InvokeThunkNull;
+    this->run_fun_ = &InvokeThunk;
   }
 
   static void InvokeThunk(void* cb_block, bool in_isr, Args... args)
@@ -124,8 +121,6 @@ class GuardedCallbackBlock : public CallbackBlock<ArgType, Args...>
     cb->pending_args_ = std::tuple<std::decay_t<Args>...>{std::forward<Args>(args)...};
     cb->pending_ = true;
   }
-
-  static void InvokeThunkNull(void*, bool, Args...) {}
 
  private:
   bool running_ = false;


### PR DESCRIPTION
## Summary
- require non-null function pointers for constructed callback blocks with `ASSERT(fun_ != nullptr)`
- remove the hot-path `fun_ == nullptr` branch from `CallbackBlock::Invoke()`
- move guarded replay args with `std::move(cb->pending_args_)`

## Rationale
`empty` remains the only valid "unregistered callback" state. Constructed callback blocks now assume a valid function pointer, so the normal `Run()` path no longer pays a null-check branch.

## Validation
- Ubuntu24 clean-tree `cmake -DLIBXR_TEST_BUILD=True`
- Ubuntu24 clean-tree build
- Ubuntu24 clean-tree `./build/test`
- verified `CallbackBlock<Probe*, int>::InvokeThunk` stays branchless on `g++ 13.3.0 -O2`

## Summary by Sourcery

Enforce non-null callbacks and streamline callback invocation to reduce dispatch overhead.

Enhancements:
- Assert that constructed callback blocks always receive a non-null function pointer, making null callbacks invalid at construction time.
- Remove the null-function branch from callback invocation to keep the hot path branchless.
- Move guarded callback pending arguments when replaying to avoid unnecessary copies and better express ownership semantics.