### PR TITLE
feat(structure): add object pool

### DIFF
--- a/src/libxr.hpp
+++ b/src/libxr.hpp
@@ -22,6 +22,7 @@
 #include "list.hpp"
 #include "lockfree_list.hpp"
 #include "lockfree_pool.hpp"
+#include "object_pool.hpp"
 #include "logger.hpp"
 #include "message.hpp"
 #if defined(LIBXR_SYSTEM_POSIX_HOST)

--- a/src/structure/object_pool.hpp
+++ b/src/structure/object_pool.hpp
@@ -1,0 +1,313 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <new>
+#include <type_traits>
+#include <utility>
+
+#include "libxr_def.hpp"
+#include "queue.hpp"
+
+namespace LibXR
+{
+template <typename QueueType>
+concept PoolIndexQueue = requires(QueueType queue,
+                                  const typename QueueType::ValueType& index_const,
+                                  typename QueueType::ValueType& index_mut)
+{
+  typename QueueType::ValueType;
+  { queue.Push(index_const) } -> std::same_as<ErrorCode>;
+  { queue.Pop(index_mut) } -> std::same_as<ErrorCode>;
+  { queue.Pop() } -> std::same_as<ErrorCode>;
+};
+
+/**
+ * @class BasicObjectPool
+ * @brief 基于空闲索引队列的 RAII 槽池。
+ * @brief RAII slot pool backed by a free-index queue.
+ *
+ * 该池使用一个索引队列管理空闲槽位；成功获取后返回 move-only `Handle`，其析构会
+ * 自动把槽位索引归还到空闲队列。这样上层只依赖四类队列共享的最小 typed 接口。
+ *
+ * This pool uses one index queue to manage free slots. Successful acquisition
+ * returns one move-only `Handle`, whose destructor automatically returns the
+ * slot index back to the free queue. This keeps the upper layer dependent only
+ * on the minimal typed interface shared by the queue family.
+ *
+ * @tparam Data 槽内对象类型。 Slot object type.
+ * @tparam FreeQueue 空闲索引队列类型。 Free-index queue type.
+ */
+template <typename Data, PoolIndexQueue FreeQueue>
+class BasicObjectPool
+{
+ public:
+  using ValueType = Data;                           ///< 槽内对象类型。 Slot object type.
+  using QueueType = FreeQueue;                     ///< 空闲索引队列类型。 Free-index queue type.
+  using IndexType = typename FreeQueue::ValueType; ///< 槽索引类型。 Slot index type.
+
+  static_assert(std::is_integral_v<IndexType>,
+                "BasicObjectPool requires an integral index queue");
+  static_assert(std::is_unsigned_v<IndexType>,
+                "BasicObjectPool requires an unsigned index queue");
+
+  class Handle
+  {
+   public:
+    Handle() = default;
+
+    Handle(BasicObjectPool* pool, IndexType index) : pool_(pool), index_(index) {}
+
+    Handle(const Handle&) = delete;
+    Handle& operator=(const Handle&) = delete;
+
+    Handle(Handle&& other) noexcept
+        : pool_(std::exchange(other.pool_, nullptr)),
+          index_(std::exchange(other.index_, IndexType{}))
+    {
+    }
+
+    Handle& operator=(Handle&& other) noexcept
+    {
+      if (this == &other)
+      {
+        return *this;
+      }
+
+      Reset();
+      pool_ = std::exchange(other.pool_, nullptr);
+      index_ = std::exchange(other.index_, IndexType{});
+      return *this;
+    }
+
+    ~Handle() { Reset(); }
+
+    [[nodiscard]] bool Valid() const { return pool_ != nullptr; }
+
+    [[nodiscard]] Data& Get()
+    {
+      ASSERT(pool_ != nullptr);
+      return pool_->slots_[index_];
+    }
+
+    [[nodiscard]] const Data& Get() const
+    {
+      ASSERT(pool_ != nullptr);
+      return pool_->slots_[index_];
+    }
+
+    [[nodiscard]] Data* operator->() { return &Get(); }
+    [[nodiscard]] const Data* operator->() const { return &Get(); }
+    [[nodiscard]] Data& operator*() { return Get(); }
+    [[nodiscard]] const Data& operator*() const { return Get(); }
+
+    [[nodiscard]] IndexType Index() const
+    {
+      ASSERT(pool_ != nullptr);
+      return index_;
+    }
+
+    void Reset()
+    {
+      if (pool_ == nullptr)
+      {
+        return;
+      }
+
+      const ErrorCode ec = pool_->Release(index_);
+      ASSERT(ec == ErrorCode::OK);
+      pool_ = nullptr;
+      index_ = IndexType{};
+    }
+
+   private:
+    BasicObjectPool* pool_ = nullptr;  ///< 所属 pool。 Owning pool.
+    IndexType index_ = {};      ///< 槽位索引。 Slot index.
+  };
+
+  /**
+   * @brief 用内部 queue 和内部 slots 构造 pool。
+   * @brief Construct the pool with an internal queue and internal slots.
+   * @param slot_count 槽位数量。 Number of slots.
+   */
+  template <typename T = Data>
+  requires std::is_default_constructible_v<T>
+  explicit BasicObjectPool(size_t slot_count) : slot_count_(slot_count)
+  {
+    ConstructOwnedQueue(slot_count_);
+    AllocateOwnedSlots();
+    InitializeFreeQueue();
+  }
+
+  /**
+   * @brief 用内部 queue 和外部 slots 构造 pool。
+   * @brief Construct the pool with an internal queue and external slots.
+   * @param slot_count 槽位数量。 Number of slots.
+   * @param slots 外部槽数组。 Caller-provided slot storage.
+   */
+  BasicObjectPool(size_t slot_count, Data* slots)
+      : slot_count_(slot_count), slots_(slots)
+  {
+    ASSERT(slots_ != nullptr);
+    ConstructOwnedQueue(slot_count_);
+    InitializeFreeQueue();
+  }
+
+  /**
+   * @brief 用外部 queue 和内部 slots 构造 pool。
+   * @brief Construct the pool with an external queue and internal slots.
+   * @param free_queue 外部空闲索引队列。 Caller-provided free-index queue.
+   * @param slot_count 槽位数量。 Number of slots.
+   *
+   * @note 调用方传入的 `free_queue` 必须是空队列，并且只供当前 pool 独占使用。
+   *       The caller-provided `free_queue` must be empty and dedicated to this pool.
+   */
+  template <typename T = Data>
+  requires std::is_default_constructible_v<T>
+  BasicObjectPool(FreeQueue& free_queue, size_t slot_count)
+      : free_queue_(&free_queue), slot_count_(slot_count)
+  {
+    AllocateOwnedSlots();
+    InitializeFreeQueue();
+  }
+
+  /**
+   * @brief 用外部 queue 和外部 slots 构造 pool。
+   * @brief Construct the pool with an external queue and external slots.
+   * @param free_queue 外部空闲索引队列。 Caller-provided free-index queue.
+   * @param slot_count 槽位数量。 Number of slots.
+   * @param slots 外部槽数组。 Caller-provided slot storage.
+   *
+   * @note 调用方传入的 `free_queue` 必须是空队列，并且只供当前 pool 独占使用。
+   *       The caller-provided `free_queue` must be empty and dedicated to this pool.
+   */
+  BasicObjectPool(FreeQueue& free_queue, size_t slot_count, Data* slots)
+      : free_queue_(&free_queue), slot_count_(slot_count), slots_(slots)
+  {
+    ASSERT(slots_ != nullptr);
+    InitializeFreeQueue();
+  }
+
+  ~BasicObjectPool()
+  {
+    if (owns_slots_)
+    {
+      delete[] slots_;
+    }
+
+    if (owns_free_queue_)
+    {
+      free_queue_->~FreeQueue();
+    }
+  }
+
+  BasicObjectPool(const BasicObjectPool&) = delete;
+  BasicObjectPool& operator=(const BasicObjectPool&) = delete;
+  BasicObjectPool(BasicObjectPool&&) = delete;
+  BasicObjectPool& operator=(BasicObjectPool&&) = delete;
+
+  ErrorCode Acquire(Handle& handle)
+  {
+    IndexType index = 0;
+    const ErrorCode ec = free_queue_->Pop(index);
+    if (ec != ErrorCode::OK)
+    {
+      return ec;
+    }
+
+    ASSERT(static_cast<size_t>(index) < slot_count_);
+    handle = Handle(this, index);
+    return ErrorCode::OK;
+  }
+
+  [[nodiscard]] ErrorCode TryAcquire(Handle& handle) { return Acquire(handle); }
+
+  [[nodiscard]] size_t EmptySize() const { return free_queue_->Size(); }
+  [[nodiscard]] size_t Size() const { return slot_count_; }
+
+  [[nodiscard]] Data& operator[](size_t index)
+  {
+    ASSERT(index < slot_count_);
+    return slots_[index];
+  }
+
+  [[nodiscard]] const Data& operator[](size_t index) const
+  {
+    ASSERT(index < slot_count_);
+    return slots_[index];
+  }
+
+ private:
+  ErrorCode Release(IndexType index)
+  {
+    ASSERT(static_cast<size_t>(index) < slot_count_);
+    return free_queue_->Push(index);
+  }
+
+  void ConstructOwnedQueue(size_t slot_count)
+  {
+    free_queue_ = new (free_queue_storage_) FreeQueue(slot_count);
+    owns_free_queue_ = true;
+  }
+
+  void AllocateOwnedSlots()
+  {
+    slots_ = new Data[slot_count_];
+    owns_slots_ = true;
+  }
+
+  void InitializeFreeQueue()
+  {
+    ASSERT(slot_count_ <= static_cast<size_t>(std::numeric_limits<IndexType>::max()) + 1U);
+    for (size_t index = 0; index < slot_count_; ++index)
+    {
+      const ErrorCode ec = free_queue_->Push(static_cast<IndexType>(index));
+      ASSERT(ec == ErrorCode::OK);
+    }
+  }
+
+  alignas(FreeQueue) std::byte free_queue_storage_[sizeof(FreeQueue)] = {};
+  FreeQueue* free_queue_ = nullptr; ///< 空闲索引队列指针。 Pointer to the free-index queue.
+  const size_t slot_count_;        ///< 槽位总数。 Total slot count.
+  Data* slots_ = nullptr;          ///< 槽数组。 Slot storage.
+  bool owns_free_queue_ = false;   ///< 是否拥有内部 queue。 Whether this pool owns the free queue.
+  bool owns_slots_ = false;        ///< 是否拥有内部 slots。 Whether this pool owns the slot storage.
+};
+
+/**
+ * @brief 基于普通 FIFO 空闲索引队列的 RAII pool 别名。
+ * @brief RAII pool alias backed by the ordinary FIFO free-index queue.
+ * @tparam Data 槽内对象类型。 Slot object type.
+ * @tparam IndexType 槽索引类型，默认 `uint32_t`。 Slot index type, default `uint32_t`.
+ */
+template <typename Data, typename IndexType = uint32_t>
+using ObjectPool = BasicObjectPool<Data, Queue<IndexType>>;
+
+/**
+ * @brief 基于 SPSC 空闲索引队列的 RAII pool 别名。
+ * @brief RAII pool alias backed by the SPSC free-index queue.
+ * @tparam Data 槽内对象类型。 Slot object type.
+ * @tparam IndexType 槽索引类型，默认 `uint32_t`。 Slot index type, default `uint32_t`.
+ */
+template <typename Data, typename IndexType = uint32_t>
+using SPSCObjectPool = BasicObjectPool<Data, SPSCQueue<IndexType>>;
+
+/**
+ * @brief 基于 SPMC 空闲索引队列的 RAII pool 别名。
+ * @brief RAII pool alias backed by the SPMC free-index queue.
+ * @tparam Data 槽内对象类型。 Slot object type.
+ * @tparam IndexType 槽索引类型，默认 `uint32_t`。 Slot index type, default `uint32_t`.
+ */
+template <typename Data, typename IndexType = uint32_t>
+using SPMCObjectPool = BasicObjectPool<Data, SPMCQueue<IndexType>>;
+
+/**
+ * @brief 基于 MPMC 空闲索引队列的 RAII pool 别名。
+ * @brief RAII pool alias backed by the MPMC free-index queue.
+ * @tparam Data 槽内对象类型。 Slot object type.
+ * @tparam IndexType 槽索引类型，默认 `uint32_t`。 Slot index type, default `uint32_t`.
+ */
+template <typename Data, typename IndexType = uint32_t>
+using MPMCObjectPool = BasicObjectPool<Data, MPMCQueue<IndexType>>;
+}  // namespace LibXR

--- a/src/structure/object_pool.hpp
+++ b/src/structure/object_pool.hpp
@@ -331,7 +331,7 @@ class BasicObjectPool
    * @return 成功返回 `ErrorCode::OK`，池空返回 `ErrorCode::EMPTY`。
    *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when the pool is empty.
    */
-  ErrorCode Acquire(Handle& handle)
+  [[nodiscard]] ErrorCode Acquire(Handle& handle)
   {
     IndexType index = 0;
     const ErrorCode ec = free_queue_->Pop(index);
@@ -344,15 +344,6 @@ class BasicObjectPool
     handle = Handle(this, index);
     return ErrorCode::OK;
   }
-
-  /**
-   * @brief 尝试获取一个槽位 handle。
-   * @brief Try to acquire one slot handle.
-   * @param handle 用于接收成功获取的 handle。 Handle receiving the acquired slot.
-   * @return 成功返回 `ErrorCode::OK`，池空返回 `ErrorCode::EMPTY`。
-   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when the pool is empty.
-   */
-  [[nodiscard]] ErrorCode TryAcquire(Handle& handle) { return Acquire(handle); }
 
   /**
    * @brief 返回当前仍可获取的空闲槽位数。

--- a/src/structure/object_pool.hpp
+++ b/src/structure/object_pool.hpp
@@ -12,6 +12,22 @@
 
 namespace LibXR
 {
+/**
+ * @brief 可作为对象池空闲索引队列的类型约束。
+ * @brief Type constraint for free-index queues used by object pools.
+ *
+ * 该约束只要求队列提供最小的强类型接口：
+ * - `ValueType`
+ * - `Push(const ValueType&)`
+ * - `Pop(ValueType&)`
+ * - `Pop()`
+ *
+ * This constraint requires only the minimal typed queue interface:
+ * - `ValueType`
+ * - `Push(const ValueType&)`
+ * - `Pop(ValueType&)`
+ * - `Pop()`
+ */
 template <typename QueueType>
 concept PoolIndexQueue = requires(QueueType queue,
                                   const typename QueueType::ValueType& index_const,
@@ -47,27 +63,61 @@ class BasicObjectPool
   using QueueType = FreeQueue;                     ///< 空闲索引队列类型。 Free-index queue type.
   using IndexType = typename FreeQueue::ValueType; ///< 槽索引类型。 Slot index type.
 
+  /// @brief 槽索引必须是整数类型。 Slot indices must use an integral type.
   static_assert(std::is_integral_v<IndexType>,
                 "BasicObjectPool requires an integral index queue");
+  /// @brief 槽索引必须是无符号整数类型。 Slot indices must use an unsigned integral type.
   static_assert(std::is_unsigned_v<IndexType>,
                 "BasicObjectPool requires an unsigned index queue");
 
+  /**
+   * @class Handle
+   * @brief 对象池槽位的 move-only RAII 句柄。
+   * @brief Move-only RAII handle for one object-pool slot.
+   *
+   * 句柄持有一个槽位索引及所属 pool 指针；析构时会自动把索引归还到空闲队列。
+   * The handle stores one slot index plus its owning pool pointer, and returns
+   * the index to the free queue automatically on destruction.
+   */
   class Handle
   {
    public:
+    /**
+     * @brief 构造一个空 handle。
+     * @brief Construct an empty handle.
+     */
     Handle() = default;
 
+    /**
+     * @brief 用指定 pool 和槽位索引构造 handle。
+     * @brief Construct a handle from the given pool and slot index.
+     * @param pool 所属对象池。 Owning object pool.
+     * @param index 槽位索引。 Slot index.
+     */
     Handle(BasicObjectPool* pool, IndexType index) : pool_(pool), index_(index) {}
 
+    /// @brief 禁止拷贝构造。 Non-copyable.
     Handle(const Handle&) = delete;
+    /// @brief 禁止拷贝赋值。 Non-copy-assignable.
     Handle& operator=(const Handle&) = delete;
 
+    /**
+     * @brief 移动构造 handle，并转移槽位所有权。
+     * @brief Move-construct the handle and transfer slot ownership.
+     * @param other 被转移的源 handle。 Source handle being moved from.
+     */
     Handle(Handle&& other) noexcept
         : pool_(std::exchange(other.pool_, nullptr)),
           index_(std::exchange(other.index_, IndexType{}))
     {
     }
 
+    /**
+     * @brief 移动赋值 handle，并转移槽位所有权。
+     * @brief Move-assign the handle and transfer slot ownership.
+     * @param other 被转移的源 handle。 Source handle being moved from.
+     * @return 当前 handle 的引用。 Reference to this handle.
+     */
     Handle& operator=(Handle&& other) noexcept
     {
       if (this == &other)
@@ -81,33 +131,85 @@ class BasicObjectPool
       return *this;
     }
 
+    /**
+     * @brief 析构 handle，并自动归还槽位。
+     * @brief Destroy the handle and return the slot automatically.
+     */
     ~Handle() { Reset(); }
 
+    /**
+     * @brief 判断当前 handle 是否持有有效槽位。
+     * @brief Return whether this handle currently owns a valid slot.
+     * @return 持有有效槽位返回 `true`，否则返回 `false`。
+     *         Returns `true` when this handle owns a valid slot, otherwise `false`.
+     */
     [[nodiscard]] bool Valid() const { return pool_ != nullptr; }
 
+    /**
+     * @brief 返回当前槽位对象的可写引用。
+     * @brief Return a writable reference to the current slot object.
+     * @return 当前槽位对象引用。 Reference to the current slot object.
+     */
     [[nodiscard]] Data& Get()
     {
       ASSERT(pool_ != nullptr);
       return pool_->slots_[index_];
     }
 
+    /**
+     * @brief 返回当前槽位对象的只读引用。
+     * @brief Return a read-only reference to the current slot object.
+     * @return 当前槽位对象常量引用。 Const reference to the current slot object.
+     */
     [[nodiscard]] const Data& Get() const
     {
       ASSERT(pool_ != nullptr);
       return pool_->slots_[index_];
     }
 
+    /**
+     * @brief 以指针形式访问当前槽位对象。
+     * @brief Access the current slot object as a pointer.
+     * @return 指向当前槽位对象的指针。 Pointer to the current slot object.
+     */
     [[nodiscard]] Data* operator->() { return &Get(); }
+
+    /**
+     * @brief 以只读指针形式访问当前槽位对象。
+     * @brief Access the current slot object as a const pointer.
+     * @return 指向当前槽位对象的只读指针。 Const pointer to the current slot object.
+     */
     [[nodiscard]] const Data* operator->() const { return &Get(); }
+
+    /**
+     * @brief 解引用当前槽位对象。
+     * @brief Dereference the current slot object.
+     * @return 当前槽位对象引用。 Reference to the current slot object.
+     */
     [[nodiscard]] Data& operator*() { return Get(); }
+
+    /**
+     * @brief 只读解引用当前槽位对象。
+     * @brief Dereference the current slot object as const.
+     * @return 当前槽位对象常量引用。 Const reference to the current slot object.
+     */
     [[nodiscard]] const Data& operator*() const { return Get(); }
 
+    /**
+     * @brief 返回当前持有的槽位索引。
+     * @brief Return the currently owned slot index.
+     * @return 当前槽位索引。 Current slot index.
+     */
     [[nodiscard]] IndexType Index() const
     {
       ASSERT(pool_ != nullptr);
       return index_;
     }
 
+    /**
+     * @brief 主动归还当前槽位，并使 handle 失效。
+     * @brief Return the current slot explicitly and invalidate the handle.
+     */
     void Reset()
     {
       if (pool_ == nullptr)
@@ -122,8 +224,8 @@ class BasicObjectPool
     }
 
    private:
-    BasicObjectPool* pool_ = nullptr;  ///< 所属 pool。 Owning pool.
-    IndexType index_ = {};      ///< 槽位索引。 Slot index.
+    BasicObjectPool* pool_ = nullptr;  ///< 所属对象池。 Owning object pool.
+    IndexType index_ = {};             ///< 当前槽位索引。 Current slot index.
   };
 
   /**
@@ -145,6 +247,10 @@ class BasicObjectPool
    * @brief Construct the pool with an internal queue and external slots.
    * @param slot_count 槽位数量。 Number of slots.
    * @param slots 外部槽数组。 Caller-provided slot storage.
+   *
+   * @note 调用方必须保证 `slots` 指向至少 `slot_count` 个 `Data` 槽位。
+   *       The caller must ensure that `slots` points to at least `slot_count`
+   *       `Data` slots.
    */
   BasicObjectPool(size_t slot_count, Data* slots)
       : slot_count_(slot_count), slots_(slots)
@@ -181,6 +287,9 @@ class BasicObjectPool
    *
    * @note 调用方传入的 `free_queue` 必须是空队列，并且只供当前 pool 独占使用。
    *       The caller-provided `free_queue` must be empty and dedicated to this pool.
+   * @note 调用方必须保证 `slots` 指向至少 `slot_count` 个 `Data` 槽位。
+   *       The caller must ensure that `slots` points to at least `slot_count`
+   *       `Data` slots.
    */
   BasicObjectPool(FreeQueue& free_queue, size_t slot_count, Data* slots)
       : free_queue_(&free_queue), slot_count_(slot_count), slots_(slots)
@@ -189,6 +298,10 @@ class BasicObjectPool
     InitializeFreeQueue();
   }
 
+  /**
+   * @brief 析构对象池，并释放其拥有的内部资源。
+   * @brief Destroy the object pool and release owned internal resources.
+   */
   ~BasicObjectPool()
   {
     if (owns_slots_)
@@ -202,11 +315,22 @@ class BasicObjectPool
     }
   }
 
+  /// @brief 禁止拷贝构造。 Non-copyable.
   BasicObjectPool(const BasicObjectPool&) = delete;
+  /// @brief 禁止拷贝赋值。 Non-copy-assignable.
   BasicObjectPool& operator=(const BasicObjectPool&) = delete;
+  /// @brief 禁止移动构造。 Non-movable.
   BasicObjectPool(BasicObjectPool&&) = delete;
+  /// @brief 禁止移动赋值。 Non-move-assignable.
   BasicObjectPool& operator=(BasicObjectPool&&) = delete;
 
+  /**
+   * @brief 获取一个槽位 handle。
+   * @brief Acquire one slot handle.
+   * @param handle 用于接收成功获取的 handle。 Handle receiving the acquired slot.
+   * @return 成功返回 `ErrorCode::OK`，池空返回 `ErrorCode::EMPTY`。
+   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when the pool is empty.
+   */
   ErrorCode Acquire(Handle& handle)
   {
     IndexType index = 0;
@@ -221,17 +345,47 @@ class BasicObjectPool
     return ErrorCode::OK;
   }
 
+  /**
+   * @brief 尝试获取一个槽位 handle。
+   * @brief Try to acquire one slot handle.
+   * @param handle 用于接收成功获取的 handle。 Handle receiving the acquired slot.
+   * @return 成功返回 `ErrorCode::OK`，池空返回 `ErrorCode::EMPTY`。
+   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when the pool is empty.
+   */
   [[nodiscard]] ErrorCode TryAcquire(Handle& handle) { return Acquire(handle); }
 
+  /**
+   * @brief 返回当前仍可获取的空闲槽位数。
+   * @brief Return the number of currently acquirable free slots.
+   * @return 当前空闲槽位数。 Current number of free slots.
+   */
   [[nodiscard]] size_t EmptySize() const { return free_queue_->Size(); }
+
+  /**
+   * @brief 返回对象池总槽位数。
+   * @brief Return the total number of slots in the pool.
+   * @return 槽位总数。 Total slot count.
+   */
   [[nodiscard]] size_t Size() const { return slot_count_; }
 
+  /**
+   * @brief 通过槽位索引访问对象。
+   * @brief Access an object by slot index.
+   * @param index 槽位索引。 Slot index.
+   * @return 对应槽位对象的引用。 Reference to the object stored in the slot.
+   */
   [[nodiscard]] Data& operator[](size_t index)
   {
     ASSERT(index < slot_count_);
     return slots_[index];
   }
 
+  /**
+   * @brief 通过槽位索引只读访问对象。
+   * @brief Access an object by slot index as const.
+   * @param index 槽位索引。 Slot index.
+   * @return 对应槽位对象的常量引用。 Const reference to the object stored in the slot.
+   */
   [[nodiscard]] const Data& operator[](size_t index) const
   {
     ASSERT(index < slot_count_);
@@ -239,24 +393,44 @@ class BasicObjectPool
   }
 
  private:
+  /**
+   * @brief 把指定槽位索引归还到空闲队列。
+   * @brief Return the given slot index back to the free queue.
+   * @param index 待归还的槽位索引。 Slot index to return.
+   * @return 底层空闲队列返回的结果码。 Result code returned by the underlying free queue.
+   */
   ErrorCode Release(IndexType index)
   {
     ASSERT(static_cast<size_t>(index) < slot_count_);
     return free_queue_->Push(index);
   }
 
+  /**
+   * @brief 在内部存储区里构造一个自拥有空闲队列。
+   * @brief Construct an owned free queue inside internal storage.
+   * @param slot_count 槽位数量，同时也是初始化时要压入的索引数量。
+   *                   Slot count and thus the number of indices to preload.
+   */
   void ConstructOwnedQueue(size_t slot_count)
   {
     free_queue_ = new (free_queue_storage_) FreeQueue(slot_count);
     owns_free_queue_ = true;
   }
 
+  /**
+   * @brief 申请并拥有内部槽数组。
+   * @brief Allocate and own the internal slot storage.
+   */
   void AllocateOwnedSlots()
   {
     slots_ = new Data[slot_count_];
     owns_slots_ = true;
   }
 
+  /**
+   * @brief 用 `0 .. slot_count - 1` 初始化空闲索引队列。
+   * @brief Initialize the free-index queue with `0 .. slot_count - 1`.
+   */
   void InitializeFreeQueue()
   {
     ASSERT(slot_count_ <= static_cast<size_t>(std::numeric_limits<IndexType>::max()) + 1U);
@@ -267,12 +441,13 @@ class BasicObjectPool
     }
   }
 
+  /// @brief 内部自拥有 queue 的原地构造存储区。 In-place storage for an internally owned queue.
   alignas(FreeQueue) std::byte free_queue_storage_[sizeof(FreeQueue)] = {};
   FreeQueue* free_queue_ = nullptr; ///< 空闲索引队列指针。 Pointer to the free-index queue.
-  const size_t slot_count_;        ///< 槽位总数。 Total slot count.
-  Data* slots_ = nullptr;          ///< 槽数组。 Slot storage.
-  bool owns_free_queue_ = false;   ///< 是否拥有内部 queue。 Whether this pool owns the free queue.
-  bool owns_slots_ = false;        ///< 是否拥有内部 slots。 Whether this pool owns the slot storage.
+  const size_t slot_count_;         ///< 槽位总数。 Total slot count.
+  Data* slots_ = nullptr;           ///< 槽数组指针。 Pointer to slot storage.
+  bool owns_free_queue_ = false;    ///< 是否拥有内部 queue。 Whether this pool owns the free queue.
+  bool owns_slots_ = false;         ///< 是否拥有内部 slots。 Whether this pool owns the slot storage.
 };
 
 /**

--- a/src/structure/object_pool.hpp
+++ b/src/structure/object_pool.hpp
@@ -20,13 +20,13 @@ namespace LibXR
  * - `ValueType`
  * - `Push(const ValueType&)`
  * - `Pop(ValueType&)`
- * - `Pop()`
+ * - `Size()`
  *
  * This constraint requires only the minimal typed queue interface:
  * - `ValueType`
  * - `Push(const ValueType&)`
  * - `Pop(ValueType&)`
- * - `Pop()`
+ * - `Size()`
  */
 template <typename QueueType>
 concept PoolIndexQueue = requires(QueueType queue,
@@ -36,7 +36,6 @@ concept PoolIndexQueue = requires(QueueType queue,
   typename QueueType::ValueType;
   { queue.Push(index_const) } -> std::same_as<ErrorCode>;
   { queue.Pop(index_mut) } -> std::same_as<ErrorCode>;
-  { queue.Pop() } -> std::same_as<ErrorCode>;
   { queue.Size() } -> std::convertible_to<size_t>;
 };
 
@@ -271,6 +270,8 @@ class BasicObjectPool
    *
    * @note 调用方传入的 `free_queue` 必须是空队列，并且只供当前 pool 独占使用。
    *       The caller-provided `free_queue` must be empty and dedicated to this pool.
+   * @note 调用方必须保证 `free_queue` 的容量至少为 `slot_count`。
+   *       The caller must ensure that `free_queue` capacity is at least `slot_count`.
    */
   template <typename T = Data>
   requires std::is_default_constructible_v<T>
@@ -292,6 +293,8 @@ class BasicObjectPool
    *
    * @note 调用方传入的 `free_queue` 必须是空队列，并且只供当前 pool 独占使用。
    *       The caller-provided `free_queue` must be empty and dedicated to this pool.
+   * @note 调用方必须保证 `free_queue` 的容量至少为 `slot_count`。
+   *       The caller must ensure that `free_queue` capacity is at least `slot_count`.
    * @note 调用方必须保证 `slots` 指向至少 `slot_count` 个 `Data` 槽位。
    *       The caller must ensure that `slots` points to at least `slot_count`
    *       `Data` slots.
@@ -311,6 +314,8 @@ class BasicObjectPool
    */
   ~BasicObjectPool()
   {
+    ASSERT(EmptySize() == slot_count_);
+
     if (owns_slots_)
     {
       delete[] slots_;
@@ -369,24 +374,36 @@ class BasicObjectPool
   [[nodiscard]] size_t Size() const { return slot_count_; }
 
   /**
-   * @brief 通过槽位索引访问对象。
-   * @brief Access an object by slot index.
+   * @brief 通过槽位索引直接访问对象，不参与所有权检查。
+   * @brief Access an object by slot index without ownership checks.
    * @param index 槽位索引。 Slot index.
    * @return 对应槽位对象的引用。 Reference to the object stored in the slot.
+   *
+   * @note 该接口会绕过 `Acquire()` / `Handle` 的所有权语义，只适合调试、检查
+   *       外部存储区或其他明确知道槽位状态的场景。
+   *       This API bypasses the ownership semantics of `Acquire()` / `Handle`,
+   *       and is intended only for debugging, external-storage inspection, or
+   *       other cases where the caller already knows the slot state.
    */
-  [[nodiscard]] Data& operator[](size_t index)
+  [[nodiscard]] Data& UnsafeAt(size_t index)
   {
     ASSERT(index < slot_count_);
     return slots_[index];
   }
 
   /**
-   * @brief 通过槽位索引只读访问对象。
-   * @brief Access an object by slot index as const.
+   * @brief 通过槽位索引只读直接访问对象，不参与所有权检查。
+   * @brief Access an object by slot index as const without ownership checks.
    * @param index 槽位索引。 Slot index.
    * @return 对应槽位对象的常量引用。 Const reference to the object stored in the slot.
+   *
+   * @note 该接口会绕过 `Acquire()` / `Handle` 的所有权语义，只适合调试、检查
+   *       外部存储区或其他明确知道槽位状态的场景。
+   *       This API bypasses the ownership semantics of `Acquire()` / `Handle`,
+   *       and is intended only for debugging, external-storage inspection, or
+   *       other cases where the caller already knows the slot state.
    */
-  [[nodiscard]] const Data& operator[](size_t index) const
+  [[nodiscard]] const Data& UnsafeAt(size_t index) const
   {
     ASSERT(index < slot_count_);
     return slots_[index];

--- a/src/structure/object_pool.hpp
+++ b/src/structure/object_pool.hpp
@@ -37,6 +37,7 @@ concept PoolIndexQueue = requires(QueueType queue,
   { queue.Push(index_const) } -> std::same_as<ErrorCode>;
   { queue.Pop(index_mut) } -> std::same_as<ErrorCode>;
   { queue.Pop() } -> std::same_as<ErrorCode>;
+  { queue.Size() } -> std::convertible_to<size_t>;
 };
 
 /**
@@ -237,6 +238,7 @@ class BasicObjectPool
   requires std::is_default_constructible_v<T>
   explicit BasicObjectPool(size_t slot_count) : slot_count_(slot_count)
   {
+    ASSERT(slot_count_ > 0);
     ConstructOwnedQueue(slot_count_);
     AllocateOwnedSlots();
     InitializeFreeQueue();
@@ -255,6 +257,7 @@ class BasicObjectPool
   BasicObjectPool(size_t slot_count, Data* slots)
       : slot_count_(slot_count), slots_(slots)
   {
+    ASSERT(slot_count_ > 0);
     ASSERT(slots_ != nullptr);
     ConstructOwnedQueue(slot_count_);
     InitializeFreeQueue();
@@ -274,6 +277,8 @@ class BasicObjectPool
   BasicObjectPool(FreeQueue& free_queue, size_t slot_count)
       : free_queue_(&free_queue), slot_count_(slot_count)
   {
+    ASSERT(slot_count_ > 0);
+    ASSERT(free_queue.Size() == 0);
     AllocateOwnedSlots();
     InitializeFreeQueue();
   }
@@ -294,7 +299,9 @@ class BasicObjectPool
   BasicObjectPool(FreeQueue& free_queue, size_t slot_count, Data* slots)
       : free_queue_(&free_queue), slot_count_(slot_count), slots_(slots)
   {
+    ASSERT(slot_count_ > 0);
     ASSERT(slots_ != nullptr);
+    ASSERT(free_queue.Size() == 0);
     InitializeFreeQueue();
   }
 
@@ -333,6 +340,8 @@ class BasicObjectPool
    */
   [[nodiscard]] ErrorCode Acquire(Handle& handle)
   {
+    ASSERT(!handle.Valid());
+
     IndexType index = 0;
     const ErrorCode ec = free_queue_->Pop(index);
     if (ec != ErrorCode::OK)
@@ -424,7 +433,9 @@ class BasicObjectPool
    */
   void InitializeFreeQueue()
   {
-    ASSERT(slot_count_ <= static_cast<size_t>(std::numeric_limits<IndexType>::max()) + 1U);
+    ASSERT(slot_count_ > 0);
+    ASSERT(slot_count_ - 1 <=
+           static_cast<size_t>(std::numeric_limits<IndexType>::max()));
     for (size_t index = 0; index < slot_count_; ++index)
     {
       const ErrorCode ec = free_queue_->Push(static_cast<IndexType>(index));

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -86,6 +86,7 @@ static void run_libxr_tests()
                                      {"spsc_queue", test_spsc_queue, false},
                                      {"mpmc_queue", test_mpmc_queue, false},
                                      {"pool", test_lock_free_pool, false},
+                                     {"object_pool", test_object_pool, false},
                                      {"stack", test_stack, false},
                                      {"list", test_list, false},
                                      {"double_buffer", test_double_buffer, false},

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -10,6 +10,7 @@ void test_mpmc_queue();
 void test_queue();
 void test_spsc_queue();
 void test_lock_free_pool();
+void test_object_pool();
 void test_rbt();
 void test_ramfs();
 void test_semaphore();

--- a/test/test_object_pool.cpp
+++ b/test/test_object_pool.cpp
@@ -1,0 +1,169 @@
+#include "libxr.hpp"
+#include "test.hpp"
+
+namespace
+{
+struct Payload
+{
+  int value = 0;
+};
+
+template <typename QueueType>
+void RunExternalQueueChecks()
+{
+  QueueType free_queue(3);
+  LibXR::BasicObjectPool<Payload, QueueType> pool(free_queue, 3);
+
+  typename LibXR::BasicObjectPool<Payload, QueueType>::Handle a;
+  typename LibXR::BasicObjectPool<Payload, QueueType>::Handle b;
+  typename LibXR::BasicObjectPool<Payload, QueueType>::Handle c;
+
+  ASSERT(pool.TryAcquire(a) == LibXR::ErrorCode::OK);
+  ASSERT(pool.TryAcquire(b) == LibXR::ErrorCode::OK);
+  ASSERT(pool.TryAcquire(c) == LibXR::ErrorCode::OK);
+  ASSERT(pool.EmptySize() == 0);
+
+  b.Reset();
+  ASSERT(pool.EmptySize() == 1);
+}
+
+template <typename QueueType>
+void RunExternalSlotChecks()
+{
+  Payload slots[3] = {};
+  LibXR::BasicObjectPool<Payload, QueueType> pool(3, slots);
+
+  typename LibXR::BasicObjectPool<Payload, QueueType>::Handle handle;
+  ASSERT(pool.TryAcquire(handle) == LibXR::ErrorCode::OK);
+  handle->value = 123;
+  ASSERT(slots[handle.Index()].value == 123);
+}
+
+template <typename QueueType>
+void RunExternalQueueAndSlotChecks()
+{
+  QueueType free_queue(3);
+  Payload slots[3] = {};
+  LibXR::BasicObjectPool<Payload, QueueType> pool(free_queue, 3, slots);
+
+  typename LibXR::BasicObjectPool<Payload, QueueType>::Handle handle;
+  ASSERT(pool.TryAcquire(handle) == LibXR::ErrorCode::OK);
+  handle->value = 456;
+  ASSERT(slots[handle.Index()].value == 456);
+}
+}  // namespace
+
+void test_object_pool()
+{
+  // Basic acquire/release using the ordinary FIFO queue as free-index storage.
+  {
+    LibXR::ObjectPool<Payload> pool(3);
+
+    LibXR::ObjectPool<Payload>::Handle a;
+    LibXR::ObjectPool<Payload>::Handle b;
+    LibXR::ObjectPool<Payload>::Handle c;
+    LibXR::ObjectPool<Payload>::Handle d;
+
+    ASSERT(pool.TryAcquire(a) == LibXR::ErrorCode::OK);
+    ASSERT(pool.TryAcquire(b) == LibXR::ErrorCode::OK);
+    ASSERT(pool.TryAcquire(c) == LibXR::ErrorCode::OK);
+    ASSERT(pool.EmptySize() == 0);
+    ASSERT(pool.TryAcquire(d) == LibXR::ErrorCode::EMPTY);
+
+    a->value = 11;
+    b->value = 22;
+    c->value = 33;
+    ASSERT((*a).value == 11);
+    ASSERT((*b).value == 22);
+    ASSERT((*c).value == 33);
+
+    const auto a_index = a.Index();
+    a.Reset();
+    ASSERT(pool.EmptySize() == 1);
+    ASSERT(pool.TryAcquire(d) == LibXR::ErrorCode::OK);
+    ASSERT(d.Index() == a_index);
+    d->value = 44;
+    ASSERT(pool[d.Index()].value == 44);
+  }
+
+  // The same pool contract should work with the typed SPSC free-index queue.
+  {
+    LibXR::SPSCObjectPool<Payload> pool(3);
+
+    LibXR::SPSCObjectPool<Payload>::Handle a;
+    LibXR::SPSCObjectPool<Payload>::Handle b;
+    LibXR::SPSCObjectPool<Payload>::Handle c;
+    LibXR::SPSCObjectPool<Payload>::Handle d;
+
+    ASSERT(pool.TryAcquire(a) == LibXR::ErrorCode::OK);
+    ASSERT(pool.TryAcquire(b) == LibXR::ErrorCode::OK);
+    ASSERT(pool.TryAcquire(c) == LibXR::ErrorCode::OK);
+    ASSERT(pool.EmptySize() == 0);
+    ASSERT(pool.TryAcquire(d) == LibXR::ErrorCode::EMPTY);
+
+    a->value = 11;
+    b->value = 22;
+    c->value = 33;
+    ASSERT((*a).value == 11);
+    ASSERT((*b).value == 22);
+    ASSERT((*c).value == 33);
+
+    const auto a_index = a.Index();
+    a.Reset();
+    ASSERT(pool.EmptySize() == 1);
+    ASSERT(pool.TryAcquire(d) == LibXR::ErrorCode::OK);
+    ASSERT(d.Index() == a_index);
+    d->value = 44;
+    ASSERT(pool[d.Index()].value == 44);
+  }
+
+  // External queue should also be supported.
+  {
+    using FreeQueue = LibXR::Queue<uint32_t>;
+    RunExternalQueueChecks<FreeQueue>();
+  }
+
+  // External slot storage should also be supported.
+  {
+    using FreeQueue = LibXR::Queue<uint32_t>;
+    RunExternalSlotChecks<FreeQueue>();
+  }
+
+  // External queue + external slot storage should both work together.
+  {
+    using FreeQueue = LibXR::Queue<uint32_t>;
+    RunExternalQueueAndSlotChecks<FreeQueue>();
+  }
+
+  // RAII release through destructor should return the slot automatically.
+  {
+    LibXR::ObjectPool<Payload> pool(2);
+
+    {
+      LibXR::ObjectPool<Payload>::Handle handle;
+      ASSERT(pool.TryAcquire(handle) == LibXR::ErrorCode::OK);
+      handle->value = 77;
+      ASSERT(pool.EmptySize() == 1);
+    }
+
+    ASSERT(pool.EmptySize() == 2);
+  }
+
+  // Move-only handle ownership should transfer the return responsibility.
+  {
+    LibXR::ObjectPool<Payload> pool(1);
+
+    LibXR::ObjectPool<Payload>::Handle first;
+    ASSERT(pool.TryAcquire(first) == LibXR::ErrorCode::OK);
+    ASSERT(pool.EmptySize() == 0);
+
+    auto second = std::move(first);
+    ASSERT(!first.Valid());
+    ASSERT(second.Valid());
+    second->value = 99;
+    ASSERT(pool[second.Index()].value == 99);
+
+    second.Reset();
+    ASSERT(pool.EmptySize() == 1);
+  }
+}

--- a/test/test_object_pool.cpp
+++ b/test/test_object_pool.cpp
@@ -117,6 +117,50 @@ void test_object_pool()
     ASSERT(pool[d.Index()].value == 44);
   }
 
+  // The same pool contract should work with the typed SPMC free-index queue.
+  {
+    LibXR::SPMCObjectPool<Payload> pool(3);
+
+    LibXR::SPMCObjectPool<Payload>::Handle a;
+    LibXR::SPMCObjectPool<Payload>::Handle b;
+    LibXR::SPMCObjectPool<Payload>::Handle c;
+    LibXR::SPMCObjectPool<Payload>::Handle d;
+
+    ASSERT(pool.Acquire(a) == LibXR::ErrorCode::OK);
+    ASSERT(pool.Acquire(b) == LibXR::ErrorCode::OK);
+    ASSERT(pool.Acquire(c) == LibXR::ErrorCode::OK);
+    ASSERT(pool.EmptySize() == 0);
+    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::EMPTY);
+
+    const auto a_index = a.Index();
+    a.Reset();
+    ASSERT(pool.EmptySize() == 1);
+    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::OK);
+    ASSERT(d.Index() == a_index);
+  }
+
+  // The same pool contract should work with the typed MPMC free-index queue.
+  {
+    LibXR::MPMCObjectPool<Payload> pool(3);
+
+    LibXR::MPMCObjectPool<Payload>::Handle a;
+    LibXR::MPMCObjectPool<Payload>::Handle b;
+    LibXR::MPMCObjectPool<Payload>::Handle c;
+    LibXR::MPMCObjectPool<Payload>::Handle d;
+
+    ASSERT(pool.Acquire(a) == LibXR::ErrorCode::OK);
+    ASSERT(pool.Acquire(b) == LibXR::ErrorCode::OK);
+    ASSERT(pool.Acquire(c) == LibXR::ErrorCode::OK);
+    ASSERT(pool.EmptySize() == 0);
+    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::EMPTY);
+
+    const auto a_index = a.Index();
+    a.Reset();
+    ASSERT(pool.EmptySize() == 1);
+    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::OK);
+    ASSERT(d.Index() == a_index);
+  }
+
   // External queue should also be supported.
   {
     using FreeQueue = LibXR::Queue<uint32_t>;

--- a/test/test_object_pool.cpp
+++ b/test/test_object_pool.cpp
@@ -83,7 +83,7 @@ void test_object_pool()
     ASSERT(pool.Acquire(d) == LibXR::ErrorCode::OK);
     ASSERT(d.Index() == a_index);
     d->value = 44;
-    ASSERT(pool[d.Index()].value == 44);
+    ASSERT(pool.UnsafeAt(d.Index()).value == 44);
   }
 
   // The same pool contract should work with the typed SPSC free-index queue.
@@ -114,7 +114,7 @@ void test_object_pool()
     ASSERT(pool.Acquire(d) == LibXR::ErrorCode::OK);
     ASSERT(d.Index() == a_index);
     d->value = 44;
-    ASSERT(pool[d.Index()].value == 44);
+    ASSERT(pool.UnsafeAt(d.Index()).value == 44);
   }
 
   // The same pool contract should work with the typed SPMC free-index queue.
@@ -205,7 +205,7 @@ void test_object_pool()
     ASSERT(!first.Valid());
     ASSERT(second.Valid());
     second->value = 99;
-    ASSERT(pool[second.Index()].value == 99);
+    ASSERT(pool.UnsafeAt(second.Index()).value == 99);
 
     second.Reset();
     ASSERT(pool.EmptySize() == 1);

--- a/test/test_object_pool.cpp
+++ b/test/test_object_pool.cpp
@@ -18,9 +18,9 @@ void RunExternalQueueChecks()
   typename LibXR::BasicObjectPool<Payload, QueueType>::Handle b;
   typename LibXR::BasicObjectPool<Payload, QueueType>::Handle c;
 
-  ASSERT(pool.TryAcquire(a) == LibXR::ErrorCode::OK);
-  ASSERT(pool.TryAcquire(b) == LibXR::ErrorCode::OK);
-  ASSERT(pool.TryAcquire(c) == LibXR::ErrorCode::OK);
+  ASSERT(pool.Acquire(a) == LibXR::ErrorCode::OK);
+  ASSERT(pool.Acquire(b) == LibXR::ErrorCode::OK);
+  ASSERT(pool.Acquire(c) == LibXR::ErrorCode::OK);
   ASSERT(pool.EmptySize() == 0);
 
   b.Reset();
@@ -34,7 +34,7 @@ void RunExternalSlotChecks()
   LibXR::BasicObjectPool<Payload, QueueType> pool(3, slots);
 
   typename LibXR::BasicObjectPool<Payload, QueueType>::Handle handle;
-  ASSERT(pool.TryAcquire(handle) == LibXR::ErrorCode::OK);
+  ASSERT(pool.Acquire(handle) == LibXR::ErrorCode::OK);
   handle->value = 123;
   ASSERT(slots[handle.Index()].value == 123);
 }
@@ -47,7 +47,7 @@ void RunExternalQueueAndSlotChecks()
   LibXR::BasicObjectPool<Payload, QueueType> pool(free_queue, 3, slots);
 
   typename LibXR::BasicObjectPool<Payload, QueueType>::Handle handle;
-  ASSERT(pool.TryAcquire(handle) == LibXR::ErrorCode::OK);
+  ASSERT(pool.Acquire(handle) == LibXR::ErrorCode::OK);
   handle->value = 456;
   ASSERT(slots[handle.Index()].value == 456);
 }
@@ -64,11 +64,11 @@ void test_object_pool()
     LibXR::ObjectPool<Payload>::Handle c;
     LibXR::ObjectPool<Payload>::Handle d;
 
-    ASSERT(pool.TryAcquire(a) == LibXR::ErrorCode::OK);
-    ASSERT(pool.TryAcquire(b) == LibXR::ErrorCode::OK);
-    ASSERT(pool.TryAcquire(c) == LibXR::ErrorCode::OK);
+    ASSERT(pool.Acquire(a) == LibXR::ErrorCode::OK);
+    ASSERT(pool.Acquire(b) == LibXR::ErrorCode::OK);
+    ASSERT(pool.Acquire(c) == LibXR::ErrorCode::OK);
     ASSERT(pool.EmptySize() == 0);
-    ASSERT(pool.TryAcquire(d) == LibXR::ErrorCode::EMPTY);
+    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::EMPTY);
 
     a->value = 11;
     b->value = 22;
@@ -80,7 +80,7 @@ void test_object_pool()
     const auto a_index = a.Index();
     a.Reset();
     ASSERT(pool.EmptySize() == 1);
-    ASSERT(pool.TryAcquire(d) == LibXR::ErrorCode::OK);
+    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::OK);
     ASSERT(d.Index() == a_index);
     d->value = 44;
     ASSERT(pool[d.Index()].value == 44);
@@ -95,11 +95,11 @@ void test_object_pool()
     LibXR::SPSCObjectPool<Payload>::Handle c;
     LibXR::SPSCObjectPool<Payload>::Handle d;
 
-    ASSERT(pool.TryAcquire(a) == LibXR::ErrorCode::OK);
-    ASSERT(pool.TryAcquire(b) == LibXR::ErrorCode::OK);
-    ASSERT(pool.TryAcquire(c) == LibXR::ErrorCode::OK);
+    ASSERT(pool.Acquire(a) == LibXR::ErrorCode::OK);
+    ASSERT(pool.Acquire(b) == LibXR::ErrorCode::OK);
+    ASSERT(pool.Acquire(c) == LibXR::ErrorCode::OK);
     ASSERT(pool.EmptySize() == 0);
-    ASSERT(pool.TryAcquire(d) == LibXR::ErrorCode::EMPTY);
+    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::EMPTY);
 
     a->value = 11;
     b->value = 22;
@@ -111,7 +111,7 @@ void test_object_pool()
     const auto a_index = a.Index();
     a.Reset();
     ASSERT(pool.EmptySize() == 1);
-    ASSERT(pool.TryAcquire(d) == LibXR::ErrorCode::OK);
+    ASSERT(pool.Acquire(d) == LibXR::ErrorCode::OK);
     ASSERT(d.Index() == a_index);
     d->value = 44;
     ASSERT(pool[d.Index()].value == 44);
@@ -141,7 +141,7 @@ void test_object_pool()
 
     {
       LibXR::ObjectPool<Payload>::Handle handle;
-      ASSERT(pool.TryAcquire(handle) == LibXR::ErrorCode::OK);
+      ASSERT(pool.Acquire(handle) == LibXR::ErrorCode::OK);
       handle->value = 77;
       ASSERT(pool.EmptySize() == 1);
     }
@@ -154,7 +154,7 @@ void test_object_pool()
     LibXR::ObjectPool<Payload> pool(1);
 
     LibXR::ObjectPool<Payload>::Handle first;
-    ASSERT(pool.TryAcquire(first) == LibXR::ErrorCode::OK);
+    ASSERT(pool.Acquire(first) == LibXR::ErrorCode::OK);
     ASSERT(pool.EmptySize() == 0);
 
     auto second = std::move(first);


### PR DESCRIPTION
## Summary
- add `BasicObjectPool<Data, FreeQueue>` backed by the shared typed queue interface
- add `ObjectPool`, `SPSCObjectPool`, `SPMCObjectPool`, and `MPMCObjectPool` aliases
- cover internal/external queue and slot-storage construction paths in focused tests

## Scope
- includes only the new object-pool structure and focused tests
- keeps the design dependent only on the queue family's shared typed `Push/Pop` interface
- does not change existing queue runtime behavior

## Verification
- Ubuntu24 configure/build PASS after the final naming and `Acquire` API cleanup
- `test_object_pool.cpp` is compiled into the test target successfully

## Artifacts
- `/home/xiao/runs/libxr_object_pool_verify_20260608T054417Z/99_summary.txt`

## Summary by Sourcery

引入一个基于通用 RAII 的对象池，该对象池由现有的类型化队列实现提供支持，并将其接入库和测试套件。

新功能：
- 添加一个模板化的 `BasicObjectPool` 结构体，通过基于空闲索引（free-index）的队列接口，以及一个仅支持移动的句柄来管理池化对象。
- 提供 `ObjectPool`、`SPSCObjectPool`、`SPMCObjectPool` 和 `MPMCObjectPool` 类型别名，将其与现有的类型化队列家族进行集成。

增强：
- 通过主 `libxr` 头文件对外暴露新的对象池结构，并在中央测试框架中注册其测试。

测试：
- 新增 `test_object_pool` 覆盖基本的获取/释放流程、RAII 析构、仅移动句柄语义，以及内部/外部队列和槽位存储组合等场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a generic RAII-based object pool backed by existing typed queue implementations and wire it into the library and test suite.

New Features:
- Add a templated BasicObjectPool structure with a move-only handle for managing pooled objects via a free-index queue interface.
- Provide ObjectPool, SPSCObjectPool, SPMCObjectPool, and MPMCObjectPool aliases integrating with the existing typed queue family.

Enhancements:
- Expose the new object pool structure through the main libxr header and register its tests in the central test harness.

Tests:
- Add test_object_pool coverage for basic acquire/release flows, RAII destruction, move-only handle semantics, and combinations of internal/external queue and slot storage.

</details>