### PR TITLE
refactor(rw): narrow fail-and-clear handling

### DIFF
--- a/src/core/libxr_rw.cpp
+++ b/src/core/libxr_rw.cpp
@@ -168,8 +168,8 @@ ErrorCode ReadPort::operator()(RawData data, ReadOperation& op, bool in_isr)
 
       if (expected == BusyState::BLOCK_DETACHED)
       {
-        // Reset detached this waiter before the timeout-side cancel won.
-        // Reset 先分离了当前 waiter；超时侧负责把端口收回 IDLE。
+        // The waiter had already detached before the timeout-side cancel won.
+        // 当前 waiter 已经先分离；超时侧负责把端口收回 IDLE。
         busy_.store(BusyState::IDLE, std::memory_order_release);
         return ErrorCode::TIMEOUT;
       }
@@ -258,25 +258,36 @@ void ReadPort::ProcessPendingReads(bool in_isr)
   }
 }
 
-void ReadPort::Reset()
+void ReadPort::FailAndClearAll(ErrorCode reason, bool in_isr)
 {
   ASSERT(queue_data_ != nullptr);
   queue_data_->Reset();
 
   auto state = busy_.load(std::memory_order_acquire);
-  if (state == BusyState::PENDING && info_.op.type == ReadOperation::OperationType::BLOCK)
+  if (state == BusyState::PENDING)
   {
-    // Reset detaches the BLOCK waiter instead of reopening the port directly.
-    // Reset 先分离 BLOCK waiter，不直接重开端口。
-    BusyState expected = BusyState::PENDING;
-    if (busy_.compare_exchange_strong(expected, BusyState::BLOCK_DETACHED,
-                                      std::memory_order_acq_rel,
-                                      std::memory_order_acquire))
+    if (info_.op.type == ReadOperation::OperationType::BLOCK)
     {
+      // Backend is already unavailable. Claim the waiter and complete it with
+      // the requested failure reason instead of leaving it to timeout.
+      // 后端已经不可用。这里直接 claim waiter，并用指定错误收口，
+      // 而不是让它继续超时等待。
+      BusyState expected = BusyState::PENDING;
+      if (busy_.compare_exchange_strong(expected, BusyState::BLOCK_CLAIMED,
+                                        std::memory_order_acq_rel,
+                                        std::memory_order_acquire))
+      {
+        Finish(in_isr, reason, info_);
+        return;
+      }
+      state = expected;
+    }
+    else
+    {
+      busy_.store(BusyState::IDLE, std::memory_order_release);
+      info_.op.UpdateStatus(in_isr, reason);
       return;
     }
-
-    state = busy_.load(std::memory_order_acquire);
   }
 
   if (state == BusyState::BLOCK_CLAIMED || state == BusyState::BLOCK_DETACHED)
@@ -334,9 +345,9 @@ void WritePort::Finish(bool in_isr, ErrorCode ans, WriteInfoBlock& info)
       return;
     }
 
-    // The waiter may have timed out and released a reset-detached operation before
-    // this late completion is reported.
-    // waiter 可能已经超时并释放了 Reset 分离的操作，随后迟到完成才上报。
+    // The waiter may have timed out and detached before this late completion is
+    // reported.
+    // waiter 可能已经先超时分离，随后迟到完成才上报。
     if (expected == BusyState::BLOCK_PUBLISHING)
     {
       expected = BusyState::BLOCK_PUBLISHING;
@@ -562,17 +573,30 @@ ErrorCode WritePort::CommitWrite(ConstRawData data, WriteOperation& op, bool met
   return ErrorCode::OK;
 }
 
-void WritePort::Reset()
+void WritePort::FailAndClearAll(ErrorCode reason, bool in_isr)
 {
   ASSERT(queue_data_ != nullptr);
+  WriteInfoBlock info{};
 
   while (true)
   {
     auto state = busy_.load(std::memory_order_acquire);
 
-    if (state == BusyState::LOCKED || state == BusyState::BLOCK_PUBLISHING ||
-        state == BusyState::RESETTING)
+    if (state == BusyState::LOCKED)
     {
+      DEV_ASSERT_FROM_CALLBACK(false, in_isr);
+      return;
+    }
+
+    if (state == BusyState::BLOCK_PUBLISHING)
+    {
+      DEV_ASSERT_FROM_CALLBACK(false, in_isr);
+      return;
+    }
+
+    if (state == BusyState::RESETTING)
+    {
+      DEV_ASSERT_FROM_CALLBACK(false, in_isr);
       return;
     }
 
@@ -587,7 +611,10 @@ void WritePort::Reset()
       }
 
       queue_data_->Reset();
-      queue_info_->Reset();
+      while (queue_info_->Pop(info) == ErrorCode::OK)
+      {
+        Finish(in_isr, reason, info);
+      }
       block_result_ = ErrorCode::OK;
       busy_.store(BusyState::IDLE, std::memory_order_release);
       return;
@@ -595,25 +622,38 @@ void WritePort::Reset()
 
     if (state == BusyState::BLOCK_WAITING)
     {
-      // Claim reset ownership before touching queues; late Finish() must not reopen
-      // the port while Reset() is clearing queue state.
-      // 先取得 reset 所有权再清队列；迟到 Finish() 不能在 Reset() 清队列期间重开端口。
-      BusyState expected = BusyState::BLOCK_WAITING;
-      if (!busy_.compare_exchange_strong(expected, BusyState::RESETTING,
-                                         std::memory_order_acq_rel,
-                                         std::memory_order_acquire))
-      {
-        continue;
-      }
-
+      // Keep BLOCK_WAITING visible until Finish() hands the terminal wakeup to
+      // the blocked caller. Switching to RESETTING here would break that
+      // existing waiter handoff.
+      // 这里必须保留 BLOCK_WAITING，直到 Finish() 把最终唤醒交给当前
+      // BLOCK waiter；若先切成 RESETTING，会破坏既有 waiter 交接。
       queue_data_->Reset();
-      queue_info_->Reset();
-      block_result_ = ErrorCode::OK;
-      busy_.store(BusyState::BLOCK_DETACHED, std::memory_order_release);
+      while (queue_info_->Pop(info) == ErrorCode::OK)
+      {
+        Finish(in_isr, reason, info);
+      }
       return;
     }
 
-    if (state == BusyState::BLOCK_CLAIMED || state == BusyState::BLOCK_DETACHED)
+    if (state == BusyState::BLOCK_DETACHED)
+    {
+      // The waiter is already gone, but BLOCK_DETACHED still blocks reentrant
+      // submissions while old queue entries are drained.
+      // waiter 已经离开，但 BLOCK_DETACHED 仍能在清理旧队列期间挡住重入提交。
+      queue_data_->Reset();
+      while (queue_info_->Pop(info) == ErrorCode::OK)
+      {
+        // The waiter has already detached. Finish() will clear the local state
+        // without re-posting that waiter.
+        // waiter 已经分离。Finish() 会清理本地状态，但不会重新唤醒该 waiter。
+        Finish(in_isr, reason, info);
+      }
+      block_result_ = ErrorCode::OK;
+      busy_.store(BusyState::IDLE, std::memory_order_release);
+      return;
+    }
+
+    if (state == BusyState::BLOCK_CLAIMED)
     {
       return;
     }
@@ -780,12 +820,6 @@ ErrorCode WritePort::Stream::Commit()
   return ans;
 }
 
-void WritePort::Stream::Discard()
-{
-  buffered_size_ = 0;
-  Release();
-}
-
 // STDIO compiled-format bridge.
 // STDIO 编译格式桥接层。
 STDIO::CompiledSink::CompiledSink(WritePort::Stream& stream) : stream_(stream) {}
@@ -873,19 +907,16 @@ int STDIO::FinishWriteSession(WritePort::Stream& stream, size_t retained_size,
 {
   ASSERT(write_mutex_ != nullptr);
 
-  auto ec = format_result;
-  if (ec == ErrorCode::OK)
-  {
-    ec = stream.Commit();
-  }
-  else
-  {
-    stream.Discard();
-  }
+  // Stream-backed STDIO is now explicitly prefix-preserving on formatting
+  // failure: any bytes already retained in this session are committed instead
+  // of being pseudo-rolled-back.
+  // 基于 Stream 的 STDIO 现在明确采用“前缀保留”语义：格式化失败时，
+  // 本会话已保留的字节仍然提交，不再尝试伪回滚。
+  auto ec = stream.Commit();
 
   write_mutex_->Unlock();
 
-  if (ec != ErrorCode::OK ||
+  if (format_result != ErrorCode::OK || ec != ErrorCode::OK ||
       retained_size > static_cast<size_t>(std::numeric_limits<int>::max()))
   {
     return -1;

--- a/src/core/libxr_rw.hpp
+++ b/src/core/libxr_rw.hpp
@@ -395,7 +395,7 @@ class ReadPort
   // Read BLOCK states:
   // PENDING = waiting for queue-fed completion after read_fun_ was notified
   // BLOCK_CLAIMED = wakeup now belongs to the waiter
-  // BLOCK_DETACHED = timeout/reset detached the waiter
+  // BLOCK_DETACHED = timeout detached the waiter
   // The same semaphore may be reused only after the previous BLOCK call
   // returns and the port goes back to IDLE.
   // 读 BLOCK 状态：
@@ -410,8 +410,8 @@ class ReadPort
                   ///< 请求已交给底层推进。
     BLOCK_CLAIMED = 2,   ///< BLOCK wakeup already belongs to the current waiter. 当前
                          ///< BLOCK 唤醒已被本次等待者认领。
-    BLOCK_DETACHED = 3,  ///< Timeout/reset detached the waiter; completion must stay
-                         ///< silent. 超时或 Reset 已分离等待者，完成侧不得再唤醒。
+    BLOCK_DETACHED = 3,  ///< Timeout detached the waiter; completion must stay silent.
+                         ///< 超时已分离等待者，完成侧不得再唤醒。
     EVENT = UINT32_MAX   ///< Data arrived before a waiter was armed; next caller must
                          ///< re-check queue. 数据先到，后续调用者要重查队列。
   };
@@ -545,9 +545,22 @@ class ReadPort
    */
   void ProcessPendingReads(bool in_isr);
 
-  /// @brief Resets the ReadPort.
-  /// @brief 重置ReadPort。
-  void Reset();
+  /**
+   * @brief 失败完成并清空当前所有挂起读操作。
+   * @brief Fail-complete and clear all currently pending read operations.
+   *
+   * @note Driver-only: call this only after the backend is known to be unavailable.
+   * @note 仅供驱动层在后端已明确不可用后调用。
+   * @note The surrounding driver must already guarantee that no new front-end
+   *       submissions or back-end completion/data events can still arrive for
+   *       this port.
+   * @note 外围驱动还必须先保证：这条端口后续不会再收到新的前端提交，也不会再收到
+   *       新的后端完成或数据事件。
+   *
+   * @param reason 最终失败原因 / Final failure reason
+   * @param in_isr 是否在 ISR 上下文 / Whether running in ISR context
+   */
+  void FailAndClearAll(ErrorCode reason, bool in_isr);
 };
 
 /**
@@ -569,8 +582,8 @@ class WritePort
   // BLOCK_PUBLISHING = BLOCK submit path is publishing queue metadata
   // BLOCK_WAITING = waiter armed, completion not claimed yet
   // BLOCK_CLAIMED = final wakeup belongs to the waiter
-  // BLOCK_DETACHED = timeout/reset detached the waiter
-  // RESETTING = reset path owns queue mutation
+  // BLOCK_DETACHED = timeout detached the waiter
+  // RESETTING = fail-and-clear path owns queue mutation
   // The same semaphore may be reused only after the previous BLOCK call
   // returns and the port goes back to IDLE.
   // 写 BLOCK 状态：
@@ -591,9 +604,10 @@ class WritePort
                         ///< 一个 BLOCK 等待者已经挂起，等待最终完成。
     BLOCK_CLAIMED =
         3,  ///< Final wakeup belongs to the current waiter. 最终唤醒已归当前等待者所有。
-    BLOCK_DETACHED = 4,  ///< Waiter already timed out/reset; completion must not post.
+    BLOCK_DETACHED = 4,  ///< Waiter already timed out/detached; completion must not post.
                          ///< 等待者已超时/被分离，完成侧不能再 Post。
-    RESETTING = 5,        ///< Reset owns queue mutation. Reset 占有写队列/元数据修改权。
+    RESETTING = 5,        ///< Fail-and-clear owns queue mutation.
+                          ///< Fail-and-clear 路径占有写队列/元数据修改权。
     IDLE = UINT32_MAX    ///< No active submitter and no armed BLOCK waiter.
                          ///< 没有活动提交者，也没有挂起中的 BLOCK 等待者。
   };
@@ -836,9 +850,28 @@ class WritePort
    */
   ErrorCode operator()(ConstRawData data, WriteOperation& op, bool in_isr = false);
 
-  /// @brief Resets queued write state when no submitter owns queue mutation.
-  /// @brief 当没有提交者占有队列修改权时，重置写队列状态。
-  void Reset();
+  /**
+   * @brief 失败完成并清空当前所有挂起写操作。
+   * @brief Fail-complete and clear all currently pending write operations.
+   *
+   * @note Driver-only: call this only after the backend is known to be unavailable.
+   * @note 仅供驱动层在后端已明确不可用后调用。
+   * @note The surrounding driver must already guarantee that no new front-end
+   *       submissions or back-end completion/data events can still arrive for
+   *       this port.
+   * @note 外围驱动还必须先保证：这条端口后续不会再收到新的前端提交，也不会再收到
+   *       新的后端完成或数据事件。
+   * @note Seeing LOCKED / BLOCK_PUBLISHING / RESETTING here means the caller
+   *       violated that driver-side precondition.
+   * @note 若此时仍看到 LOCKED / BLOCK_PUBLISHING / RESETTING，说明调用方违反了
+   *       上述驱动层前提。
+   * @note Dev builds fire DEV_ASSERT, while release builds still back off.
+   * @note 开发期会触发 DEV_ASSERT，发布构建仍保持直接退回。
+   *
+   * @param reason 最终失败原因 / Final failure reason
+   * @param in_isr 是否在 ISR 上下文 / Whether running in ISR context
+   */
+  void FailAndClearAll(ErrorCode reason, bool in_isr);
 
   /**
    * @brief 提交写入操作。

--- a/src/driver/usb/device/cdc/cdc_uart.hpp
+++ b/src/driver/usb/device/cdc/cdc_uart.hpp
@@ -427,23 +427,14 @@ class CDCUart : public CDCBase, public LibXR::UART
   void UnbindEndpoints(EndpointPool& endpoint_pool, bool in_isr) override
   {
     CDCBase::UnbindEndpoints(endpoint_pool, in_isr);
-
-    WriteInfoBlock info{};
-
-    write_port_cdc_.queue_data_->Reset();
     tx_deq_.Reset();
-
-    while (write_port_cdc_.queue_info_->Pop(info) == ErrorCode::OK)
-    {
-      write_port_cdc_.Finish(in_isr, ErrorCode::INIT_ERR, info);
-    }
+    write_port_cdc_.FailAndClearAll(ErrorCode::INIT_ERR, in_isr);
+    read_port_cdc_.FailAndClearAll(ErrorCode::INIT_ERR, in_isr);
 
     need_write_zlp_ = false;
 
     read_port_cdc_.recv_pause_ = false;
     read_port_cdc_.pending_data_ = {nullptr, 0};
-
-    write_port_cdc_.Reset();
   }
 
   /**
@@ -678,15 +669,8 @@ class CDCUart : public CDCBase, public LibXR::UART
 
     if (!Inited())
     {
-      WriteInfoBlock info{};
       tx_deq_.Reset();
-
-      while (write_port_cdc_.queue_info_->Pop(info) == ErrorCode::OK)
-      {
-        write_port_cdc_.queue_data_->Reset();
-        ASSERT(write_port_cdc_.queue_data_->Size() == 0);
-        write_port_cdc_.Finish(in_isr, ErrorCode::INIT_ERR, info);
-      }
+      write_port_cdc_.FailAndClearAll(ErrorCode::INIT_ERR, in_isr);
       return;
     }
 

--- a/test/test_print.cpp
+++ b/test/test_print.cpp
@@ -138,6 +138,48 @@ struct BrokenGenericFormat
   }
 };
 
+struct PrefixThenBrokenFormat
+{
+  template <typename... Args>
+  [[nodiscard]] static consteval bool Matches()
+  {
+    return sizeof...(Args) == 0;
+  }
+
+  [[nodiscard]] static constexpr auto Codes()
+  {
+    return std::to_array<uint8_t>({
+        static_cast<uint8_t>(LibXR::Print::FormatOp::TextInline),
+        static_cast<uint8_t>('h'),
+        static_cast<uint8_t>('e'),
+        static_cast<uint8_t>('l'),
+        static_cast<uint8_t>('l'),
+        static_cast<uint8_t>('o'),
+        static_cast<uint8_t>(' '),
+        0,
+        static_cast<uint8_t>(LibXR::Print::FormatOp::GenericField),
+        static_cast<uint8_t>(LibXR::Print::FormatType::End),
+        0,
+        static_cast<uint8_t>(' '),
+        0,
+        0xFF,
+        static_cast<uint8_t>(LibXR::Print::FormatOp::End),
+    });
+  }
+
+  [[nodiscard]] static constexpr auto ArgumentList()
+  {
+    return std::array<LibXR::Print::FormatArgumentInfo, 0>{};
+  }
+
+  [[nodiscard]] static constexpr auto ArgumentOrder() { return std::array<size_t, 0>{}; }
+
+  [[nodiscard]] static constexpr LibXR::Print::FormatProfile Profile()
+  {
+    return LibXR::Print::FormatProfile::Generic;
+  }
+};
+
 struct StdioWriteScope
 {
   explicit StdioWriteScope(LibXR::WritePort& write, LibXR::Mutex& mutex,
@@ -958,6 +1000,41 @@ void TestStdioTruncation()
   }
 }
 
+void TestStreamBackedPrintFailureKeepsPrefix()
+{
+  static constexpr char expected[] = "hello ";
+
+  LibXR::Pipe pipe(64);
+  LibXR::ReadPort& read = pipe.GetReadPort();
+  LibXR::WritePort& write = pipe.GetWritePort();
+
+  uint8_t rx[sizeof(expected) - 1] = {0};
+  LibXR::ReadOperation read_op;
+  if (read(LibXR::RawData{rx, sizeof(rx)}, read_op) != LibXR::ErrorCode::OK)
+  {
+    Fail("stream-backed print failure read arm failed");
+  }
+
+  LibXR::WriteOperation write_op;
+  LibXR::WritePort::Stream stream(&write, write_op);
+  auto ec = LibXR::Print::Write(stream, PrefixThenBrokenFormat{});
+  if (ec != LibXR::ErrorCode::STATE_ERR)
+  {
+    Fail("stream-backed print failure status mismatch");
+  }
+
+  if (stream.Commit() != LibXR::ErrorCode::OK)
+  {
+    Fail("stream-backed print failure commit mismatch");
+  }
+
+  read.ProcessPendingReads(false);
+  if (std::memcmp(rx, expected, sizeof(rx)) != 0)
+  {
+    Fail("stream-backed print failure prefix mismatch");
+  }
+}
+
 }  // namespace
 
 void test_print()
@@ -967,4 +1044,5 @@ void test_print()
   TestPrintApiWrappers();
   TestStdioPrintWrappers();
   TestStdioTruncation();
+  TestStreamBackedPrintFailureKeepsPrefix();
 }

--- a/test/test_rw_pipe.cpp
+++ b/test/test_rw_pipe.cpp
@@ -406,6 +406,57 @@ void VerifyPendingWriteMode(TestMode mode, LibXR::ErrorCode result)
   ASSERT(w.queue_info_->Size() == 0);
 }
 
+void VerifyPendingReadFailAndClearMode(TestMode mode, LibXR::ErrorCode reason)
+{
+  using namespace LibXR;
+
+  ReadPort r(16);
+  r = PendingReadFun;
+
+  uint8_t rx[4] = {0x7A, 0x7B, 0x7C, 0x7D};
+  static const uint8_t STALE_EXPECT[] = {0x7A, 0x7B, 0x7C, 0x7D};
+  ReadHarness read(mode);
+
+  auto call_result = r(RawData{rx, sizeof(rx)}, read.op);
+  ASSERT(call_result == ErrorCode::OK);
+  read.ExpectPendingSubmitted();
+
+  r.FailAndClearAll(reason, false);
+
+  if (mode != TestMode::NONE)
+  {
+    read.ExpectFinal(reason);
+  }
+  ASSERT(std::memcmp(rx, STALE_EXPECT, sizeof(STALE_EXPECT)) == 0);
+  ASSERT(r.busy_.load(std::memory_order_acquire) == ReadPort::BusyState::IDLE);
+  ASSERT(r.Size() == 0);
+}
+
+void VerifyPendingWriteFailAndClearMode(TestMode mode, LibXR::ErrorCode reason)
+{
+  using namespace LibXR;
+
+  WritePort w(2, 16);
+  w = PendingWriteFun;
+
+  static const uint8_t TX[] = {0x31, 0x41, 0x59, 0x26};
+  WriteHarness write(mode);
+
+  auto call_result = w(ConstRawData{TX, sizeof(TX)}, write.op);
+  ASSERT(call_result == ErrorCode::OK);
+  write.ExpectPendingSubmitted();
+
+  w.FailAndClearAll(reason, false);
+
+  if (mode != TestMode::NONE)
+  {
+    write.ExpectFinal(reason);
+  }
+  ASSERT(w.busy_.load(std::memory_order_acquire) == WritePort::BusyState::IDLE);
+  ASSERT(w.Size() == 0);
+  ASSERT(w.queue_info_->Size() == 0);
+}
+
 void VerifyZeroWriteMode(TestMode mode)
 {
   using namespace LibXR;
@@ -729,7 +780,23 @@ void test_rw_immediate_error_propagates()
   }
 }
 
-void test_rw_read_port_reset_detaches_block_waiter()
+void test_rw_read_port_fail_and_clear_all_completes_async_pending()
+{
+  for (auto mode : LibXRTest::ASYNC_MODES)
+  {
+    VerifyPendingReadFailAndClearMode(mode, LibXR::ErrorCode::INIT_ERR);
+  }
+}
+
+void test_rw_write_port_fail_and_clear_all_completes_async_pending()
+{
+  for (auto mode : LibXRTest::ASYNC_MODES)
+  {
+    VerifyPendingWriteFailAndClearMode(mode, LibXR::ErrorCode::INIT_ERR);
+  }
+}
+
+void test_rw_read_port_fail_and_clear_all_fails_block_waiter()
 {
   using namespace LibXR;
 
@@ -748,19 +815,14 @@ void test_rw_read_port_reset_detaches_block_waiter()
     Thread::Yield();
   }
 
-  r.Reset();
-  ASSERT(r.busy_.load(std::memory_order_acquire) == ReadPort::BusyState::BLOCK_DETACHED);
-
-  uint8_t blocked_rx[1] = {0};
-  Semaphore blocked_sem;
-  ReadOperation blocked_op(blocked_sem, 0);
-  ASSERT(r(RawData{blocked_rx, sizeof(blocked_rx)}, blocked_op) == ErrorCode::BUSY);
+  r.FailAndClearAll(ErrorCode::INIT_ERR, false);
 
   ExpectWaitOk(done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(reader);
-  ASSERT(ctx.result == ErrorCode::TIMEOUT);
+  ASSERT(ctx.result == ErrorCode::INIT_ERR);
   ASSERT(stale_rx[0] == 0xA5);
   ASSERT(r.busy_.load(std::memory_order_acquire) == ReadPort::BusyState::IDLE);
+  ASSERT(r.Size() == 0);
 
   uint8_t tx = 0x5A;
   ASSERT(r.queue_data_->PushBatch(&tx, 1) == ErrorCode::OK);
@@ -771,7 +833,7 @@ void test_rw_read_port_reset_detaches_block_waiter()
   ASSERT(fresh_rx[0] == tx);
 }
 
-void test_rw_write_port_reset_detaches_block_waiter()
+void test_rw_write_port_fail_and_clear_all_fails_block_waiter()
 {
   using namespace LibXR;
 
@@ -792,17 +854,14 @@ void test_rw_write_port_reset_detaches_block_waiter()
     Thread::Yield();
   }
 
-  w.Reset();
-  ASSERT(w.busy_.load(std::memory_order_acquire) == WritePort::BusyState::BLOCK_DETACHED);
-
-  Semaphore blocked_sem;
-  WriteOperation blocked_op(blocked_sem, 0);
-  ASSERT(w(ConstRawData{TX2, sizeof(TX2)}, blocked_op) == ErrorCode::BUSY);
+  w.FailAndClearAll(ErrorCode::INIT_ERR, false);
 
   ExpectWaitOk(done, SHORT_WAIT_MS);
   JoinThreadIfNeeded(writer);
-  ASSERT(ctx.result == ErrorCode::TIMEOUT);
+  ASSERT(ctx.result == ErrorCode::INIT_ERR);
   ASSERT(w.busy_.load(std::memory_order_acquire) == WritePort::BusyState::IDLE);
+  ASSERT(w.Size() == 0);
+  ASSERT(w.queue_info_->Size() == 0);
 
   Semaphore finish_done;
   Thread finisher;
@@ -815,7 +874,7 @@ void test_rw_write_port_reset_detaches_block_waiter()
   JoinThreadIfNeeded(finisher);
 }
 
-void test_rw_write_port_reset_clears_idle_queue()
+void test_rw_write_port_fail_and_clear_all_clears_idle_queue()
 {
   using namespace LibXR;
 
@@ -829,14 +888,14 @@ void test_rw_write_port_reset_clears_idle_queue()
   ASSERT(w.Size() == sizeof(TX));
   ASSERT(w.queue_info_->Size() == 1);
 
-  w.Reset();
+  w.FailAndClearAll(ErrorCode::INIT_ERR, false);
 
   ASSERT(w.busy_.load(std::memory_order_acquire) == WritePort::BusyState::IDLE);
   ASSERT(w.Size() == 0);
   ASSERT(w.queue_info_->Size() == 0);
 }
 
-void test_rw_write_port_reset_does_not_unlock_active_stream()
+void test_rw_write_port_fail_and_clear_all_does_not_unlock_active_stream()
 {
   using namespace LibXR;
 
@@ -851,7 +910,7 @@ void test_rw_write_port_reset_does_not_unlock_active_stream()
   ASSERT(w.busy_.load(std::memory_order_acquire) == WritePort::BusyState::LOCKED);
   ASSERT(stream.Write(ConstRawData{TX, sizeof(TX)}) == ErrorCode::OK);
 
-  w.Reset();
+  w.FailAndClearAll(ErrorCode::INIT_ERR, false);
 
   ASSERT(w.busy_.load(std::memory_order_acquire) == WritePort::BusyState::LOCKED);
   ASSERT(w.Size() == sizeof(TX));
@@ -873,86 +932,6 @@ void test_rw_write_port_reset_does_not_unlock_active_stream()
   w.Finish(false, ErrorCode::OK, completed);
   ASSERT(w.Size() == 0);
   ASSERT(w.queue_info_->Size() == 0);
-}
-
-void test_rw_write_port_reset_late_finish_before_timeout_wake()
-{
-  using namespace LibXR;
-
-  WritePort w(2, 16);
-  w = PendingWriteFun;
-
-  static const uint8_t TX1[] = {0x91, 0x92, 0x93};
-  static const uint8_t TX2[] = {0xA1, 0xA2};
-
-  Semaphore sem1(0);
-  WriteOperation op1(sem1, 20);
-  Semaphore done;
-  BlockingWriteExternalOpCallContext ctx{&w, ConstRawData{TX1, sizeof(TX1)}, &op1,
-                                         ErrorCode::FAILED, &done};
-  Thread writer;
-  StartBlockingWriteExternalOpCaller(writer, ctx, "wr_reset_late_finish");
-
-  while (w.busy_.load(std::memory_order_acquire) != WritePort::BusyState::BLOCK_WAITING)
-  {
-    Thread::Yield();
-  }
-
-  w.Reset();
-  ASSERT(w.busy_.load(std::memory_order_acquire) == WritePort::BusyState::BLOCK_DETACHED);
-
-  WriteInfoBlock completed{ConstRawData{TX1, sizeof(TX1)}, op1};
-  w.Finish(false, ErrorCode::OK, completed);
-
-  ExpectWaitOk(done, SHORT_WAIT_MS);
-  JoinThreadIfNeeded(writer);
-  ASSERT(ctx.result == ErrorCode::TIMEOUT);
-  ASSERT(sem1.Value() == 0);
-  ASSERT(w.busy_.load(std::memory_order_acquire) == WritePort::BusyState::IDLE);
-
-  WriteOperation next_op;
-  ASSERT(w(ConstRawData{TX2, sizeof(TX2)}, next_op) == ErrorCode::OK);
-}
-
-void test_rw_write_port_reset_late_finish_after_timeout_wake()
-{
-  using namespace LibXR;
-
-  WritePort w(2, 16);
-  w = PendingWriteFun;
-
-  static const uint8_t TX1[] = {0x94, 0x95, 0x96};
-  static const uint8_t TX2[] = {0xB1, 0xB2};
-
-  Semaphore sem1(0);
-  WriteOperation op1(sem1, 20);
-  Semaphore done;
-  BlockingWriteExternalOpCallContext ctx{&w, ConstRawData{TX1, sizeof(TX1)}, &op1,
-                                         ErrorCode::FAILED, &done};
-  Thread writer;
-  StartBlockingWriteExternalOpCaller(writer, ctx, "wr_reset_timeout_finish");
-
-  while (w.busy_.load(std::memory_order_acquire) != WritePort::BusyState::BLOCK_WAITING)
-  {
-    Thread::Yield();
-  }
-
-  w.Reset();
-  ASSERT(w.busy_.load(std::memory_order_acquire) == WritePort::BusyState::BLOCK_DETACHED);
-
-  ExpectWaitOk(done, SHORT_WAIT_MS);
-  JoinThreadIfNeeded(writer);
-  ASSERT(ctx.result == ErrorCode::TIMEOUT);
-  ASSERT(sem1.Value() == 0);
-  ASSERT(w.busy_.load(std::memory_order_acquire) == WritePort::BusyState::IDLE);
-
-  WriteInfoBlock completed{ConstRawData{TX1, sizeof(TX1)}, op1};
-  w.Finish(false, ErrorCode::OK, completed);
-  ASSERT(sem1.Value() == 0);
-  ASSERT(w.busy_.load(std::memory_order_acquire) == WritePort::BusyState::IDLE);
-
-  WriteOperation next_op;
-  ASSERT(w(ConstRawData{TX2, sizeof(TX2)}, next_op) == ErrorCode::OK);
 }
 
 void test_rw_read_port_block_queue_completion_copies_data()
@@ -1043,12 +1022,12 @@ void test_rw()
   test_rw_zero_read_pending_notifies_without_dequeue();
   test_rw_block_write_timeout_detaches_waiter();
   test_rw_immediate_error_propagates();
-  test_rw_read_port_reset_detaches_block_waiter();
-  test_rw_write_port_reset_detaches_block_waiter();
-  test_rw_write_port_reset_clears_idle_queue();
-  test_rw_write_port_reset_does_not_unlock_active_stream();
-  test_rw_write_port_reset_late_finish_before_timeout_wake();
-  test_rw_write_port_reset_late_finish_after_timeout_wake();
+  test_rw_read_port_fail_and_clear_all_completes_async_pending();
+  test_rw_write_port_fail_and_clear_all_completes_async_pending();
+  test_rw_read_port_fail_and_clear_all_fails_block_waiter();
+  test_rw_write_port_fail_and_clear_all_fails_block_waiter();
+  test_rw_write_port_fail_and_clear_all_clears_idle_queue();
+  test_rw_write_port_fail_and_clear_all_does_not_unlock_active_stream();
   test_rw_read_port_block_queue_completion_copies_data();
   test_rw_write_port_block_pending_result_propagates();
   test_rw_write_port_block_reused_waiter_discards_stale_signal();


### PR DESCRIPTION
## Summary
- replace `ReadPort::Reset()` / `WritePort::Reset()` with driver-only `FailAndClearAll(ErrorCode, bool)`
- route CDC teardown paths through `FailAndClearAll(...)`, including the read-side unbind gap
- tighten `FailAndClearAll()` expectations: driver must already stop new front-end submissions and new back-end completion/data events before calling it
- treat `LOCKED` / `BLOCK_PUBLISHING` / `RESETTING` as driver-side precondition violations via `DEV_ASSERT` in dev builds
- keep stream-backed STDIO prefix-preserving on formatting failure instead of pseudo-rollback, and remove the old `Stream::Discard()` path

## Notes
- this branch is intentionally a single commit relative to `master`
- the `print` change stays in the same commit because the current local line already coupled it to the rw semantics cleanup

## Validation
- Ubuntu24 print-only focused run passed:
  - `/home/xiao/runs/libxr_stdio_prefix_printonly_20260528T20260528T141959Z/99_summary.txt`
- Ubuntu24 full union run on the same line still hits the pre-existing later crash before a full green run:
  - `/home/xiao/runs/libxr_stdio_prefix_commit_20260528T20260528T141644Z/99_summary.txt`

## Summary by Sourcery

Replace generic read/write port reset paths with a driver-only fail-and-clear API and align CDC teardown and tests with the new semantics while adjusting stream-backed STDIO formatting failure behavior.

Bug Fixes:
- Ensure pending read and write operations are completed with a defined failure code when backends are torn down instead of timing out or leaving stale state.
- Preserve already-written prefixes in stream-backed STDIO output when formatting fails instead of attempting a pseudo-rollback.

Enhancements:
- Introduce ReadPort::FailAndClearAll and WritePort::FailAndClearAll with stricter driver-side preconditions and clearer state-machine semantics for backend failure handling.
- Tighten write port state handling by asserting on illegal states (LOCKED/BLOCK_PUBLISHING/RESETTING) when fail-and-clear is invoked, and by fail-completing queued items during teardown.
- Refine BLOCK_* state documentation and comments to clarify timeout vs. detach behavior and late-completion handling.

Tests:
- Update rw pipe tests to cover FailAndClearAll behavior for async and blocking callers and to remove obsolete Reset-specific scenarios.
- Add a print test to verify that stream-backed formatting failures keep the already-emitted prefix.