### PR TITLE
feat(structure): add bounded mpmc queue

### DIFF
--- a/src/libxr.hpp
+++ b/src/libxr.hpp
@@ -26,6 +26,7 @@
 #include "lockfree_queue.hpp"
 #include "logger.hpp"
 #include "message.hpp"
+#include "mpmc_queue.hpp"
 #if defined(LIBXR_SYSTEM_POSIX_HOST)
 #include "linux_shared_topic.hpp"
 #endif

--- a/src/structure/mpmc_queue.hpp
+++ b/src/structure/mpmc_queue.hpp
@@ -21,13 +21,15 @@ namespace LibXR
 template <typename Payload>
 class MPMCQueue
 {
+  /// @brief 仅接受平凡可拷贝 payload / Accepts only trivially copyable payloads.
   static_assert(std::is_trivially_copyable_v<Payload>,
                 "MPMCQueue requires trivially copyable payloads");
+  /// @brief 仅接受平凡可析构 payload / Accepts only trivially destructible payloads.
   static_assert(std::is_trivially_destructible_v<Payload>,
                 "MPMCQueue requires trivially destructible payloads");
 
  public:
-  using ValueType = Payload;
+  using ValueType = Payload;  ///< 队列元素类型 / Queue element type.
 
   /**
    * @brief 构造一个 MPMC 队列 / Construct one MPMC queue
@@ -86,6 +88,6 @@ class MPMCQueue
   [[nodiscard]] size_t EmptySize() const { return core_.EmptySize(); }
 
  protected:
-  MPMCQueueCore core_;
+  MPMCQueueCore core_;  ///< 共享字节队列内核 / Shared byte-queue core.
 };
 }  // namespace LibXR

--- a/src/structure/mpmc_queue.hpp
+++ b/src/structure/mpmc_queue.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+#include "mpmc_queue_core.hpp"
+
+namespace LibXR
+{
+/**
+ * @class MPMCQueue
+ * @brief 带固定 payload 类型的有界 MPMC 队列 / Bounded MPMC queue with a fixed payload type
+ */
+template <typename Payload>
+class MPMCQueue
+{
+  static_assert(std::is_trivially_copyable_v<Payload>,
+                "MPMCQueue requires trivially copyable payloads");
+  static_assert(std::is_trivially_destructible_v<Payload>,
+                "MPMCQueue requires trivially destructible payloads");
+  static_assert(alignof(Payload) <= alignof(size_t),
+                "MPMCQueue only supports payloads aligned no stricter than size_t");
+
+ public:
+  using ValueType = Payload;
+
+  /**
+   * @brief 构造一个 MPMC 队列 / Construct one MPMC queue
+   * @param capacity 队列容量 / Queue capacity
+   *
+   * @note 包含动态内存分配。
+   *       Contains dynamic memory allocation.
+   */
+  explicit MPMCQueue(size_t capacity)
+      : core_(sizeof(Payload), capacity)
+  {
+  }
+
+  /**
+   * @brief 向队列尾部推入一个 payload / Push one payload into the queue tail
+   * @param value 待入队 payload / Payload to enqueue
+   * @return 成功返回 `ErrorCode::OK`；队列满返回 `ErrorCode::FULL`
+   *         Returns `ErrorCode::OK` on success; returns `ErrorCode::FULL` when
+   *         the queue is full
+   */
+  ErrorCode Push(const Payload& value) { return core_.PushBytes(&value); }
+
+  /**
+   * @brief 从队列头部弹出一个 payload / Pop one payload from the queue head
+   * @param value 用于接收 payload / Receives the dequeued payload
+   * @return 成功返回 `ErrorCode::OK`；队列空返回 `ErrorCode::EMPTY`
+   *         Returns `ErrorCode::OK` on success; returns `ErrorCode::EMPTY` when
+   *         the queue is empty
+   */
+  ErrorCode Pop(Payload& value) { return core_.PopBytes(&value); }
+
+  /**
+   * @brief 丢弃一个队头 payload / Discard one front payload
+   * @return 成功返回 `ErrorCode::OK`；队列空返回 `ErrorCode::EMPTY`
+   *         Returns `ErrorCode::OK` on success; returns `ErrorCode::EMPTY` when
+   *         the queue is empty
+   */
+  ErrorCode Pop() { return core_.PopBytes(); }
+
+  /**
+   * @brief 获取队列最大容量 / Get the maximum queue capacity
+   * @return 队列容量 / Queue capacity
+   */
+  [[nodiscard]] size_t MaxSize() const { return core_.MaxSize(); }
+
+  /**
+   * @brief 获取当前已用元素数 / Get the current element count
+   * @return 当前元素个数 / Current number of stored payloads
+   */
+  [[nodiscard]] size_t Size() const { return core_.Size(); }
+
+  /**
+   * @brief 获取剩余空槽数 / Get the current free-slot count
+   * @return 当前空槽个数 / Current number of free slots
+   */
+  [[nodiscard]] size_t EmptySize() const { return core_.EmptySize(); }
+
+ protected:
+  MPMCQueueCore core_;
+};
+}  // namespace LibXR

--- a/src/structure/mpmc_queue.hpp
+++ b/src/structure/mpmc_queue.hpp
@@ -65,7 +65,7 @@ class MPMCQueue
    *         Returns `ErrorCode::OK` on success; returns `ErrorCode::EMPTY` when
    *         the queue is empty
    */
-  ErrorCode Pop() { return core_.PopBytes(); }
+  ErrorCode Pop() { return core_.PopBytes(nullptr); }
 
   /**
    * @brief 获取队列最大容量 / Get the maximum queue capacity

--- a/src/structure/mpmc_queue.hpp
+++ b/src/structure/mpmc_queue.hpp
@@ -10,6 +10,13 @@ namespace LibXR
 /**
  * @class MPMCQueue
  * @brief 带固定 payload 类型的有界 MPMC 队列 / Bounded MPMC queue with a fixed payload type
+ *
+ * 队列内部只把 payload 当成原始字节块搬运，不会在内部形成 `Payload*` 指针，
+ * 因此 `Payload` 的对齐要求不会额外约束队列内部字节缓冲区的语义边界。
+ *
+ * The queue moves payloads only as raw byte blocks and never forms internal
+ * `Payload*` pointers, so `Payload` alignment does not add an extra semantic
+ * constraint on the internal byte-buffer contract.
  */
 template <typename Payload>
 class MPMCQueue
@@ -18,8 +25,6 @@ class MPMCQueue
                 "MPMCQueue requires trivially copyable payloads");
   static_assert(std::is_trivially_destructible_v<Payload>,
                 "MPMCQueue requires trivially destructible payloads");
-  static_assert(alignof(Payload) <= alignof(size_t),
-                "MPMCQueue only supports payloads aligned no stricter than size_t");
 
  public:
   using ValueType = Payload;

--- a/src/structure/mpmc_queue_core.cpp
+++ b/src/structure/mpmc_queue_core.cpp
@@ -1,8 +1,9 @@
 #include "mpmc_queue_core.hpp"
 
 #include <algorithm>
-#include <cstring>
 #include <new>
+
+#include "libxr_mem.hpp"
 
 namespace LibXR
 {
@@ -80,7 +81,7 @@ ErrorCode MPMCQueueCore::PushBytes(const void* value)
       if (tail_.compare_exchange_weak(position, position + 1, std::memory_order_relaxed,
                                       std::memory_order_relaxed))
       {
-        std::memcpy(PayloadPtr(position % capacity_), value, element_size_);
+        LibXR::Memory::FastCopy(PayloadPtr(position % capacity_), value, element_size_);
         slot.value.store(position + 1, std::memory_order_release);
         return ErrorCode::OK;
       }
@@ -122,7 +123,7 @@ ErrorCode MPMCQueueCore::PopBytes(void* value)
       if (head_.compare_exchange_weak(position, position + 1, std::memory_order_relaxed,
                                       std::memory_order_relaxed))
       {
-        std::memcpy(value, PayloadPtr(position % capacity_), element_size_);
+        LibXR::Memory::FastCopy(value, PayloadPtr(position % capacity_), element_size_);
         slot.value.store(position + static_cast<SequenceType>(capacity_),
                          std::memory_order_release);
         return ErrorCode::OK;

--- a/src/structure/mpmc_queue_core.cpp
+++ b/src/structure/mpmc_queue_core.cpp
@@ -16,7 +16,6 @@ MPMCQueueCore::MPMCQueueCore(size_t element_size, size_t capacity)
     : element_size_(element_size),
       capacity_(capacity),
       payload_stride_(AlignUpChecked(element_size_, alignof(size_t))),
-      payload_alloc_align_(std::max(alignof(size_t), alignof(std::max_align_t))),
       sequences_(nullptr),
       payloads_(nullptr),
       head_(0),
@@ -32,7 +31,7 @@ MPMCQueueCore::MPMCQueueCore(size_t element_size, size_t capacity)
   try
   {
     payloads_ = static_cast<std::byte*>(
-        ::operator new[](payload_bytes, std::align_val_t(payload_alloc_align_)));
+        ::operator new[](payload_bytes, std::align_val_t(PAYLOAD_ALLOC_ALIGN)));
   }
   catch (...)
   {
@@ -53,7 +52,7 @@ MPMCQueueCore::MPMCQueueCore(size_t element_size, size_t capacity)
  */
 MPMCQueueCore::~MPMCQueueCore()
 {
-  ::operator delete[](payloads_, std::align_val_t(payload_alloc_align_));
+  ::operator delete[](payloads_, std::align_val_t(PAYLOAD_ALLOC_ALIGN));
   delete[] sequences_;
 }
 

--- a/src/structure/mpmc_queue_core.cpp
+++ b/src/structure/mpmc_queue_core.cpp
@@ -178,6 +178,12 @@ size_t MPMCQueueCore::AlignUpChecked(size_t value, size_t align)
   return ((value + align - 1) / align) * align;
 }
 
+/**
+ * @brief 安全地计算两个字节数的乘积 / Safely multiply two byte counts
+ * @param lhs 左操作数 / Left operand
+ * @param rhs 右操作数 / Right operand
+ * @return 乘积结果 / Product result
+ */
 size_t MPMCQueueCore::MultiplyChecked(size_t lhs, size_t rhs)
 {
   if (lhs == 0 || rhs == 0)

--- a/src/structure/mpmc_queue_core.cpp
+++ b/src/structure/mpmc_queue_core.cpp
@@ -17,9 +17,8 @@ MPMCQueueCore::MPMCQueueCore(size_t element_size, size_t capacity)
       payload_stride_(AlignUp(element_size_, alignof(size_t))),
       payload_alloc_align_(std::max(alignof(size_t), alignof(std::max_align_t))),
       sequences_(new (std::align_val_t(alignof(SequenceCell))) SequenceCell[capacity_]),
-      payloads_(static_cast<std::byte*>(
-          ::operator new[](payload_stride_ * capacity_,
-                           std::align_val_t(payload_alloc_align_)))),
+      payloads_(static_cast<std::byte*>(::operator new[](
+          payload_stride_* capacity_, std::align_val_t(payload_alloc_align_)))),
       head_(0),
       tail_(0)
 {
@@ -166,8 +165,7 @@ size_t MPMCQueueCore::Size() const
 {
   const SequenceType head_snapshot = head_.load(std::memory_order_acquire);
   const SequenceType tail_snapshot = tail_.load(std::memory_order_acquire);
-  const SequenceType used =
-      (tail_snapshot >= head_snapshot) ? (tail_snapshot - head_snapshot) : 0;
+  const SequenceType used = tail_snapshot - head_snapshot;
   return (used <= capacity_) ? used : capacity_;
 }
 
@@ -181,7 +179,8 @@ void* MPMCQueueCore::PayloadPtr(size_t index)
 }
 
 /**
- * @brief 获取指定槽位 payload 起始地址（只读） / Get the payload base address of one slot (const)
+ * @brief 获取指定槽位 payload 起始地址（只读）
+ *        / Get the payload base address of one slot (const)
  * @param index 槽位下标 / Slot index
  */
 const void* MPMCQueueCore::PayloadPtr(size_t index) const

--- a/src/structure/mpmc_queue_core.cpp
+++ b/src/structure/mpmc_queue_core.cpp
@@ -99,15 +99,12 @@ ErrorCode MPMCQueueCore::PushBytes(const void* value)
 
 /**
  * @brief 按字节出队一个 payload / Dequeue one payload by bytes
- * @param value 用于接收 payload 的缓冲区 / Buffer that receives the payload
+ * @param value 用于接收 payload 的缓冲区；传 `nullptr` 时仅丢弃队头元素
+ *        / Buffer that receives the payload; pass `nullptr` to discard the
+ *        front element only
  */
 ErrorCode MPMCQueueCore::PopBytes(void* value)
 {
-  if (value == nullptr)
-  {
-    return ErrorCode::PTR_NULL;
-  }
-
   SequenceType position = head_.load(std::memory_order_relaxed);
 
   while (true)
@@ -123,43 +120,10 @@ ErrorCode MPMCQueueCore::PopBytes(void* value)
       if (head_.compare_exchange_weak(position, position + 1, std::memory_order_relaxed,
                                       std::memory_order_relaxed))
       {
-        LibXR::Memory::FastCopy(value, PayloadPtr(position % capacity_), element_size_);
-        slot.value.store(position + static_cast<SequenceType>(capacity_),
-                         std::memory_order_release);
-        return ErrorCode::OK;
-      }
-      continue;
-    }
-
-    if (diff < 0)
-    {
-      return ErrorCode::EMPTY;
-    }
-
-    position = head_.load(std::memory_order_relaxed);
-  }
-}
-
-/**
- * @brief 丢弃一个队头 payload / Discard one front payload
- */
-ErrorCode MPMCQueueCore::PopBytes()
-{
-  SequenceType position = head_.load(std::memory_order_relaxed);
-
-  while (true)
-  {
-    SequenceCell& slot = sequences_[position % capacity_];
-    const SequenceType sequence = slot.value.load(std::memory_order_acquire);
-    const SequenceType expected_ready = position + 1;
-    const SequenceDiffType diff =
-        static_cast<SequenceDiffType>(sequence - expected_ready);
-
-    if (diff == 0)
-    {
-      if (head_.compare_exchange_weak(position, position + 1, std::memory_order_relaxed,
-                                      std::memory_order_relaxed))
-      {
+        if (value != nullptr)
+        {
+          LibXR::Memory::FastCopy(value, PayloadPtr(position % capacity_), element_size_);
+        }
         slot.value.store(position + static_cast<SequenceType>(capacity_),
                          std::memory_order_release);
         return ErrorCode::OK;

--- a/src/structure/mpmc_queue_core.cpp
+++ b/src/structure/mpmc_queue_core.cpp
@@ -26,19 +26,13 @@ MPMCQueueCore::MPMCQueueCore(size_t element_size, size_t capacity)
   REQUIRE(capacity_ <= static_cast<size_t>(std::numeric_limits<SequenceDiffType>::max()));
 
   const size_t payload_bytes = MultiplyChecked(payload_stride_, capacity_);
-  sequences_ = new (std::align_val_t(alignof(SequenceCell))) SequenceCell[capacity_];
+  sequences_ =
+      new (std::align_val_t(alignof(SequenceCell)), std::nothrow) SequenceCell[capacity_];
+  REQUIRE(sequences_ != nullptr);
 
-  try
-  {
-    payloads_ = static_cast<std::byte*>(
-        ::operator new[](payload_bytes, std::align_val_t(PAYLOAD_ALLOC_ALIGN)));
-  }
-  catch (...)
-  {
-    delete[] sequences_;
-    sequences_ = nullptr;
-    throw;
-  }
+  payloads_ = static_cast<std::byte*>(::operator new[](
+      payload_bytes, std::align_val_t(PAYLOAD_ALLOC_ALIGN), std::nothrow));
+  REQUIRE(payloads_ != nullptr);
 
   for (size_t index = 0; index < capacity_; ++index)
   {

--- a/src/structure/mpmc_queue_core.cpp
+++ b/src/structure/mpmc_queue_core.cpp
@@ -14,16 +14,31 @@ namespace LibXR
 MPMCQueueCore::MPMCQueueCore(size_t element_size, size_t capacity)
     : element_size_(element_size),
       capacity_(capacity),
-      payload_stride_(AlignUp(element_size_, alignof(size_t))),
+      payload_stride_(AlignUpChecked(element_size_, alignof(size_t))),
       payload_alloc_align_(std::max(alignof(size_t), alignof(std::max_align_t))),
-      sequences_(new (std::align_val_t(alignof(SequenceCell))) SequenceCell[capacity_]),
-      payloads_(static_cast<std::byte*>(::operator new[](
-          payload_stride_* capacity_, std::align_val_t(payload_alloc_align_)))),
+      sequences_(nullptr),
+      payloads_(nullptr),
       head_(0),
       tail_(0)
 {
-  ASSERT(element_size_ > 0);
+  REQUIRE(element_size_ > 0);
   REQUIRE(capacity_ > 1);
+  REQUIRE(capacity_ <= static_cast<size_t>(std::numeric_limits<SequenceDiffType>::max()));
+
+  const size_t payload_bytes = MultiplyChecked(payload_stride_, capacity_);
+  sequences_ = new (std::align_val_t(alignof(SequenceCell))) SequenceCell[capacity_];
+
+  try
+  {
+    payloads_ = static_cast<std::byte*>(
+        ::operator new[](payload_bytes, std::align_val_t(payload_alloc_align_)));
+  }
+  catch (...)
+  {
+    delete[] sequences_;
+    sequences_ = nullptr;
+    throw;
+  }
 
   for (size_t index = 0; index < capacity_; ++index)
   {
@@ -58,8 +73,9 @@ ErrorCode MPMCQueueCore::PushBytes(const void* value)
   {
     SequenceCell& slot = sequences_[position % capacity_];
     const SequenceType sequence = slot.value.load(std::memory_order_acquire);
+    const SequenceDiffType diff = static_cast<SequenceDiffType>(sequence - position);
 
-    if (sequence == position)
+    if (diff == 0)
     {
       if (tail_.compare_exchange_weak(position, position + 1, std::memory_order_relaxed,
                                       std::memory_order_relaxed))
@@ -71,7 +87,7 @@ ErrorCode MPMCQueueCore::PushBytes(const void* value)
       continue;
     }
 
-    if (sequence < position)
+    if (diff < 0)
     {
       return ErrorCode::FULL;
     }
@@ -98,8 +114,10 @@ ErrorCode MPMCQueueCore::PopBytes(void* value)
     SequenceCell& slot = sequences_[position % capacity_];
     const SequenceType sequence = slot.value.load(std::memory_order_acquire);
     const SequenceType expected_ready = position + 1;
+    const SequenceDiffType diff =
+        static_cast<SequenceDiffType>(sequence - expected_ready);
 
-    if (sequence == expected_ready)
+    if (diff == 0)
     {
       if (head_.compare_exchange_weak(position, position + 1, std::memory_order_relaxed,
                                       std::memory_order_relaxed))
@@ -112,7 +130,7 @@ ErrorCode MPMCQueueCore::PopBytes(void* value)
       continue;
     }
 
-    if (sequence < expected_ready)
+    if (diff < 0)
     {
       return ErrorCode::EMPTY;
     }
@@ -133,8 +151,10 @@ ErrorCode MPMCQueueCore::PopBytes()
     SequenceCell& slot = sequences_[position % capacity_];
     const SequenceType sequence = slot.value.load(std::memory_order_acquire);
     const SequenceType expected_ready = position + 1;
+    const SequenceDiffType diff =
+        static_cast<SequenceDiffType>(sequence - expected_ready);
 
-    if (sequence == expected_ready)
+    if (diff == 0)
     {
       if (head_.compare_exchange_weak(position, position + 1, std::memory_order_relaxed,
                                       std::memory_order_relaxed))
@@ -146,7 +166,7 @@ ErrorCode MPMCQueueCore::PopBytes()
       continue;
     }
 
-    if (sequence < expected_ready)
+    if (diff < 0)
     {
       return ErrorCode::EMPTY;
     }
@@ -193,8 +213,21 @@ const void* MPMCQueueCore::PayloadPtr(size_t index) const
  * @param value 待对齐字节数 / Byte count to align
  * @param align 目标对齐粒度 / Target alignment granularity
  */
-size_t MPMCQueueCore::AlignUp(size_t value, size_t align)
+size_t MPMCQueueCore::AlignUpChecked(size_t value, size_t align)
 {
+  REQUIRE(align > 0);
+  REQUIRE(value <= std::numeric_limits<size_t>::max() - (align - 1));
   return ((value + align - 1) / align) * align;
+}
+
+size_t MPMCQueueCore::MultiplyChecked(size_t lhs, size_t rhs)
+{
+  if (lhs == 0 || rhs == 0)
+  {
+    return 0;
+  }
+
+  REQUIRE(lhs <= std::numeric_limits<size_t>::max() / rhs);
+  return lhs * rhs;
 }
 }  // namespace LibXR

--- a/src/structure/mpmc_queue_core.cpp
+++ b/src/structure/mpmc_queue_core.cpp
@@ -1,0 +1,201 @@
+#include "mpmc_queue_core.hpp"
+
+#include <algorithm>
+#include <cstring>
+#include <new>
+
+namespace LibXR
+{
+/**
+ * @brief 构造字节队列内核 / Construct the byte-queue core
+ * @param element_size 单个 payload 的字节数 / Byte size of one payload
+ * @param capacity 队列容量 / Queue capacity
+ */
+MPMCQueueCore::MPMCQueueCore(size_t element_size, size_t capacity)
+    : element_size_(element_size),
+      capacity_(capacity),
+      payload_stride_(AlignUp(element_size_, alignof(size_t))),
+      payload_alloc_align_(std::max(alignof(size_t), alignof(std::max_align_t))),
+      sequences_(new (std::align_val_t(alignof(SequenceCell))) SequenceCell[capacity_]),
+      payloads_(static_cast<std::byte*>(
+          ::operator new[](payload_stride_ * capacity_,
+                           std::align_val_t(payload_alloc_align_)))),
+      head_(0),
+      tail_(0)
+{
+  ASSERT(element_size_ > 0);
+  REQUIRE(capacity_ > 1);
+
+  for (size_t index = 0; index < capacity_; ++index)
+  {
+    sequences_[index].value.store(static_cast<SequenceType>(index),
+                                  std::memory_order_relaxed);
+  }
+}
+
+/**
+ * @brief 析构字节队列内核 / Destroy the byte-queue core
+ */
+MPMCQueueCore::~MPMCQueueCore()
+{
+  ::operator delete[](payloads_, std::align_val_t(payload_alloc_align_));
+  delete[] sequences_;
+}
+
+/**
+ * @brief 按字节入队一个 payload / Enqueue one payload by bytes
+ * @param value 指向待入队 payload 的指针 / Pointer to the payload to enqueue
+ */
+ErrorCode MPMCQueueCore::PushBytes(const void* value)
+{
+  if (value == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+
+  SequenceType position = tail_.load(std::memory_order_relaxed);
+
+  while (true)
+  {
+    SequenceCell& slot = sequences_[position % capacity_];
+    const SequenceType sequence = slot.value.load(std::memory_order_acquire);
+
+    if (sequence == position)
+    {
+      if (tail_.compare_exchange_weak(position, position + 1, std::memory_order_relaxed,
+                                      std::memory_order_relaxed))
+      {
+        std::memcpy(PayloadPtr(position % capacity_), value, element_size_);
+        slot.value.store(position + 1, std::memory_order_release);
+        return ErrorCode::OK;
+      }
+      continue;
+    }
+
+    if (sequence < position)
+    {
+      return ErrorCode::FULL;
+    }
+
+    position = tail_.load(std::memory_order_relaxed);
+  }
+}
+
+/**
+ * @brief 按字节出队一个 payload / Dequeue one payload by bytes
+ * @param value 用于接收 payload 的缓冲区 / Buffer that receives the payload
+ */
+ErrorCode MPMCQueueCore::PopBytes(void* value)
+{
+  if (value == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+
+  SequenceType position = head_.load(std::memory_order_relaxed);
+
+  while (true)
+  {
+    SequenceCell& slot = sequences_[position % capacity_];
+    const SequenceType sequence = slot.value.load(std::memory_order_acquire);
+    const SequenceType expected_ready = position + 1;
+
+    if (sequence == expected_ready)
+    {
+      if (head_.compare_exchange_weak(position, position + 1, std::memory_order_relaxed,
+                                      std::memory_order_relaxed))
+      {
+        std::memcpy(value, PayloadPtr(position % capacity_), element_size_);
+        slot.value.store(position + static_cast<SequenceType>(capacity_),
+                         std::memory_order_release);
+        return ErrorCode::OK;
+      }
+      continue;
+    }
+
+    if (sequence < expected_ready)
+    {
+      return ErrorCode::EMPTY;
+    }
+
+    position = head_.load(std::memory_order_relaxed);
+  }
+}
+
+/**
+ * @brief 丢弃一个队头 payload / Discard one front payload
+ */
+ErrorCode MPMCQueueCore::PopBytes()
+{
+  SequenceType position = head_.load(std::memory_order_relaxed);
+
+  while (true)
+  {
+    SequenceCell& slot = sequences_[position % capacity_];
+    const SequenceType sequence = slot.value.load(std::memory_order_acquire);
+    const SequenceType expected_ready = position + 1;
+
+    if (sequence == expected_ready)
+    {
+      if (head_.compare_exchange_weak(position, position + 1, std::memory_order_relaxed,
+                                      std::memory_order_relaxed))
+      {
+        slot.value.store(position + static_cast<SequenceType>(capacity_),
+                         std::memory_order_release);
+        return ErrorCode::OK;
+      }
+      continue;
+    }
+
+    if (sequence < expected_ready)
+    {
+      return ErrorCode::EMPTY;
+    }
+
+    position = head_.load(std::memory_order_relaxed);
+  }
+}
+
+/**
+ * @brief 获取并发快照下的当前元素数 / Get the current approximate element count
+ * @return 并发快照下的元素数，范围被钳在 `[0, MaxSize()]`
+ *         Approximate element count from a concurrent snapshot, clamped to
+ *         `[0, MaxSize()]`
+ */
+size_t MPMCQueueCore::Size() const
+{
+  const SequenceType head_snapshot = head_.load(std::memory_order_acquire);
+  const SequenceType tail_snapshot = tail_.load(std::memory_order_acquire);
+  const SequenceType used =
+      (tail_snapshot >= head_snapshot) ? (tail_snapshot - head_snapshot) : 0;
+  return (used <= capacity_) ? used : capacity_;
+}
+
+/**
+ * @brief 获取指定槽位 payload 起始地址 / Get the payload base address of one slot
+ * @param index 槽位下标 / Slot index
+ */
+void* MPMCQueueCore::PayloadPtr(size_t index)
+{
+  return payloads_ + index * payload_stride_;
+}
+
+/**
+ * @brief 获取指定槽位 payload 起始地址（只读） / Get the payload base address of one slot (const)
+ * @param index 槽位下标 / Slot index
+ */
+const void* MPMCQueueCore::PayloadPtr(size_t index) const
+{
+  return payloads_ + index * payload_stride_;
+}
+
+/**
+ * @brief 向上对齐到指定粒度 / Align one byte count upward to the target granularity
+ * @param value 待对齐字节数 / Byte count to align
+ * @param align 目标对齐粒度 / Target alignment granularity
+ */
+size_t MPMCQueueCore::AlignUp(size_t value, size_t align)
+{
+  return ((value + align - 1) / align) * align;
+}
+}  // namespace LibXR

--- a/src/structure/mpmc_queue_core.hpp
+++ b/src/structure/mpmc_queue_core.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+#include "libxr_def.hpp"
+
+namespace LibXR
+{
+/**
+ * @class MPMCQueueCore
+ * @brief 有界 MPMC 字节队列内核 / Bounded MPMC byte-queue core
+ *
+ * 这个内核把并发协议和字节搬运集中在一个非模板实现里，以减少不同 payload
+ * 类型各自实例化一整套无锁协议所带来的 flash 膨胀。它只负责搬运固定大小、
+ * 默认字宽对齐的字节 payload；类型语义由上层薄包装负责。
+ *
+ * This core keeps the concurrency protocol and byte-copying logic in one
+ * non-template implementation so different payload types do not each instantiate
+ * a full copy of the lock-free protocol. It only moves fixed-size, word-aligned
+ * byte payloads; type semantics are handled by thin wrappers above it.
+ */
+class MPMCQueueCore
+{
+ public:
+  using SequenceType = uint32_t;
+
+  MPMCQueueCore(size_t element_size, size_t capacity);
+  ~MPMCQueueCore();
+
+  MPMCQueueCore(const MPMCQueueCore&) = delete;
+  MPMCQueueCore& operator=(const MPMCQueueCore&) = delete;
+  MPMCQueueCore(MPMCQueueCore&&) = delete;
+  MPMCQueueCore& operator=(MPMCQueueCore&&) = delete;
+
+  ErrorCode PushBytes(const void* value);
+  ErrorCode PopBytes(void* value);
+  ErrorCode PopBytes();
+
+  [[nodiscard]] size_t MaxSize() const { return capacity_; }
+  [[nodiscard]] size_t Size() const;
+  [[nodiscard]] size_t EmptySize() const { return capacity_ - Size(); }
+  [[nodiscard]] size_t ElementSize() const { return element_size_; }
+
+ private:
+  struct alignas(LibXR::CONCURRENCY_ALIGNMENT) SequenceCell
+  {
+    std::atomic<SequenceType> value;
+  };
+
+  [[nodiscard]] void* PayloadPtr(size_t index);
+  [[nodiscard]] const void* PayloadPtr(size_t index) const;
+  [[nodiscard]] static size_t AlignUp(size_t value, size_t align);
+
+  const size_t element_size_;
+  const size_t capacity_;
+  const size_t payload_stride_;
+  const size_t payload_alloc_align_;
+  SequenceCell* sequences_;
+  std::byte* payloads_;
+
+  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<SequenceType> head_;
+  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<SequenceType> tail_;
+};
+}  // namespace LibXR

--- a/src/structure/mpmc_queue_core.hpp
+++ b/src/structure/mpmc_queue_core.hpp
@@ -3,6 +3,8 @@
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
+#include <limits>
+#include <type_traits>
 
 #include "libxr_def.hpp"
 
@@ -25,6 +27,7 @@ class MPMCQueueCore
 {
  public:
   using SequenceType = size_t;
+  using SequenceDiffType = std::make_signed_t<SequenceType>;
 
   MPMCQueueCore(size_t element_size, size_t capacity);
   ~MPMCQueueCore();
@@ -64,7 +67,8 @@ class MPMCQueueCore
 
   [[nodiscard]] void* PayloadPtr(size_t index);
   [[nodiscard]] const void* PayloadPtr(size_t index) const;
-  [[nodiscard]] static size_t AlignUp(size_t value, size_t align);
+  [[nodiscard]] static size_t AlignUpChecked(size_t value, size_t align);
+  [[nodiscard]] static size_t MultiplyChecked(size_t lhs, size_t rhs);
 
   const size_t element_size_;
   const size_t capacity_;

--- a/src/structure/mpmc_queue_core.hpp
+++ b/src/structure/mpmc_queue_core.hpp
@@ -38,8 +38,7 @@ class MPMCQueueCore
   MPMCQueueCore& operator=(MPMCQueueCore&&) = delete;
 
   ErrorCode PushBytes(const void* value);
-  ErrorCode PopBytes(void* value);
-  ErrorCode PopBytes();
+  ErrorCode PopBytes(void* value = nullptr);
 
   [[nodiscard]] size_t MaxSize() const { return capacity_; }
   /**

--- a/src/structure/mpmc_queue_core.hpp
+++ b/src/structure/mpmc_queue_core.hpp
@@ -70,6 +70,10 @@ class MPMCQueueCore
    */
   ErrorCode PopBytes(void* value = nullptr);
 
+  /**
+   * @brief 获取队列最大容量 / Get the maximum queue capacity
+   * @return 队列容量 / Queue capacity
+   */
   [[nodiscard]] size_t MaxSize() const { return capacity_; }
   /**
    * @brief 获取并发快照下的当前元素数 / Get the current approximate element count
@@ -85,7 +89,15 @@ class MPMCQueueCore
    *         exact even after very long-lived sequence wraparound.
    */
   [[nodiscard]] size_t Size() const;
+  /**
+   * @brief 获取剩余空槽数 / Get the current free-slot count
+   * @return 当前空槽个数 / Current number of free slots
+   */
   [[nodiscard]] size_t EmptySize() const { return capacity_ - Size(); }
+  /**
+   * @brief 获取单个 payload 的字节数 / Get the byte size of one payload
+   * @return 单个 payload 的字节数 / Byte size of one payload
+   */
   [[nodiscard]] size_t ElementSize() const { return element_size_; }
 
  private:

--- a/src/structure/mpmc_queue_core.hpp
+++ b/src/structure/mpmc_queue_core.hpp
@@ -68,11 +68,12 @@ class MPMCQueueCore
   [[nodiscard]] const void* PayloadPtr(size_t index) const;
   [[nodiscard]] static size_t AlignUpChecked(size_t value, size_t align);
   [[nodiscard]] static size_t MultiplyChecked(size_t lhs, size_t rhs);
+  static constexpr size_t PAYLOAD_ALLOC_ALIGN =
+      std::max(alignof(size_t), alignof(std::max_align_t));
 
   const size_t element_size_;
   const size_t capacity_;
   const size_t payload_stride_;
-  const size_t payload_alloc_align_;
   SequenceCell* sequences_;
   std::byte* payloads_;
 

--- a/src/structure/mpmc_queue_core.hpp
+++ b/src/structure/mpmc_queue_core.hpp
@@ -26,18 +26,48 @@ namespace LibXR
 class MPMCQueueCore
 {
  public:
-  using SequenceType = size_t;
-  using SequenceDiffType = std::make_signed_t<SequenceType>;
+  using SequenceType = size_t;  ///< 单调递增的逻辑序号类型 / Monotonic logical sequence type.
+  using SequenceDiffType =
+      std::make_signed_t<SequenceType>;  ///< 序号差值判定类型 / Signed type used for sequence-delta checks.
 
+  /**
+   * @brief 构造一个字节队列内核 / Construct one byte-queue core
+   * @param element_size 单个 payload 的字节数 / Byte size of one payload
+   * @param capacity 队列容量 / Queue capacity
+   */
   MPMCQueueCore(size_t element_size, size_t capacity);
+  /**
+   * @brief 析构字节队列内核 / Destroy the byte-queue core
+   */
   ~MPMCQueueCore();
 
+  /// @brief 禁止拷贝构造 / Non-copyable.
   MPMCQueueCore(const MPMCQueueCore&) = delete;
+  /// @brief 禁止拷贝赋值 / Non-copy-assignable.
   MPMCQueueCore& operator=(const MPMCQueueCore&) = delete;
+  /// @brief 禁止移动构造 / Non-movable.
   MPMCQueueCore(MPMCQueueCore&&) = delete;
+  /// @brief 禁止移动赋值 / Non-move-assignable.
   MPMCQueueCore& operator=(MPMCQueueCore&&) = delete;
 
+  /**
+   * @brief 按字节入队一个 payload / Enqueue one payload by bytes
+   * @param value 指向待入队 payload 的指针 / Pointer to the payload to enqueue
+   * @return 成功返回 `ErrorCode::OK`；队列满返回 `ErrorCode::FULL`；空指针返回
+   *         `ErrorCode::PTR_NULL`
+   *         Returns `ErrorCode::OK` on success; `ErrorCode::FULL` when the
+   *         queue is full; `ErrorCode::PTR_NULL` when `value` is null
+   */
   ErrorCode PushBytes(const void* value);
+  /**
+   * @brief 按字节出队一个 payload；传空指针时只丢弃队头元素
+   *        / Dequeue one payload by bytes; pass null to discard the front item only
+   * @param value 用于接收 payload 的缓冲区；传 `nullptr` 时仅丢弃
+   *        / Buffer that receives the payload; pass `nullptr` to discard only
+   * @return 成功返回 `ErrorCode::OK`；队列空返回 `ErrorCode::EMPTY`
+   *         Returns `ErrorCode::OK` on success; returns `ErrorCode::EMPTY` when
+   *         the queue is empty
+   */
   ErrorCode PopBytes(void* value = nullptr);
 
   [[nodiscard]] size_t MaxSize() const { return capacity_; }
@@ -59,25 +89,33 @@ class MPMCQueueCore
   [[nodiscard]] size_t ElementSize() const { return element_size_; }
 
  private:
+  /// @brief 每个逻辑槽对应的序号单元 / Sequence cell for one logical slot.
   struct alignas(LibXR::CONCURRENCY_ALIGNMENT) SequenceCell
   {
-    std::atomic<SequenceType> value;
+    std::atomic<SequenceType> value;  ///< 当前槽的逻辑序号 / Current logical sequence of the slot.
   };
 
+  /// @brief 获取指定槽位 payload 起始地址 / Get the payload base address of one slot.
   [[nodiscard]] void* PayloadPtr(size_t index);
+  /// @brief 获取指定槽位 payload 起始地址（只读） / Get the payload base address of one slot (const).
   [[nodiscard]] const void* PayloadPtr(size_t index) const;
+  /// @brief 安全地向上对齐字节数 / Safely align one byte count upward.
   [[nodiscard]] static size_t AlignUpChecked(size_t value, size_t align);
+  /// @brief 安全地计算乘积 / Safely multiply two size values.
   [[nodiscard]] static size_t MultiplyChecked(size_t lhs, size_t rhs);
   static constexpr size_t PAYLOAD_ALLOC_ALIGN =
-      std::max(alignof(size_t), alignof(std::max_align_t));
+      std::max(alignof(size_t),
+               alignof(std::max_align_t));  ///< payload 缓冲区整体分配对齐 / Allocation alignment used for the whole payload buffer.
 
-  const size_t element_size_;
-  const size_t capacity_;
-  const size_t payload_stride_;
-  SequenceCell* sequences_;
-  std::byte* payloads_;
+  const size_t element_size_;    ///< 单个 payload 的字节数 / Byte size of one payload.
+  const size_t capacity_;        ///< 队列容量 / Queue capacity.
+  const size_t payload_stride_;  ///< 相邻 payload 槽位之间的步长 / Byte stride between adjacent payload slots.
+  SequenceCell* sequences_;      ///< 槽序号数组 / Array of per-slot sequence cells.
+  std::byte* payloads_;          ///< payload 字节缓冲区 / Byte buffer storing payloads.
 
-  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<SequenceType> head_;
-  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<SequenceType> tail_;
+  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<SequenceType>
+      head_;  ///< 下一个待出队的逻辑位置 / Next logical dequeue position.
+  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<SequenceType>
+      tail_;  ///< 下一个待入队的逻辑位置 / Next logical enqueue position.
 };
 }  // namespace LibXR

--- a/src/structure/mpmc_queue_core.hpp
+++ b/src/structure/mpmc_queue_core.hpp
@@ -24,7 +24,7 @@ namespace LibXR
 class MPMCQueueCore
 {
  public:
-  using SequenceType = uint32_t;
+  using SequenceType = size_t;
 
   MPMCQueueCore(size_t element_size, size_t capacity);
   ~MPMCQueueCore();
@@ -39,6 +39,19 @@ class MPMCQueueCore
   ErrorCode PopBytes();
 
   [[nodiscard]] size_t MaxSize() const { return capacity_; }
+  /**
+   * @brief 获取并发快照下的当前元素数 / Get the current approximate element count
+   *
+   * @note 该值是近似快照：
+   *       - 在并发入队/出队时，该值可能已经过期；
+   *       - 这里按 `SequenceType` 的模差值估算已用槽数，再钳到 `[0, MaxSize()]`，
+   *         因此即使极端长寿命下序号回绕后，它仍然只是近似值，而不是精确值。
+   *       This value is an approximate snapshot:
+   *       - it may already be stale while producers/consumers are progressing;
+   *       - it is computed from modular `SequenceType` differences and then
+   *         clamped to `[0, MaxSize()]`, so it remains approximate rather than
+   *         exact even after very long-lived sequence wraparound.
+   */
   [[nodiscard]] size_t Size() const;
   [[nodiscard]] size_t EmptySize() const { return capacity_ - Size(); }
   [[nodiscard]] size_t ElementSize() const { return element_size_; }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -83,6 +83,7 @@ static void run_libxr_tests()
 
   TestCase data_structure_tests[] = {{"rbt", test_rbt, false},
                                      {"queue", test_queue, false},
+                                     {"mpmc_queue", test_mpmc_queue, false},
                                      {"pool", test_lock_free_pool, false},
                                      {"stack", test_stack, false},
                                      {"list", test_list, false},

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -6,6 +6,7 @@ void test_inertia();
 void test_list();
 void test_kinematic();
 void test_message();
+void test_mpmc_queue();
 void test_queue();
 void test_lock_free_pool();
 void test_rbt();

--- a/test/test_mpmc_queue.cpp
+++ b/test/test_mpmc_queue.cpp
@@ -30,7 +30,7 @@ struct ConsumerArg
   std::atomic<size_t>* consumed_done_count;
   std::atomic<size_t>* pop_count;
   std::atomic<unsigned long long>* pop_sum;
-  uint8_t* seen;
+  std::atomic<uint8_t>* seen;
 };
 
 void ProducerTask(ProducerArg arg)
@@ -57,7 +57,7 @@ void ConsumerTask(ConsumerArg arg)
     if (ec == LibXR::ErrorCode::OK)
     {
       ASSERT(value < arg.total_items);
-      const auto previous = __sync_lock_test_and_set(&arg.seen[value], 1);
+      const auto previous = arg.seen[value].exchange(1, std::memory_order_relaxed);
       ASSERT(previous == 0);
 
       arg.pop_sum->fetch_add(static_cast<unsigned long long>(value),
@@ -160,7 +160,7 @@ void test_mpmc_queue()
     static_assert(TOTAL_ITEMS - 1 <= UINT16_MAX);
 
     Queue queue(2);
-    uint8_t seen[TOTAL_ITEMS] = {};
+    std::atomic<uint8_t> seen[TOTAL_ITEMS] = {};
     std::atomic<size_t> produced_done_count = 0;
     std::atomic<size_t> consumed_done_count = 0;
     std::atomic<size_t> pop_count = 0;
@@ -202,7 +202,7 @@ void test_mpmc_queue()
 
     for (size_t index = 0; index < TOTAL_ITEMS; ++index)
     {
-      ASSERT(seen[index] == 1);
+      ASSERT(seen[index].load(std::memory_order_relaxed) == 1);
     }
   }
 
@@ -218,7 +218,7 @@ void test_mpmc_queue()
     static_assert(TOTAL_ITEMS - 1 <= UINT16_MAX);
 
     Queue queue(64);
-    uint8_t seen[TOTAL_ITEMS] = {};
+    std::atomic<uint8_t> seen[TOTAL_ITEMS] = {};
     std::atomic<size_t> produced_done_count = 0;
     std::atomic<size_t> consumed_done_count = 0;
     std::atomic<size_t> pop_count = 0;
@@ -260,7 +260,7 @@ void test_mpmc_queue()
 
     for (size_t index = 0; index < TOTAL_ITEMS; ++index)
     {
-      ASSERT(seen[index] == 1);
+      ASSERT(seen[index].load(std::memory_order_relaxed) == 1);
     }
   }
 }

--- a/test/test_mpmc_queue.cpp
+++ b/test/test_mpmc_queue.cpp
@@ -1,0 +1,248 @@
+#include "libxr.hpp"
+#include "libxr_def.hpp"
+#include "test.hpp"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+
+namespace
+{
+using Queue = LibXR::MPMCQueue<uint16_t>;
+
+struct ProducerArg
+{
+  size_t begin;
+  size_t count;
+  Queue* queue;
+  std::atomic<size_t>* done_count;
+};
+
+struct ConsumerArg
+{
+  Queue* queue;
+  size_t total_items;
+  size_t producer_count;
+  std::atomic<size_t>* produced_done_count;
+  std::atomic<size_t>* consumed_done_count;
+  std::atomic<size_t>* pop_count;
+  std::atomic<unsigned long long>* pop_sum;
+  uint8_t* seen;
+};
+
+void ProducerTask(ProducerArg arg)
+{
+  for (size_t offset = 0; offset < arg.count; ++offset)
+  {
+    const size_t value = arg.begin + offset;
+    ASSERT(value <= UINT16_MAX);
+    while (arg.queue->Push(static_cast<uint16_t>(value)) != LibXR::ErrorCode::OK)
+    {
+      LibXR::Thread::Yield();
+    }
+  }
+
+  arg.done_count->fetch_add(1, std::memory_order_release);
+}
+
+void ConsumerTask(ConsumerArg arg)
+{
+  while (true)
+  {
+    Queue::ValueType value = 0;
+    const auto ec = arg.queue->Pop(value);
+    if (ec == LibXR::ErrorCode::OK)
+    {
+      ASSERT(value < arg.total_items);
+      const auto previous = __sync_lock_test_and_set(&arg.seen[value], 1);
+      ASSERT(previous == 0);
+
+      arg.pop_sum->fetch_add(static_cast<unsigned long long>(value),
+                             std::memory_order_relaxed);
+      const size_t pop_index = arg.pop_count->fetch_add(1, std::memory_order_relaxed) + 1;
+      ASSERT(pop_index <= arg.total_items);
+      continue;
+    }
+
+    if (arg.produced_done_count->load(std::memory_order_acquire) == arg.producer_count &&
+        arg.pop_count->load(std::memory_order_acquire) == arg.total_items)
+    {
+      break;
+    }
+
+    LibXR::Thread::Yield();
+  }
+
+  arg.consumed_done_count->fetch_add(1, std::memory_order_release);
+}
+}  // namespace
+
+void test_mpmc_queue()
+{
+  {
+    Queue queue(3);
+    Queue::ValueType value = 0;
+
+    ASSERT(queue.MaxSize() == 3);
+    ASSERT(queue.Size() == 0);
+    ASSERT(queue.EmptySize() == 3);
+    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+
+    ASSERT(queue.Push(11) == LibXR::ErrorCode::OK);
+    ASSERT(queue.Push(22) == LibXR::ErrorCode::OK);
+    ASSERT(queue.Push(33) == LibXR::ErrorCode::OK);
+    ASSERT(queue.Push(44) == LibXR::ErrorCode::FULL);
+    ASSERT(queue.Size() == 3);
+    ASSERT(queue.EmptySize() == 0);
+
+    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    ASSERT(value == 11);
+    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    ASSERT(value == 22);
+    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    ASSERT(value == 33);
+    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    ASSERT(queue.Size() == 0);
+    ASSERT(queue.EmptySize() == 3);
+  }
+
+  {
+    Queue queue(4);
+    Queue::ValueType value = 0;
+
+    for (size_t round = 0; round < 256; ++round)
+    {
+      ASSERT(queue.Push(round * 4 + 0) == LibXR::ErrorCode::OK);
+      ASSERT(queue.Push(round * 4 + 1) == LibXR::ErrorCode::OK);
+      ASSERT(queue.Push(round * 4 + 2) == LibXR::ErrorCode::OK);
+      ASSERT(queue.Push(round * 4 + 3) == LibXR::ErrorCode::OK);
+      ASSERT(queue.Push(9999) == LibXR::ErrorCode::FULL);
+
+      ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+      ASSERT(value == round * 4 + 0);
+      ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+      ASSERT(value == round * 4 + 1);
+      ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+      ASSERT(value == round * 4 + 2);
+      ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+      ASSERT(value == round * 4 + 3);
+      ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+    }
+  }
+
+  {
+    constexpr size_t PRODUCER_COUNT = 2;
+    constexpr size_t CONSUMER_COUNT = 2;
+    constexpr size_t ITEMS_PER_PRODUCER = 5000;
+    constexpr size_t TOTAL_ITEMS = PRODUCER_COUNT * ITEMS_PER_PRODUCER;
+    constexpr unsigned long long EXPECTED_SUM =
+        (static_cast<unsigned long long>(TOTAL_ITEMS) *
+         static_cast<unsigned long long>(TOTAL_ITEMS - 1)) /
+        2ULL;
+    static_assert(TOTAL_ITEMS - 1 <= UINT16_MAX);
+
+    Queue queue(2);
+    uint8_t seen[TOTAL_ITEMS] = {};
+    std::atomic<size_t> produced_done_count = 0;
+    std::atomic<size_t> consumed_done_count = 0;
+    std::atomic<size_t> pop_count = 0;
+    std::atomic<unsigned long long> pop_sum = 0;
+    Queue::ValueType value = 0;
+
+    LibXR::Thread producers[PRODUCER_COUNT];
+    LibXR::Thread consumers[CONSUMER_COUNT];
+
+    for (size_t index = 0; index < PRODUCER_COUNT; ++index)
+    {
+      producers[index].Create<ProducerArg>(
+          ProducerArg{index * ITEMS_PER_PRODUCER, ITEMS_PER_PRODUCER, &queue,
+                      &produced_done_count},
+          ProducerTask, "mpmc_prod2", 1024, LibXR::Thread::Priority::REALTIME);
+    }
+
+    for (size_t index = 0; index < CONSUMER_COUNT; ++index)
+    {
+      consumers[index].Create<ConsumerArg>(
+          ConsumerArg{&queue, TOTAL_ITEMS, PRODUCER_COUNT, &produced_done_count,
+                      &consumed_done_count, &pop_count, &pop_sum, seen},
+          ConsumerTask, "mpmc_cons2", 1024, LibXR::Thread::Priority::REALTIME);
+    }
+
+    const uint32_t start_ms = LibXR::Thread::GetTime();
+    while ((produced_done_count.load(std::memory_order_acquire) != PRODUCER_COUNT ||
+            consumed_done_count.load(std::memory_order_acquire) != CONSUMER_COUNT) &&
+           (LibXR::Thread::GetTime() - start_ms) < 5000U)
+    {
+      LibXR::Thread::Sleep(1);
+    }
+
+    ASSERT(produced_done_count.load(std::memory_order_acquire) == PRODUCER_COUNT);
+    ASSERT(consumed_done_count.load(std::memory_order_acquire) == CONSUMER_COUNT);
+    ASSERT(pop_count.load(std::memory_order_acquire) == TOTAL_ITEMS);
+    ASSERT(pop_sum.load(std::memory_order_acquire) == EXPECTED_SUM);
+    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+
+    for (size_t index = 0; index < TOTAL_ITEMS; ++index)
+    {
+      ASSERT(seen[index] == 1);
+    }
+  }
+
+  {
+    constexpr size_t PRODUCER_COUNT = 4;
+    constexpr size_t CONSUMER_COUNT = 4;
+    constexpr size_t ITEMS_PER_PRODUCER = 2000;
+    constexpr size_t TOTAL_ITEMS = PRODUCER_COUNT * ITEMS_PER_PRODUCER;
+    constexpr unsigned long long EXPECTED_SUM =
+        (static_cast<unsigned long long>(TOTAL_ITEMS) *
+         static_cast<unsigned long long>(TOTAL_ITEMS - 1)) /
+        2ULL;
+    static_assert(TOTAL_ITEMS - 1 <= UINT16_MAX);
+
+    Queue queue(64);
+    uint8_t seen[TOTAL_ITEMS] = {};
+    std::atomic<size_t> produced_done_count = 0;
+    std::atomic<size_t> consumed_done_count = 0;
+    std::atomic<size_t> pop_count = 0;
+    std::atomic<unsigned long long> pop_sum = 0;
+    Queue::ValueType value = 0;
+
+    LibXR::Thread producers[PRODUCER_COUNT];
+    LibXR::Thread consumers[CONSUMER_COUNT];
+
+    for (size_t index = 0; index < PRODUCER_COUNT; ++index)
+    {
+      producers[index].Create<ProducerArg>(
+          ProducerArg{index * ITEMS_PER_PRODUCER, ITEMS_PER_PRODUCER, &queue,
+                      &produced_done_count},
+          ProducerTask, "mpmc_prod", 1024, LibXR::Thread::Priority::REALTIME);
+    }
+
+    for (size_t index = 0; index < CONSUMER_COUNT; ++index)
+    {
+      consumers[index].Create<ConsumerArg>(
+          ConsumerArg{&queue, TOTAL_ITEMS, PRODUCER_COUNT, &produced_done_count,
+                      &consumed_done_count, &pop_count, &pop_sum, seen},
+          ConsumerTask, "mpmc_cons", 1024, LibXR::Thread::Priority::REALTIME);
+    }
+
+    const uint32_t start_ms = LibXR::Thread::GetTime();
+    while ((produced_done_count.load(std::memory_order_acquire) != PRODUCER_COUNT ||
+            consumed_done_count.load(std::memory_order_acquire) != CONSUMER_COUNT) &&
+           (LibXR::Thread::GetTime() - start_ms) < 5000U)
+    {
+      LibXR::Thread::Sleep(1);
+    }
+
+    ASSERT(produced_done_count.load(std::memory_order_acquire) == PRODUCER_COUNT);
+    ASSERT(consumed_done_count.load(std::memory_order_acquire) == CONSUMER_COUNT);
+    ASSERT(pop_count.load(std::memory_order_acquire) == TOTAL_ITEMS);
+    ASSERT(pop_sum.load(std::memory_order_acquire) == EXPECTED_SUM);
+    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
+
+    for (size_t index = 0; index < TOTAL_ITEMS; ++index)
+    {
+      ASSERT(seen[index] == 1);
+    }
+  }
+}

--- a/test/test_mpmc_queue.cpp
+++ b/test/test_mpmc_queue.cpp
@@ -9,30 +9,44 @@
 
 namespace
 {
-using Queue = LibXR::MPMCQueue<uint16_t>;
+using Queue = LibXR::MPMCQueue<uint16_t>;  ///< 默认压力用 16 位 payload 队列 / Default stress-test queue using 16-bit payloads.
 
+/**
+ * @brief 比较两个双精度值是否足够接近 / Check whether two doubles are close enough
+ */
 bool EqualDouble(double a, double b) { return std::abs(a - b) < 1e-9; }
 
+/**
+ * @struct ProducerArg
+ * @brief 生产者线程参数 / Producer-thread arguments
+ */
 struct ProducerArg
 {
-  size_t begin;
-  size_t count;
-  Queue* queue;
-  std::atomic<size_t>* done_count;
+  size_t begin;                    ///< 本生产者负责的起始值 / First value owned by this producer.
+  size_t count;                    ///< 本生产者负责推送的元素数 / Number of items pushed by this producer.
+  Queue* queue;                    ///< 共享队列 / Shared queue instance.
+  std::atomic<size_t>* done_count;  ///< 完成计数器 / Producer completion counter.
 };
 
+/**
+ * @struct ConsumerArg
+ * @brief 消费者线程参数 / Consumer-thread arguments
+ */
 struct ConsumerArg
 {
-  Queue* queue;
-  size_t total_items;
-  size_t producer_count;
-  std::atomic<size_t>* produced_done_count;
-  std::atomic<size_t>* consumed_done_count;
-  std::atomic<size_t>* pop_count;
-  std::atomic<unsigned long long>* pop_sum;
-  std::atomic<uint8_t>* seen;
+  Queue* queue;                                 ///< 共享队列 / Shared queue instance.
+  size_t total_items;                           ///< 目标总元素数 / Expected total item count.
+  size_t producer_count;                        ///< 生产者总数 / Total number of producers.
+  std::atomic<size_t>* produced_done_count;     ///< 生产者完成计数 / Producer completion counter.
+  std::atomic<size_t>* consumed_done_count;     ///< 消费者完成计数 / Consumer completion counter.
+  std::atomic<size_t>* pop_count;               ///< 已消费元素数 / Total consumed item count.
+  std::atomic<unsigned long long>* pop_sum;     ///< 已消费元素和 / Running sum of consumed values.
+  std::atomic<uint8_t>* seen;                   ///< 去重标记表 / Deduplication mark table.
 };
 
+/**
+ * @brief 生产者线程函数 / Producer-thread entry
+ */
 void ProducerTask(ProducerArg arg)
 {
   for (size_t offset = 0; offset < arg.count; ++offset)
@@ -48,6 +62,9 @@ void ProducerTask(ProducerArg arg)
   arg.done_count->fetch_add(1, std::memory_order_release);
 }
 
+/**
+ * @brief 消费者线程函数 / Consumer-thread entry
+ */
 void ConsumerTask(ConsumerArg arg)
 {
   while (true)
@@ -80,8 +97,13 @@ void ConsumerTask(ConsumerArg arg)
 }
 }  // namespace
 
+/**
+ * @brief 验证有界 MPMC 队列的基础行为和并发语义 / Verify basic behavior and
+ *        concurrent semantics of the bounded MPMC queue
+ */
 void test_mpmc_queue()
 {
+  // Basic empty/full behavior on a tiny queue.
   {
     Queue queue(3);
     Queue::ValueType value = 0;
@@ -109,6 +131,7 @@ void test_mpmc_queue()
     ASSERT(queue.EmptySize() == 3);
   }
 
+  // Repeat fill-and-drain cycles to verify FIFO order stays stable.
   {
     Queue queue(4);
     Queue::ValueType value = 0;
@@ -133,6 +156,7 @@ void test_mpmc_queue()
     }
   }
 
+  // Verify naturally aligned non-integer payloads also work.
   {
     LibXR::MPMCQueue<double> queue(2);
     double value = 0.0;
@@ -148,6 +172,7 @@ void test_mpmc_queue()
     ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
   }
 
+  // Two producers and two consumers with the smallest legal capacity.
   {
     constexpr size_t PRODUCER_COUNT = 2;
     constexpr size_t CONSUMER_COUNT = 2;
@@ -206,6 +231,7 @@ void test_mpmc_queue()
     }
   }
 
+  // Wider producer/consumer fan-in/fan-out on a moderate queue capacity.
   {
     constexpr size_t PRODUCER_COUNT = 4;
     constexpr size_t CONSUMER_COUNT = 4;

--- a/test/test_mpmc_queue.cpp
+++ b/test/test_mpmc_queue.cpp
@@ -3,12 +3,15 @@
 #include "test.hpp"
 
 #include <atomic>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 
 namespace
 {
 using Queue = LibXR::MPMCQueue<uint16_t>;
+
+bool EqualDouble(double a, double b) { return std::abs(a - b) < 1e-9; }
 
 struct ProducerArg
 {
@@ -128,6 +131,21 @@ void test_mpmc_queue()
       ASSERT(value == round * 4 + 3);
       ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
     }
+  }
+
+  {
+    LibXR::MPMCQueue<double> queue(2);
+    double value = 0.0;
+
+    ASSERT(queue.Push(1.25) == LibXR::ErrorCode::OK);
+    ASSERT(queue.Push(2.5) == LibXR::ErrorCode::OK);
+    ASSERT(queue.Push(3.75) == LibXR::ErrorCode::FULL);
+
+    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    ASSERT(EqualDouble(value, 1.25));
+    ASSERT(queue.Pop(value) == LibXR::ErrorCode::OK);
+    ASSERT(EqualDouble(value, 2.5));
+    ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
   }
 
   {


### PR DESCRIPTION
## Summary
- add a bounded templated `MPMCQueue<Payload>`
- keep the lock-free byte protocol in a shared non-template `MPMCQueueCore` to avoid per-payload code duplication
- add focused MPMC queue tests without pulling in the later `spsc/spmc` queue-family split

## Scope
- includes only MPMC queue/core/export/tests
- does not include the later single-producer queue split
- does not include message-layer or port-layer queue replacement

## Verification
- Ubuntu24 normal Linux configure/build PASS
- targeted `mpmc_queue_only` executable PASS, running `test_mpmc_queue()` directly
- `LIBXR_SINGLE_CORE` Linux default remains `OFF`

## Artifacts
- `/home/xiao/runs/libxr_pr2_mpmc_verify_20260607T120255Z/99_summary.txt`
- `/home/xiao/runs/libxr_pr2_mpmc_verify_20260607T120255Z/test_mpmc_only.log`

## Summary by Sourcery

引入一个有界、无锁的多生产者多消费者队列，其核心为共享的非模板实现，并将其集成到公共的 libxr 接口与测试套件中。

New Features:
- 添加模版封装 `MPMCQueue<Payload>`，为可平凡拷贝的负载类型提供有界的 MPMC 队列 API。
- 添加共享的非模板 `MPMCQueueCore`，实现底层基于字节的无锁队列协议。

Tests:
- 添加单元测试和并发测试，用于验证 MPMC 队列的容量统计、满/空行为以及多线程生产者/消费者的正确性。
- 在现有测试框架中注册新的 MPMC 队列测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a bounded, lock-free multi-producer multi-consumer queue with a shared non-templated core and integrate it into the public libxr interface and test suite.

New Features:
- Add a templated MPMCQueue<Payload> wrapper providing a bounded MPMC queue API for trivially copyable payload types.
- Add a shared non-templated MPMCQueueCore implementing the underlying lock-free byte-based queue protocol.

Tests:
- Add unit and concurrency tests validating MPMC queue capacity accounting, full/empty behavior, and multi-threaded producer/consumer correctness.
- Register the new MPMC queue tests in the existing test harness.

</details>