### PR TITLE
docs(assert): complete diag comments

### DIFF
--- a/src/core/assert/diag.hpp
+++ b/src/core/assert/diag.hpp
@@ -7,14 +7,27 @@
 
 namespace LibXR::Assert
 {
+/**
+ * @brief Fatal 错误回调类型，参数为文件名与行号 / Fatal error callback type taking file name and line number
+ */
 using FatalCallback = LibXR::Callback<const char*, uint32_t>;
 
+// Process-global fatal callback storage.
+// 进程级 fatal 回调存根。
 inline FatalCallback fatal_error_callback_;  // NOLINT
 
+/**
+ * @brief 注册 fatal 错误回调 / Register the fatal error callback
+ * @param cb 用户提供的 fatal 错误回调 / User-provided fatal error callback
+ */
 inline void RegisterFatalErrorCallback(FatalCallback cb)
 {
   fatal_error_callback_ = std::move(cb);
 }
 
+/**
+ * @brief 返回当前注册的 fatal 错误回调对象 / Return the currently registered fatal error callback object
+ * @return 当前注册的 fatal 错误回调对象 / Returns the currently registered fatal error callback object
+ */
 [[nodiscard]] inline FatalCallback& FatalErrorCallback() { return fatal_error_callback_; }
 }  // namespace LibXR::Assert


### PR DESCRIPTION
## Summary
- add missing comments in `src/core/assert/diag.hpp`
- keep the change scoped to the fatal callback registration helpers only

## Summary by Sourcery

Documentation:
- Add bilingual API documentation comments for the fatal error callback type, global storage, and registration/accessor helpers in the assert diagnostics header.