### PR TITLE
fix(terminal): harden autocomplete and printable-byte handling

### DIFF
--- a/src/middleware/terminal.hpp
+++ b/src/middleware/terminal.hpp
@@ -749,7 +749,7 @@ class Terminal
     /* prepre for match */
     RamFS::FsNode* ans_node = nullptr;
     uint32_t number = 0;
-    size_t same_char_number = 0;
+    size_t shared_prefix_len = 0;
 
     if (*prefix_start == '/')
     {
@@ -799,7 +799,7 @@ class Terminal
           if (ans_node == nullptr)
           {
             ans_node = &node;
-            same_char_number = name_len;
+            shared_prefix_len = name_len;
             return ErrorCode::OK;
           }
 
@@ -807,14 +807,16 @@ class Terminal
           {
             if (node.GetName()[i] != ans_node->GetName()[i])
             {
-              same_char_number = i;
+              shared_prefix_len = i;
               break;
             }
           }
 
-          if (same_char_number > name_len)
+          // Once one candidate is shorter than the previously retained shared
+          // prefix, the shared prefix must shrink to this candidate length.
+          if (shared_prefix_len > name_len)
           {
-            same_char_number = name_len;
+            shared_prefix_len = name_len;
           }
 
           ans_node = &node;
@@ -828,7 +830,7 @@ class Terminal
       ShowHeader();
       write_stream_ << ConstRawData(&input_line_[0], input_line_.Size());
 
-      for (size_t i = 0; i < same_char_number - prefix_len; i++)
+      for (size_t i = 0; i < shared_prefix_len - prefix_len; i++)
       {
         DisplayChar(ans_node->GetName()[i + prefix_len]);
       }

--- a/src/middleware/terminal.hpp
+++ b/src/middleware/terminal.hpp
@@ -629,7 +629,7 @@ class Terminal
   {
     if (flag_ansi_ == 1)
     {
-      if (isprint(data))
+      if (std::isprint(static_cast<unsigned char>(data)))
       {
         flag_ansi_++;
       }
@@ -814,7 +814,7 @@ class Terminal
 
           if (same_char_number > name_len)
           {
-            name_len = same_char_number;
+            same_char_number = name_len;
           }
 
           ans_node = &node;
@@ -901,7 +901,7 @@ class Terminal
     {
       HandleAnsiCharacter(data);
     }
-    else if (isprint(data))
+    else if (std::isprint(static_cast<unsigned char>(data)))
     {
       DisplayChar(data);
     }

--- a/test/test_terminal.cpp
+++ b/test/test_terminal.cpp
@@ -68,20 +68,17 @@ void test_terminal()
     ASSERT(false);
   };
 
-  auto write_line = [&](const char* command_line)
-  {
-    LibXR::WriteOperation write_op;
-    ASSERT(input.GetWritePort()(LibXR::ConstRawData{command_line}, write_op) ==
-           LibXR::ErrorCode::OK);
-    run_terminal_until_idle();
-  };
-
-  auto write_bytes = [&](const void* data, size_t size)
+  auto write_raw = [&](const void* data, size_t size)
   {
     LibXR::WriteOperation write_op;
     ASSERT(input.GetWritePort()(LibXR::ConstRawData{data, size}, write_op) ==
            LibXR::ErrorCode::OK);
     run_terminal_until_idle();
+  };
+
+  auto write_line = [&](const char* command_line)
+  {
+    write_raw(command_line, std::strlen(command_line));
   };
 
   write_line("dir1/dir2/dir3/run\n");
@@ -94,7 +91,7 @@ void test_terminal()
   write_line("alph\t\n");
   const unsigned char non_printable_unknown[] = {0xFF, 'u', 'n', 'k', 'n',
                                                  'o', 'w', 'n', '\n'};
-  write_bytes(non_printable_unknown, sizeof(non_printable_unknown));
+  write_raw(non_printable_unknown, sizeof(non_printable_unknown));
 
   const size_t output_size = output.GetReadPort().Size();
   ASSERT(output_size > 0);

--- a/test/test_terminal.cpp
+++ b/test/test_terminal.cpp
@@ -76,6 +76,14 @@ void test_terminal()
     run_terminal_until_idle();
   };
 
+  auto write_bytes = [&](const void* data, size_t size)
+  {
+    LibXR::WriteOperation write_op;
+    ASSERT(input.GetWritePort()(LibXR::ConstRawData{data, size}, write_op) ==
+           LibXR::ErrorCode::OK);
+    run_terminal_until_idle();
+  };
+
   write_line("dir1/dir2/dir3/run\n");
   ASSERT(command_count == 1);
   write_line("/dir1/dir2/dir3/run\n");
@@ -84,7 +92,9 @@ void test_terminal()
   ASSERT(command_count == 2);
   write_line("unknown\n");
   write_line("alph\t\n");
-  write_line("\xFFunknown\n");
+  const unsigned char non_printable_unknown[] = {0xFF, 'u', 'n', 'k', 'n',
+                                                 'o', 'w', 'n', '\n'};
+  write_bytes(non_printable_unknown, sizeof(non_printable_unknown));
 
   const size_t output_size = output.GetReadPort().Size();
   ASSERT(output_size > 0);
@@ -95,6 +105,17 @@ void test_terminal()
                               read_op) == LibXR::ErrorCode::OK);
   ASSERT(std::strstr(terminal_output.data(), "Not an executable file.") != nullptr);
   ASSERT(std::strstr(terminal_output.data(), "Command not found.") != nullptr);
+  ASSERT(std::memchr(terminal_output.data(), static_cast<unsigned char>(0xFF),
+                     output_size) == nullptr);
   ASSERT(std::strstr(terminal_output.data(), "alpha") != nullptr);
   ASSERT(std::strstr(terminal_output.data(), "alphabet") != nullptr);
+
+  size_t command_not_found_count = 0;
+  const char* search = terminal_output.data();
+  while ((search = std::strstr(search, "Command not found.")) != nullptr)
+  {
+    command_not_found_count++;
+    search += std::strlen("Command not found.");
+  }
+  ASSERT(command_not_found_count == 2);
 }

--- a/test/test_terminal.cpp
+++ b/test/test_terminal.cpp
@@ -31,8 +31,12 @@ void test_terminal()
       },
       &command_count);
   auto data_file = LibXR::RamFS::CreateFile("data", data_value);
+  auto alpha_file = LibXR::RamFS::CreateFile("alpha", data_value);
+  auto alphabet_file = LibXR::RamFS::CreateFile("alphabet", data_value);
 
   ramfs.Add(dir_1);
+  ramfs.Add(alpha_file);
+  ramfs.Add(alphabet_file);
   dir_1.Add(dir_2);
   dir_2.Add(dir_3);
   dir_3.Add(command);
@@ -79,6 +83,8 @@ void test_terminal()
   write_line("/dir1/dir2/dir3/data\n");
   ASSERT(command_count == 2);
   write_line("unknown\n");
+  write_line("alph\t\n");
+  write_line("\xFFunknown\n");
 
   const size_t output_size = output.GetReadPort().Size();
   ASSERT(output_size > 0);
@@ -89,4 +95,6 @@ void test_terminal()
                               read_op) == LibXR::ErrorCode::OK);
   ASSERT(std::strstr(terminal_output.data(), "Not an executable file.") != nullptr);
   ASSERT(std::strstr(terminal_output.data(), "Command not found.") != nullptr);
+  ASSERT(std::strstr(terminal_output.data(), "alpha") != nullptr);
+  ASSERT(std::strstr(terminal_output.data(), "alphabet") != nullptr);
 }


### PR DESCRIPTION
## Summary
- fix terminal autocomplete when one candidate name is a prefix of another
- avoid undefined behavior from passing signed `char` directly to `isprint()`
- add terminal regression coverage for both paths

## Validation
- Ubuntu24: `/home/xiao/runs/libxr_terminal_fix_20260604T175014Z/99_summary.txt`
- result: `clone=PASS`, `apply=PASS`, `cmake=PASS`, `build=PASS`, `test=PASS`

## Summary by Sourcery

Harden terminal input handling and autocomplete behavior and extend regression coverage for these cases.

Bug Fixes:
- Prevent undefined behavior in terminal ANSI and printable-character handling by ensuring characters passed to std::isprint are treated as unsigned bytes.
- Correct terminal autocomplete so that completions work when one candidate name is a prefix of another without truncating the shared prefix.

Tests:
- Extend terminal regression tests to cover autocomplete with prefix-related filenames and handling of non-printable input bytes, including asserting no raw non-printable bytes leak to output.