### PR TITLE
Add assert for non-empty ADC channel list

### DIFF
--- a/driver/st/stm32_adc.cpp
+++ b/driver/st/stm32_adc.cpp
@@ -34,8 +34,7 @@ uint8_t CalculateFilterSize(RawData dma_buff, std::size_t channel_count)
     return 0U;
   }
 
-  const std::size_t filter_size =
-      dma_buff.size_ / channel_count / sizeof(uint16_t);
+  const std::size_t filter_size = dma_buff.size_ / channel_count / sizeof(uint16_t);
   ASSERT(filter_size > 0U);
   ASSERT(filter_size <= std::numeric_limits<uint8_t>::max());
   return static_cast<uint8_t>(filter_size);

--- a/driver/st/stm32_adc.cpp
+++ b/driver/st/stm32_adc.cpp
@@ -29,10 +29,6 @@ namespace
 uint8_t CalculateFilterSize(RawData dma_buff, std::size_t channel_count)
 {
   ASSERT(channel_count > 0U);
-  if (channel_count == 0U)
-  {
-    return 0U;
-  }
 
   const std::size_t filter_size = dma_buff.size_ / channel_count / sizeof(uint16_t);
   ASSERT(filter_size > 0U);

--- a/driver/st/stm32_adc.cpp
+++ b/driver/st/stm32_adc.cpp
@@ -1,5 +1,8 @@
 #include "stm32_adc.hpp"
 
+#include <cstddef>
+#include <limits>
+
 #include "libxr_def.hpp"
 #include "stm32_dcache.hpp"
 
@@ -20,6 +23,26 @@ extern "C" HAL_StatusTypeDef
 }
 #endif
 
+namespace
+{
+
+uint8_t CalculateFilterSize(RawData dma_buff, std::size_t channel_count)
+{
+  ASSERT(channel_count > 0U);
+  if (channel_count == 0U)
+  {
+    return 0U;
+  }
+
+  const std::size_t filter_size =
+      dma_buff.size_ / channel_count / sizeof(uint16_t);
+  ASSERT(filter_size > 0U);
+  ASSERT(filter_size <= std::numeric_limits<uint8_t>::max());
+  return static_cast<uint8_t>(filter_size);
+}
+
+}  // namespace
+
 STM32ADC::Channel::Channel(STM32ADC* adc, uint8_t index, uint32_t ch)
     : adc_(adc), index_(index), ch_(ch)
 {
@@ -31,7 +54,7 @@ STM32ADC::STM32ADC(ADC_HandleTypeDef* hadc, RawData dma_buff,
                    std::initializer_list<uint32_t> channels, float vref)
     : hadc_(hadc),
       NUM_CHANNELS(channels.size()),
-      filter_size_(dma_buff.size_ / NUM_CHANNELS / 2),
+      filter_size_(CalculateFilterSize(dma_buff, channels.size())),
       use_dma_(hadc_->DMA_Handle != nullptr),
       dma_buffer_(dma_buff),
       resolution_(GetADCResolution<ADC_HandleTypeDef>{}.Get(hadc)),


### PR DESCRIPTION
Fix #147 

- Add CalculateFilterSize helper to initialize filter_size_ in constructor
- Add assert in CalculateFilterSize to prevent division by zero

## Summary by Sourcery

Guard ADC filter size computation against invalid channel configurations and centralize the calculation in a helper.

Bug Fixes:
- Prevent potential division by zero when ADC channel list is empty by asserting a positive channel count before computing filter size.

Enhancements:
- Extract ADC filter size computation into a dedicated helper function with bounds checks to ensure it fits in an 8-bit field.