### PR TITLE
fix(mspm0): overwrite gpio interrupt polarity bits

### DIFF
--- a/driver/mspm0/mspm0_gpio.cpp
+++ b/driver/mspm0/mspm0_gpio.cpp
@@ -212,14 +212,14 @@ ErrorCode MSPM0GPIO::SetConfig(Configuration config)
           uint32_t current_polarity = DL_GPIO_getLowerPinsPolarity(port_);
           current_polarity &= ~clear_mask;
           current_polarity |= pol_mask;
-          DL_GPIO_setLowerPinsPolarity(port_, current_polarity);
+          port_->POLARITY15_0 = current_polarity;
         }
         else
         {
           uint32_t current_polarity = DL_GPIO_getUpperPinsPolarity(port_);
           current_polarity &= ~clear_mask;
           current_polarity |= pol_mask;
-          DL_GPIO_setUpperPinsPolarity(port_, current_polarity);
+          port_->POLARITY31_16 = current_polarity;
         }
       }
 


### PR DESCRIPTION
# fix(mspm0): 修复 GPIO 中断边沿极性配置残留问题

## 概述

修复 MSPM0 GPIO 中断边沿配置时，旧的 polarity bit 无法被正确清除的问题。

原实现中，`MSPM0GPIO::SetConfig()` 会先读取当前 polarity 寄存器的值，然后清除目标 pin 对应的 2 bit，再写入新的边沿配置：

```cpp
current_polarity &= ~clear_mask;
current_polarity |= pol_mask;
```

但最后写回时使用了：

```cpp
DL_GPIO_setLowerPinsPolarity(port_, current_polarity);
DL_GPIO_setUpperPinsPolarity(port_, current_polarity);
```

TI DriverLib 中这两个函数内部是 OR 写入，并不是直接赋值。因此它们只能置位 bit，不能清除已经存在的 bit。

## 问题现象

例如 SysConfig 先将 `GPIOB.21` 配置为上升沿触发，之后在 `app_main()` 中重新配置为下降沿触发：

```cpp
key.SetConfig({LibXR::GPIO::Direction::FALL_INTERRUPT, LibXR::GPIO::Pull::UP});
```

期望结果是只在下降沿触发中断。

但由于旧的 RISE bit 没有被真正清除，最终寄存器中的配置会变成：

```text
RISE | FALL
```

实际表现为双边沿触发。

## 修复方式

将 polarity 寄存器的写回方式改为直接赋值：

```cpp
port_->POLARITY15_0 = current_polarity;
port_->POLARITY31_16 = current_polarity;
```

这里不是直接覆盖所有配置，而是先读取当前寄存器值，只修改目标 pin 对应的 2 bit，再将完整寄存器值写回，因此其他 pin 的配置仍会被保留。

## 测试情况

测试场景：

* SysConfig 中先将 `GPIOB.21` 配置为上升沿中断；
* 在 `app_main()` 中通过 `MSPM0GPIO::SetConfig()` 将其重新配置为下降沿中断。

修复前：

* 按下按键时下降沿触发中断；
* 松开按键时上升沿也会触发中断；
* 实际表现类似 `FALL_RISING_INTERRUPT`。

修复后：

* 只有按下按键产生的下降沿会触发中断；
* 松开按键产生的上升沿不会再触发中断；
* 行为符合 `FALL_INTERRUPT` 预期。

## 备注

`EnableInterrupt()` 只负责打开对应 pin 的 interrupt mask，不负责配置触发边沿。

本问题的根因是 polarity 寄存器旧 bit 未被清除，而不是中断使能逻辑问题。

## Summary by Sourcery

错误修复：
- 在重新配置引脚时，确保正确清除并重新写入 MSPM0 GPIO 中断极性位，防止出现非预期的双沿触发。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure MSPM0 GPIO interrupt polarity bits are properly cleared and rewritten when reconfiguring a pin, preventing unintended dual-edge triggering.

</details>