### PR TITLE
correct MSPM0 timebase and GPIO port index handling

### DIFF
--- a/driver/mspm0/mspm0_gpio.hpp
+++ b/driver/mspm0/mspm0_gpio.hpp
@@ -40,10 +40,12 @@ class MSPM0GPIO : public GPIO
 
   static constexpr int GetPortIndex(uint32_t base_addr)
   {
+#ifdef GPIOA_BASE
     if (base_addr == GPIOA_BASE)
     {
       return 0;
     }
+#endif
 #ifdef GPIOB_BASE
     if (base_addr == GPIOB_BASE)
     {

--- a/driver/mspm0/mspm0_timebase.cpp
+++ b/driver/mspm0/mspm0_timebase.cpp
@@ -18,7 +18,7 @@ MicrosecondTimestamp MSPM0Timebase::_get_microseconds()
 
     auto tick_diff = tick_new - tick_old;
 
-    uint32_t cycles_per_ms = DL_SYSTICK_getPeriod() + 1;
+    uint32_t cycles_per_ms = DL_SYSTICK_getPeriod();
 
     switch (tick_diff)
     {


### PR DESCRIPTION
本 PR 修复了 MSPM0 平台相关的两个问题：

- 修复 `MSPM0GPIO::GetPortIndex()` 中对 `GPIOA_BASE` 的直接引用问题
- 修正 `MSPM0Timebase::_get_microseconds()` 中 SysTick 周期计算的偏差问题

## 由 Sourcery 提供的摘要

防护 MSPM0 GPIO 端口索引查找逻辑，并修正基于 SysTick 的微秒时间基准计算。

错误修复：
- 当平台上不存在 `GPIOA` 时，避免在 `MSPM0GPIO::GetPortIndex` 中引用未定义的 `GPIOA_BASE`，以防止在无 `GPIOA` 的平台上出现构建或运行时问题。
- 通过使用正确的 SysTick 周期值，修复 `MSPM0Timebase` 微秒计算中的偏移一位（off-by-one）错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard MSPM0 GPIO port index lookup and correct SysTick-based microsecond timebase calculations.

Bug Fixes:
- Avoid referencing GPIOA_BASE when it is undefined in MSPM0GPIO::GetPortIndex, preventing build or runtime issues on platforms without GPIOA.
- Fix off-by-one error in MSPM0Timebase microsecond calculation by using the correct SysTick period value.

</details>