### PR TITLE
refactor(core): align print public include surface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,18 @@ set(_xr_public_include_dirs
     ${CMAKE_CURRENT_SOURCE_DIR}/system/${_xr_system}
 )
 
+file(GLOB _xr_core_SUBDIRS CONFIGURE_DEPENDS LIST_DIRECTORIES true
+     "${CMAKE_CURRENT_SOURCE_DIR}/src/core/*"
+)
+foreach(_xr_core_SUBDIR IN LISTS _xr_core_SUBDIRS)
+  if(IS_DIRECTORY "${_xr_core_SUBDIR}")
+    get_filename_component(_xr_core_NAME "${_xr_core_SUBDIR}" NAME)
+    if(EXISTS "${_xr_core_SUBDIR}/${_xr_core_NAME}.hpp")
+      list(APPEND _xr_public_include_dirs "${_xr_core_SUBDIR}")
+    endif()
+  endif()
+endforeach()
+
 file(GLOB _xr_middleware_SUBDIRS CONFIGURE_DEPENDS LIST_DIRECTORIES true
      "${CMAKE_CURRENT_SOURCE_DIR}/src/middleware/*"
 )

--- a/src/core/libxr_rw.hpp
+++ b/src/core/libxr_rw.hpp
@@ -12,7 +12,7 @@
 #include "libxr_cb.hpp"
 #include "libxr_def.hpp"
 #include "libxr_mem.hpp"
-#include "print/print_api.hpp"
+#include "print.hpp"
 #include "libxr_type.hpp"
 #include "lockfree_queue.hpp"
 #include "mutex.hpp"

--- a/src/core/libxr_string.hpp
+++ b/src/core/libxr_string.hpp
@@ -11,7 +11,7 @@
 #include <utility>
 
 #include "libxr_def.hpp"
-#include "print/print_api.hpp"
+#include "print.hpp"
 
 namespace LibXR
 {

--- a/src/core/print/print.hpp
+++ b/src/core/print/print.hpp
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "print_api.hpp"

--- a/src/libxr.hpp
+++ b/src/libxr.hpp
@@ -13,6 +13,7 @@
 #include "libxr_color.hpp"
 #include "libxr_def.hpp"
 #include "libxr_pipe.hpp"
+#include "print.hpp"
 #include "libxr_rw.hpp"
 #include "libxr_string.hpp"
 #include "libxr_system.hpp"


### PR DESCRIPTION
## Summary by Sourcery

Align the core print module’s public header surface and update includes to use a unified print entrypoint.

Enhancements:
- Auto-detect and add core subdirectories with matching public headers to the CMake public include directories.
- Introduce a new core print umbrella header and update existing core and top-level headers to include it instead of the previous nested print API header.