### PR TITLE
fix(string): delete retained move assignment

### DIFF
--- a/src/core/libxr_string.hpp
+++ b/src/core/libxr_string.hpp
@@ -265,22 +265,7 @@ class RuntimeStringView
     other.status_ = ErrorCode::OK;
   }
 
-  /// Move-assigns by taking the retained storage handle. / 移动赋值并接管保留存储句柄。
-  RuntimeStringView& operator=(RuntimeStringView&& other) noexcept
-  {
-    if (this != &other)
-    {
-      data_ = other.data_;
-      size_ = other.size_;
-      capacity_ = other.capacity_;
-      status_ = other.status_;
-      other.data_ = nullptr;
-      other.size_ = 0;
-      other.capacity_ = 0;
-      other.status_ = ErrorCode::OK;
-    }
-    return *this;
-  }
+  RuntimeStringView& operator=(RuntimeStringView&&) = delete;
 
   /// Copies text into retained storage. / 拷贝文本到保留存储。
   explicit RuntimeStringView(std::string_view text)

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -2,6 +2,7 @@
 #include <limits>
 #include <string>
 #include <string_view>
+#include <type_traits>
 
 #include "libxr_def.hpp"
 #include "libxr_string.hpp"
@@ -25,6 +26,8 @@ static_assert(accepts_uint32_reformat<std::uint32_t>);
 static_assert(!accepts_uint32_reformat<std::uint64_t>);
 static_assert(accepts_uint_reprintf<unsigned int>);
 static_assert(!accepts_uint_reprintf<std::uint64_t>);
+static_assert(std::is_move_constructible_v<LibXR::RuntimeStringView<>>);
+static_assert(!std::is_move_assignable_v<LibXR::RuntimeStringView<>>);
 
 static void TestRuntimeStringText()
 {


### PR DESCRIPTION
## Summary
- delete `RuntimeStringView::operator=(RuntimeStringView&&)`
- keep move construction intact
- add compile-time coverage that the type remains move-constructible but is no longer move-assignable

## Rationale
`RuntimeStringView` intentionally retains allocated storage for process lifetime. Move assignment was inconsistent with that model because assigning into an already-owning target overwrote the old retained pointer without releasing it, creating an immediate unrecoverable leak. Deleting move assignment keeps the retained-storage contract coherent.

## Validation
- Ubuntu24 clean-tree `cmake -DLIBXR_TEST_BUILD=True`
- Ubuntu24 clean-tree build
- Ubuntu24 clean-tree `./build/test`
- validation run:
  - `/tmp/libxr_string_move_validate_20260523T075400Z`
- downstream check:
  - real `WebotsCamera` / `CaptureFileCamera` usage patterns compiled successfully

## Summary by Sourcery

Remove move assignment from RuntimeStringView to align with its retained-storage lifetime model and add tests to enforce its move constructibility but non-move-assignability.

Bug Fixes:
- Prevent memory leaks by deleting RuntimeStringView's move-assignment operator that could overwrite retained storage without releasing it.

Tests:
- Add static type-trait checks ensuring RuntimeStringView remains move-constructible but is no longer move-assignable.