### PR TITLE
refactor(string): assert retained allocation failures

### DIFF
--- a/src/core/libxr_string.hpp
+++ b/src/core/libxr_string.hpp
@@ -425,10 +425,14 @@ class RuntimeStringView
    * RuntimeStringView 的容量策略是一次分配后复用。格式化路径会先从编译格式
    * 元数据计算最大容量，因此已有存储不足表示设计边界被突破，不能在这里静默
    * new 第二块内存。
+   * 第一次保留分配若失败，开发期应直接暴露问题；发布构建仍保留 `NO_MEM`
+   * 回退状态。
    *
    * RuntimeStringView reuses one allocation. The formatted path computes maximum
    * capacity from compiled format metadata first, so an oversized later write is
    * a boundary error rather than a reason to allocate again.
+   * If the first retained allocation fails, debug builds should surface it
+   * immediately; release builds still keep the `NO_MEM` fallback status.
    */
   [[nodiscard]] ErrorCode EnsureCapacity(size_t payload_size)
   {
@@ -452,6 +456,7 @@ class RuntimeStringView
     data_ = new (std::nothrow) char[payload_size + 1U];
     if (data_ == nullptr)
     {
+      ASSERT(data_ != nullptr);
       return ErrorCode::NO_MEM;
     }
     capacity_ = payload_size;


### PR DESCRIPTION
## Summary
- treat first retained allocation failure in `RuntimeStringView::EnsureCapacity()` as `ASSERT`-worthy in debug builds
- keep the release-path `NO_MEM` fallback return unchanged
- document the retained-allocation failure contract inline in `libxr_string.hpp`

## Validation
- Ubuntu24 string-only test: `/home/xiao/runs/libxr_string_no_mem_assert_validate_20260529T143900Z/99_summary.txt`

## Summary by Sourcery

Enhancements:
- Clarify the documented contract around retained allocation failures in RuntimeStringView::EnsureCapacity for both debug and release builds.