### PR TITLE
Clean test pool volatile warning

### DIFF
--- a/test/test_pool.cpp
+++ b/test/test_pool.cpp
@@ -91,7 +91,10 @@ void test_lock_free_pool()
 
   // ---- 多线程并发完整性测试 ----
   {
-    push_sum = pop_sum = push_cnt = pop_cnt = 0;
+    push_sum = 0;
+    pop_sum = 0;
+    push_cnt = 0;
+    pop_cnt = 0;
     for (int i = 0; i < N; ++i)
     {
       pop_taken[i] = 0;


### PR DESCRIPTION
## Summary
- replace the chained volatile reset in `test/test_pool.cpp` with standalone assignments
- keep test behavior unchanged while removing the retained `-Wvolatile` warning in strict builds

## Testing
- warning cleanup only

## Summary by Sourcery

Tests:
- 使用单独赋值的方式重置池测试计数器，以避免与 `volatile` 相关的编译器警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tests:
- Reset pool test counters with separate assignments to avoid volatile-related compiler warnings.

</details>