### PR TITLE
Fix print integer buffer bounds

### DIFF
--- a/src/core/print/writer.hpp
+++ b/src/core/print/writer.hpp
@@ -326,17 +326,26 @@ class Writer
   static void StoreArgumentsOrdered(uint8_t*& out, Tuple& tuple);
 
   /**
-   * @brief 把一个无符号整数写进调用方提供的数字缓冲区 / Append one unsigned integer into a caller-provided digit buffer
+   * @brief 返回某个无符号整数在指定进制下所需的最大数字个数 / Return the maximum digit count required for one unsigned integer under the selected radix
+   * @tparam UInt 无符号整数类型 / Unsigned integer type
+   * @tparam Base 整数进制 / Integer radix
+   * @return 返回该整型在所选进制下的最大数字个数 / Returns the maximum digit count under the selected radix
+   */
+  template <std::unsigned_integral UInt, uint8_t Base>
+  [[nodiscard]] static constexpr size_t UnsignedDigitCapacity();
+
+  /**
+   * @brief 把一个无符号整数写进调用方提供的定长数字缓冲区 / Append one unsigned integer into a caller-provided fixed-size digit buffer
+   * @tparam Base 整数进制 / Integer radix
+   * @tparam UpperCase 十六进制数字是否使用大写字母 / Whether hexadecimal digits should use uppercase letters
+   * @tparam N 目标缓冲区长度 / Destination buffer size
    * @tparam UInt 无符号整数类型 / Unsigned integer type
    * @param out 目标数字缓冲区 / Destination digit buffer
    * @param value 待编码的无符号值 / Unsigned value to encode
-   * @param base 整数进制 / Integer radix
-   * @param upper_case 十六进制数字是否使用大写字母 / Whether hexadecimal digits should use uppercase letters
    * @return 返回输出的数字个数 / Returns the emitted digit count
    */
-  template <std::unsigned_integral UInt>
-  [[nodiscard]] static size_t AppendUnsigned(char* out, UInt value, uint8_t base,
-                                             bool upper_case);
+  template <uint8_t Base, bool UpperCase = false, size_t N, std::unsigned_integral UInt>
+  [[nodiscard]] static size_t AppendUnsigned(char (&out)[N], UInt value);
 
   /**
    * @brief 以十进制形式追加一个较小的无符号整数 / Append one small unsigned integer in base 10
@@ -344,7 +353,8 @@ class Writer
    * @param value 待编码的无符号值 / Unsigned value to encode
    * @return 返回输出的数字个数 / Returns the emitted digit count
    */
-  [[nodiscard]] static size_t AppendSmallUnsigned(char* out, uint8_t value);
+  template <size_t N>
+  [[nodiscard]] static size_t AppendSmallUnsigned(char (&out)[N], uint8_t value);
 
   /**
    * @brief 返回把某段载荷扩展到目标字段宽度所需的填充长度 / Return the padding width needed to expand one payload to the requested field width
@@ -362,21 +372,6 @@ class Writer
    */
   [[nodiscard]] static constexpr size_t IntegerPrecisionZeros(const Spec& spec,
                                                               size_t digit_count);
-
-  /**
-   * @brief 返回某个无符号运行期类型对应的整数进制 / Returns the integer radix selected by one unsigned runtime type.
-   * @param type Runtime field type. / 运行期字段类型。
-   * @return Returns the selected integer radix. / 返回选中的整数进制。
-   */
-  [[nodiscard]] static constexpr uint8_t IntegerBase(FormatType type);
-
-  /**
-   * @brief 判断某个无符号运行期类型是否应输出大写十六进制数字 / Returns whether one unsigned runtime type should emit uppercase hex digits.
-   * @param type Runtime field type. / 运行期字段类型。
-   * @return Returns `true` when uppercase hex digits are required, otherwise
-   *         `false`. / 需要输出大写十六进制数字时返回 `true`，否则返回 `false`。
-   */
-  [[nodiscard]] static constexpr bool IntegerUpperCase(FormatType type);
 
   /**
    * @brief 返回放在数字载荷之外的备用格式前缀 / Return the alternate-form prefix carried outside the digit payload

--- a/src/core/print/writer.hpp
+++ b/src/core/print/writer.hpp
@@ -327,12 +327,20 @@ class Writer
 
   /**
    * @brief 返回某个无符号整数在指定进制下所需的最大数字个数 / Return the maximum digit count required for one unsigned integer under the selected radix
+   *
+   * This helper intentionally uses a short exact integer division loop instead
+   * of a floating-point approximation. It is `consteval`, so it can only be
+   * used in immediate compile-time contexts such as array extents and
+   * `static_assert`, and therefore adds no runtime cost.
+   * 本辅助函数有意使用一个简短且精确的整数除法循环，而不是浮点近似公式。
+   * 它被声明为 `consteval`，只能用于数组长度、`static_assert` 等立即编译期
+   * 场景，因此不会引入任何运行期开销。
    * @tparam UInt 无符号整数类型 / Unsigned integer type
    * @tparam Base 整数进制 / Integer radix
    * @return 返回该整型在所选进制下的最大数字个数 / Returns the maximum digit count under the selected radix
    */
   template <std::unsigned_integral UInt, uint8_t Base>
-  [[nodiscard]] static constexpr size_t UnsignedDigitCapacity();
+  [[nodiscard]] static consteval size_t UnsignedDigitCapacity();
 
   /**
    * @brief 把一个无符号整数写进调用方提供的定长数字缓冲区 / Append one unsigned integer into a caller-provided fixed-size digit buffer

--- a/src/core/print/writer/writer_executor.hpp
+++ b/src/core/print/writer/writer_executor.hpp
@@ -45,6 +45,17 @@ class Writer::Executor
   template <FormatType Type, std::unsigned_integral UInt>
   [[nodiscard]] ErrorCode WriteUnsigned(const Spec& spec, UInt value);
 
+  /**
+   * @brief 按编译期进制/大小写/八进制备用格式参数复用无符号数字载荷写出逻辑 / Reuse the unsigned-digit payload writer with compile-time radix, case, and octal-alternate parameters
+   * @tparam Base 整数进制 / Integer radix
+   * @tparam UpperCase 十六进制数字是否使用大写字符 / Whether hexadecimal digits should use uppercase characters
+   * @tparam InlineAlternateOctal 是否把 `%#o` 的前导 `0` 直接并入数字载荷 / Whether `%#o` should inline its leading `0` into the digit payload
+   * @tparam UInt 无符号整数类型 / Unsigned integer type
+   * @param prefix 脱离数字载荷输出的前缀 / Prefix emitted outside the digit payload
+   * @param spec 解码后的字段规格 / Decoded field spec
+   * @param value 待写出的整数值 / Integer value to write
+   * @return 返回共享无符号数字写出路径的结果 / Returns the shared unsigned-digit write result
+   */
   template <uint8_t Base, bool UpperCase = false,
             bool InlineAlternateOctal = false, std::unsigned_integral UInt>
   [[nodiscard]] ErrorCode WriteUnsignedDigits(std::string_view prefix, const Spec& spec,

--- a/src/core/print/writer/writer_executor.hpp
+++ b/src/core/print/writer/writer_executor.hpp
@@ -42,8 +42,8 @@ class Writer::Executor
   template <std::signed_integral Int>
   [[nodiscard]] ErrorCode WriteSigned(const Spec& spec, Int value);
 
-  template <std::unsigned_integral UInt>
-  [[nodiscard]] ErrorCode WriteUnsigned(FormatType type, const Spec& spec, UInt value);
+  template <FormatType Type, std::unsigned_integral UInt>
+  [[nodiscard]] ErrorCode WriteUnsigned(const Spec& spec, UInt value);
   [[nodiscard]] ErrorCode WritePointer(const Spec& spec, uintptr_t value);
   [[nodiscard]] ErrorCode WriteCharacter(const Spec& spec, char ch);
   [[nodiscard]] ErrorCode WriteString(const Spec& spec, std::string_view text);

--- a/src/core/print/writer/writer_executor.hpp
+++ b/src/core/print/writer/writer_executor.hpp
@@ -44,6 +44,11 @@ class Writer::Executor
 
   template <FormatType Type, std::unsigned_integral UInt>
   [[nodiscard]] ErrorCode WriteUnsigned(const Spec& spec, UInt value);
+
+  template <uint8_t Base, bool UpperCase = false,
+            bool InlineAlternateOctal = false, std::unsigned_integral UInt>
+  [[nodiscard]] ErrorCode WriteUnsignedDigits(std::string_view prefix, const Spec& spec,
+                                              UInt value);
   [[nodiscard]] ErrorCode WritePointer(const Spec& spec, uintptr_t value);
   [[nodiscard]] ErrorCode WriteCharacter(const Spec& spec, char ch);
   [[nodiscard]] ErrorCode WriteString(const Spec& spec, std::string_view text);

--- a/src/core/print/writer/writer_executor_generic.hpp
+++ b/src/core/print/writer/writer_executor_generic.hpp
@@ -26,7 +26,7 @@ template <OutputSink Sink, FormatProfile Profile>
 template <FormatType Type, std::unsigned_integral UInt>
 ErrorCode Writer::Executor<Sink, Profile>::DispatchUnsignedField()
 {
-  return WriteUnsigned(Type, codes_.ReadSpec(), args_.Read<UInt>());
+  return WriteUnsigned<Type>(codes_.ReadSpec(), args_.Read<UInt>());
 }
 
 /**

--- a/src/core/print/writer/writer_executor_value.hpp
+++ b/src/core/print/writer/writer_executor_value.hpp
@@ -124,6 +124,11 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteUnsignedDigits(std::string_view 
  * @param spec 解码后的字段规格 / Decoded field spec
  * @param value 待写出的整数值 / Integer value to write
  * @return 返回共享整数字段路径的写出结果 / Returns the shared integer-field write result
+ *
+ * This bridge does not format digits itself; it only maps one runtime integer
+ * semantic type onto the shared compile-time radix/case helper above.
+ * 这个桥接函数本身不直接格式化数字；它只负责把运行期整数语义类型映射到上面的
+ * 编译期进制/大小写共享辅助路径。
  */
 template <OutputSink Sink, FormatProfile Profile>
 template <FormatType Type, std::unsigned_integral UInt>

--- a/src/core/print/writer/writer_executor_value.hpp
+++ b/src/core/print/writer/writer_executor_value.hpp
@@ -84,6 +84,41 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteSigned(const Spec& spec, Int val
 
 /**
  * @brief 通过共享整数字段路径写出一个无符号整数语义值 / Write one unsigned integer semantic value through the shared integer-field path
+ * @tparam Base 整数进制 / Integer radix
+ * @tparam UpperCase 十六进制数字是否使用大写字符 / Whether hexadecimal digits should use uppercase characters
+ * @tparam InlineAlternateOctal 是否把 `%#o` 的前导 `0` 直接并入数字载荷 / Whether `%#o` should inline its leading `0` into the digit payload
+ * @tparam UInt 无符号整数类型 / Unsigned integer type
+ * @param prefix 脱离数字载荷输出的前缀 / Prefix emitted outside the digit payload
+ * @param spec 解码后的字段规格 / Decoded field spec
+ * @param value 待写出的整数值 / Integer value to write
+ * @return 返回共享整数字段路径的写出结果 / Returns the shared integer-field write result
+ */
+template <OutputSink Sink, FormatProfile Profile>
+template <uint8_t Base, bool UpperCase, bool InlineAlternateOctal,
+          std::unsigned_integral UInt>
+ErrorCode Writer::Executor<Sink, Profile>::WriteUnsignedDigits(std::string_view prefix,
+                                                               const Spec& spec,
+                                                               UInt value)
+{
+  char digit_buffer[UnsignedDigitCapacity<UInt, Base>() +
+                    (InlineAlternateOctal ? 1U : 0U)];
+  size_t digit_count = AppendUnsigned<Base, UpperCase>(digit_buffer, value);
+
+  if constexpr (InlineAlternateOctal)
+  {
+    digit_count = ApplyAlternateOctal(digit_buffer, digit_count, spec, value);
+  }
+  else if (value == 0 && spec.precision == 0)
+  {
+    digit_count = 0;
+  }
+
+  return WriteIntegerField('\0', prefix, std::string_view(digit_buffer, digit_count),
+                           spec);
+}
+
+/**
+ * @brief 通过共享整数字段路径写出一个无符号整数语义值 / Write one unsigned integer semantic value through the shared integer-field path
  * @tparam Type 运行期整数语义类型 / Runtime integer semantic type
  * @tparam UInt 无符号整数类型 / Unsigned integer type
  * @param spec 解码后的字段规格 / Decoded field spec
@@ -98,55 +133,23 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteUnsigned(const Spec& spec, UInt 
 
   if constexpr (Type == FormatType::Unsigned32 || Type == FormatType::Unsigned64)
   {
-    char digit_buffer[UnsignedDigitCapacity<UInt, 10>()];
-    size_t digit_count = AppendUnsigned<10>(digit_buffer, value);
-    if (value == 0 && spec.precision == 0)
-    {
-      digit_count = 0;
-    }
-    return WriteIntegerField('\0', prefix, std::string_view(digit_buffer, digit_count),
-                             spec);
+    return WriteUnsignedDigits<10>(prefix, spec, value);
   }
   if constexpr (Type == FormatType::Binary32 || Type == FormatType::Binary64)
   {
-    char digit_buffer[UnsignedDigitCapacity<UInt, 2>()];
-    size_t digit_count = AppendUnsigned<2>(digit_buffer, value);
-    if (value == 0 && spec.precision == 0)
-    {
-      digit_count = 0;
-    }
-    return WriteIntegerField('\0', prefix, std::string_view(digit_buffer, digit_count),
-                             spec);
+    return WriteUnsignedDigits<2>(prefix, spec, value);
   }
   if constexpr (Type == FormatType::Octal32 || Type == FormatType::Octal64)
   {
-    char digit_buffer[UnsignedDigitCapacity<UInt, 8>() + 1];
-    size_t digit_count = AppendUnsigned<8>(digit_buffer, value);
-    digit_count = ApplyAlternateOctal(digit_buffer, digit_count, spec, value);
-    return WriteIntegerField('\0', prefix, std::string_view(digit_buffer, digit_count),
-                             spec);
+    return WriteUnsignedDigits<8, false, true>(prefix, spec, value);
   }
   if constexpr (Type == FormatType::HexLower32 || Type == FormatType::HexLower64)
   {
-    char digit_buffer[UnsignedDigitCapacity<UInt, 16>()];
-    size_t digit_count = AppendUnsigned<16>(digit_buffer, value);
-    if (value == 0 && spec.precision == 0)
-    {
-      digit_count = 0;
-    }
-    return WriteIntegerField('\0', prefix, std::string_view(digit_buffer, digit_count),
-                             spec);
+    return WriteUnsignedDigits<16>(prefix, spec, value);
   }
   if constexpr (Type == FormatType::HexUpper32 || Type == FormatType::HexUpper64)
   {
-    char digit_buffer[UnsignedDigitCapacity<UInt, 16>()];
-    size_t digit_count = AppendUnsigned<16, true>(digit_buffer, value);
-    if (value == 0 && spec.precision == 0)
-    {
-      digit_count = 0;
-    }
-    return WriteIntegerField('\0', prefix, std::string_view(digit_buffer, digit_count),
-                             spec);
+    return WriteUnsignedDigits<16, true>(prefix, spec, value);
   }
 
   return ErrorCode::ARG_ERR;

--- a/src/core/print/writer/writer_executor_value.hpp
+++ b/src/core/print/writer/writer_executor_value.hpp
@@ -68,10 +68,10 @@ template <std::signed_integral Int>
 ErrorCode Writer::Executor<Sink, Profile>::WriteSigned(const Spec& spec, Int value)
 {
   using UInt = std::make_unsigned_t<Int>;
-  char digit_buffer[32];
+  char digit_buffer[UnsignedDigitCapacity<UInt, 10>()];
   UInt bits = static_cast<UInt>(value);
   UInt magnitude = (value < 0) ? (UInt{0} - bits) : bits;
-  size_t digit_count = AppendUnsigned(digit_buffer, magnitude, 10, false);
+  size_t digit_count = AppendUnsigned<10>(digit_buffer, magnitude);
 
   std::string_view digits(digit_buffer, digit_count);
   if (value == 0 && spec.precision == 0)
@@ -84,40 +84,72 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteSigned(const Spec& spec, Int val
 
 /**
  * @brief 通过共享整数字段路径写出一个无符号整数语义值 / Write one unsigned integer semantic value through the shared integer-field path
+ * @tparam Type 运行期整数语义类型 / Runtime integer semantic type
  * @tparam UInt 无符号整数类型 / Unsigned integer type
- * @param type 运行期整数语义类型 / Runtime integer semantic type
  * @param spec 解码后的字段规格 / Decoded field spec
  * @param value 待写出的整数值 / Integer value to write
  * @return 返回共享整数字段路径的写出结果 / Returns the shared integer-field write result
  */
 template <OutputSink Sink, FormatProfile Profile>
-template <std::unsigned_integral UInt>
-ErrorCode Writer::Executor<Sink, Profile>::WriteUnsigned(FormatType type,
-                                                         const Spec& spec, UInt value)
+template <FormatType Type, std::unsigned_integral UInt>
+ErrorCode Writer::Executor<Sink, Profile>::WriteUnsigned(const Spec& spec, UInt value)
 {
-  uint8_t base = IntegerBase(type);
-  if (base == 0)
+  auto prefix = IntegerPrefix(Type, spec, value);
+
+  if constexpr (Type == FormatType::Unsigned32 || Type == FormatType::Unsigned64)
   {
-    return ErrorCode::ARG_ERR;
+    char digit_buffer[UnsignedDigitCapacity<UInt, 10>()];
+    size_t digit_count = AppendUnsigned<10>(digit_buffer, value);
+    if (value == 0 && spec.precision == 0)
+    {
+      digit_count = 0;
+    }
+    return WriteIntegerField('\0', prefix, std::string_view(digit_buffer, digit_count),
+                             spec);
   }
-
-  bool upper_case = IntegerUpperCase(type);
-  auto prefix = IntegerPrefix(type, spec, value);
-
-  char digit_buffer[33];
-  size_t digit_count = AppendUnsigned(digit_buffer, value, base, upper_case);
-
-  if (type == FormatType::Octal32 || type == FormatType::Octal64)
+  if constexpr (Type == FormatType::Binary32 || Type == FormatType::Binary64)
   {
+    char digit_buffer[UnsignedDigitCapacity<UInt, 2>()];
+    size_t digit_count = AppendUnsigned<2>(digit_buffer, value);
+    if (value == 0 && spec.precision == 0)
+    {
+      digit_count = 0;
+    }
+    return WriteIntegerField('\0', prefix, std::string_view(digit_buffer, digit_count),
+                             spec);
+  }
+  if constexpr (Type == FormatType::Octal32 || Type == FormatType::Octal64)
+  {
+    char digit_buffer[UnsignedDigitCapacity<UInt, 8>() + 1];
+    size_t digit_count = AppendUnsigned<8>(digit_buffer, value);
     digit_count = ApplyAlternateOctal(digit_buffer, digit_count, spec, value);
+    return WriteIntegerField('\0', prefix, std::string_view(digit_buffer, digit_count),
+                             spec);
   }
-  else if (value == 0 && spec.precision == 0)
+  if constexpr (Type == FormatType::HexLower32 || Type == FormatType::HexLower64)
   {
-    digit_count = 0;
+    char digit_buffer[UnsignedDigitCapacity<UInt, 16>()];
+    size_t digit_count = AppendUnsigned<16>(digit_buffer, value);
+    if (value == 0 && spec.precision == 0)
+    {
+      digit_count = 0;
+    }
+    return WriteIntegerField('\0', prefix, std::string_view(digit_buffer, digit_count),
+                             spec);
+  }
+  if constexpr (Type == FormatType::HexUpper32 || Type == FormatType::HexUpper64)
+  {
+    char digit_buffer[UnsignedDigitCapacity<UInt, 16>()];
+    size_t digit_count = AppendUnsigned<16, true>(digit_buffer, value);
+    if (value == 0 && spec.precision == 0)
+    {
+      digit_count = 0;
+    }
+    return WriteIntegerField('\0', prefix, std::string_view(digit_buffer, digit_count),
+                             spec);
   }
 
-  std::string_view digits(digit_buffer, digit_count);
-  return WriteIntegerField('\0', prefix, digits, spec);
+  return ErrorCode::ARG_ERR;
 }
 
 /**
@@ -130,8 +162,8 @@ template <OutputSink Sink, FormatProfile Profile>
 ErrorCode Writer::Executor<Sink, Profile>::WritePointer(const Spec& spec,
                                                         uintptr_t value)
 {
-  char digit_buffer[2 * sizeof(uintptr_t)];
-  size_t digit_count = AppendUnsigned(digit_buffer, value, 16, false);
+  char digit_buffer[UnsignedDigitCapacity<uintptr_t, 16>()];
+  size_t digit_count = AppendUnsigned<16>(digit_buffer, value);
   Spec actual = spec;
 
   if (!actual.HasPrecision() || actual.precision == 0)
@@ -240,8 +272,8 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteFloat(FormatType type,
 template <OutputSink Sink, FormatProfile Profile>
 ErrorCode Writer::Executor<Sink, Profile>::WriteU32Dec(uint32_t value)
 {
-  char digit_buffer[10];
-  size_t digit_count = AppendUnsigned(digit_buffer, value, 10, false);
+  char digit_buffer[UnsignedDigitCapacity<uint32_t, 10>()];
+  size_t digit_count = AppendUnsigned<10>(digit_buffer, value);
   return WriteRaw(std::string_view(digit_buffer, digit_count));
 }
 
@@ -255,8 +287,8 @@ template <OutputSink Sink, FormatProfile Profile>
 ErrorCode Writer::Executor<Sink, Profile>::WriteU32ZeroPadWidth(uint8_t width,
                                                                 uint32_t value)
 {
-  char digit_buffer[10];
-  size_t digit_count = AppendUnsigned(digit_buffer, value, 10, false);
+  char digit_buffer[UnsignedDigitCapacity<uint32_t, 10>()];
+  size_t digit_count = AppendUnsigned<10>(digit_buffer, value);
   size_t zeros = FieldPadding(width, digit_count);
   if (auto ec = WritePadding('0', zeros); ec != ErrorCode::OK)
   {

--- a/src/core/print/writer/writer_float_math.hpp
+++ b/src/core/print/writer/writer_float_math.hpp
@@ -222,10 +222,10 @@ inline bool Writer::AppendExponentText(char* out, size_t& out_size, int exponent
     return false;
   }
 
-  char digits[16];
+  char digits[UnsignedDigitCapacity<unsigned int, 10>()];
   unsigned int magnitude =
       static_cast<unsigned int>(exponent < 0 ? -exponent : exponent);
-  size_t digit_count = AppendUnsigned(digits, magnitude, 10, false);
+  size_t digit_count = AppendUnsigned<10>(digits, magnitude);
   if (digit_count < 2 &&
       !AppendBufferChar(out, float_buffer_capacity, out_size, '0'))
   {

--- a/src/core/print/writer/writer_float_runtime.hpp
+++ b/src/core/print/writer/writer_float_runtime.hpp
@@ -148,8 +148,8 @@ inline bool Writer::AppendBufferText(char* buffer, size_t capacity, size_t& size
 inline bool Writer::AppendBufferU32ZeroPad(char* buffer, size_t capacity, size_t& size,
                                            uint32_t value, uint8_t width)
 {
-  char digits[10];
-  size_t digit_count = AppendUnsigned(digits, value, 10, false);
+  char digits[UnsignedDigitCapacity<uint32_t, 10>()];
+  size_t digit_count = AppendUnsigned<10>(digits, value);
   size_t zero_count = (width > digit_count) ? static_cast<size_t>(width) - digit_count : 0;
 
   for (size_t i = 0; i < zero_count; ++i)

--- a/src/core/print/writer/writer_integer.hpp
+++ b/src/core/print/writer/writer_integer.hpp
@@ -4,22 +4,42 @@
  * @brief 运行期 writer 后端共享的整数文本辅助函数 / Shared integer-text helpers for the runtime writer backend
  */
 
+template <std::unsigned_integral UInt, uint8_t Base>
+constexpr size_t Writer::UnsignedDigitCapacity()
+{
+  static_assert(Base == 2 || Base == 8 || Base == 10 || Base == 16,
+                "LibXR::Print::Writer only supports base 2, 8, 10, and 16");
+
+  UInt value = std::numeric_limits<UInt>::max();
+  size_t digits = 1;
+  while (value >= static_cast<UInt>(Base))
+  {
+    value /= static_cast<UInt>(Base);
+    ++digits;
+  }
+  return digits;
+}
+
 /**
- * @brief 将一个无符号整数写入调用方提供的数字缓冲区 / Append one unsigned integer into a caller-provided digit buffer
+ * @brief 将一个无符号整数写入调用方提供的定长数字缓冲区 / Append one unsigned integer into a caller-provided fixed-size digit buffer
+ * @tparam Base 整数进制 / Integer radix
+ * @tparam UpperCase 十六进制数字是否使用大写字母 / Whether hexadecimal digits should use uppercase letters
+ * @tparam N 目标缓冲区长度 / Destination buffer size
  * @tparam UInt 无符号整数类型 / Unsigned integer type
  * @param out 目标数字缓冲区 / Destination digit buffer
  * @param value 待编码的无符号值 / Unsigned value to encode
- * @param base 整数进制 / Integer radix
- * @param upper_case 十六进制数字是否使用大写字母 / Whether hexadecimal digits should use uppercase letters
  * @return 返回输出的数字个数 / Returns the emitted digit count
  */
-template <std::unsigned_integral UInt>
-size_t Writer::AppendUnsigned(char* out, UInt value, uint8_t base, bool upper_case)
+template <uint8_t Base, bool UpperCase, size_t N, std::unsigned_integral UInt>
+size_t Writer::AppendUnsigned(char (&out)[N], UInt value)
 {
   constexpr char lower_digits[] = "0123456789abcdef";
   constexpr char upper_digits[] = "0123456789ABCDEF";
-  const char* digits = upper_case ? upper_digits : lower_digits;
-  char reverse[32];
+  static_assert(N >= UnsignedDigitCapacity<UInt, Base>(),
+                "LibXR::Print::Writer digit buffer is too small for the selected integer type");
+
+  const char* digits = UpperCase ? upper_digits : lower_digits;
+  char reverse[UnsignedDigitCapacity<UInt, Base>()];
   size_t count = 0;
 
   if (value == 0)
@@ -30,8 +50,8 @@ size_t Writer::AppendUnsigned(char* out, UInt value, uint8_t base, bool upper_ca
 
   while (value != 0)
   {
-    reverse[count++] = digits[value % base];
-    value /= base;
+    reverse[count++] = digits[static_cast<size_t>(value % static_cast<UInt>(Base))];
+    value /= static_cast<UInt>(Base);
   }
 
   for (size_t i = 0; i < count; ++i)
@@ -48,9 +68,10 @@ size_t Writer::AppendUnsigned(char* out, UInt value, uint8_t base, bool upper_ca
  * @param value 待编码的无符号值 / Unsigned value to encode
  * @return 返回输出的数字个数 / Returns the emitted digit count
  */
-inline size_t Writer::AppendSmallUnsigned(char* out, uint8_t value)
+template <size_t N>
+inline size_t Writer::AppendSmallUnsigned(char (&out)[N], uint8_t value)
 {
-  return AppendUnsigned(out, value, 10, false);
+  return AppendUnsigned<10>(out, value);
 }
 
 /**
@@ -75,44 +96,6 @@ constexpr size_t Writer::IntegerPrecisionZeros(const Spec& spec, size_t digit_co
   return (spec.HasPrecision() && spec.precision > digit_count)
              ? static_cast<size_t>(spec.precision) - digit_count
              : 0;
-}
-
-/**
- * @brief 返回某个运行期语义类型对应的整数进制 / Return the integer radix selected by one runtime semantic type
- * @param type 运行期字段类型 / Runtime field type
- * @return 返回选中的整数进制 / Returns the selected integer radix
- */
-constexpr uint8_t Writer::IntegerBase(FormatType type)
-{
-  switch (type)
-  {
-    case FormatType::Unsigned32:
-    case FormatType::Unsigned64:
-      return 10;
-    case FormatType::Binary32:
-    case FormatType::Binary64:
-      return 2;
-    case FormatType::Octal32:
-    case FormatType::Octal64:
-      return 8;
-    case FormatType::HexLower32:
-    case FormatType::HexLower64:
-    case FormatType::HexUpper32:
-    case FormatType::HexUpper64:
-      return 16;
-    default:
-      return 0;
-  }
-}
-
-/**
- * @brief 判断某个运行期整数语义是否使用大写数字字符 / Return whether one runtime integer semantic uses uppercase digits
- * @param type 运行期字段类型 / Runtime field type
- * @return 需要输出大写数字字符时返回 `true`，否则返回 `false` / Returns `true` when uppercase digits are required, otherwise `false`
- */
-constexpr bool Writer::IntegerUpperCase(FormatType type)
-{
-  return type == FormatType::HexUpper32 || type == FormatType::HexUpper64;
 }
 
 /**

--- a/src/core/print/writer/writer_integer.hpp
+++ b/src/core/print/writer/writer_integer.hpp
@@ -5,7 +5,7 @@
  */
 
 template <std::unsigned_integral UInt, uint8_t Base>
-constexpr size_t Writer::UnsignedDigitCapacity()
+consteval size_t Writer::UnsignedDigitCapacity()
 {
   static_assert(Base == 2 || Base == 8 || Base == 10 || Base == 16,
                 "LibXR::Print::Writer only supports base 2, 8, 10, and 16");

--- a/test/test_pool.cpp
+++ b/test/test_pool.cpp
@@ -91,10 +91,7 @@ void test_lock_free_pool()
 
   // ---- 多线程并发完整性测试 ----
   {
-    push_sum = 0;
-    pop_sum = 0;
-    push_cnt = 0;
-    pop_cnt = 0;
+    push_sum = pop_sum = push_cnt = pop_cnt = 0;
     for (int i = 0; i < N; ++i)
     {
       pop_taken[i] = 0;

--- a/test/test_pool.cpp
+++ b/test/test_pool.cpp
@@ -91,7 +91,10 @@ void test_lock_free_pool()
 
   // ---- 多线程并发完整性测试 ----
   {
-    push_sum = pop_sum = push_cnt = pop_cnt = 0;
+    push_sum = 0;
+    pop_sum = 0;
+    push_cnt = 0;
+    pop_cnt = 0;
     for (int i = 0; i < N; ++i)
     {
       pop_taken[i] = 0;

--- a/test/test_print.cpp
+++ b/test/test_print.cpp
@@ -271,6 +271,30 @@ std::string PointerText(const void* value)
   return std::string(buffer.data(), static_cast<size_t>(size));
 }
 
+template <typename UInt>
+std::string UnsignedBaseText(UInt value, uint8_t base, bool upper_case = false)
+{
+  static_assert(std::is_unsigned_v<UInt>);
+  constexpr char lower_digits[] = "0123456789abcdef";
+  constexpr char upper_digits[] = "0123456789ABCDEF";
+  const char* digits = upper_case ? upper_digits : lower_digits;
+
+  if (value == 0)
+  {
+    return "0";
+  }
+
+  std::string reversed;
+  while (value != 0)
+  {
+    reversed.push_back(
+        digits[static_cast<size_t>(value % static_cast<UInt>(base))]);
+    value /= static_cast<UInt>(base);
+  }
+
+  return std::string(reversed.rbegin(), reversed.rend());
+}
+
 int Fail(const char* message)
 {
   std::cerr << message << '\n';
@@ -324,6 +348,21 @@ void TestPrintfFrontendSemantics()
                                                   5U, 5U, 5U))
   {
     Fail("binary integer semantics mismatch");
+  }
+
+  {
+    unsigned long long max_value = std::numeric_limits<unsigned long long>::max();
+    std::string binary = UnsignedBaseText(max_value, 2);
+    std::string octal = UnsignedBaseText(max_value, 8);
+    std::string hex_lower = UnsignedBaseText(max_value, 16);
+    std::string hex_upper = UnsignedBaseText(max_value, 16, true);
+    std::string expected = binary + "|0b" + binary + "|0" + octal + "|" + hex_lower +
+                           "|" + hex_upper;
+    if (!SamePrintfAsExpected<"%llb|%#llb|%#llo|%llx|%llX">(
+            expected, max_value, max_value, max_value, max_value, max_value))
+    {
+      Fail("64-bit integer base semantics mismatch");
+    }
   }
 
   if (!SameAsSnprintf<"x=%+08d y=%-4s z=%#x %% %.2f">(-12, "ok", 42U, 1.25))
@@ -491,6 +530,21 @@ void TestFormatFrontendSemantics()
   if (!SameFormatAsExpected<"{:#b} {:#B} {:#o}">("0b101 0B101 010", 5U, 5U, 8U))
   {
     Fail("format frontend non-decimal mismatch");
+  }
+
+  {
+    uint64_t max_value = std::numeric_limits<uint64_t>::max();
+    std::string binary = UnsignedBaseText(max_value, 2);
+    std::string octal = UnsignedBaseText(max_value, 8);
+    std::string hex_lower = UnsignedBaseText(max_value, 16);
+    std::string hex_upper = UnsignedBaseText(max_value, 16, true);
+    std::string expected = binary + "|0b" + binary + "|0" + octal + "|" + hex_lower +
+                           "|" + hex_upper;
+    if (!SameFormatAsExpected<"{:b}|{:#b}|{:#o}|{:x}|{:X}">(
+            expected, max_value, max_value, max_value, max_value, max_value))
+    {
+      Fail("format frontend 64-bit base mismatch");
+    }
   }
 
   if (!SameFormatAsExpected<"[{:.3s}] [{:_>6s}] [{:*^7s}]">("[abc] [___abc] [**abc**]",


### PR DESCRIPTION
## Summary
- make the runtime print integer writer use compile-time digit capacities instead of bare `char*` plus runtime base selection
- fix the retained 64-bit non-decimal buffer sizing issue, including the real `Binary64` under-sized path and `%#o` headroom
- add 64-bit binary/octal/hex regression coverage for both `printf` and brace-format frontends
- clean the remaining `test_pool.cpp` volatile reset warning so strict whole-tree `-Werror` builds stay clean

## Testing
- Ubuntu24 host: `Release/-O3`, `LIBXR_TEST_BUILD=ON`, `-Werror`
- Docker `gcc:14.3.0`: `Release/-O3`, `LIBXR_TEST_BUILD=ON`, `-Werror`

## Summary by Sourcery

修复无符号整数打印缓冲区，以使用编译期数字容量和基于模板的进制选择，并为 64 位非十进制格式添加回归覆盖。

Bug 修复：
- 修正 64 位非十进制整数打印的缓冲区大小问题，包括二进制和带替代形式（alternate-form）的八进制情况。
- 消除无锁池（lock-free pool）测试中易变变量（volatile variable）重置的警告，以确保 `-Werror` 构建保持干净。

增强：
- 重构无符号整数格式化逻辑，改为使用编译期数字容量计算和模板化的 `AppendUnsigned` 辅助函数，而不是在运行时选择进制。
- 通过使用编译期 `FormatType` 参数并移除运行时进制（radix）/大写（uppercase）查询，简化无符号整数分发逻辑。

测试：
- 添加覆盖 64 位二进制、八进制和十六进制格式的回归测试，适用于 `printf` 风格和大括号格式（brace-format）前端。
- 在测试中引入共享的 `UnsignedBaseText` 辅助工具，用于为各种进制生成期望字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix unsigned integer printing buffers to use compile-time digit capacities and template-based radix selection, and add regression coverage for 64-bit non-decimal formatting.

Bug Fixes:
- Correct buffer sizing for 64-bit non-decimal integer printing, including binary and alternate-form octal cases.
- Eliminate volatile variable reset warning in the lock-free pool test to keep -Werror builds clean.

Enhancements:
- Refactor unsigned integer formatting to use compile-time digit capacity calculation and templated AppendUnsigned helpers instead of runtime base selection.
- Simplify unsigned integer dispatch by using compile-time FormatType parameters and removing runtime radix/uppercase queries.

Tests:
- Add regression tests covering 64-bit binary, octal, and hexadecimal formatting for both printf-style and brace-format frontends.
- Introduce shared UnsignedBaseText helper in tests to generate expected strings for various bases.

</details>