### PR TITLE
refactor(timebase): remove global instance dispatch

### DIFF
--- a/driver/ch/ch32_timebase.cpp
+++ b/driver/ch/ch32_timebase.cpp
@@ -3,9 +3,13 @@
 
 using namespace LibXR;
 
-CH32Timebase::CH32Timebase() : Timebase(UINT32_MAX * 1000 + 999, UINT32_MAX) {}
+CH32Timebase::CH32Timebase()
+{
+  ConfigureWrapRange(static_cast<uint64_t>(UINT32_MAX) * 1000ULL + 999ULL, UINT32_MAX);
+  SetReady();
+}
 
-MicrosecondTimestamp CH32Timebase::_get_microseconds()
+MicrosecondTimestamp Timebase::GetMicroseconds()
 {
   do
   {
@@ -26,14 +30,14 @@ MicrosecondTimestamp CH32Timebase::_get_microseconds()
         return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000 +
                                     static_cast<uint64_t>(cnt_new) * 1000 / tick_cmp);
       default:
-        /* 中断耗时过长（超过1ms），程序异常 / Indicates that interrupt took more than
-         * 1ms, an error case */
+        /* 中断耗时过长（超过1ms），程序异常 / Indicates that interrupt took more
+         * than 1ms, an error case */
         continue;
     }
   } while (true);
 }
 
-MillisecondTimestamp CH32Timebase::_get_milliseconds() { return sys_tick_ms_; }
+MillisecondTimestamp Timebase::GetMilliseconds() { return CH32Timebase::sys_tick_ms_; }
 
 void CH32Timebase::OnSysTickInterrupt() { sys_tick_ms_++; }
 

--- a/driver/ch/ch32_timebase.hpp
+++ b/driver/ch/ch32_timebase.hpp
@@ -15,16 +15,31 @@ namespace LibXR
 class CH32Timebase : public Timebase
 {
  public:
+  /**
+   * @brief 构造函数 / Constructor
+   *
+   * 配置 CH32 SysTick 时间基的回绕范围，并标记时间基已就绪。
+   * Configures the CH32 SysTick wrap range and marks the timebase ready.
+   */
   CH32Timebase();
 
-  MicrosecondTimestamp _get_microseconds() override;
-
-  MillisecondTimestamp _get_milliseconds() override;
-
+  /**
+   * @brief SysTick 中断入口辅助函数。
+   *        Helper called from the SysTick interrupt path.
+   */
   static inline void OnSysTickInterrupt();
 
+  /**
+   * @brief 同步毫秒计数器。
+   *        Synchronize the millisecond counter.
+   * @param ticks 新的毫秒计数值。New millisecond tick value.
+   */
   void Sync(uint32_t ticks);
 
+  /**
+   * @brief SysTick 毫秒计数器。
+   *        SysTick millisecond counter.
+   */
   static inline volatile uint32_t sys_tick_ms_ = 0;
 };
 

--- a/driver/esp/esp_i2c.cpp
+++ b/driver/esp/esp_i2c.cpp
@@ -26,14 +26,7 @@ uint64_t ToTimeoutUs(uint32_t timeout_ms)
                                     : static_cast<uint64_t>(timeout_ms) * 1000ULL;
 }
 
-uint64_t GetNowUs()
-{
-  if (Timebase::timebase != nullptr)
-  {
-    return static_cast<uint64_t>(Timebase::GetMicroseconds());
-  }
-  return static_cast<uint64_t>(esp_timer_get_time());
-}
+uint64_t GetNowUs() { return static_cast<uint64_t>(Timebase::GetMicroseconds()); }
 
 inline void SetBusClockAtomic(i2c_port_t port, bool enable)
 {
@@ -127,7 +120,8 @@ ErrorCode StartAndWaitSegment(i2c_hal_context_t& hal, int done_cmd_idx,
 template <typename OperationType>
 ErrorCode Complete(OperationType& op, bool in_isr, ErrorCode result)
 {
-  // Synchronous fast path: BLOCK ops return directly without post+wait round-trip.
+  // Synchronous fast path: BLOCK ops return directly without post+wait
+  // round-trip.
   if (op.type != OperationType::OperationType::BLOCK)
   {
     op.UpdateStatus(in_isr, result);

--- a/driver/esp/esp_spi.cpp
+++ b/driver/esp/esp_spi.cpp
@@ -39,21 +39,15 @@ uint8_t ResolveSpiMode(SPI::ClockPolarity polarity, SPI::ClockPhase phase)
 
 spi_dma_ctx_t* ToDmaCtx(void* ctx) { return reinterpret_cast<spi_dma_ctx_t*>(ctx); }
 
-uint64_t GetNowUs()
-{
-  if (Timebase::timebase != nullptr)
-  {
-    return static_cast<uint64_t>(Timebase::GetMicroseconds());
-  }
-  return static_cast<uint64_t>(esp_timer_get_time());
-}
+uint64_t GetNowUs() { return static_cast<uint64_t>(Timebase::GetMicroseconds()); }
 
 uint64_t CalcPollingTimeoutUs(size_t size, uint32_t bus_hz)
 {
   const uint32_t safe_hz = (bus_hz == 0U) ? 1U : bus_hz;
   const uint64_t bits = static_cast<uint64_t>(size) * 8ULL;
   const uint64_t wire_time_us = (bits * 1000000ULL + safe_hz - 1ULL) / safe_hz;
-  // Keep a generous margin for bus contention / APB jitter while staying time-based.
+  // Keep a generous margin for bus contention / APB jitter while staying
+  // time-based.
   return std::max<uint64_t>(100ULL, wire_time_us * 8ULL + 50ULL);
 }
 
@@ -103,7 +97,8 @@ bool CacheSyncDmaBuffer(const void* addr, size_t size, bool cache_to_mem)
   flags |= CACHE_SYNC_FLAG_UNALIGNED;
 
   const esp_err_t ret = esp_cache_msync(const_cast<void*>(addr), size, flags);
-  // Non-cacheable regions can return ESP_ERR_INVALID_ARG; treat as no-op success.
+  // Non-cacheable regions can return ESP_ERR_INVALID_ARG; treat as no-op
+  // success.
   return (ret == ESP_OK) || (ret == ESP_ERR_INVALID_ARG);
 }
 #endif
@@ -680,7 +675,8 @@ ErrorCode ESP32SPI::StartAsyncTransfer(const uint8_t* tx, uint8_t* rx, size_t si
   }
   started = true;
 
-  // On ESP32 classic, enable data lines only after DMA descriptors/channels are ready.
+  // On ESP32 classic, enable data lines only after DMA descriptors/channels are
+  // ready.
   spi_ll_enable_mosi(hw_, 1);
   spi_ll_enable_miso(hw_, rx_enabled ? 1 : 0);
   spi_ll_clear_int_stat(hw_);

--- a/driver/esp/esp_timebase.cpp
+++ b/driver/esp/esp_timebase.cpp
@@ -8,35 +8,48 @@
 namespace LibXR
 {
 
-ESP32Timebase::ESP32Timebase() : Timebase(static_cast<uint64_t>(UINT64_MAX), UINT32_MAX)
+namespace
 {
 #if SOC_SYSTIMER_SUPPORTED
-  systimer_hal_init(&systimer_hal_);
-
-  systimer_hal_tick_rate_ops_t tick_rate_ops = {
-      .ticks_to_us = systimer_ticks_to_us,
-      .us_to_ticks = systimer_us_to_ticks,
-  };
-  systimer_hal_set_tick_rate_ops(&systimer_hal_, &tick_rate_ops);
-  systimer_hal_enable_counter(&systimer_hal_, SYSTIMER_COUNTER_ESPTIMER);
-  systimer_ready_ = true;
+systimer_hal_context_t g_systimer_hal = {};
+bool g_systimer_ready = false;
 #endif
+}  // namespace
+
+ESP32Timebase::ESP32Timebase()
+{
+  ConfigureWrapRange(UINT64_MAX, UINT32_MAX);
+#if SOC_SYSTIMER_SUPPORTED
+  if (!g_systimer_ready)
+  {
+    systimer_hal_init(&g_systimer_hal);
+
+    systimer_hal_tick_rate_ops_t tick_rate_ops = {
+        .ticks_to_us = systimer_ticks_to_us,
+        .us_to_ticks = systimer_us_to_ticks,
+    };
+    systimer_hal_set_tick_rate_ops(&g_systimer_hal, &tick_rate_ops);
+    systimer_hal_enable_counter(&g_systimer_hal, SYSTIMER_COUNTER_ESPTIMER);
+    g_systimer_ready = true;
+  }
+#endif
+  SetReady();
 }
 
-MicrosecondTimestamp IRAM_ATTR ESP32Timebase::_get_microseconds()
+MicrosecondTimestamp IRAM_ATTR Timebase::GetMicroseconds()
 {
 #if SOC_SYSTIMER_SUPPORTED
-  if (systimer_ready_)
+  if (g_systimer_ready)
   {
-    return systimer_hal_get_time(&systimer_hal_, SYSTIMER_COUNTER_ESPTIMER);
+    return systimer_hal_get_time(&g_systimer_hal, SYSTIMER_COUNTER_ESPTIMER);
   }
 #endif
   return static_cast<MicrosecondTimestamp>(esp_timer_get_time());
 }
 
-MillisecondTimestamp IRAM_ATTR ESP32Timebase::_get_milliseconds()
+MillisecondTimestamp IRAM_ATTR Timebase::GetMilliseconds()
 {
-  return MillisecondTimestamp(static_cast<uint32_t>(_get_microseconds() / 1000ULL));
+  return MillisecondTimestamp(static_cast<uint32_t>(GetMicroseconds() / 1000ULL));
 }
 
 }  // namespace LibXR

--- a/driver/esp/esp_timebase.hpp
+++ b/driver/esp/esp_timebase.hpp
@@ -25,26 +25,12 @@ class ESP32Timebase : public Timebase
  public:
   /**
    * @brief 构造函数 / Constructor
+   *
+   * 初始化 ESP 时间基，并在支持的芯片上启用 systimer 快速路径。
+   * Initializes the ESP timebase and enables the systimer fast path when the
+   * target supports it.
    */
   ESP32Timebase();
-
-  /**
-   * @brief 获取当前微秒计数 / Get current timestamp in microseconds
-   * @return MicrosecondTimestamp 微秒时间戳 / Microsecond timestamp
-   */
-  MicrosecondTimestamp _get_microseconds() override;
-
-  /**
-   * @brief 获取当前毫秒计数 / Get current timestamp in milliseconds
-   * @return MillisecondTimestamp 毫秒时间戳 / Millisecond timestamp
-   */
-  MillisecondTimestamp _get_milliseconds() override;
-
- private:
-#if SOC_SYSTIMER_SUPPORTED
-  systimer_hal_context_t systimer_hal_ = {};  ///< Systimer HAL context
-  bool systimer_ready_ = false;               ///< Systimer fast path status
-#endif
 };
 
 }  // namespace LibXR

--- a/driver/hpm/hpm_timebase.cpp
+++ b/driver/hpm/hpm_timebase.cpp
@@ -4,6 +4,9 @@ using namespace LibXR;
 
 namespace
 {
+MCHTMR_Type* g_timer = HPM_MCHTMR;
+uint32_t g_clock_hz = 0u;
+
 static inline uint64_t ConvertTicksToTime(uint64_t ticks, uint32_t freq_hz,
                                           uint64_t scale)
 {
@@ -17,20 +20,21 @@ static inline uint64_t ConvertTicksToTime(uint64_t ticks, uint32_t freq_hz,
 }  // namespace
 
 HPMTimebase::HPMTimebase(MCHTMR_Type* timer, clock_name_t clock)
-    : Timebase(static_cast<uint64_t>(UINT32_MAX) * 1000 + 999, UINT32_MAX),
-      timer_(timer),
-      clock_hz_(clock_get_frequency(clock))
 {
+  g_timer = timer;
+  g_clock_hz = clock_get_frequency(clock);
+  ConfigureWrapRange(static_cast<uint64_t>(UINT32_MAX) * 1000ULL + 999ULL, UINT32_MAX);
+  SetReady();
 }
 
-MicrosecondTimestamp HPMTimebase::_get_microseconds()
+MicrosecondTimestamp Timebase::GetMicroseconds()
 {
-  const uint64_t ticks = mchtmr_get_count(timer_);
-  return MicrosecondTimestamp(ConvertTicksToTime(ticks, clock_hz_, 1000000ULL));
+  const uint64_t ticks = mchtmr_get_count(g_timer);
+  return MicrosecondTimestamp(ConvertTicksToTime(ticks, g_clock_hz, 1000000ULL));
 }
 
-MillisecondTimestamp HPMTimebase::_get_milliseconds()
+MillisecondTimestamp Timebase::GetMilliseconds()
 {
-  const uint64_t ticks = mchtmr_get_count(timer_);
-  return MillisecondTimestamp(ConvertTicksToTime(ticks, clock_hz_, 1000ULL));
+  const uint64_t ticks = mchtmr_get_count(g_timer);
+  return MillisecondTimestamp(ConvertTicksToTime(ticks, g_clock_hz, 1000ULL));
 }

--- a/driver/hpm/hpm_timebase.hpp
+++ b/driver/hpm/hpm_timebase.hpp
@@ -23,26 +23,11 @@ class HPMTimebase : public Timebase
    * @brief 构造 HPM 时间基对象 / Construct an HPM timebase object.
    * @param timer MCHTMR 外设基地址 / MCHTMR base address.
    * @param clock 定时器时钟源 / Clock source used by the timer.
+   *
+   * 构造时选择计数器实例并缓存输入时钟频率。
+   * Construction selects the counter instance and caches the input clock rate.
    */
   HPMTimebase(MCHTMR_Type* timer = HPM_MCHTMR, clock_name_t clock = clock_mchtmr0);
-
-  /**
-   * @brief 获取微秒时间戳 / Get current timestamp in microseconds.
-   * @return 当前微秒时间戳 / Current microsecond timestamp.
-   */
-  MicrosecondTimestamp _get_microseconds() override;
-
-  /**
-   * @brief 获取毫秒时间戳 / Get current timestamp in milliseconds.
-   * @return 当前毫秒时间戳 / Current millisecond timestamp.
-   */
-  MillisecondTimestamp _get_milliseconds() override;
-
- private:
-  /** @brief 定时器外设实例 / Timer peripheral instance. */
-  MCHTMR_Type* timer_;
-  /** @brief 定时器输入时钟频率(Hz) / Timer input clock frequency in Hz. */
-  uint32_t clock_hz_;
 };
 
 }  // namespace LibXR

--- a/driver/linux/linux_timebase.cpp
+++ b/driver/linux/linux_timebase.cpp
@@ -1,0 +1,33 @@
+#include "linux_timebase.hpp"
+
+namespace LibXR
+{
+namespace
+{
+int64_t GetElapsedMicroseconds()
+{
+  timespec ts = {};
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return static_cast<int64_t>(ts.tv_sec - libxr_linux_start_time_spec.tv_sec) *
+             1000000LL +
+         static_cast<int64_t>(ts.tv_nsec - libxr_linux_start_time_spec.tv_nsec) / 1000LL;
+}
+}  // namespace
+
+LinuxTimebase::LinuxTimebase()
+{
+  (void)clock_gettime(CLOCK_MONOTONIC, &libxr_linux_start_time_spec);
+  ConfigureWrapRange(UINT64_MAX, UINT32_MAX);
+  SetReady();
+}
+
+MicrosecondTimestamp Timebase::GetMicroseconds()
+{
+  return MicrosecondTimestamp(static_cast<uint64_t>(GetElapsedMicroseconds()));
+}
+
+MillisecondTimestamp Timebase::GetMilliseconds()
+{
+  return MillisecondTimestamp(static_cast<uint32_t>(GetElapsedMicroseconds() / 1000LL));
+}
+}  // namespace LibXR

--- a/driver/linux/linux_timebase.hpp
+++ b/driver/linux/linux_timebase.hpp
@@ -14,32 +14,11 @@ class LinuxTimebase : public Timebase
 {
  public:
   /**
-   * @brief 获取当前微秒计数 / Get current timestamp in microseconds
+   * @brief 构造函数 / Constructor
    *
-   * @return MicrosecondTimestamp 微秒时间戳 / Microsecond timestamp
+   * 记录 Linux monotonic 参考起点并标记时间基已就绪。
+   * Captures the Linux monotonic reference point and marks the timebase ready.
    */
-  MicrosecondTimestamp _get_microseconds()
-  {
-    return MicrosecondTimestamp(static_cast<uint64_t>(GetElapsedMicroseconds()));
-  }
-
-  /**
-   * @brief 获取当前毫秒计数 / Get current timestamp in milliseconds
-   *
-   * @return MillisecondTimestamp 毫秒时间戳 / Millisecond timestamp
-   */
-  MillisecondTimestamp _get_milliseconds()
-  {
-    return MillisecondTimestamp(static_cast<uint32_t>(GetElapsedMicroseconds() / 1000LL));
-  }
-
- private:
-  static int64_t GetElapsedMicroseconds()
-  {
-    struct timespec ts = {};
-    clock_gettime(CLOCK_MONOTONIC, &ts);
-    return static_cast<int64_t>(ts.tv_sec - libxr_linux_start_time_spec.tv_sec) * 1000000LL +
-           static_cast<int64_t>(ts.tv_nsec - libxr_linux_start_time_spec.tv_nsec) / 1000LL;
-  }
+  LinuxTimebase();
 };
 }  // namespace LibXR

--- a/driver/mspm0/mspm0_spi.cpp
+++ b/driver/mspm0/mspm0_spi.cpp
@@ -87,25 +87,20 @@ ErrorCode MSPM0SPI::PollingTransfer(uint8_t* rx, const uint8_t* tx, uint32_t len
     return ErrorCode::OK;
   }
 
-  const bool HAS_TIMEBASE = (Timebase::timebase != nullptr);
-  const uint64_t START_US =
-      HAS_TIMEBASE ? static_cast<uint64_t>(Timebase::GetMicroseconds()) : 0ULL;
+  const uint64_t START_US = static_cast<uint64_t>(Timebase::GetMicroseconds());
 
   uint32_t spin_budget = POLLING_FALLBACK_SPIN_BUDGET;
   auto polling_timed_out = [&]() -> bool
   {
-    if (HAS_TIMEBASE)
-    {
-      const uint64_t NOW_US = static_cast<uint64_t>(Timebase::GetMicroseconds());
-      return (NOW_US - START_US) >= POLLING_TIMEOUT_US;
-    }
-    // timebase 未就绪时的最后兜底策略 / Last-resort fallback when timebase is
-    // not ready yet.
-    if (spin_budget == 0U)
+    const uint64_t NOW_US = static_cast<uint64_t>(Timebase::GetMicroseconds());
+    if ((NOW_US - START_US) >= POLLING_TIMEOUT_US)
     {
       return true;
     }
-    --spin_budget;
+    if (spin_budget > 0U)
+    {
+      --spin_budget;
+    }
     return false;
   };
 

--- a/driver/mspm0/mspm0_timebase.cpp
+++ b/driver/mspm0/mspm0_timebase.cpp
@@ -3,11 +3,12 @@
 using namespace LibXR;
 
 MSPM0Timebase::MSPM0Timebase()
-    : Timebase(static_cast<uint64_t>(UINT32_MAX) * 1000 + 999, UINT32_MAX)
 {
+  ConfigureWrapRange(static_cast<uint64_t>(UINT32_MAX) * 1000ULL + 999ULL, UINT32_MAX);
+  SetReady();
 }
 
-MicrosecondTimestamp MSPM0Timebase::_get_microseconds()
+MicrosecondTimestamp Timebase::GetMicroseconds()
 {
   do
   {
@@ -34,14 +35,14 @@ MicrosecondTimestamp MSPM0Timebase::_get_microseconds()
             static_cast<uint64_t>(DL_SYSTICK_getPeriod() - val_new) * 1000 /
                 cycles_per_ms);
       default:
-        /* 中断耗时过长（超过1ms），程序异常 / Indicates that interrupt took more than
-         * 1ms, an error case */
+        /* 中断耗时过长（超过1ms），程序异常 / Indicates that interrupt took more
+         * than 1ms, an error case */
         continue;
     }
   } while (true);
 }
 
-MillisecondTimestamp MSPM0Timebase::_get_milliseconds() { return sys_tick_ms; }
+MillisecondTimestamp Timebase::GetMilliseconds() { return MSPM0Timebase::sys_tick_ms; }
 void MSPM0Timebase::OnSysTickInterrupt() { sys_tick_ms++; }
 void MSPM0Timebase::Sync(uint32_t ticks) { sys_tick_ms = ticks; }
 

--- a/driver/mspm0/mspm0_timebase.hpp
+++ b/driver/mspm0/mspm0_timebase.hpp
@@ -9,16 +9,31 @@ namespace LibXR
 class MSPM0Timebase : public Timebase
 {
  public:
+  /**
+   * @brief 构造函数 / Constructor
+   *
+   * 配置 MSPM0 SysTick 时间基的回绕范围，并标记时间基已就绪。
+   * Configures the MSPM0 SysTick wrap range and marks the timebase ready.
+   */
   MSPM0Timebase();
 
+  /**
+   * @brief SysTick 中断入口辅助函数。
+   *        Helper called from the SysTick interrupt path.
+   */
   static void OnSysTickInterrupt();
 
+  /**
+   * @brief 同步毫秒计数器。
+   *        Synchronize the millisecond counter.
+   * @param ticks 新的毫秒计数值。New millisecond tick value.
+   */
   static void Sync(uint32_t ticks);
 
-  MicrosecondTimestamp _get_microseconds() override;
-
-  MillisecondTimestamp _get_milliseconds() override;
-
+  /**
+   * @brief SysTick 毫秒计数器。
+   *        SysTick millisecond counter.
+   */
   inline static volatile uint32_t sys_tick_ms;  // NOLINT
 };
 

--- a/driver/st/stm32_timebase.cpp
+++ b/driver/st/stm32_timebase.cpp
@@ -2,12 +2,17 @@
 
 using namespace LibXR;
 
-STM32Timebase::STM32Timebase()
-    : Timebase(static_cast<uint64_t>(UINT32_MAX) * 1000 + 999, UINT32_MAX)
+namespace
 {
-}
+enum class STM32TimebaseBackend : uint8_t
+{
+  SYSTICK = 0,
+  TIMER = 1,
+};
 
-MicrosecondTimestamp STM32Timebase::_get_microseconds()
+STM32TimebaseBackend g_backend = STM32TimebaseBackend::SYSTICK;
+
+MicrosecondTimestamp GetSysTickMicroseconds()
 {
   do
   {
@@ -16,39 +21,27 @@ MicrosecondTimestamp STM32Timebase::_get_microseconds()
     uint32_t tick_new = HAL_GetTick();
     uint32_t cnt_new = SysTick->VAL;
 
-    auto time_diff = tick_new - tick_old;
-    uint32_t tick_load = SysTick->LOAD + 1;
+    const auto time_diff = tick_new - tick_old;
+    const uint32_t tick_load = SysTick->LOAD + 1U;
     switch (time_diff)
     {
       case 0:
-        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000 + 1000 -
-                                    static_cast<uint64_t>(cnt_old) * 1000 / tick_load);
+        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000ULL + 1000ULL -
+                                    static_cast<uint64_t>(cnt_old) * 1000ULL / tick_load);
       case 1:
-        /* 中断发生在两次读取之间 / Interrupt happened between two reads */
-        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000 + 1000 -
-                                    static_cast<uint64_t>(cnt_new) * 1000 / tick_load);
+        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000ULL + 1000ULL -
+                                    static_cast<uint64_t>(cnt_new) * 1000ULL / tick_load);
       default:
-        /* 中断耗时过长（超过1ms），程序异常 / Indicates that interrupt took more than
-         * 1ms, an error case */
         continue;
     }
   } while (true);
 }
 
-MillisecondTimestamp STM32Timebase::_get_milliseconds() { return HAL_GetTick(); }
-
 #ifdef HAL_TIM_MODULE_ENABLED
-
-TIM_HandleTypeDef* STM32TimerTimebase::htim = nullptr;
-
-STM32TimerTimebase::STM32TimerTimebase(TIM_HandleTypeDef* timer)
-    : Timebase(static_cast<uint64_t>(UINT32_MAX) * 1000 + 999, UINT32_MAX)
+MicrosecondTimestamp GetTimerMicroseconds(TIM_HandleTypeDef* htim)
 {
-  htim = timer;
-}
+  ASSERT(htim != nullptr);
 
-MicrosecondTimestamp STM32TimerTimebase::_get_microseconds()
-{
   do
   {
     uint32_t tick_old = HAL_GetTick();
@@ -56,26 +49,62 @@ MicrosecondTimestamp STM32TimerTimebase::_get_microseconds()
     uint32_t tick_new = HAL_GetTick();
     uint32_t cnt_new = __HAL_TIM_GET_COUNTER(htim);
 
-    uint32_t autoreload = __HAL_TIM_GET_AUTORELOAD(htim) + 1;
-
-    uint32_t delta_ms = tick_new - tick_old;
+    const uint32_t autoreload = __HAL_TIM_GET_AUTORELOAD(htim) + 1U;
+    const uint32_t delta_ms = tick_new - tick_old;
     switch (delta_ms)
     {
       case 0:
-        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000 +
-                                    static_cast<uint64_t>(cnt_old) * 1000 / autoreload);
+        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000ULL +
+                                    static_cast<uint64_t>(cnt_old) * 1000ULL /
+                                        autoreload);
       case 1:
-        /* 中断发生在两次读取之间 / Interrupt happened between two reads */
-        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000 +
-                                    static_cast<uint64_t>(cnt_new) * 1000 / autoreload);
+        return MicrosecondTimestamp(static_cast<uint64_t>(tick_new) * 1000ULL +
+                                    static_cast<uint64_t>(cnt_new) * 1000ULL /
+                                        autoreload);
       default:
-        /* 中断耗时过长（超过1ms），程序异常 / Indicates that interrupt took more than
-         * 1ms, an error case */
         continue;
     }
   } while (true);
 }
 
-MillisecondTimestamp STM32TimerTimebase::_get_milliseconds() { return HAL_GetTick(); }
+#endif
+}  // namespace
+
+STM32Timebase::STM32Timebase()
+{
+  ConfigureWrapRange(static_cast<uint64_t>(UINT32_MAX) * 1000ULL + 999ULL, UINT32_MAX);
+  g_backend = STM32TimebaseBackend::SYSTICK;
+  SetReady();
+}
+
+MicrosecondTimestamp Timebase::GetMicroseconds()
+{
+  switch (g_backend)
+  {
+    case STM32TimebaseBackend::SYSTICK:
+      return GetSysTickMicroseconds();
+#ifdef HAL_TIM_MODULE_ENABLED
+    case STM32TimebaseBackend::TIMER:
+      return GetTimerMicroseconds(STM32TimerTimebase::htim);
+#endif
+  }
+
+  ASSERT(false);
+  return MicrosecondTimestamp(0ULL);
+}
+
+MillisecondTimestamp Timebase::GetMilliseconds() { return HAL_GetTick(); }
+
+#ifdef HAL_TIM_MODULE_ENABLED
+
+TIM_HandleTypeDef* STM32TimerTimebase::htim = nullptr;
+
+STM32TimerTimebase::STM32TimerTimebase(TIM_HandleTypeDef* timer)
+{
+  htim = timer;
+  ConfigureWrapRange(static_cast<uint64_t>(UINT32_MAX) * 1000ULL + 999ULL, UINT32_MAX);
+  g_backend = STM32TimebaseBackend::TIMER;
+  SetReady();
+}
 
 #endif

--- a/driver/st/stm32_timebase.hpp
+++ b/driver/st/stm32_timebase.hpp
@@ -13,22 +13,11 @@ class STM32Timebase : public Timebase
  public:
   /**
    * @brief 默认构造函数 / Default constructor
+   *
+   * 选择 SysTick 作为当前时间基后端，并配置对应的回绕范围。
+   * Selects SysTick as the active backend and configures the matching wrap range.
    */
   STM32Timebase();
-
-  /**
-   * @brief 获取当前微秒计数 / Get current timestamp in microseconds
-   *
-   * @return MicrosecondTimestamp 微秒时间戳 / Microsecond timestamp
-   */
-  MicrosecondTimestamp _get_microseconds();
-
-  /**
-   * @brief 获取当前毫秒计数 / Get current timestamp in milliseconds
-   *
-   * @return MillisecondTimestamp 毫秒时间戳 / Millisecond timestamp
-   */
-  MillisecondTimestamp _get_milliseconds();
 };
 
 #ifdef HAL_TIM_MODULE_ENABLED
@@ -42,22 +31,12 @@ class STM32TimerTimebase : public Timebase
   /**
    * @brief 构造函数 / Constructor
    * @param timer 定时器句柄指针 / Pointer to timer handle
+   *
+   * 选择硬件定时器作为当前时间基后端，并缓存句柄供静态入口使用。
+   * Selects the hardware timer as the active backend and caches the handle for
+   * the static entry points.
    */
   STM32TimerTimebase(TIM_HandleTypeDef* timer);
-
-  /**
-   * @brief 获取当前微秒计数 / Get current timestamp in microseconds
-   *
-   * @return MicrosecondTimestamp 微秒时间戳 / Microsecond timestamp
-   */
-  MicrosecondTimestamp _get_microseconds();
-
-  /**
-   * @brief 获取当前毫秒计数 / Get current timestamp in milliseconds
-   *
-   * @return MillisecondTimestamp 毫秒时间戳 / Millisecond timestamp
-   */
-  MillisecondTimestamp _get_milliseconds();
 
   /**
    * @brief 硬件定时器句柄静态指针 / Static pointer to timer handle

--- a/driver/webasm/webasm_timebase.cpp
+++ b/driver/webasm/webasm_timebase.cpp
@@ -1,0 +1,34 @@
+#include "webasm_timebase.hpp"
+
+#include <chrono>
+
+namespace LibXR
+{
+namespace
+{
+std::chrono::system_clock::time_point g_start_time;
+}  // namespace
+
+WebAsmTimebase::WebAsmTimebase()
+{
+  g_start_time = std::chrono::system_clock::now();
+  ConfigureWrapRange(UINT64_MAX, UINT32_MAX);
+  SetReady();
+}
+
+MicrosecondTimestamp Timebase::GetMicroseconds()
+{
+  const auto now = std::chrono::system_clock::now();
+  const auto us =
+      std::chrono::duration_cast<std::chrono::microseconds>(now - g_start_time).count();
+  return MicrosecondTimestamp(static_cast<uint64_t>(us));
+}
+
+MillisecondTimestamp Timebase::GetMilliseconds()
+{
+  const auto now = std::chrono::system_clock::now();
+  const auto ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(now - g_start_time).count();
+  return MillisecondTimestamp(static_cast<uint32_t>(ms));
+}
+}  // namespace LibXR

--- a/driver/webasm/webasm_timebase.hpp
+++ b/driver/webasm/webasm_timebase.hpp
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <chrono>
-#include <cstdint>
-
 #include "timebase.hpp"
 
 namespace LibXR
@@ -14,38 +11,13 @@ namespace LibXR
 class WebAsmTimebase : public Timebase
 {
  public:
-  WebAsmTimebase()
-  {
-    // Initialize reference timestamp.
-    start_time_ = std::chrono::system_clock::now();
-  }
-
   /**
-   * @brief 获取当前微秒计数 / Get current timestamp in microseconds
-   * @return MicrosecondTimestamp 微秒时间戳 / Microsecond timestamp
+   * @brief 构造函数 / Constructor
+   *
+   * 记录 WebAssembly 运行时的时间参考点。
+   * Captures the WebAssembly runtime reference timestamp.
    */
-  MicrosecondTimestamp _get_microseconds() override
-  {
-    auto now = std::chrono::system_clock::now();
-    auto us =
-        std::chrono::duration_cast<std::chrono::microseconds>(now - start_time_).count();
-    return MicrosecondTimestamp(static_cast<uint64_t>(us));
-  }
-
-  /**
-   * @brief 获取当前毫秒计数 / Get current timestamp in milliseconds
-   * @return MillisecondTimestamp 毫秒时间戳 / Millisecond timestamp
-   */
-  MillisecondTimestamp _get_milliseconds() override
-  {
-    auto now = std::chrono::system_clock::now();
-    auto ms =
-        std::chrono::duration_cast<std::chrono::milliseconds>(now - start_time_).count();
-    return MillisecondTimestamp(static_cast<uint32_t>(ms));
-  }
-
- private:
-  std::chrono::system_clock::time_point start_time_;
+  WebAsmTimebase();
 };
 
 }  // namespace LibXR

--- a/driver/webots/webots_timebase.cpp
+++ b/driver/webots/webots_timebase.cpp
@@ -1,0 +1,20 @@
+#include "webots_timebase.hpp"
+
+namespace LibXR
+{
+WebotsTimebase::WebotsTimebase()
+{
+  ConfigureWrapRange(UINT64_MAX, UINT32_MAX);
+  SetReady();
+}
+
+MicrosecondTimestamp Timebase::GetMicroseconds()
+{
+  return _libxr_webots_time_count * 1000ULL;
+}
+
+MillisecondTimestamp Timebase::GetMilliseconds()
+{
+  return static_cast<uint32_t>(_libxr_webots_time_count);
+}
+}  // namespace LibXR

--- a/driver/webots/webots_timebase.hpp
+++ b/driver/webots/webots_timebase.hpp
@@ -15,17 +15,12 @@ class WebotsTimebase : public Timebase
 {
  public:
   /**
-   * @brief 获取当前微秒计数 / Get current timestamp in microseconds
+   * @brief 构造函数 / Constructor
    *
-   * @return MicrosecondTimestamp 微秒时间戳 / Microsecond timestamp
+   * 标记 Webots 时间基已就绪；具体计数由仿真时钟提供。
+   * Marks the Webots timebase ready; the actual counter is driven by the
+   * simulator clock.
    */
-  MicrosecondTimestamp _get_microseconds() { return _libxr_webots_time_count * 1000; }
-
-  /**
-   * @brief 获取当前毫秒计数 / Get current timestamp in milliseconds
-   *
-   * @return MillisecondTimestamp 毫秒时间戳 / Millisecond timestamp
-   */
-  MillisecondTimestamp _get_milliseconds() { return _libxr_webots_time_count; }
+  WebotsTimebase();
 };
 }  // namespace LibXR

--- a/src/driver/timebase.hpp
+++ b/src/driver/timebase.hpp
@@ -9,57 +9,54 @@ namespace LibXR
  * @brief 时间基类，用于提供高精度时间戳。
  *        Timebase class for providing high-precision timestamps.
  *
- * 该类提供了微秒和毫秒级的时间戳获取接口，并要求派生类实现具体的时间获取方法。
+ * 该类提供了微秒和毫秒级的时间戳获取接口。
  * This class provides interfaces for obtaining timestamps in microseconds and
- * milliseconds, and requires derived classes to implement the actual time retrieval
- * methods.
+ * milliseconds.
  */
 class Timebase
 {
  public:
   /**
-   * @brief 默认构造函数，初始化全局时间基指针。
-   *        Default constructor, initializing the global timebase pointer.
-   *
-   * 该构造函数在实例化对象时，将 `timebase` 指针指向当前对象，
-   * 以便静态方法可以访问具体的时间基实例。
-   * This constructor sets the `timebase` pointer to the current object
-   * when an instance is created, allowing static methods to access the specific timebase
-   * instance.
+   * @brief 默认构造函数。
+   *        Default constructor.
    */
-  Timebase(uint64_t max_valid_us = UINT64_MAX, uint32_t max_valid_ms = UINT32_MAX)
-  {
-    ConfigureWrapRange(max_valid_us, max_valid_ms);
-    timebase = this;
-  }
+  Timebase() = default;
+
+  /**
+   * @brief 禁止拷贝构造。
+   *        Copy construction is disabled.
+   */
+  Timebase(const Timebase&) = delete;
+
+  /**
+   * @brief 禁止拷贝赋值。
+   *        Copy assignment is disabled.
+   */
+  Timebase& operator=(const Timebase&) = delete;
 
   /**
    * @brief 获取当前时间的微秒级时间戳。
    *        Gets the current timestamp in microseconds.
    *
-   * 该函数通过静态方法调用 `_get_microseconds()`，
-   * 从 `timebase` 实例中获取当前时间。
-   * This function calls `_get_microseconds()` via a static method
-   * to retrieve the current time from the `timebase` instance.
-   *
    * @return 返回当前的时间戳（单位：微秒）。
    *         Returns the current timestamp (in microseconds).
    */
-  static MicrosecondTimestamp GetMicroseconds() { return timebase->_get_microseconds(); }
+  static MicrosecondTimestamp GetMicroseconds();
 
   /**
    * @brief 获取当前时间的毫秒级时间戳。
    *        Gets the current timestamp in milliseconds.
    *
-   * 该函数通过静态方法调用 `_get_milliseconds()`，
-   * 从 `timebase` 实例中获取当前时间。
-   * This function calls `_get_milliseconds()` via a static method
-   * to retrieve the current time from the `timebase` instance.
-   *
    * @return 返回当前的时间戳（单位：毫秒）。
    *         Returns the current timestamp (in milliseconds).
    */
-  static MillisecondTimestamp GetMilliseconds() { return timebase->_get_milliseconds(); }
+  static MillisecondTimestamp GetMilliseconds();
+
+  /**
+   * @brief 检查时间基是否已经初始化。
+   *        Check whether the active timebase backend is initialized.
+   */
+  [[nodiscard]] static bool IsReady() noexcept { return ready_; }
 
   /**
    * @brief 微秒级延时 / Delay in microseconds
@@ -79,59 +76,51 @@ class Timebase
     }
   }
 
-  /**
-   * @brief 纯虚函数，获取当前时间的微秒级时间戳（由派生类实现）。
-   *        Pure virtual function for obtaining the current timestamp in microseconds
-   * (implemented by derived classes).
-   *
-   * 该函数需要在派生类中实现，以提供具体的时间获取机制。
-   * This function must be implemented in derived classes to provide
-   * the actual time retrieval mechanism.
-   *
-   * @return 返回当前的时间戳（单位：微秒）。
-   *         Returns the current timestamp (in microseconds).
-   */
-  virtual MicrosecondTimestamp _get_microseconds() = 0;  // NOLINT
-
-  /**
-   * @brief 纯虚函数，获取当前时间的毫秒级时间戳（由派生类实现）。
-   *        Pure virtual function for obtaining the current timestamp in milliseconds
-   * (implemented by derived classes).
-   *
-   * 该函数需要在派生类中实现，以提供具体的时间获取机制。
-   * This function must be implemented in derived classes to provide
-   * the actual time retrieval mechanism.
-   *
-   * @return 返回当前的时间戳（单位：毫秒）。
-   *         Returns the current timestamp (in milliseconds).
-   */
-  virtual MillisecondTimestamp _get_milliseconds() = 0;  // NOLINT
-
-  /**
-   * @brief 静态指针，用于存储全局时间基对象。
-   *        Static pointer storing the global timebase instance.
-   *
-   * 该指针指向当前生效的 `Timebase` 实例，所有静态时间函数都通过该指针访问实际实现。
-   * This pointer refers to the currently active `Timebase` instance,
-   * and all static time functions access the actual implementation through this pointer.
-   */
-  static inline Timebase* timebase = nullptr;  // NOLINT
-
  protected:
+  /**
+   * @brief 设置时间基就绪状态。
+   *        Set the timebase ready flag.
+   * @param ready 是否就绪。Whether the backend is ready.
+   */
+  static void SetReady(bool ready = true) noexcept { ready_ = ready; }
+
+  /**
+   * @brief 配置时间戳回绕上界。
+   *        Configure the timestamp wraparound limits.
+   * @param max_valid_us 微秒时间戳的有效上界。
+   *                     Maximum valid microsecond timestamp value.
+   * @param max_valid_ms 毫秒时间戳的有效上界。
+   *                     Maximum valid millisecond timestamp value.
+   */
   static void ConfigureWrapRange(uint64_t max_valid_us, uint32_t max_valid_ms) noexcept
   {
     Detail::ConfigureTimebaseWrapRange(max_valid_us, max_valid_ms);
   }
 
+  /**
+   * @brief 读取当前配置的微秒回绕上界。
+   *        Read the configured microsecond wraparound limit.
+   */
   [[nodiscard]] static uint64_t GetConfiguredWrapRangeUs() noexcept
   {
     return Detail::TimebaseMaxValidUs();
   }
 
+  /**
+   * @brief 读取当前配置的毫秒回绕上界。
+   *        Read the configured millisecond wraparound limit.
+   */
   [[nodiscard]] static uint32_t GetConfiguredWrapRangeMs() noexcept
   {
     return Detail::TimebaseMaxValidMs();
   }
+
+ private:
+  /**
+   * @brief 时间基是否已完成初始化。
+   *        Whether the timebase backend has been initialized.
+   */
+  static inline bool ready_ = false;
 };
 
 }  // namespace LibXR

--- a/src/driver/usb/device/gsusb/gs_usb.hpp
+++ b/src/driver/usb/device/gsusb/gs_usb.hpp
@@ -1900,8 +1900,7 @@ LIBXR_PACKED_END
    */
   uint32_t MakeTimestampUs(uint8_t ch) const
   {
-    if (ch < can_count_ && timestamps_enabled_ch_[ch] &&
-        LibXR::Timebase::timebase != nullptr)
+    if (ch < can_count_ && timestamps_enabled_ch_[ch])
     {
       return static_cast<uint32_t>(LibXR::Timebase::GetMicroseconds() & 0xFFFFFFFFu);
     }
@@ -1914,11 +1913,7 @@ LIBXR_PACKED_END
    */
   uint32_t MakeTimestampUsGlobal() const
   {
-    if (LibXR::Timebase::timebase != nullptr)
-    {
-      return static_cast<uint32_t>(LibXR::Timebase::GetMicroseconds() & 0xFFFFFFFFu);
-    }
-    return 0u;
+    return static_cast<uint32_t>(LibXR::Timebase::GetMicroseconds() & 0xFFFFFFFFu);
   }
 
   /**

--- a/src/middleware/message/publish.cpp
+++ b/src/middleware/message/publish.cpp
@@ -77,11 +77,7 @@ void Topic::DispatchSubscribers(TopicHandle topic, MicrosecondTimestamp timestam
       });
 }
 
-MicrosecondTimestamp Topic::NowTimestamp()
-{
-  ASSERT(Timebase::timebase != nullptr);
-  return Timebase::GetMicroseconds();
-}
+MicrosecondTimestamp Topic::NowTimestamp() { return Timebase::GetMicroseconds(); }
 
 void Topic::CheckPublishContract(TopicHandle topic, TypeID::ID payload_type_id,
                                  size_t payload_size, size_t payload_alignment)

--- a/system/freertos/libxr_system.cpp
+++ b/system/freertos/libxr_system.cpp
@@ -22,7 +22,7 @@ uint32_t LibXR::libxr_freertos_timebase_tick_offset = 0;
 
 void LibXR::PlatformInit(uint32_t timer_pri, uint32_t timer_stack_depth)
 {
-  if (Timebase::timebase == nullptr)
+  if (!Timebase::IsReady())
   {
     /* You should initialize Timebase first */
     ASSERT(false);

--- a/system/linux/libxr_system.cpp
+++ b/system/linux/libxr_system.cpp
@@ -119,8 +119,6 @@ void LibXR::PlatformInit(uint32_t timer_pri, uint32_t timer_stack_depth)
 
   *LibXR::STDIO::read_ = read_fun;
 
-  UNUSED(clock_gettime(CLOCK_MONOTONIC, &libxr_linux_start_time_spec));
-
   struct termios tty;
   tcgetattr(STDIN_FILENO, &tty);           // 获取当前终端属性
   tty.c_lflag &= ~(ICANON | ECHO);         // 禁用规范模式和回显

--- a/system/threadx/libxr_system.cpp
+++ b/system/threadx/libxr_system.cpp
@@ -13,7 +13,7 @@
 
 void LibXR::PlatformInit(uint32_t timer_pri, uint32_t timer_stack_depth)
 {
-  if (Timebase::timebase == nullptr)
+  if (!Timebase::IsReady())
   {
     /* You should initialize Timebase first */
     ASSERT(false);

--- a/test/test_timebase.cpp
+++ b/test/test_timebase.cpp
@@ -14,17 +14,6 @@ struct TimebaseWrapProbe : LibXR::Timebase
   static uint64_t GetUs() { return GetConfiguredWrapRangeUs(); }
   static uint32_t GetMs() { return GetConfiguredWrapRangeMs(); }
 
-  LibXR::MicrosecondTimestamp _get_microseconds() override
-  {
-    ASSERT(false);
-    return 0;
-  }
-
-  LibXR::MillisecondTimestamp _get_milliseconds() override
-  {
-    ASSERT(false);
-    return 0;
-  }
 };
 }  // namespace
 


### PR DESCRIPTION
## Summary
- remove global `Timebase::timebase` instance dispatch and switch supported drivers to static backend entry points
- initialize timebase readiness inside each platform timebase constructor and keep bootstrap checks in `system/freertos` and `system/threadx`
- keep `gs_usb` queue types aligned with current `master` while updating its timebase readiness checks
- sync `publish.cpp` with current `topic.hpp` contract on top of the timebase refactor

## Scope
- `src/driver/timebase.hpp`
- platform timebase implementations under `driver/{ch,esp,hpm,linux,mspm0,st,webasm,webots}`
- `system/freertos/libxr_system.cpp`
- `system/threadx/libxr_system.cpp`
- `src/middleware/message/publish.cpp`
- `src/driver/usb/device/gsusb/gs_usb.hpp`
- `driver/esp/esp_i2c.cpp`
- `driver/esp/esp_spi.cpp`
- `driver/mspm0/mspm0_spi.cpp`
- `test/test_timebase.cpp`

## Validation
- Ubuntu24 clean-branch validation passed earlier for the branch contents on Linux build/test path
  - `/tmp/libxr_clean_master_timebase_verify_20260614T2319Z`
- supported pairing re-check passed for static Linux build plus real link probe
  - branch: `/tmp/libxr_timebase_branch_linux_valid_check_20260614T232751Z`
  - master control: `/tmp/libxr_timebase_master_linux_valid_compare_20260614T232843Z`

## Notes
- `LIBXR_SYSTEM=none` without a matching driver is not a valid regression signal for this change; timebase backend selection comes from `driver/${_xr_driver}`
- the temporary `gs_usb` queue-type rollback to `LockFreeQueue<QueueItem>` was corrected on-branch and no longer appears in the final compare

## Summary by Sourcery

重构跨平台时间基子系统，移除全局实例指针，改为使用具有显式就绪状态的静态后端入口点，并更新所有受影响的平台驱动和调用点。

Enhancements:
- 将全局 `Timebase` 实例分发机制替换为各平台专用的静态后端实现，并在所有受支持平台间共享一个就绪标志。
- 调整各平台的时间基构造函数（STM32、ESP32、CH32、MSPM0、HPM、Linux、WebAssembly、Webots），以配置回绕范围、选择后端，并标记时间基已完成初始化。
- 简化 ESP 和 MSPM0 的 SPI/I2C 以及 `gs_usb` 时间戳处理路径，假设时间基后端已就绪，而不是使用临时的备用逻辑或空指针检查。
- 使 `Topic::NowTimestamp` 和系统引导检查与新的 `Timebase::IsReady` 约定保持一致。

Tests:
- 更新时间基测试，依赖回绕范围辅助函数，而不再实现未使用的虚拟时间戳方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the cross-platform timebase subsystem to remove the global instance pointer and use static backend entry points with explicit readiness, updating all affected platform drivers and call sites.

Enhancements:
- Replace the global Timebase instance dispatch with static backend-specific implementations and a shared readiness flag across supported platforms.
- Adjust platform timebase constructors (STM32, ESP32, CH32, MSPM0, HPM, Linux, WebAssembly, Webots) to configure wrap ranges, select backends, and mark the timebase as initialized.
- Simplify ESP and MSPM0 SPI/I2C and gs_usb timestamp paths to assume a ready timebase backend instead of ad hoc fallbacks or null checks.
- Align Topic::NowTimestamp and system bootstrap checks with the new Timebase::IsReady contract.

Tests:
- Update timebase tests to rely on wrap-range helpers without implementing unused virtual timestamp methods.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构跨平台时间基子系统，移除全局实例指针，改为使用具有显式就绪状态的静态后端入口点，并更新所有受影响的平台驱动和调用点。

Enhancements:
- 将全局 `Timebase` 实例分发机制替换为各平台专用的静态后端实现，并在所有受支持平台间共享一个就绪标志。
- 调整各平台的时间基构造函数（STM32、ESP32、CH32、MSPM0、HPM、Linux、WebAssembly、Webots），以配置回绕范围、选择后端，并标记时间基已完成初始化。
- 简化 ESP 和 MSPM0 的 SPI/I2C 以及 `gs_usb` 时间戳处理路径，假设时间基后端已就绪，而不是使用临时的备用逻辑或空指针检查。
- 使 `Topic::NowTimestamp` 和系统引导检查与新的 `Timebase::IsReady` 约定保持一致。

Tests:
- 更新时间基测试，依赖回绕范围辅助函数，而不再实现未使用的虚拟时间戳方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the cross-platform timebase subsystem to remove the global instance pointer and use static backend entry points with explicit readiness, updating all affected platform drivers and call sites.

Enhancements:
- Replace the global Timebase instance dispatch with static backend-specific implementations and a shared readiness flag across supported platforms.
- Adjust platform timebase constructors (STM32, ESP32, CH32, MSPM0, HPM, Linux, WebAssembly, Webots) to configure wrap ranges, select backends, and mark the timebase as initialized.
- Simplify ESP and MSPM0 SPI/I2C and gs_usb timestamp paths to assume a ready timebase backend instead of ad hoc fallbacks or null checks.
- Align Topic::NowTimestamp and system bootstrap checks with the new Timebase::IsReady contract.

Tests:
- Update timebase tests to rely on wrap-range helpers without implementing unused virtual timestamp methods.

</details>

</details>