### PR TITLE
fix(print): bound char array string arguments

### DIFF
--- a/src/core/print/writer.hpp
+++ b/src/core/print/writer.hpp
@@ -142,6 +142,18 @@ class Writer
     }
   };
 
+  template <size_t N>
+  [[nodiscard]] static constexpr size_t BoundedTextLength(const char (&text)[N]) noexcept
+  {
+    size_t size = 0;
+    while (size < N && text[size] != '\0')
+    {
+      ++size;
+    }
+    ASSERT(size < N);
+    return size;
+  }
+
   template <typename T>
   [[nodiscard]] static constexpr std::string_view ToStringView(const T& text)
   {
@@ -166,7 +178,7 @@ class Writer
     }
     else if constexpr (Traits::is_char_array)
     {
-      return std::string_view(text, std::strlen(text));
+      return std::string_view(text, BoundedTextLength(text));
     }
     else
     {

--- a/test/test_print.cpp
+++ b/test/test_print.cpp
@@ -445,6 +445,15 @@ void TestPrintfFrontendSemantics()
   }
 
   {
+    char bounded_text[4] = {'i', 'm', 'u', '\0'};
+    const char embedded_text[5] = {'a', 'b', '\0', 'c', 'd'};
+    if (!SamePrintfAsExpected<"[%s][%s]">("[imu][ab]", bounded_text, embedded_text))
+    {
+      Fail("printf bounded char array mismatch");
+    }
+  }
+
+  {
     enum PlainHex : unsigned
     {
       PLAIN_HEX = 42U
@@ -536,6 +545,15 @@ void TestFormatFrontendSemantics()
     if (!SameFormatAsExpected<"[{}][{}]">("[hello][xy]", text, view))
     {
       Fail("format frontend string object mismatch");
+    }
+  }
+
+  {
+    char bounded_text[4] = {'i', 'm', 'u', '\0'};
+    const char embedded_text[5] = {'a', 'b', '\0', 'c', 'd'};
+    if (!SameFormatAsExpected<"[{}][{}]">("[imu][ab]", bounded_text, embedded_text))
+    {
+      Fail("format frontend bounded char array mismatch");
     }
   }
 


### PR DESCRIPTION
## Summary
- change print runtime char-array conversion from unbounded `strlen()` to bounded C-string scanning
- require `char[N]` / `const char[N]` arguments to contain a terminating `\0` within the array bound in debug builds
- keep `char*` / `const char*` pointer semantics unchanged
- add focused brace/printf regressions for bounded mutable C-string arrays and embedded-NUL bounded arrays

## Validation
- Ubuntu24 print-only test: `/home/xiao/runs/libxr_print_bounded_char_array_validate_20260530T003300Z/99_summary.txt`

## Summary by Sourcery

Ensure bounded handling of char array string arguments in the print/format writer and add regression coverage for these cases.

Bug Fixes:
- Prevent unbounded strlen usage for char array arguments in the print writer by using a bounded C-string length calculation.

Tests:
- Add regression tests covering bounded mutable C-string arrays and embedded-NUL bounded char arrays for both printf-style and format-style frontends.