### PR TITLE
fix(event): harden event comparator and bind path

### DIFF
--- a/src/middleware/event.cpp
+++ b/src/middleware/event.cpp
@@ -4,9 +4,26 @@ using namespace LibXR;
 
 template class LibXR::Callback<uint32_t>;
 
+namespace
+{
+
+int CompareEventId(uint32_t a, uint32_t b)
+{
+  if (a < b)
+  {
+    return -1;
+  }
+  if (a > b)
+  {
+    return 1;
+  }
+  return 0;
+}
+
+}  // namespace
+
 Event::Event()
-    : rbt_([](const uint32_t& a, const uint32_t& b)
-           { return static_cast<int>(a) - static_cast<int>(b); })
+    : rbt_([](const uint32_t& a, const uint32_t& b) { return CompareEventId(a, b); })
 {
 }
 
@@ -77,16 +94,16 @@ void Event::Bind(Event& sources, uint32_t source_event, uint32_t target_event)
   struct BindBlock
   {
     Event* target;
+    Event::CallbackList list;
     uint32_t event;
   };
 
-  auto block = new BindBlock{this, target_event};
+  auto block = new BindBlock{this, GetList(target_event), target_event};
 
   auto bind_fun = [](bool in_isr, BindBlock* block, uint32_t event)
   {
     UNUSED(event);
-    block->target->ActiveFromCallback(block->target->GetList(block->event), block->event,
-                                      in_isr);
+    block->target->ActiveFromCallback(block->list, block->event, in_isr);
   };
 
   auto cb = Callback::Create(bind_fun, block);

--- a/src/middleware/event.hpp
+++ b/src/middleware/event.hpp
@@ -76,6 +76,12 @@ class Event
    * @param event 要查询的事件 ID。 The event ID to search.
    * @return 回调链表指针，如果未注册则主动创建。 The callback list pointer, if not
    * registered, it is actively created.
+   * @note 当前 Event 只支持“查找或创建”回调链表，不提供删除或替换某个事件链表的接口；
+   *       因此在 Event 对象存活期间，这个函数返回的链表指针保持稳定。
+   *       The current Event API only supports finding or creating a callback
+   *       list; it does not provide any way to remove or replace one event's
+   *       list, so the returned pointer stays stable for the lifetime of the
+   *       Event object.
    */
   CallbackList GetList(uint32_t event);
 
@@ -89,6 +95,18 @@ class Event
    *
    * @note 包含动态内存分配。
    *       Contains dynamic memory allocation.
+   * @note 当前实现会在绑定时预先拿到目标事件的回调链表指针，因此后续 callback-safe
+   *       触发路径不需要再为这个绑定做惰性查找或分配。
+   *       The current implementation acquires the target event's callback-list
+   *       pointer during binding, so later callback-safe activation does not
+   *       need an extra lazy lookup or allocation for this binding.
+   * @note 这依赖 `GetList()` 的稳定性约束：当前 Event 不支持删除或替换某个事件的回调
+   *       链表，因此绑定后缓存的目标链表指针会一直指向同一个链表，直到目标 Event 对象
+   *       自身结束生命周期。
+   *       This relies on `GetList()` stability: Event does not support removing
+   *       or replacing one event's callback list, so the cached target-list
+   *       pointer keeps referring to the same list until the target Event
+   *       object itself reaches the end of its lifetime.
    */
   void Bind(Event& sources, uint32_t source_event, uint32_t target_event);
 

--- a/test/test_event.cpp
+++ b/test/test_event.cpp
@@ -6,6 +6,7 @@ void test_event()
 {
   static int event_arg = 0;
   static bool last_in_isr = false;
+  static int high_event_arg = 0;
 
   auto event_cb = LibXR::Event::Callback::Create(
       [](bool in_isr, int* arg, uint32_t event)
@@ -15,6 +16,15 @@ void test_event()
         ASSERT(event == 0x1234);
       },
       &event_arg);
+
+  auto high_event_cb = LibXR::Event::Callback::Create(
+      [](bool in_isr, int* arg, uint32_t event)
+      {
+        last_in_isr = in_isr;
+        *arg = *arg + 1;
+        ASSERT(event == 0xF0001234);
+      },
+      &high_event_arg);
 
   LibXR::Event event, event_bind;
 
@@ -58,4 +68,10 @@ void test_event()
   event_bind.ActiveFromCallback(event_bind.GetList(0x4321), 0x4321, true);
   ASSERT(event_arg == 8);
   ASSERT(last_in_isr == true);
+
+  // High-value event IDs must still compare and dispatch correctly.
+  event.Register(0xF0001234, high_event_cb);
+  event.Active(0xF0001234);
+  ASSERT(high_event_arg == 1);
+  ASSERT(last_in_isr == false);
 }


### PR DESCRIPTION
## Summary
This PR hardens the `event` middleware around two concrete safety issues without changing the public API surface.

## What changed
- Replace the event RB-tree comparator from `static_cast<int>(a) - static_cast<int>(b)` to explicit `< / > / ==` ordering so high-value event IDs cannot miscompare through signed overflow.
- Make `Bind()` acquire the target event's callback-list pointer during binding, so the later callback-safe dispatch path does not need an extra lazy lookup / allocation for that binding.
- Add a regression test covering a high-value event ID (`0xF0001234`) to prove dispatch still works correctly in that range.

## Validation
Ubuntu24 validation:
- `/home/xiao/runs/libxr_event_fix_v2_20260605T094526Z/99_summary.txt`

Result:
- `clone=PASS`
- `apply=PASS`
- `cmake=PASS`
- `build=PASS`
- `test=PASS`

## Summary by Sourcery

加强事件中间件的比较和绑定行为，以避免溢出问题和不必要的查找，同时保持现有 API 不变。

Bug 修复：
- 通过用显式关系比较替换算术比较器，防止由于高事件 ID 导致有符号溢出，从而避免 RB 树中事件排序错误。

增强功能：
- 在绑定时捕获目标事件的回调列表，这样在 callback-safe 派发时，不再需要为该绑定执行额外的查找或分配。
- 为更新后的 `Bind()` 行为编写文档，说明其对目标回调列表指针的提前获取。

测试：
- 扩展事件测试，覆盖派发高值事件 ID 的场景，以防止比较器行为回归。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden event middleware comparison and binding behavior to avoid overflow issues and unnecessary lookups while preserving the existing API.

Bug Fixes:
- Prevent incorrect ordering of events in the RB-tree by replacing the arithmetic comparator with explicit relational comparison to avoid signed overflow for high event IDs.

Enhancements:
- Capture the target event's callback list at bind time so callback-safe dispatch no longer performs an extra lookup or allocation for the binding.
- Document the updated Bind() behavior around early acquisition of the target callback list pointer.

Tests:
- Extend event tests to cover dispatching of a high-value event ID to guard against regressions in comparator behavior.

</details>