### PR TITLE
refactor(core): unify compiler compatibility macros

### DIFF
--- a/driver/ch/ch32_flash.cpp
+++ b/driver/ch/ch32_flash.cpp
@@ -10,9 +10,9 @@ using namespace LibXR;
 // WCH GCC15 对当前已验证可用的 CH32V2/V3 自擦写路径代码形状很敏感。
 // 这里把擦除/写入热循环放到明确的 noinline 边界后面，
 // 但解锁、降频、清标志这些外围时序仍留在原来的调用点。
-extern "C" __attribute__((noinline)) ErrorCode CH32FlashWriteHotPath(uint32_t start_addr,
-                                                                     uint32_t end_addr,
-                                                                     const uint8_t* src);
+extern "C" LIBXR_NOINLINE ErrorCode CH32FlashWriteHotPath(uint32_t start_addr,
+                                                          uint32_t end_addr,
+                                                          const uint8_t* src);
 
 namespace
 {
@@ -193,9 +193,9 @@ ErrorCode CH32Flash::Write(size_t offset, ConstRawData data)
   return CH32FlashWriteHotPath(START_ADDR, END_ADDR, src);
 }
 
-extern "C" __attribute__((noinline)) ErrorCode CH32FlashWriteHotPath(uint32_t start_addr,
-                                                                     uint32_t end_addr,
-                                                                     const uint8_t* src)
+extern "C" LIBXR_NOINLINE ErrorCode CH32FlashWriteHotPath(uint32_t start_addr,
+                                                          uint32_t end_addr,
+                                                          const uint8_t* src)
 {
   const auto write_hot_loop = g_ch32_flash_hot_paths.write_halfword;
   const auto write_page = g_ch32_flash_hot_paths.write_page;

--- a/src/core/libxr_def.hpp
+++ b/src/core/libxr_def.hpp
@@ -21,23 +21,23 @@
 #define LIBXR_FORCE_OPTIMIZE_O3
 #define LIBXR_FORCE_OPTIMIZE_OS
 #define LIBXR_NOINLINE __declspec(noinline)
-#define LIBXR_PACK_PUSH_1 __pragma(pack(push, 1))
-#define LIBXR_PACK_POP() __pragma(pack(pop))
+#define LIBXR_PACKED_BEGIN __pragma(pack(push, 1))
+#define LIBXR_PACKED_END __pragma(pack(pop))
 #define LIBXR_PACKED
 #elif defined(__clang__) || defined(__GNUC__)
 #define LIBXR_FORCE_OPTIMIZE_O3 __attribute__((optimize("O3")))
 #define LIBXR_FORCE_OPTIMIZE_OS __attribute__((optimize("Os")))
 #define LIBXR_NOINLINE __attribute__((noinline))
-#define LIBXR_PACK_PUSH_1 _Pragma("pack(push, 1)")
-#define LIBXR_PACK_POP() _Pragma("pack(pop)")
+#define LIBXR_PACKED_BEGIN _Pragma("pack(push, 1)")
+#define LIBXR_PACKED_END _Pragma("pack(pop)")
 #define LIBXR_PACKED __attribute__((packed))
 #else
 #warning "LibXR compiler compatibility macros fallback to no-op on unknown compiler"
 #define LIBXR_FORCE_OPTIMIZE_O3
 #define LIBXR_FORCE_OPTIMIZE_OS
 #define LIBXR_NOINLINE
-#define LIBXR_PACK_PUSH_1
-#define LIBXR_PACK_POP()
+#define LIBXR_PACKED_BEGIN
+#define LIBXR_PACKED_END
 #define LIBXR_PACKED
 #endif
 

--- a/src/core/libxr_def.hpp
+++ b/src/core/libxr_def.hpp
@@ -17,6 +17,30 @@
 #define UNUSED(_x) ((void)(_x))
 #endif
 
+#if defined(_MSC_VER)
+#define LIBXR_FORCE_OPTIMIZE_O3
+#define LIBXR_FORCE_OPTIMIZE_OS
+#define LIBXR_NOINLINE __declspec(noinline)
+#define LIBXR_PACK_PUSH_1 __pragma(pack(push, 1))
+#define LIBXR_PACK_POP() __pragma(pack(pop))
+#define LIBXR_PACKED
+#elif defined(__clang__) || defined(__GNUC__)
+#define LIBXR_FORCE_OPTIMIZE_O3 __attribute__((optimize("O3")))
+#define LIBXR_FORCE_OPTIMIZE_OS __attribute__((optimize("Os")))
+#define LIBXR_NOINLINE __attribute__((noinline))
+#define LIBXR_PACK_PUSH_1 _Pragma("pack(push, 1)")
+#define LIBXR_PACK_POP() _Pragma("pack(pop)")
+#define LIBXR_PACKED __attribute__((packed))
+#else
+#warning "LibXR compiler compatibility macros fallback to no-op on unknown compiler"
+#define LIBXR_FORCE_OPTIMIZE_O3
+#define LIBXR_FORCE_OPTIMIZE_OS
+#define LIBXR_NOINLINE
+#define LIBXR_PACK_PUSH_1
+#define LIBXR_PACK_POP()
+#define LIBXR_PACKED
+#endif
+
 namespace LibXR
 {
 /// \brief PI 常量 / PI constant

--- a/src/core/libxr_mem.cpp
+++ b/src/core/libxr_mem.cpp
@@ -2,7 +2,7 @@
 
 #include "libxr_def.hpp"
 
-LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastCopy(void *dst, const void *src,
+LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastCopy(void* dst, const void* src,
                                                      size_t size)
 {
   uint8_t* d = static_cast<uint8_t*>(dst);
@@ -213,7 +213,7 @@ LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastCopy(void *dst, const void *src,
   }
 }
 
-LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastMove(void *dst, const void *src,
+LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastMove(void* dst, const void* src,
                                                      size_t size)
 {
   if (size == 0 || dst == src)

--- a/src/core/libxr_mem.cpp
+++ b/src/core/libxr_mem.cpp
@@ -2,8 +2,7 @@
 
 #include "libxr_def.hpp"
 
-LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastCopy(void* dst, const void* src,
-                                                      size_t size)
+LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastCopy(void* dst, const void* src, size_t size)
 {
   uint8_t* d = static_cast<uint8_t*>(dst);
   const uint8_t* s = static_cast<const uint8_t*>(src);
@@ -213,8 +212,7 @@ LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastCopy(void* dst, const void* src,
   }
 }
 
-LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastMove(void* dst, const void* src,
-                                                      size_t size)
+LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastMove(void* dst, const void* src, size_t size)
 {
   if (size == 0 || dst == src)
   {
@@ -449,8 +447,7 @@ LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastMove(void* dst, const void* src,
   }
 }
 
-LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastSet(void* dst, uint8_t value,
-                                                     size_t size)
+LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastSet(void* dst, uint8_t value, size_t size)
 {
   if (size == 0)
   {

--- a/src/core/libxr_mem.cpp
+++ b/src/core/libxr_mem.cpp
@@ -2,7 +2,8 @@
 
 #include "libxr_def.hpp"
 
-void LibXR::Memory::FastCopy(void* dst, const void* src, size_t size)
+LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastCopy(void* dst, const void* src,
+                                                      size_t size)
 {
   uint8_t* d = static_cast<uint8_t*>(dst);
   const uint8_t* s = static_cast<const uint8_t*>(src);
@@ -212,7 +213,8 @@ void LibXR::Memory::FastCopy(void* dst, const void* src, size_t size)
   }
 }
 
-void LibXR::Memory::FastMove(void* dst, const void* src, size_t size)
+LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastMove(void* dst, const void* src,
+                                                      size_t size)
 {
   if (size == 0 || dst == src)
   {
@@ -447,7 +449,8 @@ void LibXR::Memory::FastMove(void* dst, const void* src, size_t size)
   }
 }
 
-void LibXR::Memory::FastSet(void* dst, uint8_t value, size_t size)
+LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastSet(void* dst, uint8_t value,
+                                                     size_t size)
 {
   if (size == 0)
   {

--- a/src/core/libxr_mem.cpp
+++ b/src/core/libxr_mem.cpp
@@ -2,7 +2,8 @@
 
 #include "libxr_def.hpp"
 
-LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastCopy(void* dst, const void* src, size_t size)
+LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastCopy(void *dst, const void *src,
+                                                     size_t size)
 {
   uint8_t* d = static_cast<uint8_t*>(dst);
   const uint8_t* s = static_cast<const uint8_t*>(src);
@@ -212,7 +213,8 @@ LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastCopy(void* dst, const void* src,
   }
 }
 
-LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastMove(void* dst, const void* src, size_t size)
+LIBXR_FORCE_OPTIMIZE_O3 void LibXR::Memory::FastMove(void *dst, const void *src,
+                                                     size_t size)
 {
   if (size == 0 || dst == src)
   {

--- a/src/core/print/writer.hpp
+++ b/src/core/print/writer.hpp
@@ -607,9 +607,9 @@ class Writer
    * @param codes 指向编译字节流的指针 / Pointer to the compiled byte stream
    * @param args 指向已打包参数字节块的指针；无参数时可为空 / Pointer to the packed argument blob, or null when no arguments exist
    * @return 执行器运行结果 / Returns the executor result
-   */
+  */
   template <OutputSink Sink, FormatProfile Profile>
-  [[nodiscard]] __attribute__((noinline)) static ErrorCode Execute(
+  LIBXR_FORCE_OPTIMIZE_OS LIBXR_NOINLINE [[nodiscard]] static ErrorCode Execute(
       Sink& sink, const uint8_t* codes, const uint8_t* args)
   {
     return Executor<Sink, Profile>(sink, codes, args).Run();
@@ -626,10 +626,10 @@ class Writer
    * @param codes 指向编译字节流的指针 / Pointer to the compiled byte stream
    * @param args 转发后的运行期实参 / Forwarded runtime arguments
    * @return 执行器运行结果 / Returns the executor result
-   */
+  */
   template <OutputSink Sink, auto ArgumentInfoList, auto ArgumentOrder,
             FormatProfile Profile, typename... Args>
-  [[nodiscard]] __attribute__((noinline)) static ErrorCode RunTaggedArgumentOrder(
+  LIBXR_FORCE_OPTIMIZE_OS LIBXR_NOINLINE [[nodiscard]] static ErrorCode RunTaggedArgumentOrder(
       Sink& sink, const uint8_t* codes, Args&&... args)
   {
     if constexpr (ArgumentInfoList.size() == 0)

--- a/src/driver/can.hpp
+++ b/src/driver/can.hpp
@@ -120,7 +120,7 @@ class CAN
    */
   virtual ~CAN() = default;
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @struct ClassicPack
    * @brief 经典 CAN 帧数据结构。Classic CAN frame structure.
@@ -132,7 +132,7 @@ class CAN
     uint8_t dlc;      ///< 有效数据长度（0~8）。Data length code (0–8).
     uint8_t data[8];  ///< 数据载荷。Data payload (up to 8 bytes).
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   /// 错误 ID 前缀 Error ID prefix.
   static constexpr uint32_t CAN_ERROR_ID_PREFIX = 0xFFFF0000u;
@@ -256,7 +256,7 @@ class FDCAN : public CAN
    */
   virtual ~FDCAN() = default;
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @struct FDPack
    * @brief CAN FD 帧数据结构。CAN FD frame structure.
@@ -268,7 +268,7 @@ class FDCAN : public CAN
     uint8_t len;       ///< 数据长度（0~64）。Data length (0–64 bytes).
     uint8_t data[64];  ///< 数据载荷。Data payload.
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   using CAN::AddMessage;
   using CAN::FilterMode;

--- a/src/driver/can.hpp
+++ b/src/driver/can.hpp
@@ -120,7 +120,7 @@ class CAN
    */
   virtual ~CAN() = default;
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @struct ClassicPack
    * @brief 经典 CAN 帧数据结构。Classic CAN frame structure.
@@ -132,7 +132,7 @@ LIBXR_PACK_PUSH_1
     uint8_t dlc;      ///< 有效数据长度（0~8）。Data length code (0–8).
     uint8_t data[8];  ///< 数据载荷。Data payload (up to 8 bytes).
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   /// 错误 ID 前缀 Error ID prefix.
   static constexpr uint32_t CAN_ERROR_ID_PREFIX = 0xFFFF0000u;
@@ -256,7 +256,7 @@ class FDCAN : public CAN
    */
   virtual ~FDCAN() = default;
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @struct FDPack
    * @brief CAN FD 帧数据结构。CAN FD frame structure.
@@ -268,7 +268,7 @@ LIBXR_PACK_PUSH_1
     uint8_t len;       ///< 数据长度（0~64）。Data length (0–64 bytes).
     uint8_t data[64];  ///< 数据载荷。Data payload.
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   using CAN::AddMessage;
   using CAN::FilterMode;

--- a/src/driver/usb/core/core.hpp
+++ b/src/driver/usb/core/core.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "libxr_def.hpp"
 #include <cstdint>
 
 namespace LibXR::USB
@@ -45,7 +46,7 @@ constexpr uint8_t REQ_DIRECTION_MASK = 0x80;  ///< 位7：方向 / Bit 7: Direct
 constexpr uint8_t REQ_TYPE_MASK = 0x60;       ///< 位6-5：类型 / Bits 6-5: Type
 constexpr uint8_t REQ_RECIPIENT_MASK = 0x1F;  ///< 位4-0：接收对象 / Bits 4-0: Recipient
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
 /**
  * @brief USB 标准请求 SETUP 包（固定8字节）
  *        Standard USB setup packet (8 bytes)
@@ -63,7 +64,7 @@ struct SetupPacket
   uint16_t wIndex;   ///< 对象索引，如接口号或端点号 / Index (e.g., interface or endpoint)
   uint16_t wLength;  ///< 数据阶段长度 / Number of bytes in data stage
 };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
 // 标准请求枚举
 enum class StandardRequest : uint8_t

--- a/src/driver/usb/core/core.hpp
+++ b/src/driver/usb/core/core.hpp
@@ -46,7 +46,7 @@ constexpr uint8_t REQ_DIRECTION_MASK = 0x80;  ///< 位7：方向 / Bit 7: Direct
 constexpr uint8_t REQ_TYPE_MASK = 0x60;       ///< 位6-5：类型 / Bits 6-5: Type
 constexpr uint8_t REQ_RECIPIENT_MASK = 0x1F;  ///< 位4-0：接收对象 / Bits 4-0: Recipient
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
 /**
  * @brief USB 标准请求 SETUP 包（固定8字节）
  *        Standard USB setup packet (8 bytes)
@@ -64,7 +64,7 @@ struct SetupPacket
   uint16_t wIndex;   ///< 对象索引，如接口号或端点号 / Index (e.g., interface or endpoint)
   uint16_t wLength;  ///< 数据阶段长度 / Number of bytes in data stage
 };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
 // 标准请求枚举
 enum class StandardRequest : uint8_t

--- a/src/driver/usb/core/desc_cfg.hpp
+++ b/src/driver/usb/core/desc_cfg.hpp
@@ -37,7 +37,7 @@ class ConfigDescriptorItem : public BosCapabilityProvider
  public:
   virtual ~ConfigDescriptorItem() = default;
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief 配置描述符头（9 字节）/ Configuration descriptor header (9 bytes)
    */
@@ -96,7 +96,7 @@ class ConfigDescriptorItem : public BosCapabilityProvider
     uint16_t wMaxPacketSize;         ///< 最大包长 / Maximum packet size
     uint8_t bInterval;               ///< 轮询间隔 / Polling interval
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   /**
    * @brief 绑定端点资源 / Bind endpoint resources

--- a/src/driver/usb/core/desc_cfg.hpp
+++ b/src/driver/usb/core/desc_cfg.hpp
@@ -37,7 +37,7 @@ class ConfigDescriptorItem : public BosCapabilityProvider
  public:
   virtual ~ConfigDescriptorItem() = default;
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief 配置描述符头（9 字节）/ Configuration descriptor header (9 bytes)
    */
@@ -96,7 +96,7 @@ LIBXR_PACK_PUSH_1
     uint16_t wMaxPacketSize;         ///< 最大包长 / Maximum packet size
     uint8_t bInterval;               ///< 轮询间隔 / Polling interval
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   /**
    * @brief 绑定端点资源 / Bind endpoint resources

--- a/src/driver/usb/core/desc_dev.hpp
+++ b/src/driver/usb/core/desc_dev.hpp
@@ -83,7 +83,7 @@ class DeviceDescriptor
   static constexpr uint8_t DEVICE_DESC_LENGTH =
       18;  ///< 设备描述符长度（固定18字节）/ Device descriptor length (18 bytes)
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   struct Data
   {
     uint8_t bLength;  ///< 描述符长度（固定18）/ Descriptor length (always 18)
@@ -102,7 +102,7 @@ class DeviceDescriptor
     uint8_t iSerialNumber;        ///< 序列号字符串索引 / Index of serial number string
     uint8_t bNumConfigurations;   ///< 支持的配置数 / Number of possible configurations
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   static_assert(sizeof(Data) == 18, "DeviceDescriptor must be 18 bytes");
 

--- a/src/driver/usb/core/desc_dev.hpp
+++ b/src/driver/usb/core/desc_dev.hpp
@@ -83,7 +83,7 @@ class DeviceDescriptor
   static constexpr uint8_t DEVICE_DESC_LENGTH =
       18;  ///< 设备描述符长度（固定18字节）/ Device descriptor length (18 bytes)
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   struct Data
   {
     uint8_t bLength;  ///< 描述符长度（固定18）/ Descriptor length (always 18)
@@ -102,7 +102,7 @@ LIBXR_PACK_PUSH_1
     uint8_t iSerialNumber;        ///< 序列号字符串索引 / Index of serial number string
     uint8_t bNumConfigurations;   ///< 支持的配置数 / Number of possible configurations
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   static_assert(sizeof(Data) == 18, "DeviceDescriptor must be 18 bytes");
 

--- a/src/driver/usb/device/bos/webusb.hpp
+++ b/src/driver/usb/device/bos/webusb.hpp
@@ -27,7 +27,7 @@ static constexpr uint8_t WEBUSB_PLATFORM_CAPABILITY_UUID[16] = {
     0x8B, 0xFD, 0xA0, 0x76, 0x88, 0x15, 0xB6, 0x65,
 };
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
 
 /**
  * @brief WebUSB BOS 平台能力描述符 / WebUSB BOS platform capability descriptor
@@ -43,7 +43,7 @@ struct WebUsbPlatformCapability
   uint8_t bVendorCode = WEBUSB_VENDOR_CODE_DEFAULT;
   uint8_t iLandingPage = 0u;
 };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
 static_assert(sizeof(WebUsbPlatformCapability) == 24,
               "WebUSB platform capability size mismatch.");

--- a/src/driver/usb/device/bos/webusb.hpp
+++ b/src/driver/usb/device/bos/webusb.hpp
@@ -27,7 +27,7 @@ static constexpr uint8_t WEBUSB_PLATFORM_CAPABILITY_UUID[16] = {
     0x8B, 0xFD, 0xA0, 0x76, 0x88, 0x15, 0xB6, 0x65,
 };
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
 
 /**
  * @brief WebUSB BOS 平台能力描述符 / WebUSB BOS platform capability descriptor
@@ -43,7 +43,7 @@ struct WebUsbPlatformCapability
   uint8_t bVendorCode = WEBUSB_VENDOR_CODE_DEFAULT;
   uint8_t iLandingPage = 0u;
 };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
 static_assert(sizeof(WebUsbPlatformCapability) == 24,
               "WebUSB platform capability size mismatch.");

--- a/src/driver/usb/device/bos/winusb_msos20.hpp
+++ b/src/driver/usb/device/bos/winusb_msos20.hpp
@@ -47,7 +47,7 @@ static constexpr uint8_t PROP_NAME_DEVICE_INTERFACE_GUIDS_UTF16[] = {
 static constexpr uint16_t PROP_NAME_DEVICE_INTERFACE_GUIDS_BYTES =
     static_cast<uint16_t>(sizeof(PROP_NAME_DEVICE_INTERFACE_GUIDS_UTF16));
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
 
 // ---- MS OS 2.0 basic blocks ----
 
@@ -243,7 +243,7 @@ struct FunctionScopedWinUsbMsOs20DescSet
   }
 };
 
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
 // ---- sanity checks ----
 static_assert(sizeof(MsOs20SetHeader) == 10, "SetHeader size mismatch");

--- a/src/driver/usb/device/bos/winusb_msos20.hpp
+++ b/src/driver/usb/device/bos/winusb_msos20.hpp
@@ -47,7 +47,7 @@ static constexpr uint8_t PROP_NAME_DEVICE_INTERFACE_GUIDS_UTF16[] = {
 static constexpr uint16_t PROP_NAME_DEVICE_INTERFACE_GUIDS_BYTES =
     static_cast<uint16_t>(sizeof(PROP_NAME_DEVICE_INTERFACE_GUIDS_UTF16));
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
 
 // ---- MS OS 2.0 basic blocks ----
 
@@ -243,7 +243,7 @@ struct FunctionScopedWinUsbMsOs20DescSet
   }
 };
 
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
 // ---- sanity checks ----
 static_assert(sizeof(MsOs20SetHeader) == 10, "SetHeader size mismatch");

--- a/src/driver/usb/device/cdc/cdc_base.hpp
+++ b/src/driver/usb/device/cdc/cdc_base.hpp
@@ -81,7 +81,7 @@ class CDCBase : public DeviceClass
                           ///< (required for CDC-ACM)
   };
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief CDC线路编码参数结构体
    *        CDC line coding parameters structure
@@ -115,7 +115,7 @@ class CDCBase : public DeviceClass
     uint16_t wLength;       ///< 数据长度（固定为2）| Data length (fixed to 2)
     uint16_t serialState;   ///< 串行状态位图 / Serial state bitmap
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   // 确保 CDCLineCoding 结构体大小为 7 字节。
   // Ensure CDCLineCoding is exactly 7 bytes.
@@ -603,7 +603,7 @@ class CDCBase : public DeviceClass
     }
   }
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief CDC描述符块结构
    *        CDC descriptor block structure
@@ -659,7 +659,7 @@ class CDCBase : public DeviceClass
     EndpointDescriptor data_ep_out;  ///< 数据OUT端点描述符 / Data OUT endpoint descriptor
     EndpointDescriptor data_ep_in;   ///< 数据IN端点描述符 / Data IN endpoint descriptor
   } desc_block_;
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
  protected:
   CDCLineCoding& GetLineCoding() { return line_coding_; }

--- a/src/driver/usb/device/cdc/cdc_base.hpp
+++ b/src/driver/usb/device/cdc/cdc_base.hpp
@@ -81,7 +81,7 @@ class CDCBase : public DeviceClass
                           ///< (required for CDC-ACM)
   };
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief CDC线路编码参数结构体
    *        CDC line coding parameters structure
@@ -115,7 +115,7 @@ LIBXR_PACK_PUSH_1
     uint16_t wLength;       ///< 数据长度（固定为2）| Data length (fixed to 2)
     uint16_t serialState;   ///< 串行状态位图 / Serial state bitmap
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   // 确保 CDCLineCoding 结构体大小为 7 字节。
   // Ensure CDCLineCoding is exactly 7 bytes.
@@ -603,7 +603,7 @@ LIBXR_PACK_POP()
     }
   }
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief CDC描述符块结构
    *        CDC descriptor block structure
@@ -659,7 +659,7 @@ LIBXR_PACK_PUSH_1
     EndpointDescriptor data_ep_out;  ///< 数据OUT端点描述符 / Data OUT endpoint descriptor
     EndpointDescriptor data_ep_in;   ///< 数据IN端点描述符 / Data IN endpoint descriptor
   } desc_block_;
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
  protected:
   CDCLineCoding& GetLineCoding() { return line_coding_; }

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -2969,7 +2969,7 @@ class DapLinkV2Class : public DeviceClass
   uint8_t in_tx_multi_storage_[MAX_DAP_PACKET_SIZE] = {};
   LibXR::RawData in_tx_multi_buf_{in_tx_multi_storage_, DEFAULT_DAP_PACKET_SIZE};
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief MS OS 2.0 描述符集合布局 / MS OS 2.0 descriptor set layout
    */
@@ -2998,7 +2998,7 @@ LIBXR_PACK_PUSH_1
           data[GUID_MULTI_SZ_UTF_16_BYTES];  ///< REG_MULTI_SZ 数据 / REG_MULTI_SZ data
     } prop;
   } winusb_msos20_{};
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
  private:
   SwdPort& swd_;  ///< SWD 链路 / SWD link
@@ -3028,7 +3028,7 @@ LIBXR_PACK_POP()
   bool inited_ = false;        ///< Initialized flag
   uint8_t interface_num_ = 0;  ///< Interface number
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief Descriptor block (Interface + 2x Endpoint)
    *
@@ -3039,7 +3039,7 @@ LIBXR_PACK_PUSH_1
     EndpointDescriptor ep_out;  ///< OUT endpoint descriptor / OUT endpoint descriptor
     EndpointDescriptor ep_in;   ///< IN endpoint descriptor / IN endpoint descriptor
   } desc_block_{};
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
  private:
   LibXR::USB::WinUsbMsOs20::MsOs20BosCapability winusb_msos20_cap_{

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -2969,7 +2969,7 @@ class DapLinkV2Class : public DeviceClass
   uint8_t in_tx_multi_storage_[MAX_DAP_PACKET_SIZE] = {};
   LibXR::RawData in_tx_multi_buf_{in_tx_multi_storage_, DEFAULT_DAP_PACKET_SIZE};
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief MS OS 2.0 描述符集合布局 / MS OS 2.0 descriptor set layout
    */
@@ -2998,7 +2998,7 @@ class DapLinkV2Class : public DeviceClass
           data[GUID_MULTI_SZ_UTF_16_BYTES];  ///< REG_MULTI_SZ 数据 / REG_MULTI_SZ data
     } prop;
   } winusb_msos20_{};
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
  private:
   SwdPort& swd_;  ///< SWD 链路 / SWD link
@@ -3028,7 +3028,7 @@ class DapLinkV2Class : public DeviceClass
   bool inited_ = false;        ///< Initialized flag
   uint8_t interface_num_ = 0;  ///< Interface number
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief Descriptor block (Interface + 2x Endpoint)
    *
@@ -3039,7 +3039,7 @@ class DapLinkV2Class : public DeviceClass
     EndpointDescriptor ep_out;  ///< OUT endpoint descriptor / OUT endpoint descriptor
     EndpointDescriptor ep_in;   ///< IN endpoint descriptor / IN endpoint descriptor
   } desc_block_{};
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
  private:
   LibXR::USB::WinUsbMsOs20::MsOs20BosCapability winusb_msos20_cap_{

--- a/src/driver/usb/device/dfu/dfu_bootloader.hpp
+++ b/src/driver/usb/device/dfu/dfu_bootloader.hpp
@@ -16,7 +16,7 @@ class DfuBootloaderBackend
   using JumpCallback = void (*)(void*);
   static constexpr uint32_t SEAL_MAGIC = 0x4C414553u;  // "SEAL"
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief seal 区固定记录 / Fixed record stored in the seal region
    */
@@ -27,7 +27,7 @@ class DfuBootloaderBackend
     uint32_t crc32 = 0u;
     uint32_t crc32_inv = 0u;
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   // Backend 负责：
   // - 管理 download/upload/manifest 状态
@@ -754,7 +754,7 @@ class DFUClass : public DfuInterfaceClassBase
   static constexpr uint8_t ATTR_WILL_DETACH = 0x08u;
 
  public:
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief DFU Functional Descriptor（固件模式）
    *        DFU Functional Descriptor for firmware mode.
@@ -804,7 +804,7 @@ class DFUClass : public DfuInterfaceClassBase
         0};
     FunctionalDescriptor func_desc = {};
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   static_assert(sizeof(FunctionalDescriptor) == 9,
                 "DFU functional descriptor size mismatch.");

--- a/src/driver/usb/device/dfu/dfu_bootloader.hpp
+++ b/src/driver/usb/device/dfu/dfu_bootloader.hpp
@@ -16,7 +16,7 @@ class DfuBootloaderBackend
   using JumpCallback = void (*)(void*);
   static constexpr uint32_t SEAL_MAGIC = 0x4C414553u;  // "SEAL"
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief seal 区固定记录 / Fixed record stored in the seal region
    */
@@ -27,7 +27,7 @@ LIBXR_PACK_PUSH_1
     uint32_t crc32 = 0u;
     uint32_t crc32_inv = 0u;
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   // Backend 负责：
   // - 管理 download/upload/manifest 状态
@@ -754,7 +754,7 @@ class DFUClass : public DfuInterfaceClassBase
   static constexpr uint8_t ATTR_WILL_DETACH = 0x08u;
 
  public:
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief DFU Functional Descriptor（固件模式）
    *        DFU Functional Descriptor for firmware mode.
@@ -804,7 +804,7 @@ LIBXR_PACK_PUSH_1
         0};
     FunctionalDescriptor func_desc = {};
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   static_assert(sizeof(FunctionalDescriptor) == 9,
                 "DFU functional descriptor size mismatch.");

--- a/src/driver/usb/device/dfu/dfu_runtime.hpp
+++ b/src/driver/usb/device/dfu/dfu_runtime.hpp
@@ -58,7 +58,7 @@ class DfuRuntimeClass : public DfuInterfaceClassBase
   }
 
  protected:
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief DFU Functional Descriptor（Runtime 变体）
    *        DFU Functional Descriptor for the runtime variant.
@@ -102,7 +102,7 @@ LIBXR_PACK_PUSH_1
         0};
     FunctionalDescriptor func_desc = {};
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   void BindEndpoints(EndpointPool&, uint8_t start_itf_num, bool) override
   {

--- a/src/driver/usb/device/dfu/dfu_runtime.hpp
+++ b/src/driver/usb/device/dfu/dfu_runtime.hpp
@@ -58,7 +58,7 @@ class DfuRuntimeClass : public DfuInterfaceClassBase
   }
 
  protected:
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief DFU Functional Descriptor（Runtime 变体）
    *        DFU Functional Descriptor for the runtime variant.
@@ -102,7 +102,7 @@ class DfuRuntimeClass : public DfuInterfaceClassBase
         0};
     FunctionalDescriptor func_desc = {};
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   void BindEndpoints(EndpointPool&, uint8_t start_itf_num, bool) override
   {

--- a/src/driver/usb/device/gsusb/gs_usb.hpp
+++ b/src/driver/usb/device/gsusb/gs_usb.hpp
@@ -39,7 +39,7 @@ class GsUsbClass : public DeviceClass
  private:
   // ===== Linux gs_usb 线缆格式（固定 12 字节头） / Linux gs_usb wire format
   // (fixed 12-byte header) =====
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
 
   /**
    * @brief gs_usb 线缆格式头（12 字节） / gs_usb wire-format header (12 bytes)
@@ -53,7 +53,7 @@ LIBXR_PACK_PUSH_1
     uint8_t flags;     ///< 帧标志（GS_CAN_FLAG_*） / Frame flags (GS_CAN_FLAG_*)
     uint8_t reserved;  ///< 保留 / Reserved
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   static constexpr uint32_t ECHO_ID_RX =
       0xFFFFFFFFu;  ///< RX 帧 echo_id 固定值 / Fixed echo_id for RX frames
@@ -966,7 +966,7 @@ LIBXR_PACK_POP()
   uint8_t ctrl_target_channel_ =
       0;  ///< 控制请求目标通道 / Control request target channel
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief 本类的接口与端点描述符块 / Descriptor block for interface and endpoints
    */
@@ -976,7 +976,7 @@ LIBXR_PACK_PUSH_1
     EndpointDescriptor ep_out;  ///< OUT 端点描述符 / OUT endpoint descriptor
     EndpointDescriptor ep_in;   ///< IN 端点描述符 / IN endpoint descriptor
   } desc_block_{};
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   uint8_t rx_buf_[WIRE_MAX_SIZE]{};  ///< OUT 接收缓冲区 / OUT receive buffer
   std::array<uint8_t, WIRE_MAX_SIZE>

--- a/src/driver/usb/device/gsusb/gs_usb.hpp
+++ b/src/driver/usb/device/gsusb/gs_usb.hpp
@@ -39,7 +39,7 @@ class GsUsbClass : public DeviceClass
  private:
   // ===== Linux gs_usb 线缆格式（固定 12 字节头） / Linux gs_usb wire format
   // (fixed 12-byte header) =====
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
 
   /**
    * @brief gs_usb 线缆格式头（12 字节） / gs_usb wire-format header (12 bytes)
@@ -53,7 +53,7 @@ class GsUsbClass : public DeviceClass
     uint8_t flags;     ///< 帧标志（GS_CAN_FLAG_*） / Frame flags (GS_CAN_FLAG_*)
     uint8_t reserved;  ///< 保留 / Reserved
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   static constexpr uint32_t ECHO_ID_RX =
       0xFFFFFFFFu;  ///< RX 帧 echo_id 固定值 / Fixed echo_id for RX frames
@@ -966,7 +966,7 @@ class GsUsbClass : public DeviceClass
   uint8_t ctrl_target_channel_ =
       0;  ///< 控制请求目标通道 / Control request target channel
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief 本类的接口与端点描述符块 / Descriptor block for interface and endpoints
    */
@@ -976,7 +976,7 @@ class GsUsbClass : public DeviceClass
     EndpointDescriptor ep_out;  ///< OUT 端点描述符 / OUT endpoint descriptor
     EndpointDescriptor ep_in;   ///< IN 端点描述符 / IN endpoint descriptor
   } desc_block_{};
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   uint8_t rx_buf_[WIRE_MAX_SIZE]{};  ///< OUT 接收缓冲区 / OUT receive buffer
   std::array<uint8_t, WIRE_MAX_SIZE>

--- a/src/driver/usb/device/gsusb/gs_usb_protocol.hpp
+++ b/src/driver/usb/device/gsusb/gs_usb_protocol.hpp
@@ -140,7 +140,7 @@ enum class TerminationState : uint32_t
 
 // =================== 控制传输结构体（packed 对齐原协议） ===================
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
 
 /**
  * @brief 主机配置（字节序协商） / Host configuration (byte order negotiation)
@@ -266,7 +266,7 @@ struct HostFrame
   uint32_t timestamp_us;  ///< 时间戳（可选） / Timestamp (optional)
 };
 
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
 // =================== MODE 标志位（GS_CAN_MODE_*） ===================
 

--- a/src/driver/usb/device/gsusb/gs_usb_protocol.hpp
+++ b/src/driver/usb/device/gsusb/gs_usb_protocol.hpp
@@ -140,7 +140,7 @@ enum class TerminationState : uint32_t
 
 // =================== 控制传输结构体（packed 对齐原协议） ===================
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
 
 /**
  * @brief 主机配置（字节序协商） / Host configuration (byte order negotiation)
@@ -266,7 +266,7 @@ struct HostFrame
   uint32_t timestamp_us;  ///< 时间戳（可选） / Timestamp (optional)
 };
 
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
 // =================== MODE 标志位（GS_CAN_MODE_*） ===================
 

--- a/src/driver/usb/device/hid/hid.hpp
+++ b/src/driver/usb/device/hid/hid.hpp
@@ -61,7 +61,7 @@ class HID : public DeviceClass
     FEATURE = 3  ///< 特征报告 / Feature report
   };
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief HID描述符结构体
    *        HID descriptor structure
@@ -100,7 +100,7 @@ LIBXR_PACK_PUSH_1
     EndpointDescriptor ep_in;   ///< IN 端点描述符 / IN endpoint descriptor
     EndpointDescriptor ep_out;  ///< OUT 端点描述符 / OUT endpoint descriptor
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   /**
    * @brief HID 构造函数

--- a/src/driver/usb/device/hid/hid.hpp
+++ b/src/driver/usb/device/hid/hid.hpp
@@ -61,7 +61,7 @@ class HID : public DeviceClass
     FEATURE = 3  ///< 特征报告 / Feature report
   };
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief HID描述符结构体
    *        HID descriptor structure
@@ -100,7 +100,7 @@ class HID : public DeviceClass
     EndpointDescriptor ep_in;   ///< IN 端点描述符 / IN endpoint descriptor
     EndpointDescriptor ep_out;  ///< OUT 端点描述符 / OUT endpoint descriptor
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   /**
    * @brief HID 构造函数

--- a/src/driver/usb/device/hid/hid_gamepad.hpp
+++ b/src/driver/usb/device/hid/hid_gamepad.hpp
@@ -71,7 +71,7 @@ class HIDGamepadT
     BTN8 = 0x80,
   };
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief 输入报告结构（9 字节） / Input report structure (9 bytes)
    * @details 4 个 16 位轴（LOG_MIN..LOG_MAX）+ 8 位按钮 / Four 16-bit axes
@@ -85,7 +85,7 @@ LIBXR_PACK_PUSH_1
     int16_t rx;       ///< Rx 轴 / Rx axis (LOG_MIN..LOG_MAX)
     uint8_t buttons;  ///< 按钮位 / Button bits (8)
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   static_assert(sizeof(Report) == 9, "Report size must be 9 bytes");
 

--- a/src/driver/usb/device/hid/hid_gamepad.hpp
+++ b/src/driver/usb/device/hid/hid_gamepad.hpp
@@ -71,7 +71,7 @@ class HIDGamepadT
     BTN8 = 0x80,
   };
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief 输入报告结构（9 字节） / Input report structure (9 bytes)
    * @details 4 个 16 位轴（LOG_MIN..LOG_MAX）+ 8 位按钮 / Four 16-bit axes
@@ -85,7 +85,7 @@ class HIDGamepadT
     int16_t rx;       ///< Rx 轴 / Rx axis (LOG_MIN..LOG_MAX)
     uint8_t buttons;  ///< 按钮位 / Button bits (8)
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   static_assert(sizeof(Report) == 9, "Report size must be 9 bytes");
 

--- a/src/driver/usb/device/uac/uac_mic.hpp
+++ b/src/driver/usb/device/uac/uac_mic.hpp
@@ -182,7 +182,7 @@ class UAC1MicrophoneQ : public DeviceClass
     ID_OT_USB = 3
   };
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief AC 头描述符
    *        AC header descriptor
@@ -308,7 +308,7 @@ class UAC1MicrophoneQ : public DeviceClass
     EndpointDescriptorIso9 ep_in;  ///< 标准 IN 端点（9B）/ Std IN EP (9B)
     CSEndpointGeneral ep_cs;       ///< 类特定端点 / CS EP
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   // ===== DeviceClass 接口实现 / DeviceClass implementation =====
   /**

--- a/src/driver/usb/device/uac/uac_mic.hpp
+++ b/src/driver/usb/device/uac/uac_mic.hpp
@@ -182,7 +182,7 @@ class UAC1MicrophoneQ : public DeviceClass
     ID_OT_USB = 3
   };
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief AC 头描述符
    *        AC header descriptor
@@ -308,7 +308,7 @@ LIBXR_PACK_PUSH_1
     EndpointDescriptorIso9 ep_in;  ///< 标准 IN 端点（9B）/ Std IN EP (9B)
     CSEndpointGeneral ep_cs;       ///< 类特定端点 / CS EP
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   // ===== DeviceClass 接口实现 / DeviceClass implementation =====
   /**

--- a/src/middleware/database/raw/layout.hpp
+++ b/src/middleware/database/raw/layout.hpp
@@ -13,7 +13,7 @@
     BACKUP = 1  ///< 备份块 (Backup block).
   };
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief 按最小写入单元存放布尔位图块
    *        (Boolean flag block stored in one aligned write unit span).
@@ -24,7 +24,7 @@
   {
     uint8_t data[BlockSize];
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   /**
    * @brief 读写对齐布尔位图块的工具
@@ -97,7 +97,7 @@
     }
   };
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief 键信息结构，存储键的元数据
    *        (Structure containing key metadata).
@@ -152,9 +152,9 @@
      */
     uint32_t GetDataSize() const { return raw_info & 0x01FFFFFF; }
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief Flash 存储的块信息结构
    *        (Structure representing a Flash storage block).
@@ -183,4 +183,4 @@
     };
     KeyInfo key;  ///< 紧跟在块头后的首个键头 / First key header stored right after the block header.
   };
-#pragma pack(pop)
+LIBXR_PACK_POP()

--- a/src/middleware/database/raw/layout.hpp
+++ b/src/middleware/database/raw/layout.hpp
@@ -13,7 +13,7 @@
     BACKUP = 1  ///< 备份块 (Backup block).
   };
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief 按最小写入单元存放布尔位图块
    *        (Boolean flag block stored in one aligned write unit span).
@@ -24,7 +24,7 @@ LIBXR_PACK_PUSH_1
   {
     uint8_t data[BlockSize];
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   /**
    * @brief 读写对齐布尔位图块的工具
@@ -97,7 +97,7 @@ LIBXR_PACK_POP()
     }
   };
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief 键信息结构，存储键的元数据
    *        (Structure containing key metadata).
@@ -152,9 +152,9 @@ LIBXR_PACK_PUSH_1
      */
     uint32_t GetDataSize() const { return raw_info & 0x01FFFFFF; }
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief Flash 存储的块信息结构
    *        (Structure representing a Flash storage block).
@@ -183,4 +183,4 @@ LIBXR_PACK_PUSH_1
     };
     KeyInfo key;  ///< 紧跟在块头后的首个键头 / First key header stored right after the block header.
   };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END

--- a/src/middleware/database/raw_sequential.hpp
+++ b/src/middleware/database/raw_sequential.hpp
@@ -109,7 +109,7 @@ class DatabaseRawSequential : public Database
     BACKUP = 1  ///< 备份块 (Backup block).
   };
 
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
   /**
    * @brief 键信息结构，存储键的元数据
    *        (Structure containing key metadata).
@@ -172,7 +172,7 @@ class DatabaseRawSequential : public Database
   };
 
   static_assert(sizeof(KeyInfo) == 4, "KeyInfo size must be 4 bytes");
-#pragma pack(pop)
+LIBXR_PACK_POP()
 
   /**
    * @brief Flash 存储的块信息结构

--- a/src/middleware/database/raw_sequential.hpp
+++ b/src/middleware/database/raw_sequential.hpp
@@ -109,7 +109,7 @@ class DatabaseRawSequential : public Database
     BACKUP = 1  ///< 备份块 (Backup block).
   };
 
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
   /**
    * @brief 键信息结构，存储键的元数据
    *        (Structure containing key metadata).
@@ -172,7 +172,7 @@ LIBXR_PACK_PUSH_1
   };
 
   static_assert(sizeof(KeyInfo) == 4, "KeyInfo size must be 4 bytes");
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 
   /**
    * @brief Flash 存储的块信息结构

--- a/src/middleware/message/packet/packet.hpp
+++ b/src/middleware/message/packet/packet.hpp
@@ -5,7 +5,7 @@
 namespace LibXR
 {
 #ifndef __DOXYGEN__
-#pragma pack(push, 1)
+LIBXR_PACK_PUSH_1
 /**
  * @struct Topic::PackedDataHeader
  * @brief 打包消息的固定 16 字节头 / Fixed 16-byte header of one packed message
@@ -92,7 +92,7 @@ class Topic::PackedData
    */
   MicrosecondTimestamp GetTimestamp() const { return raw.header_.GetTimestamp(); }
 };
-#pragma pack(pop)
+LIBXR_PACK_POP()
 #endif
 
 /**

--- a/src/middleware/message/packet/packet.hpp
+++ b/src/middleware/message/packet/packet.hpp
@@ -5,7 +5,7 @@
 namespace LibXR
 {
 #ifndef __DOXYGEN__
-LIBXR_PACK_PUSH_1
+LIBXR_PACKED_BEGIN
 /**
  * @struct Topic::PackedDataHeader
  * @brief 打包消息的固定 16 字节头 / Fixed 16-byte header of one packed message
@@ -92,7 +92,7 @@ class Topic::PackedData
    */
   MicrosecondTimestamp GetTimestamp() const { return raw.header_.GetTimestamp(); }
 };
-LIBXR_PACK_POP()
+LIBXR_PACKED_END
 #endif
 
 /**

--- a/src/utils/crc.hpp
+++ b/src/utils/crc.hpp
@@ -4,6 +4,8 @@
 #include <cstdio>
 #include <cstring>
 
+#include "libxr_def.hpp"
+
 namespace LibXR
 {
 /**
@@ -64,7 +66,7 @@ class CRC8
    * @param len 数据长度 / Length of the data
    * @return 计算得到的 CRC8 值 / Computed CRC8 value
    */
-  static uint8_t Calculate(const void* raw, size_t len)
+  LIBXR_FORCE_OPTIMIZE_O3 static uint8_t Calculate(const void* raw, size_t len)
   {
     const uint8_t* buf = reinterpret_cast<const uint8_t*>(raw);
     if (!inited_)
@@ -156,7 +158,7 @@ class CRC16
    * @param len 数据长度 / Length of the data
    * @return 计算得到的 CRC16 值 / Computed CRC16 value
    */
-  static uint16_t Calculate(const void* raw, size_t len)
+  LIBXR_FORCE_OPTIMIZE_O3 static uint16_t Calculate(const void* raw, size_t len)
   {
     const uint8_t* buf = reinterpret_cast<const uint8_t*>(raw);
     if (!inited_)
@@ -251,7 +253,7 @@ class CRC32
    * @param len 数据长度 / Length of the data
    * @return 计算得到的 CRC32 值 / Computed CRC32 value
    */
-  static uint32_t Calculate(const void* raw, size_t len)
+  LIBXR_FORCE_OPTIMIZE_O3 static uint32_t Calculate(const void* raw, size_t len)
   {
     const uint8_t* buf = reinterpret_cast<const uint8_t*>(raw);
     if (!inited_)
@@ -347,7 +349,7 @@ class CRC64
    * @param len 数据长度 / Length of the data
    * @return 计算得到的 CRC64 值 / Computed CRC64 value
    */
-  static uint64_t Calculate(const void* raw, size_t len)
+  LIBXR_FORCE_OPTIMIZE_O3 static uint64_t Calculate(const void* raw, size_t len)
   {
     const uint8_t* buf = reinterpret_cast<const uint8_t*>(raw);
     if (!inited_)


### PR DESCRIPTION
## Summary

- unify compiler compatibility macros in `src/core/libxr_def.hpp`
- replace raw pack pragmas and raw `noinline` attributes with shared macros
- keep targeted per-function optimization hints on selected hot paths
- add `LIBXR_FORCE_OPTIMIZE_OS` for the `print` runtime entry shells
- apply `LIBXR_FORCE_OPTIMIZE_O3` to `FastCopy`, `FastMove`, `FastSet`, and CRC calculate paths

## Details

This patch consolidates the compiler-facing boundary into shared macros:

- `LIBXR_FORCE_OPTIMIZE_O3`
- `LIBXR_FORCE_OPTIMIZE_OS`
- `LIBXR_NOINLINE`
- `LIBXR_PACK_PUSH_1`
- `LIBXR_PACK_POP()`
- `LIBXR_PACKED`

Then it updates existing call sites to use those macros instead of raw compiler attributes or raw pack pragmas.

Targeted runtime tuning included in this branch:

- `LibXR::Memory::FastCopy`
- `LibXR::Memory::FastMove`
- `LibXR::Memory::FastSet`
- `CRC8::Calculate`
- `CRC16::Calculate`
- `CRC32::Calculate`
- `CRC64::Calculate`
- `Print::Writer::Execute`
- `Print::Writer::RunTaggedArgumentOrder`

The `print` entry shells keep their explicit `noinline` boundary and now use `LIBXR_FORCE_OPTIMIZE_OS` rather than a speed-oriented optimization level.

## Validation

Validated on Ubuntu24:

- `/home/xiao/runs/libxr_mem_crc_os_probe_verify_20260606T181032Z/99_summary.txt`
  - `cmake=PASS`
  - `build=PASS`
  - `test=PASS`
- `/home/xiao/runs/libxr_noinline_tidy_probe_verify_20260606T182820Z/99_summary.txt`
  - `cmake=PASS`
  - `build=PASS`
  - `test=PASS`
- `/home/xiao/runs/libxr_print_os_probe_verify_20260606T180639Z/99_summary.txt`
  - `cmake=PASS`
  - `build=PASS`
  - `test=PASS`
- `/home/xiao/runs/libxr_macro_final_pushverify_20260606T115416Z/99_summary.txt`
  - `cmake=PASS`
  - `build=PASS`
  - `test=PASS`

Additional host probe retained for decision-making only:

- `/home/xiao/runs/libxr_fastcmp_o3_bench_20260606T181235Z/fastcmp_compare.csv`
- `/home/xiao/runs/libxr_fastcmp_o3_bench_20260606T181235Z/fastcmp_compare_r2.csv`
- `/home/xiao/runs/libxr_fastcmp_o3_bench_20260606T181235Z/fastcmp_compare_r3.csv`

That probe showed mixed host-only results for forcing `O3` on `FastCmp`, so `FastCmp` is intentionally left unchanged in this branch.

## 由 Sourcery 提供的摘要

统一用于优化提示、`noinline` 边界以及紧凑结构（packed structure）的编译器兼容宏，并将它们应用到核心内存、CRC、打印、闪存以及 USB 相关的代码路径中。

增强内容：
- 引入用于优化级别、`noinline` 和结构体紧凑（struct packing）的共享编译器抽象宏，用它们替换各编译器特定的属性和编译指示（pragmas）。
- 使用显式的优化级别和 `noinline` 宏来调优内存操作、CRC 计算、打印执行器等热点路径函数，以在不同编译器之间实现一致的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify compiler compatibility macros for optimization hints, noinline boundaries, and packed structures, and apply them across core memory, CRC, print, flash, and USB-related code paths.

Enhancements:
- Introduce shared compiler abstraction macros for optimization level, noinline, and struct packing and use them in place of compiler-specific attributes and pragmas.
- Tune hot-path functions such as memory operations, CRC calculations, and print executors with explicit optimization-level and noinline macros for consistent cross-compiler behavior.

</details>