### PR TITLE
refactor(time): encapsulate wrap-range configuration

### DIFF
--- a/src/core/libxr_time.hpp
+++ b/src/core/libxr_time.hpp
@@ -4,32 +4,41 @@
 
 #include "libxr_assert.hpp"
 
-/**
- * @brief 微秒时间基准的最大有效值 / Maximum valid value of the microsecond timebase
- *
- * @note 当微秒时间基准发生回绕时，`MicrosecondTimestamp::operator-` 使用该值恢复跨回绕的
- *       时间差。默认值为 `UINT64_MAX`，表示 64 位时间基准的完整计数范围。
- *       / When the microsecond timebase wraps around,
- *       `MicrosecondTimestamp::operator-` uses this value to recover the elapsed
- *       time across the wrap. The default `UINT64_MAX` means the full range of a
- *       64-bit timebase.
- */
-inline uint64_t libxr_timebase_max_valid_us = UINT64_MAX;  // NOLINT
-
-/**
- * @brief 毫秒时间基准的最大有效值 / Maximum valid value of the millisecond timebase
- *
- * @note 当毫秒时间基准发生回绕时，`MillisecondTimestamp::operator-` 使用该值恢复跨回绕的
- *       时间差。默认值为 `UINT32_MAX`，表示 32 位时间基准的完整计数范围。
- *       / When the millisecond timebase wraps around,
- *       `MillisecondTimestamp::operator-` uses this value to recover the elapsed
- *       time across the wrap. The default `UINT32_MAX` means the full range of a
- *       32-bit timebase.
- */
-inline uint32_t libxr_timebase_max_valid_ms = UINT32_MAX;  // NOLINT
-
 namespace LibXR
 {
+namespace Detail
+{
+
+[[nodiscard]] inline uint64_t& TimebaseMaxValidUsStorage() noexcept
+{
+  static uint64_t value = UINT64_MAX;
+  return value;
+}
+
+[[nodiscard]] inline uint32_t& TimebaseMaxValidMsStorage() noexcept
+{
+  static uint32_t value = UINT32_MAX;
+  return value;
+}
+
+[[nodiscard]] inline uint64_t TimebaseMaxValidUs() noexcept
+{
+  return TimebaseMaxValidUsStorage();
+}
+
+[[nodiscard]] inline uint32_t TimebaseMaxValidMs() noexcept
+{
+  return TimebaseMaxValidMsStorage();
+}
+
+inline void ConfigureTimebaseWrapRange(uint64_t max_valid_us,
+                                       uint32_t max_valid_ms) noexcept
+{
+  TimebaseMaxValidUsStorage() = max_valid_us;
+  TimebaseMaxValidMsStorage() = max_valid_ms;
+}
+
+}  // namespace Detail
 
 /**
  * @brief 微秒时间戳 / Microsecond timestamp
@@ -112,14 +121,15 @@ class MicrosecondTimestamp
    * @return 当前时间戳相对旧时间戳的时长 / Elapsed duration from the older timestamp
    *
    * @note 若当前时间戳小于旧时间戳，则按一次时间基准回绕处理，回绕上界由
-   *       `libxr_timebase_max_valid_us` 指定。
+   *       当前已配置的微秒时间基准有效上界指定。
    *       / If the current timestamp is smaller than the older one, the function
-   *       treats it as one wraparound event whose upper bound is defined by
-   *       `libxr_timebase_max_valid_us`.
+   *       treats it as one wraparound event whose upper bound is defined by the
+   *       currently configured microsecond timebase limit.
    */
   [[nodiscard]] Duration operator-(const MicrosecondTimestamp& old_timestamp) const
   {
     uint64_t elapsed = 0;
+    const uint64_t max_valid = Detail::TimebaseMaxValidUs();
 
     if (microsecond_ >= old_timestamp.microsecond_)
     {
@@ -127,11 +137,10 @@ class MicrosecondTimestamp
     }
     else
     {
-      elapsed = microsecond_ + (libxr_timebase_max_valid_us - old_timestamp.microsecond_) +
-                1ULL;
+      elapsed = microsecond_ + (max_valid - old_timestamp.microsecond_) + 1ULL;
     }
 
-    ASSERT(elapsed <= libxr_timebase_max_valid_us);
+    ASSERT(elapsed <= max_valid);
 
     return Duration(elapsed);
   }
@@ -231,14 +240,15 @@ class MillisecondTimestamp
    * @return 当前时间戳相对旧时间戳的时长 / Elapsed duration from the older timestamp
    *
    * @note 若当前时间戳小于旧时间戳，则按一次时间基准回绕处理，回绕上界由
-   *       `libxr_timebase_max_valid_ms` 指定。
+   *       当前已配置的毫秒时间基准有效上界指定。
    *       / If the current timestamp is smaller than the older one, the function
-   *       treats it as one wraparound event whose upper bound is defined by
-   *       `libxr_timebase_max_valid_ms`.
+   *       treats it as one wraparound event whose upper bound is defined by the
+   *       currently configured millisecond timebase limit.
    */
   [[nodiscard]] Duration operator-(const MillisecondTimestamp& old_timestamp) const
   {
     uint32_t elapsed = 0;
+    const uint32_t max_valid = Detail::TimebaseMaxValidMs();
 
     if (millisecond_ >= old_timestamp.millisecond_)
     {
@@ -246,11 +256,10 @@ class MillisecondTimestamp
     }
     else
     {
-      elapsed =
-          millisecond_ + (libxr_timebase_max_valid_ms - old_timestamp.millisecond_) + 1U;
+      elapsed = millisecond_ + (max_valid - old_timestamp.millisecond_) + 1U;
     }
 
-    ASSERT(elapsed <= libxr_timebase_max_valid_ms);
+    ASSERT(elapsed <= max_valid);
 
     return Duration(elapsed);
   }

--- a/src/driver/timebase.hpp
+++ b/src/driver/timebase.hpp
@@ -29,8 +29,7 @@ class Timebase
    */
   Timebase(uint64_t max_valid_us = UINT64_MAX, uint32_t max_valid_ms = UINT32_MAX)
   {
-    libxr_timebase_max_valid_ms = max_valid_ms;
-    libxr_timebase_max_valid_us = max_valid_us;
+    ConfigureWrapRange(max_valid_us, max_valid_ms);
     timebase = this;
   }
 
@@ -117,6 +116,22 @@ class Timebase
    * and all static time functions access the actual implementation through this pointer.
    */
   static inline Timebase* timebase = nullptr;  // NOLINT
+
+ protected:
+  static void ConfigureWrapRange(uint64_t max_valid_us, uint32_t max_valid_ms) noexcept
+  {
+    Detail::ConfigureTimebaseWrapRange(max_valid_us, max_valid_ms);
+  }
+
+  [[nodiscard]] static uint64_t GetConfiguredWrapRangeUs() noexcept
+  {
+    return Detail::TimebaseMaxValidUs();
+  }
+
+  [[nodiscard]] static uint32_t GetConfiguredWrapRangeMs() noexcept
+  {
+    return Detail::TimebaseMaxValidMs();
+  }
 };
 
 }  // namespace LibXR

--- a/test/test_timebase.cpp
+++ b/test/test_timebase.cpp
@@ -2,12 +2,38 @@
 #include "libxr_def.hpp"
 #include "test.hpp"
 
+namespace
+{
+struct TimebaseWrapProbe : LibXR::Timebase
+{
+  static void Set(uint64_t max_valid_us, uint32_t max_valid_ms)
+  {
+    ConfigureWrapRange(max_valid_us, max_valid_ms);
+  }
+
+  static uint64_t GetUs() { return GetConfiguredWrapRangeUs(); }
+  static uint32_t GetMs() { return GetConfiguredWrapRangeMs(); }
+
+  LibXR::MicrosecondTimestamp _get_microseconds() override
+  {
+    ASSERT(false);
+    return 0;
+  }
+
+  LibXR::MillisecondTimestamp _get_milliseconds() override
+  {
+    ASSERT(false);
+    return 0;
+  }
+};
+}  // namespace
+
 void test_timebase()
 {
   LibXR::MillisecondTimestamp start_ms(1000), end_ms(2005);
   LibXR::MicrosecondTimestamp start_us(1000), end_us(2005);
-  const uint64_t old_max_valid_us = libxr_timebase_max_valid_us;
-  const uint32_t old_max_valid_ms = libxr_timebase_max_valid_ms;
+  const uint64_t old_max_valid_us = TimebaseWrapProbe::GetUs();
+  const uint32_t old_max_valid_ms = TimebaseWrapProbe::GetMs();
 
   start_ms = LibXR::Timebase::GetMilliseconds();
   start_us = LibXR::Timebase::GetMicroseconds();
@@ -18,14 +44,13 @@ void test_timebase()
   ASSERT(std::fabs((end_ms - start_ms).ToMillisecond() - 100.0f) < 10);
   ASSERT(std::fabs((end_us - start_us).ToMicrosecond() - 100000.0f) < 10000);
 
-  libxr_timebase_max_valid_ms = 999u;
+  TimebaseWrapProbe::Set(old_max_valid_us, 999u);
   ASSERT((LibXR::MillisecondTimestamp(3u) - LibXR::MillisecondTimestamp(998u))
              .ToMillisecond() == 5u);
 
-  libxr_timebase_max_valid_us = 999999u;
+  TimebaseWrapProbe::Set(999999u, 999u);
   ASSERT((LibXR::MicrosecondTimestamp(7u) - LibXR::MicrosecondTimestamp(999995u))
              .ToMicrosecond() == 12u);
 
-  libxr_timebase_max_valid_us = old_max_valid_us;
-  libxr_timebase_max_valid_ms = old_max_valid_ms;
+  TimebaseWrapProbe::Set(old_max_valid_us, old_max_valid_ms);
 }


### PR DESCRIPTION
## Summary
- remove the two naked public wrap-range globals from `libxr_time.hpp`
- route wrap-range ownership through `Timebase`'s internal configuration hooks
- update `test_timebase.cpp` to adjust wrap-range settings through a local probe instead of mutating globals directly

## Validation
- Ubuntu24 timebase-only test: `/home/xiao/runs/libxr_time_wrap_validate_20260529T175200Z/99_summary.txt`

## Summary by Sourcery

Encapsulate timebase wrap-range configuration behind Timebase internals and remove direct use of global wrap-range variables.

Enhancements:
- Introduce internal Detail helpers to store and access microsecond and millisecond timebase wrap limits instead of public globals.
- Expose protected Timebase APIs to configure and query the active wrap-range used by timestamp arithmetic.

Tests:
- Update timebase tests to adjust and verify wrap-range behavior via a Timebase-derived probe class rather than mutating global configuration.