### PR TITLE
style(logger): fix clang-format indentation

### DIFF
--- a/src/middleware/logger.cpp
+++ b/src/middleware/logger.cpp
@@ -56,7 +56,7 @@ void PrintLogToTerminal(const LogData& data, MicrosecondTimestamp timestamp)
   const uint32_t timestamp_ms =
       static_cast<uint32_t>(static_cast<uint64_t>(timestamp) / 1000U);
   STDIO::Print<"{}{} [{}]({}:{}) {}{}\r\n">(
-    color, LogLevelToString(data.level), timestamp_ms, data.file, data.line,
+      color, LogLevelToString(data.level), timestamp_ms, data.file, data.line,
       data.message,
       LIBXR_TERMINAL_CONTROL_STR[static_cast<uint8_t>(TerminalControl::RESET)]);
 }


### PR DESCRIPTION
## Summary
- fix the logger print call indentation to satisfy clang-format

## Notes
- formatting-only change
- no behavior change

## Summary by Sourcery

Align logger terminal print call with project formatting guidelines