### PR TITLE
feat(debug): base JTAG/DAP respin on current master

### DIFF
--- a/src/driver/debug/jtag.hpp
+++ b/src/driver/debug/jtag.hpp
@@ -1,0 +1,101 @@
+#pragma once
+
+#include <cstdint>
+
+#include "libxr_def.hpp"
+
+namespace LibXR::Debug
+{
+/**
+ * @brief JTAG TAP 状态。JTAG TAP states.
+ */
+enum class TapState : uint8_t
+{
+  TEST_LOGIC_RESET = 0,
+  RUN_TEST_IDLE,
+  SELECT_DR_SCAN,
+  CAPTURE_DR,
+  SHIFT_DR,
+  EXIT1_DR,
+  PAUSE_DR,
+  EXIT2_DR,
+  UPDATE_DR,
+  SELECT_IR_SCAN,
+  CAPTURE_IR,
+  SHIFT_IR,
+  EXIT1_IR,
+  PAUSE_IR,
+  EXIT2_IR,
+  UPDATE_IR,
+};
+
+/**
+ * @class Jtag
+ * @brief JTAG 抽象基类，提供 TAP 控制与 IR/DR 移位能力。
+ *        Abstract JTAG base class providing TAP control and IR/DR shifting.
+ */
+class Jtag
+{
+ public:
+  virtual ~Jtag() = default;
+
+  Jtag(const Jtag&) = delete;
+  Jtag& operator=(const Jtag&) = delete;
+
+  /**
+   * @brief 设置 TCK 频率（可选）。Set TCK frequency (optional).
+   * @param hz 目标频率（Hz）。Target frequency in Hz.
+   * @return ErrorCode 操作结果。Error code.
+   */
+  virtual ErrorCode SetClockHz(uint32_t hz) = 0;
+
+  /**
+   * @brief 关闭 JTAG 并释放资源。Close JTAG and release resources.
+   */
+  virtual void Close() = 0;
+
+  /**
+   * @brief 复位 TAP 到 Test-Logic-Reset。Reset TAP to Test-Logic-Reset.
+   * @return ErrorCode 操作结果。Error code.
+   */
+  virtual ErrorCode ResetTap() = 0;
+
+  /**
+   * @brief 切换到指定 TAP 状态。Goto target TAP state.
+   * @param target 目标状态。Target state.
+   * @return ErrorCode 操作结果。Error code.
+   */
+  virtual ErrorCode GotoState(TapState target) = 0;
+
+  /**
+   * @brief IR 移位（LSB-first）。Shift IR (LSB-first).
+   * @param bits 位数。Bit count.
+   * @param in_lsb_first 输入 TDI 数据（LSB-first），可为 nullptr。
+   * @param out_lsb_first 输出 TDO 数据（LSB-first），可为 nullptr。
+   * @return ErrorCode 操作结果。Error code.
+   */
+  virtual ErrorCode ShiftIR(uint32_t bits, const uint8_t* in_lsb_first,
+                            uint8_t* out_lsb_first) = 0;
+
+  /**
+   * @brief DR 移位（LSB-first）。Shift DR (LSB-first).
+   * @param bits 位数。Bit count.
+   * @param in_lsb_first 输入 TDI 数据（LSB-first），可为 nullptr。
+   * @param out_lsb_first 输出 TDO 数据（LSB-first），可为 nullptr。
+   * @return ErrorCode 操作结果。Error code.
+   */
+  virtual ErrorCode ShiftDR(uint32_t bits, const uint8_t* in_lsb_first,
+                            uint8_t* out_lsb_first) = 0;
+
+  /**
+   * @brief 插入空闲时钟周期（Run-Test/Idle）。Insert idle cycles.
+   * @param cycles 周期数。Number of cycles.
+   */
+  virtual void IdleClocks(uint32_t cycles) = 0;
+
+ protected:
+  Jtag() = default;
+};
+
+}  // namespace LibXR::Debug
+

--- a/src/driver/debug/jtag.hpp
+++ b/src/driver/debug/jtag.hpp
@@ -88,6 +88,17 @@ class Jtag
                             uint8_t* out_lsb_first) = 0;
 
   /**
+   * @brief 产生固定 TMS 的序列移位（LSB-first）。Shift sequence with fixed TMS (LSB-first).
+   * @param cycles 位数。Bit count.
+   * @param tms 固定的 TMS 值。Fixed TMS value.
+   * @param tdi_lsb_first 输入 TDI 数据（LSB-first），可为 nullptr。
+   * @param tdo_lsb_first 输出 TDO 数据（LSB-first），可为 nullptr。
+   * @return ErrorCode 操作结果。Error code.
+   */
+  virtual ErrorCode Sequence(uint32_t cycles, bool tms, const uint8_t* tdi_lsb_first,
+                             uint8_t* tdo_lsb_first) = 0;
+
+  /**
    * @brief 插入空闲时钟周期（Run-Test/Idle）。Insert idle cycles.
    * @param cycles 周期数。Number of cycles.
    */
@@ -98,4 +109,3 @@ class Jtag
 };
 
 }  // namespace LibXR::Debug
-

--- a/src/driver/debug/jtag.hpp
+++ b/src/driver/debug/jtag.hpp
@@ -7,7 +7,7 @@
 namespace LibXR::Debug
 {
 /**
- * @brief JTAG TAP 状态。JTAG TAP states.
+ * @brief JTAG TAP states.
  */
 enum class TapState : uint8_t
 {
@@ -31,8 +31,7 @@ enum class TapState : uint8_t
 
 /**
  * @class Jtag
- * @brief JTAG 抽象基类，提供 TAP 控制与 IR/DR 移位能力。
- *        Abstract JTAG base class providing TAP control and IR/DR shifting.
+ * @brief Abstract JTAG base class providing TAP control and IR/DR shifting.
  */
 class Jtag
 {
@@ -43,64 +42,64 @@ class Jtag
   Jtag& operator=(const Jtag&) = delete;
 
   /**
-   * @brief 设置 TCK 频率（可选）。Set TCK frequency (optional).
-   * @param hz 目标频率（Hz）。Target frequency in Hz.
-   * @return ErrorCode 操作结果。Error code.
+   * @brief Set TCK frequency, if supported.
+   * @param hz Target frequency in Hz.
+   * @return Operation result.
    */
   virtual ErrorCode SetClockHz(uint32_t hz) = 0;
 
   /**
-   * @brief 关闭 JTAG 并释放资源。Close JTAG and release resources.
+   * @brief Close JTAG and release resources.
    */
   virtual void Close() = 0;
 
   /**
-   * @brief 复位 TAP 到 Test-Logic-Reset。Reset TAP to Test-Logic-Reset.
-   * @return ErrorCode 操作结果。Error code.
+   * @brief Reset TAP to Test-Logic-Reset.
+   * @return Operation result.
    */
   virtual ErrorCode ResetTap() = 0;
 
   /**
-   * @brief 切换到指定 TAP 状态。Goto target TAP state.
-   * @param target 目标状态。Target state.
-   * @return ErrorCode 操作结果。Error code.
+   * @brief Move to the requested TAP state.
+   * @param target Target TAP state.
+   * @return Operation result.
    */
   virtual ErrorCode GotoState(TapState target) = 0;
 
   /**
-   * @brief IR 移位（LSB-first）。Shift IR (LSB-first).
-   * @param bits 位数。Bit count.
-   * @param in_lsb_first 输入 TDI 数据（LSB-first），可为 nullptr。
-   * @param out_lsb_first 输出 TDO 数据（LSB-first），可为 nullptr。
-   * @return ErrorCode 操作结果。Error code.
+   * @brief Shift IR, LSB first.
+   * @param bits Bit count.
+   * @param in_lsb_first Optional TDI data, LSB first.
+   * @param out_lsb_first Optional TDO data, LSB first.
+   * @return Operation result.
    */
   virtual ErrorCode ShiftIR(uint32_t bits, const uint8_t* in_lsb_first,
                             uint8_t* out_lsb_first) = 0;
 
   /**
-   * @brief DR 移位（LSB-first）。Shift DR (LSB-first).
-   * @param bits 位数。Bit count.
-   * @param in_lsb_first 输入 TDI 数据（LSB-first），可为 nullptr。
-   * @param out_lsb_first 输出 TDO 数据（LSB-first），可为 nullptr。
-   * @return ErrorCode 操作结果。Error code.
+   * @brief Shift DR, LSB first.
+   * @param bits Bit count.
+   * @param in_lsb_first Optional TDI data, LSB first.
+   * @param out_lsb_first Optional TDO data, LSB first.
+   * @return Operation result.
    */
   virtual ErrorCode ShiftDR(uint32_t bits, const uint8_t* in_lsb_first,
                             uint8_t* out_lsb_first) = 0;
 
   /**
-   * @brief 产生固定 TMS 的序列移位（LSB-first）。Shift sequence with fixed TMS (LSB-first).
-   * @param cycles 位数。Bit count.
-   * @param tms 固定的 TMS 值。Fixed TMS value.
-   * @param tdi_lsb_first 输入 TDI 数据（LSB-first），可为 nullptr。
-   * @param tdo_lsb_first 输出 TDO 数据（LSB-first），可为 nullptr。
-   * @return ErrorCode 操作结果。Error code.
+   * @brief Shift a fixed-TMS sequence, LSB first.
+   * @param cycles Bit count.
+   * @param tms Fixed TMS value.
+   * @param tdi_lsb_first Optional TDI data, LSB first.
+   * @param tdo_lsb_first Optional TDO data, LSB first.
+   * @return Operation result.
    */
   virtual ErrorCode Sequence(uint32_t cycles, bool tms, const uint8_t* tdi_lsb_first,
                              uint8_t* tdo_lsb_first) = 0;
 
   /**
-   * @brief 插入空闲时钟周期（Run-Test/Idle）。Insert idle cycles.
-   * @param cycles 周期数。Number of cycles.
+   * @brief Insert idle clock cycles in Run-Test/Idle.
+   * @param cycles Number of cycles.
    */
   virtual void IdleClocks(uint32_t cycles) = 0;
 

--- a/src/driver/debug/jtag_dp.hpp
+++ b/src/driver/debug/jtag_dp.hpp
@@ -1,0 +1,345 @@
+// jtag_dp.hpp
+#pragma once
+
+#include <cstdint>
+
+#include "jtag.hpp"
+#include "jtag_protocol.hpp"
+#include "libxr_def.hpp"
+
+namespace LibXR::Debug
+{
+/**
+ * @brief JTAG-DP 事务层封装（DP/AP 访问与 IDCODE/ABORT）。
+ *
+ * 说明：
+ * - JTAG-DP 读为管线化：读请求返回上一笔结果。
+ * - 本类提供 DpReadTxn/ApReadTxn 等“带取数”的事务方法。
+ */
+class JtagDp final
+{
+ public:
+  explicit JtagDp(Jtag& jtag, JtagProtocol::ChainConfig* chain = nullptr)
+      : jtag_(jtag), chain_(chain)
+  {
+  }
+
+  void SetChainConfig(JtagProtocol::ChainConfig* chain)
+  {
+    chain_ = chain;
+    current_ir_valid_ = false;
+  }
+
+  ErrorCode DpRead(uint8_t addr2b, uint32_t& val, JtagProtocol::Ack& ack)
+  {
+    JtagProtocol::Response resp;
+    const ErrorCode EC =
+        Transfer(JtagProtocol::make_dp_req(true, addr2b, 0u), resp);
+    ack = resp.ack;
+    val = resp.rdata;
+    return EC;
+  }
+
+  ErrorCode DpWrite(uint8_t addr2b, uint32_t val, JtagProtocol::Ack& ack)
+  {
+    JtagProtocol::Response resp;
+    const ErrorCode EC =
+        Transfer(JtagProtocol::make_dp_req(false, addr2b, val), resp);
+    ack = resp.ack;
+    return EC;
+  }
+
+  ErrorCode DpReadTxn(uint8_t addr2b, uint32_t& val, JtagProtocol::Ack& ack)
+  {
+    JtagProtocol::Response resp;
+    ErrorCode EC = Transfer(JtagProtocol::make_dp_req(true, addr2b, 0u), resp);
+    if (EC != ErrorCode::OK)
+    {
+      ack = resp.ack;
+      return EC;
+    }
+    // 读为管线化：第二次读取 RDBUFF 拿到结果
+    EC = Transfer(JtagProtocol::make_dp_req(true, 3u, 0u), resp);
+    ack = resp.ack;
+    if (EC != ErrorCode::OK || resp.ack != JtagProtocol::Ack::OK)
+    {
+      return EC;
+    }
+    val = resp.rdata;
+    return ErrorCode::OK;
+  }
+
+  ErrorCode DpWriteTxn(uint8_t addr2b, uint32_t val, JtagProtocol::Ack& ack)
+  {
+    return DpWrite(addr2b, val, ack);
+  }
+
+  ErrorCode ApReadTxn(uint8_t addr2b, uint32_t& val, JtagProtocol::Ack& ack)
+  {
+    JtagProtocol::Response resp;
+    ErrorCode EC = Transfer(JtagProtocol::make_ap_req(true, addr2b, 0u), resp);
+    if (EC != ErrorCode::OK)
+    {
+      ack = resp.ack;
+      return EC;
+    }
+    // AP 读同样是 posted：读 RDBUFF 获取实际数据
+    EC = Transfer(JtagProtocol::make_dp_req(true, 3u, 0u), resp);
+    ack = resp.ack;
+    if (EC != ErrorCode::OK || resp.ack != JtagProtocol::Ack::OK)
+    {
+      return EC;
+    }
+    val = resp.rdata;
+    return ErrorCode::OK;
+  }
+
+  ErrorCode ApWriteTxn(uint8_t addr2b, uint32_t val, JtagProtocol::Ack& ack)
+  {
+    JtagProtocol::Response resp;
+    const ErrorCode EC =
+        Transfer(JtagProtocol::make_ap_req(false, addr2b, val), resp);
+    ack = resp.ack;
+    return EC;
+  }
+
+  ErrorCode ReadIdCode(uint32_t& idcode)
+  {
+    const ErrorCode EC = SelectIr(JtagProtocol::JTAG_IR_IDCODE);
+    if (EC != ErrorCode::OK)
+    {
+      return EC;
+    }
+
+    uint64_t out_dr = 0u;
+    const ErrorCode EC2 = ShiftValueThroughChain(0u, 32u, out_dr);
+    if (EC2 != ErrorCode::OK)
+    {
+      return EC2;
+    }
+    idcode = static_cast<uint32_t>(out_dr & 0xFFFF'FFFFu);
+    return ErrorCode::OK;
+  }
+
+  ErrorCode WriteAbort(uint32_t data, JtagProtocol::Ack& ack)
+  {
+    return DpWrite(0u, data, ack);
+  }
+
+  ErrorCode Transfer(const JtagProtocol::Request& req, JtagProtocol::Response& resp)
+  {
+    const ErrorCode EC = SelectIr(req.port == JtagProtocol::Port::AP
+                                      ? JtagProtocol::JTAG_IR_APACC
+                                      : JtagProtocol::JTAG_IR_DPACC);
+    if (EC != ErrorCode::OK)
+    {
+      resp.ack = JtagProtocol::Ack::PROTOCOL;
+      return EC;
+    }
+
+    uint64_t out_dr = 0u;
+    const ErrorCode EC2 =
+        ShiftValueThroughChain(JtagProtocol::PackDpDr(req),
+                               JtagProtocol::JTAG_DP_DR_LEN, out_dr);
+    if (EC2 != ErrorCode::OK)
+    {
+      resp.ack = JtagProtocol::Ack::PROTOCOL;
+      return EC2;
+    }
+
+    JtagProtocol::UnpackDpDr(out_dr, resp);
+    return ErrorCode::OK;
+  }
+
+ private:
+  static constexpr uint32_t DEFAULT_IR_BITS = 4u;
+  static constexpr uint32_t MAX_BITS = 512u;
+  static constexpr uint32_t MAX_BYTES = (MAX_BITS + 7u) / 8u;
+
+  uint32_t IrBits() const
+  {
+    if (chain_ != nullptr && chain_->ir_length != nullptr && chain_->count > 0 &&
+        chain_->index < chain_->count)
+    {
+      const uint8_t bits = chain_->ir_length[chain_->index];
+      return (bits == 0u) ? DEFAULT_IR_BITS : bits;
+    }
+    return DEFAULT_IR_BITS;
+  }
+
+  uint32_t IrBeforeBits()
+  {
+    if (chain_ == nullptr)
+    {
+      return 0u;
+    }
+    if (chain_->ir_before_bits_len == 0u && chain_->ir_after_bits_len == 0u)
+    {
+      JtagProtocol::UpdateChainCache(*chain_);
+    }
+    return chain_->ir_before_bits_len;
+  }
+
+  uint32_t IrAfterBits()
+  {
+    if (chain_ == nullptr)
+    {
+      return 0u;
+    }
+    if (chain_->ir_before_bits_len == 0u && chain_->ir_after_bits_len == 0u)
+    {
+      JtagProtocol::UpdateChainCache(*chain_);
+    }
+    return chain_->ir_after_bits_len;
+  }
+
+  uint32_t DrBeforeBits()
+  {
+    if (chain_ == nullptr)
+    {
+      return 0u;
+    }
+    return (chain_->count == 0 || chain_->index >= chain_->count)
+               ? 0u
+               : static_cast<uint32_t>(chain_->index);
+  }
+
+  uint32_t DrAfterBits()
+  {
+    if (chain_ == nullptr)
+    {
+      return 0u;
+    }
+    return (chain_->count == 0 || chain_->index >= chain_->count)
+               ? 0u
+               : static_cast<uint32_t>(chain_->count - chain_->index - 1u);
+  }
+
+  ErrorCode SelectIr(uint32_t ir)
+  {
+    if (current_ir_valid_ && current_ir_ == ir)
+    {
+      return ErrorCode::OK;
+    }
+
+    const uint32_t ir_bits = IrBits();
+    const uint32_t pre = IrBeforeBits();
+    const uint32_t post = IrAfterBits();
+    const uint32_t total_bits = pre + ir_bits + post;
+
+    if (total_bits > MAX_BITS)
+    {
+      return ErrorCode::SIZE_ERR;
+    }
+
+    uint8_t buf[MAX_BYTES] = {};
+    PutOnes(buf, 0u, pre);
+    PutBits(buf, pre, ir, ir_bits);
+    PutOnes(buf, pre + ir_bits, post);
+    const ErrorCode EC = jtag_.ShiftIR(total_bits, buf, nullptr);
+    if (EC == ErrorCode::OK)
+    {
+      current_ir_ = ir;
+      current_ir_valid_ = true;
+    }
+    return EC;
+  }
+
+  ErrorCode ShiftValueThroughChain(uint64_t in_value, uint32_t value_bits,
+                                   uint64_t& out_value)
+  {
+    const uint32_t pre = DrBeforeBits();
+    const uint32_t post = DrAfterBits();
+    const uint32_t total_bits = pre + value_bits + post;
+    if (total_bits > MAX_BITS)
+    {
+      return ErrorCode::SIZE_ERR;
+    }
+
+    uint8_t tx[MAX_BYTES] = {};
+    uint8_t rx[MAX_BYTES] = {};
+    PutOnes(tx, 0u, pre);
+    PutBits64(tx, pre, in_value, value_bits);
+    PutOnes(tx, pre + value_bits, post);
+
+    const ErrorCode EC = jtag_.ShiftDR(total_bits, tx, rx);
+    if (EC != ErrorCode::OK)
+    {
+      return EC;
+    }
+
+    out_value = GetBits64(rx, pre, value_bits);
+    return ErrorCode::OK;
+  }
+
+  static void PutOnes(uint8_t* buf, uint32_t bit_off, uint32_t bits)
+  {
+    for (uint32_t i = 0; i < bits; ++i)
+    {
+      const uint32_t idx = bit_off + i;
+      const uint32_t byte = idx / 8u;
+      const uint32_t shift = idx & 7u;
+      buf[byte] = static_cast<uint8_t>(buf[byte] | (1u << shift));
+    }
+  }
+
+  static void PutBits(uint8_t* buf, uint32_t bit_off, uint32_t value, uint32_t bits)
+  {
+    for (uint32_t i = 0; i < bits; ++i)
+    {
+      const bool bit = ((value >> i) & 0x1u) != 0u;
+      const uint32_t idx = bit_off + i;
+      const uint32_t byte = idx / 8u;
+      const uint32_t shift = idx & 7u;
+      if (bit)
+      {
+        buf[byte] = static_cast<uint8_t>(buf[byte] | (1u << shift));
+      }
+      else
+      {
+        buf[byte] = static_cast<uint8_t>(buf[byte] & ~(1u << shift));
+      }
+    }
+  }
+
+  static void PutBits64(uint8_t* buf, uint32_t bit_off, uint64_t value, uint32_t bits)
+  {
+    for (uint32_t i = 0; i < bits; ++i)
+    {
+      const bool bit = ((value >> i) & 0x1u) != 0u;
+      const uint32_t idx = bit_off + i;
+      const uint32_t byte = idx / 8u;
+      const uint32_t shift = idx & 7u;
+      if (bit)
+      {
+        buf[byte] = static_cast<uint8_t>(buf[byte] | (1u << shift));
+      }
+      else
+      {
+        buf[byte] = static_cast<uint8_t>(buf[byte] & ~(1u << shift));
+      }
+    }
+  }
+
+  static uint64_t GetBits64(const uint8_t* buf, uint32_t bit_off, uint32_t bits)
+  {
+    uint64_t v = 0u;
+    for (uint32_t i = 0; i < bits; ++i)
+    {
+      const uint32_t idx = bit_off + i;
+      const uint32_t byte = idx / 8u;
+      const uint32_t shift = idx & 7u;
+      const uint64_t bit = (buf[byte] >> shift) & 0x1u;
+      v |= (bit << i);
+    }
+    return v;
+  }
+
+ private:
+  Jtag& jtag_;
+  JtagProtocol::ChainConfig* chain_ = nullptr;
+  uint32_t current_ir_ = 0u;
+  bool current_ir_valid_ = false;
+};
+
+}  // namespace LibXR::Debug

--- a/src/driver/debug/jtag_dp.hpp
+++ b/src/driver/debug/jtag_dp.hpp
@@ -70,11 +70,27 @@ class JtagDp final
       return EC;
     }
     val = resp.rdata;
+
+    if ((addr2b & 0x03u) == 0u && val == 0u)
+    {
+      uint32_t idcode = 0u;
+      const ErrorCode id_ec = ReadIdCode(idcode);
+      if (id_ec == ErrorCode::OK && idcode != 0u && idcode != 0xFFFF'FFFFu)
+      {
+        val = idcode;
+        ack = JtagProtocol::Ack::OK;
+      }
+    }
     return ErrorCode::OK;
   }
 
   ErrorCode DpWriteTxn(uint8_t addr2b, uint32_t val, JtagProtocol::Ack& ack)
   {
+    if ((addr2b & 0x03u) == 0u)
+    {
+      return WriteAbort(val, ack);
+    }
+
     return DpWrite(addr2b, val, ack);
   }
 
@@ -113,7 +129,12 @@ class JtagDp final
 
   ErrorCode ReadIdCode(uint32_t& idcode)
   {
-    const ErrorCode EC = SelectIr(JtagProtocol::JTAG_IR_IDCODE);
+    return ReadIdCodeWithIr(JtagProtocol::JTAG_IR_IDCODE, idcode);
+  }
+
+  ErrorCode ReadIdCodeWithIr(uint32_t ir, uint32_t& idcode)
+  {
+    const ErrorCode EC = SelectIr(ir);
     if (EC != ErrorCode::OK)
     {
       return EC;
@@ -138,7 +159,6 @@ class JtagDp final
       return EC;
     }
 
-    JtagProtocol::Response resp;
     uint64_t out_dr = 0u;
     const ErrorCode EC2 = ShiftValueThroughChain(
         JtagProtocol::PackDpDr(JtagProtocol::make_dp_req(false, 0u, data)),
@@ -149,9 +169,11 @@ class JtagDp final
       return EC2;
     }
 
-    JtagProtocol::UnpackDpDr(out_dr, resp);
-    ack = resp.ack;
-    return (resp.ack == JtagProtocol::Ack::OK) ? ErrorCode::OK : ErrorCode::FAILED;
+    (void)out_dr;
+    // JTAG ABORT uses its own scan chain; captured TDO bits are not a
+    // DPACC/APACC ACK field. A completed shift means the ABORT was issued.
+    ack = JtagProtocol::Ack::OK;
+    return ErrorCode::OK;
   }
 
   ErrorCode Transfer(const JtagProtocol::Request& req, JtagProtocol::Response& resp)

--- a/src/driver/debug/jtag_dp.hpp
+++ b/src/driver/debug/jtag_dp.hpp
@@ -53,10 +53,14 @@ class JtagDp final
   {
     JtagProtocol::Response resp;
     ErrorCode EC = Transfer(JtagProtocol::make_dp_req(true, addr2b, 0u), resp);
+    ack = resp.ack;
     if (EC != ErrorCode::OK)
     {
-      ack = resp.ack;
       return EC;
+    }
+    if (resp.ack != JtagProtocol::Ack::OK)
+    {
+      return ErrorCode::OK;
     }
     // 读为管线化：第二次读取 RDBUFF 拿到结果
     EC = Transfer(JtagProtocol::make_dp_req(true, 3u, 0u), resp);
@@ -78,10 +82,14 @@ class JtagDp final
   {
     JtagProtocol::Response resp;
     ErrorCode EC = Transfer(JtagProtocol::make_ap_req(true, addr2b, 0u), resp);
+    ack = resp.ack;
     if (EC != ErrorCode::OK)
     {
-      ack = resp.ack;
       return EC;
+    }
+    if (resp.ack != JtagProtocol::Ack::OK)
+    {
+      return ErrorCode::OK;
     }
     // AP 读同样是 posted：读 RDBUFF 获取实际数据
     EC = Transfer(JtagProtocol::make_dp_req(true, 3u, 0u), resp);

--- a/src/driver/debug/jtag_general_gpio.hpp
+++ b/src/driver/debug/jtag_general_gpio.hpp
@@ -1,0 +1,343 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+#include "gpio.hpp"
+#include "jtag.hpp"
+#include "libxr_def.hpp"
+
+namespace LibXR::Debug
+{
+/**
+ * @brief 基于 GpioType 轮询 bit-bang 的 JTAG 探针。
+ *        JTAG probe based on polling bit-bang using GpioType.
+ *
+ * @tparam TckGpioType TCK GPIO 类型 / TCK GPIO type
+ * @tparam TmsGpioType TMS GPIO 类型 / TMS GPIO type
+ * @tparam TdiGpioType TDI GPIO 类型 / TDI GPIO type
+ * @tparam TdoGpioType TDO GPIO 类型 / TDO GPIO type
+ *
+ * @note 推荐外围电路：TCK/TMS/TDI 串联 33Ω，TMS 上拉 10k；TDO 由目标驱动。
+ *       Recommended circuit: 33Ω series on TCK/TMS/TDI, 10k pull-up on TMS; TDO
+ *       driven by target.
+ */
+template <typename TckGpioType, typename TmsGpioType, typename TdiGpioType,
+          typename TdoGpioType>
+class JtagGeneralGPIO final : public Jtag
+{
+  static constexpr uint32_t MIN_HZ = 10'000u;
+  static constexpr uint32_t MAX_HZ = 100'000'000u;
+
+  static constexpr uint32_t NS_PER_SEC = 1'000'000'000u;
+  static constexpr uint32_t LOOPS_SCALE = 1000u;
+  static constexpr uint32_t CEIL_BIAS = LOOPS_SCALE - 1u;
+
+  static constexpr uint32_t DEFAULT_CLOCK_HZ = 500'000u;
+  static constexpr uint32_t RESET_CYCLES = 5u;
+
+  static constexpr uint32_t HALF_PERIOD_NS_MAX =
+      (NS_PER_SEC + (2u * MIN_HZ) - 1u) / (2u * MIN_HZ);
+  static constexpr uint32_t MAX_LOOPS_PER_US =
+      (UINT32_MAX - CEIL_BIAS) / HALF_PERIOD_NS_MAX;
+
+ public:
+  /**
+   * @brief 构造函数。Constructor.
+   * @param tck 用作 TCK 的 GPIO。GPIO used as TCK.
+   * @param tms 用作 TMS 的 GPIO。GPIO used as TMS.
+   * @param tdi 用作 TDI 的 GPIO。GPIO used as TDI.
+   * @param tdo 用作 TDO 的 GPIO。GPIO used as TDO.
+   * @param loops_per_us 每个 us 的循延时环次数。Loops per us of delay.
+   * @param default_hz 默认 TCK 频率（Hz）。Default TCK frequency (Hz).
+   */
+  explicit JtagGeneralGPIO(TckGpioType& tck, TmsGpioType& tms, TdiGpioType& tdi,
+                           TdoGpioType& tdo, uint32_t loops_per_us,
+                           uint32_t default_hz = DEFAULT_CLOCK_HZ)
+      : tck_(tck), tms_(tms), tdi_(tdi), tdo_(tdo), loops_per_us_(loops_per_us)
+  {
+    if (loops_per_us_ > MAX_LOOPS_PER_US)
+    {
+      loops_per_us_ = MAX_LOOPS_PER_US;
+    }
+
+    tck_.SetConfig({TckGpioType::Direction::OUTPUT_PUSH_PULL, TckGpioType::Pull::NONE});
+    tms_.SetConfig({TmsGpioType::Direction::OUTPUT_PUSH_PULL, TmsGpioType::Pull::UP});
+    tdi_.SetConfig({TdiGpioType::Direction::OUTPUT_PUSH_PULL, TdiGpioType::Pull::NONE});
+    tdo_.SetConfig({TdoGpioType::Direction::INPUT, TdoGpioType::Pull::NONE});
+
+    tck_.Write(false);
+    tms_.Write(true);
+    tdi_.Write(false);
+
+    (void)SetClockHz(default_hz);
+    (void)ResetTap();
+  }
+
+  ~JtagGeneralGPIO() override = default;
+
+  JtagGeneralGPIO(const JtagGeneralGPIO&) = delete;
+  JtagGeneralGPIO& operator=(const JtagGeneralGPIO&) = delete;
+
+  ErrorCode SetClockHz(uint32_t hz) override
+  {
+    if (hz == 0u)
+    {
+      clock_hz_ = 0u;
+      half_period_ns_ = 0u;
+      half_period_loops_ = 0u;
+      return ErrorCode::OK;
+    }
+
+    if (hz < MIN_HZ)
+    {
+      hz = MIN_HZ;
+    }
+    if (hz > MAX_HZ)
+    {
+      hz = MAX_HZ;
+    }
+
+    clock_hz_ = hz;
+
+    const double DEN = 2.0 * static_cast<double>(hz);
+    const double HALF_PERIOD_NS_F = std::ceil(static_cast<double>(NS_PER_SEC) / DEN);
+    half_period_ns_ = static_cast<uint32_t>(HALF_PERIOD_NS_F);
+
+    if (loops_per_us_ == 0u)
+    {
+      half_period_loops_ = 0u;
+      return ErrorCode::OK;
+    }
+
+    const double HALF_PERIOD_LOOPS_F =
+        (static_cast<double>(loops_per_us_) * static_cast<double>(half_period_ns_)) /
+        static_cast<double>(LOOPS_SCALE);
+
+    if (HALF_PERIOD_LOOPS_F < 1.0)
+    {
+      half_period_loops_ = 0u;
+    }
+    else
+    {
+      const double LOOPS_CEIL_F = std::ceil(HALF_PERIOD_LOOPS_F);
+      half_period_loops_ = (LOOPS_CEIL_F >= static_cast<double>(UINT32_MAX))
+                               ? UINT32_MAX
+                               : static_cast<uint32_t>(LOOPS_CEIL_F);
+    }
+
+    return ErrorCode::OK;
+  }
+
+  void Close() override
+  {
+    tck_.Write(false);
+    tms_.Write(true);
+    tdi_.Write(false);
+  }
+
+  ErrorCode ResetTap() override
+  {
+    tms_.Write(true);
+    for (uint32_t i = 0; i < RESET_CYCLES; ++i)
+    {
+      ClockCycle(true, false, nullptr);
+    }
+    current_state_ = TapState::TEST_LOGIC_RESET;
+    return ErrorCode::OK;
+  }
+
+  ErrorCode GotoState(TapState target) override
+  {
+    if (target == current_state_)
+    {
+      return ErrorCode::OK;
+    }
+
+    switch (target)
+    {
+      case TapState::TEST_LOGIC_RESET:
+        return ResetTap();
+      case TapState::RUN_TEST_IDLE:
+        EnsureIdle();
+        return ErrorCode::OK;
+      case TapState::SHIFT_IR:
+        EnsureIdle();
+        ApplyTmsSequence(SEQ_TO_SHIFT_IR, SEQ_TO_SHIFT_IR_LEN);
+        current_state_ = TapState::SHIFT_IR;
+        return ErrorCode::OK;
+      case TapState::SHIFT_DR:
+        EnsureIdle();
+        ApplyTmsSequence(SEQ_TO_SHIFT_DR, SEQ_TO_SHIFT_DR_LEN);
+        current_state_ = TapState::SHIFT_DR;
+        return ErrorCode::OK;
+      default:
+        return ErrorCode::NOT_SUPPORT;
+    }
+  }
+
+  ErrorCode ShiftIR(uint32_t bits, const uint8_t* in_lsb_first,
+                    uint8_t* out_lsb_first) override
+  {
+    if (bits == 0u)
+    {
+      return ErrorCode::OK;
+    }
+
+    const ErrorCode EC = GotoState(TapState::SHIFT_IR);
+    if (EC != ErrorCode::OK)
+    {
+      return EC;
+    }
+
+    ShiftBits(bits, in_lsb_first, out_lsb_first);
+    ExitToIdle();
+    return ErrorCode::OK;
+  }
+
+  ErrorCode ShiftDR(uint32_t bits, const uint8_t* in_lsb_first,
+                    uint8_t* out_lsb_first) override
+  {
+    if (bits == 0u)
+    {
+      return ErrorCode::OK;
+    }
+
+    const ErrorCode EC = GotoState(TapState::SHIFT_DR);
+    if (EC != ErrorCode::OK)
+    {
+      return EC;
+    }
+
+    ShiftBits(bits, in_lsb_first, out_lsb_first);
+    ExitToIdle();
+    return ErrorCode::OK;
+  }
+
+  void IdleClocks(uint32_t cycles) override
+  {
+    if (cycles == 0u)
+    {
+      return;
+    }
+
+    (void)GotoState(TapState::RUN_TEST_IDLE);
+    for (uint32_t i = 0; i < cycles; ++i)
+    {
+      ClockCycle(false, false, nullptr);
+    }
+  }
+
+ private:
+  static constexpr uint8_t SEQ_TO_SHIFT_DR[] = {1u, 0u, 0u};
+  static constexpr uint32_t SEQ_TO_SHIFT_DR_LEN = 3u;
+  static constexpr uint8_t SEQ_TO_SHIFT_IR[] = {1u, 1u, 0u, 0u};
+  static constexpr uint32_t SEQ_TO_SHIFT_IR_LEN = 4u;
+
+  void ApplyTmsSequence(const uint8_t* seq, uint32_t len)
+  {
+    for (uint32_t i = 0; i < len; ++i)
+    {
+      const bool TMS_VAL = (seq[i] != 0u);
+      ClockCycle(TMS_VAL, false, nullptr);
+    }
+  }
+
+  void EnsureIdle()
+  {
+    if (current_state_ == TapState::RUN_TEST_IDLE)
+    {
+      return;
+    }
+    (void)ResetTap();
+    ClockCycle(false, false, nullptr);
+    current_state_ = TapState::RUN_TEST_IDLE;
+  }
+  void ExitToIdle()
+  {
+    // EXIT1 -> UPDATE (TMS=1), UPDATE -> IDLE (TMS=0)
+    ClockCycle(true, false, nullptr);
+    ClockCycle(false, false, nullptr);
+    current_state_ = TapState::RUN_TEST_IDLE;
+  }
+
+  void ShiftBits(uint32_t bits, const uint8_t* in_lsb_first, uint8_t* out_lsb_first)
+  {
+    if (out_lsb_first != nullptr)
+    {
+      const uint32_t BYTES = (bits + 7u) / 8u;
+      Memory::FastSet(out_lsb_first, 0, BYTES);
+    }
+
+    for (uint32_t i = 0; i < bits; ++i)
+    {
+      const bool TMS_VAL = (i + 1u == bits);
+      const bool TDI_VAL = (in_lsb_first == nullptr)
+                               ? false
+                               : (((in_lsb_first[i / 8u] >> (i & 7u)) & 0x1u) != 0u);
+      bool tdo_bit = false;
+      ClockCycle(TMS_VAL, TDI_VAL, out_lsb_first ? &tdo_bit : nullptr);
+
+      if (out_lsb_first != nullptr && tdo_bit)
+      {
+        out_lsb_first[i / 8u] =
+            static_cast<uint8_t>(out_lsb_first[i / 8u] | (1u << (i & 7u)));
+      }
+    }
+  }
+
+  void ClockCycle(bool tms, bool tdi, bool* tdo)
+  {
+    tms_.Write(tms);
+    tdi_.Write(tdi);
+
+    if (half_period_loops_ == 0u)
+    {
+      tck_.Write(false);
+      tck_.Write(true);
+      if (tdo != nullptr)
+      {
+        *tdo = tdo_.Read();
+      }
+      tck_.Write(false);
+    }
+    else
+    {
+      tck_.Write(false);
+      DelayHalf();
+      tck_.Write(true);
+      DelayHalf();
+      if (tdo != nullptr)
+      {
+        *tdo = tdo_.Read();
+      }
+      tck_.Write(false);
+    }
+
+  }
+
+  inline void DelayHalf() { BusyLoop(half_period_loops_); }
+
+  static void BusyLoop(uint32_t loops)
+  {
+    volatile uint32_t sink = loops;
+    while (sink--)
+    {
+    }
+  }
+
+ private:
+  TckGpioType& tck_;
+  TmsGpioType& tms_;
+  TdiGpioType& tdi_;
+  TdoGpioType& tdo_;
+
+  uint32_t clock_hz_ = 0u;
+  uint32_t loops_per_us_ = 0u;
+  uint32_t half_period_ns_ = 0u;
+  uint32_t half_period_loops_ = 0u;
+
+  TapState current_state_ = TapState::TEST_LOGIC_RESET;
+};
+
+}  // namespace LibXR::Debug

--- a/src/driver/debug/jtag_general_gpio.hpp
+++ b/src/driver/debug/jtag_general_gpio.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <cmath>
 #include <cstdint>
 
 #include "gpio.hpp"
 #include "jtag.hpp"
 #include "libxr_def.hpp"
+#include "libxr_mem.hpp"
 
 namespace LibXR::Debug
 {
@@ -100,9 +100,7 @@ class JtagGeneralGPIO final : public Jtag
 
     clock_hz_ = hz;
 
-    const double DEN = 2.0 * static_cast<double>(hz);
-    const double HALF_PERIOD_NS_F = std::ceil(static_cast<double>(NS_PER_SEC) / DEN);
-    half_period_ns_ = static_cast<uint32_t>(HALF_PERIOD_NS_F);
+    half_period_ns_ = (NS_PER_SEC + (2u * hz) - 1u) / (2u * hz);
 
     if (loops_per_us_ == 0u)
     {
@@ -110,20 +108,17 @@ class JtagGeneralGPIO final : public Jtag
       return ErrorCode::OK;
     }
 
-    const double HALF_PERIOD_LOOPS_F =
-        (static_cast<double>(loops_per_us_) * static_cast<double>(half_period_ns_)) /
-        static_cast<double>(LOOPS_SCALE);
-
-    if (HALF_PERIOD_LOOPS_F < 1.0)
+    const uint64_t LOOPS_SCALED =
+        static_cast<uint64_t>(loops_per_us_) * static_cast<uint64_t>(half_period_ns_);
+    if (LOOPS_SCALED < LOOPS_SCALE)
     {
       half_period_loops_ = 0u;
     }
     else
     {
-      const double LOOPS_CEIL_F = std::ceil(HALF_PERIOD_LOOPS_F);
-      half_period_loops_ = (LOOPS_CEIL_F >= static_cast<double>(UINT32_MAX))
-                               ? UINT32_MAX
-                               : static_cast<uint32_t>(LOOPS_CEIL_F);
+      const uint64_t LOOPS_CEIL = (LOOPS_SCALED + CEIL_BIAS) / LOOPS_SCALE;
+      half_period_loops_ = (LOOPS_CEIL > UINT32_MAX) ? UINT32_MAX
+                                                     : static_cast<uint32_t>(LOOPS_CEIL);
     }
 
     return ErrorCode::OK;
@@ -295,7 +290,7 @@ class JtagGeneralGPIO final : public Jtag
 
   void ShiftBits(uint32_t bits, const uint8_t* in_lsb_first, uint8_t* out_lsb_first)
   {
-    if (out_lsb_first != nullptr && bits <= 1u)
+    if (out_lsb_first != nullptr && bits != 0u)
     {
       const uint32_t BYTES = (bits + 7u) / 8u;
       Memory::FastSet(out_lsb_first, 0, BYTES);

--- a/src/driver/debug/jtag_protocol.hpp
+++ b/src/driver/debug/jtag_protocol.hpp
@@ -1,0 +1,135 @@
+// jtag_protocol.hpp
+#pragma once
+
+#include <cstdint>
+
+namespace LibXR::Debug::JtagProtocol
+{
+/**
+ * @brief JTAG 传输端口选择 / JTAG transfer port selector
+ */
+enum class Port : uint8_t
+{
+  DP = 0,  ///< Debug Port / 调试端口
+  AP = 1,  ///< Access Port / 访问端口
+};
+
+/**
+ * @brief JTAG ACK 返回码 / JTAG ACK response codes
+ *
+ * @note ACK 为 3-bit（LSB-first）编码；此处以解码后的枚举值表示。
+ *       ACK is a 3-bit (LSB-first) encoding; this enum represents decoded values.
+ */
+enum class Ack : uint8_t
+{
+  NO_ACK = 0x0,    ///< 无应答 / No ACK
+  OK = 0x1,        ///< OK / OK
+  WAIT = 0x2,      ///< WAIT / WAIT
+  FAULT = 0x4,     ///< FAULT / FAULT
+  PROTOCOL = 0x7,  ///< 协议错误（非法 ACK）/ Protocol error (invalid ACK)
+};
+
+/**
+ * @brief JTAG 传输请求 / JTAG transfer request
+ *
+ * @note request 位域与 SWD 一致：APnDP/RnW/A2/A3。JTAG 中由 DPACC/APACC IR 选择端口。
+ */
+struct Request
+{
+  Port port = Port::DP;  ///< 目标端口（DP/AP）/ Target port (DP/AP)
+  bool rnw =
+      true;  ///< 读写标志：true=读，false=写 / Read-not-write: true=read, false=write
+  uint8_t addr2b = 0;  ///< A[3:2] 两位地址编码（0..3）/ A[3:2] encoded as 0..3
+  uint32_t wdata = 0;  ///< 写数据（仅写请求有效）/ Write data (valid for write requests)
+};
+
+/**
+ * @brief JTAG 传输响应 / JTAG transfer response
+ */
+struct Response
+{
+  Ack ack = Ack::PROTOCOL;  ///< ACK / ACK
+  uint32_t rdata = 0;  ///< 读数据（仅读响应有效）/ Read data (valid for read responses)
+};
+
+/**
+ * @brief JTAG IR 指令码 / JTAG IR codes
+ */
+inline constexpr uint32_t JTAG_IR_ABORT = 0x08u;
+inline constexpr uint32_t JTAG_IR_DPACC = 0x0Au;
+inline constexpr uint32_t JTAG_IR_APACC = 0x0Bu;
+inline constexpr uint32_t JTAG_IR_IDCODE = 0x0Eu;
+inline constexpr uint32_t JTAG_IR_BYPASS = 0x0Fu;
+
+/**
+ * @brief JTAG Sequence 信息字段 / JTAG sequence info fields
+ */
+inline constexpr uint8_t JTAG_SEQUENCE_TCK = 0x3Fu;  ///< TCK count (1..64, 0->64)
+inline constexpr uint8_t JTAG_SEQUENCE_TMS = 0x40u;  ///< TMS value
+inline constexpr uint8_t JTAG_SEQUENCE_TDO = 0x80u;  ///< TDO capture
+
+/**
+ * @brief JTAG-DP DR 长度（bit）/ JTAG-DP DR length in bits
+ */
+inline constexpr uint32_t JTAG_DP_DR_LEN = 35u;
+
+/**
+ * @brief JTAG ACK 原始值映射（JTAG-DP 与 SWD ACK 编码不同）
+ *
+ * JTAG 原始 3-bit：OK=0x2, WAIT=0x1, FAULT=0x4
+ * 映射后使用本枚举（OK=0x1, WAIT=0x2, FAULT=0x4）
+ */
+constexpr Ack map_jtag_ack(uint8_t raw_ack)
+{
+  switch (raw_ack & 0x7u)
+  {
+    case 0x2:
+      return Ack::OK;
+    case 0x1:
+      return Ack::WAIT;
+    case 0x4:
+      return Ack::FAULT;
+    case 0x0:
+      return Ack::NO_ACK;
+    default:
+      return Ack::PROTOCOL;
+  }
+}
+
+/**
+ * @brief JTAG 设备链配置 / JTAG device chain configuration
+ *
+ * @note 该结构仅描述设备链参数，不分配内存。
+ */
+struct ChainConfig
+{
+  uint8_t count = 0;        ///< 设备数（TDO 端为 index=0）/ Device count (TDO side index=0)
+  uint8_t index = 0;        ///< 当前设备索引 / Current device index
+  const uint8_t* ir_length = nullptr;  ///< 各设备 IR 长度数组 / IR length array
+  const uint16_t* ir_before = nullptr; ///< 当前设备前的 bypass 位数 / Bypass bits before
+  const uint16_t* ir_after = nullptr;  ///< 当前设备后的 bypass 位数 / Bypass bits after
+
+  // 运行期缓存（可选）：用于减少每次 Shift 计算
+  uint32_t ir_before_bits_len = 0;  ///< 前面设备 IR 总位数 / IR bits before
+  uint32_t ir_after_bits_len = 0;   ///< 后面设备 IR 总位数 / IR bits after
+  uint32_t dr_before_bits_len = 0;  ///< 前面设备 DR 总位数 / DR bits before
+  uint32_t dr_after_bits_len = 0;   ///< 后面设备 DR 总位数 / DR bits after
+};
+
+/**
+ * @brief 构造 DP 请求 / Build DP request
+ */
+constexpr Request make_dp_req(bool rnw, uint8_t addr2b, uint32_t wdata = 0u)
+{
+  return Request{Port::DP, rnw, static_cast<uint8_t>(addr2b & 0x03u), wdata};
+}
+
+/**
+ * @brief 构造 AP 请求 / Build AP request
+ */
+constexpr Request make_ap_req(bool rnw, uint8_t addr2b, uint32_t wdata = 0u)
+{
+  return Request{Port::AP, rnw, static_cast<uint8_t>(addr2b & 0x03u), wdata};
+}
+
+}  // namespace LibXR::Debug::JtagProtocol

--- a/src/driver/debug/swd_general_gpio.hpp
+++ b/src/driver/debug/swd_general_gpio.hpp
@@ -107,11 +107,11 @@ class SwdGeneralGPIO final : public Swd
 
     clock_hz_ = hz;
 
-    // 半周期计算改为浮点（double），最终再转为整型。Half period computed in double, then
-    // converted to integer.
-    const double DEN = 2.0 * static_cast<double>(hz);
-    const double HALF_PERIOD_NS_F = std::ceil(static_cast<double>(NS_PER_SEC) / DEN);
-    half_period_ns_ = static_cast<uint32_t>(HALF_PERIOD_NS_F);
+    // Keep MCU timing setup integer-only so simple SWD clock setup does not
+    // pull in floating-point runtime helpers.
+    const uint64_t DEN = static_cast<uint64_t>(2u) * static_cast<uint64_t>(hz);
+    half_period_ns_ =
+        static_cast<uint32_t>((static_cast<uint64_t>(NS_PER_SEC) + DEN - 1u) / DEN);
 
     if (loops_per_us_ == 0u)
     {
@@ -119,24 +119,21 @@ class SwdGeneralGPIO final : public Swd
       return ErrorCode::OK;
     }
 
-    // half_period_loops 使用浮点计算，最终再转为整型（ceil）。
-    // 允许 < 1 时转换为 0，用于进入 no-delay 路径。
-    // Compute loops in double, then convert to integer (ceil). Allow < 1 to become 0
-    // to enter no-delay path.
-    const double HALF_PERIOD_LOOPS_F =
-        (static_cast<double>(loops_per_us_) * static_cast<double>(half_period_ns_)) /
-        static_cast<double>(LOOPS_SCALE);
+    const uint64_t loops_num =
+        static_cast<uint64_t>(loops_per_us_) * static_cast<uint64_t>(half_period_ns_);
 
-    if (HALF_PERIOD_LOOPS_F < 1.0)
+    if (loops_num < static_cast<uint64_t>(LOOPS_SCALE))
     {
       half_period_loops_ = 0u;
     }
     else
     {
-      const double LOOPS_CEIL_F = std::ceil(HALF_PERIOD_LOOPS_F);
-      half_period_loops_ = (LOOPS_CEIL_F >= static_cast<double>(UINT32_MAX))
+      const uint64_t loops_ceil =
+          (loops_num + static_cast<uint64_t>(LOOPS_SCALE) - 1u) /
+          static_cast<uint64_t>(LOOPS_SCALE);
+      half_period_loops_ = (loops_ceil >= static_cast<uint64_t>(UINT32_MAX))
                                ? UINT32_MAX
-                               : static_cast<uint32_t>(LOOPS_CEIL_F);
+                               : static_cast<uint32_t>(loops_ceil);
     }
 
     return ErrorCode::OK;

--- a/src/driver/debug/swd_general_gpio.hpp
+++ b/src/driver/debug/swd_general_gpio.hpp
@@ -31,7 +31,7 @@ template <typename SwclkGpioType, typename SwdioGpioType,
           SwdIoDriveMode IO_DRIVE_MODE = SwdIoDriveMode::PUSH_PULL>
 class SwdGeneralGPIO final : public Swd
 {
-  static constexpr uint32_t MIN_HZ = 10'000u;
+  static constexpr uint32_t MIN_HZ = 50'000u;
   static constexpr uint32_t MAX_HZ = 100'000'000u;
 
   static constexpr uint32_t NS_PER_SEC = 1'000'000'000u;
@@ -243,12 +243,13 @@ class SwdGeneralGPIO final : public Swd
       const bool BIT = (((data_lsb_first[i / 8u] >> (i & 7u)) & 0x01u) != 0u);
       swdio_.Write(BIT);
 
-      // one clock cycle: low->high (with DelayHalf inside GenOneClk)
-      // NOTE: your GenOneClk ends at high; to keep "end low" legacy for SeqWrite,
-      // we explicitly pull low after each cycle (no extra DelayHalf added).
+      // Match the DAP_Transfer request path: one bit owns one complete
+      // low-high clock cycle. Do not add an un-timed low pulse after every bit.
+      // 匹配 DAP_Transfer 请求路径：每个 bit 只产生一个完整低-高时钟周期，
+      // 不在每 bit 末尾额外插入无定时低脉冲。
       GenOneClk();
-      swclk_.Write(false);
     }
+    swclk_.Write(false);
 
     return ErrorCode::OK;
   }

--- a/src/driver/usb/device/dap/daplink_v1.hpp
+++ b/src/driver/usb/device/dap/daplink_v1.hpp
@@ -2479,7 +2479,10 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransfer(bool /*in_isr*/, const uin
       }
 
       response_count++;
-      check_write = true;
+      if (AP)
+      {
+        check_write = true;
+      }
     }
     else
     {
@@ -2819,7 +2822,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransferBlock(bool /*in_isr*/,
       done = static_cast<uint16_t>(i + 1u);
     }
 
-    if (xresp == LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK && done > 0u)
+    if (AP && xresp == LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK && done > 0u)
     {
       uint32_t dummy = 0u;
       LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;

--- a/src/driver/usb/device/dap/daplink_v1.hpp
+++ b/src/driver/usb/device/dap/daplink_v1.hpp
@@ -203,8 +203,6 @@ class DapLinkV1Class
   LibXR::Debug::Jtag* jtag_ = nullptr;
   LibXR::Debug::JtagProtocol::ChainConfig jtag_chain_{};
   uint8_t jtag_ir_len_[JTAG_MAX_DEVICES] = {};
-  uint16_t jtag_ir_before_[JTAG_MAX_DEVICES] = {};
-  uint16_t jtag_ir_after_[JTAG_MAX_DEVICES] = {};
   LibXR::GPIO* nreset_gpio_ = nullptr;
 
   uint8_t swj_shadow_ = static_cast<uint8_t>(DapLinkV1Def::DAP_SWJ_SWDIO_TMS |
@@ -236,8 +234,6 @@ DapLinkV1Class<SwdPort>::DapLinkV1Class(SwdPort& swd_link, LibXR::GPIO* nreset_g
     : HID(true, 1, 1, in_ep_num, out_ep_num), swd_(swd_link), nreset_gpio_(nreset_gpio)
 {
   jtag_chain_.ir_length = jtag_ir_len_;
-  jtag_chain_.ir_before = jtag_ir_before_;
-  jtag_chain_.ir_after = jtag_ir_after_;
   jtag_chain_.count = 0u;
   jtag_chain_.index = 0u;
   (void)swd_.SetClockHz(swj_clock_hz_);
@@ -321,8 +317,6 @@ void DapLinkV1Class<SwdPort>::BindEndpoints(EndpointPool& endpoint_pool, uint8_t
   jtag_chain_.dr_before_bits_len = 0u;
   jtag_chain_.dr_after_bits_len = 0u;
   Memory::FastSet(jtag_ir_len_, 0, sizeof(jtag_ir_len_));
-  Memory::FastSet(jtag_ir_before_, 0, sizeof(jtag_ir_before_));
-  Memory::FastSet(jtag_ir_after_, 0, sizeof(jtag_ir_after_));
 
   last_nreset_level_high_ = true;
   swj_shadow_ = static_cast<uint8_t>(DapLinkV1Def::DAP_SWJ_SWDIO_TMS |
@@ -1337,21 +1331,13 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGConfigure(bool /*in_isr*/, const ui
   }
 
   Memory::FastSet(jtag_ir_len_, 0, sizeof(jtag_ir_len_));
-  Memory::FastSet(jtag_ir_before_, 0, sizeof(jtag_ir_before_));
-  Memory::FastSet(jtag_ir_after_, 0, sizeof(jtag_ir_after_));
 
   uint32_t bits = 0u;
   for (uint32_t i = 0; i < COUNT; ++i)
   {
     const uint8_t LEN = req[static_cast<uint16_t>(2u + i)];
     jtag_ir_len_[i] = LEN;
-    jtag_ir_before_[i] = static_cast<uint16_t>(bits);
     bits += LEN;
-  }
-  for (uint32_t i = 0; i < COUNT; ++i)
-  {
-    bits -= jtag_ir_len_[i];
-    jtag_ir_after_[i] = static_cast<uint16_t>(bits);
   }
 
   jtag_chain_.count = COUNT;
@@ -1409,7 +1395,23 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGIdCode(bool /*in_isr*/, const uint8
 
   LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
   uint32_t idcode = 0u;
-  const ErrorCode EC = dp.ReadIdCode(idcode);
+  ErrorCode EC = dp.ReadIdCode(idcode);
+  if (EC == ErrorCode::OK && (idcode == 0u || idcode == 0xFFFF'FFFFu ||
+                              ((idcode & 0x1u) == 0u)) &&
+      jtag_ir_len_[INDEX] != 4u)
+  {
+    uint32_t fallback_idcode = 0u;
+    EC = dp.ReadIdCodeWithIr(0x01u, fallback_idcode);
+    if (EC != ErrorCode::OK)
+    {
+      return EC;
+    }
+    if (fallback_idcode != 0u && fallback_idcode != 0xFFFF'FFFFu &&
+        ((fallback_idcode & 0x1u) != 0u))
+    {
+      idcode = fallback_idcode;
+    }
+  }
   if (EC != ErrorCode::OK)
   {
     return EC;

--- a/src/driver/usb/device/dap/daplink_v1.hpp
+++ b/src/driver/usb/device/dap/daplink_v1.hpp
@@ -5,6 +5,7 @@
 #include <cstring>
 
 #include "daplink_v1_def.hpp"
+#include "debug/jtag_dp.hpp"
 #include "debug/swd.hpp"
 #include "gpio.hpp"
 #include "hid.hpp"
@@ -65,6 +66,7 @@ class DapLinkV1Class
   DapLinkV1Class& operator=(const DapLinkV1Class&) = delete;
 
   void SetInfoStrings(const InfoStrings& info);
+  void SetJtag(LibXR::Debug::Jtag* jtag);
   const LibXR::USB::DapLinkV1Def::State& GetState() const;
   bool IsInited() const;
 
@@ -72,17 +74,11 @@ class DapLinkV1Class
   ErrorCode WriteDeviceDescriptor(DeviceDescriptor& header) override;
   ConstRawData GetReportDesc() override;
 
-  void BindEndpoints(EndpointPool& endpoint_pool, uint8_t start_itf_num,
-                     bool in_isr) override;
-  void UnbindEndpoints(EndpointPool& endpoint_pool, bool in_isr) override;
+  void BindEndpoints(EndpointPool& endpoint_pool, uint8_t start_itf_num) override;
+  void UnbindEndpoints(EndpointPool& endpoint_pool) override;
 
   void OnDataOutComplete(bool in_isr, LibXR::ConstRawData& data) override;
   void OnDataInComplete(bool in_isr, LibXR::ConstRawData& data) override;
-  ErrorCode OnSetReportData(bool in_isr, LibXR::ConstRawData& data) override;
-  ErrorCode OnGetInputReport(uint8_t report_id,
-                             DeviceClass::ControlTransferResult& result) override;
-  ErrorCode OnGetFeatureReport(uint8_t report_id,
-                               DeviceClass::ControlTransferResult& result) override;
 
  private:
   static void OnDataOutCompleteStatic(bool in_isr, DapLinkV1Class* self,
@@ -90,24 +86,7 @@ class DapLinkV1Class
   static void OnDataInCompleteStatic(bool in_isr, DapLinkV1Class* self,
                                      LibXR::ConstRawData& data);
 
-  uint16_t GetDapPacketSize() const;
-  uint16_t ClipResponseLength(uint16_t len, uint16_t cap) const;
-  static constexpr uint8_t NextRespQueueIndex(uint8_t idx);
-  void ResetResponseQueue();
-  bool HasDeferredResponseInEpBuffer() const;
-  void SetDeferredResponseInEpBuffer(uint16_t len);
-  bool SubmitDeferredResponseIfIdle();
-  bool IsResponseQueueEmpty() const;
-  bool IsResponseQueueFull() const;
-  bool TryBuildAndEnqueueResponse(bool in_isr, const uint8_t* req, uint16_t req_len);
-  uint8_t OutstandingResponseCount() const;
-  bool EnqueueResponse(const uint8_t* data, uint16_t len);
-  bool SubmitNextQueuedResponseIfIdle();
   void ArmOutTransferIfIdle();
-  uint16_t PrepareResponseReport(uint8_t* resp, uint16_t payload_len, uint16_t cap);
-  void UpdateControlInputReport(const uint8_t* resp, uint16_t len);
-  ErrorCode HandleControlReportRequest(bool in_isr, const uint8_t* req, uint16_t req_len);
-  void HandleHostRequest(bool in_isr, const uint8_t* req, uint16_t req_len);
 
   ErrorCode ProcessOneCommand(bool in_isr, const uint8_t* req, uint16_t req_len,
                               uint8_t* resp, uint16_t resp_cap, uint16_t& out_len);
@@ -145,6 +124,16 @@ class DapLinkV1Class
                                uint8_t* resp, uint16_t resp_cap, uint16_t& out_len);
   ErrorCode HandleSWDSequence(bool in_isr, const uint8_t* req, uint16_t req_len,
                               uint8_t* resp, uint16_t resp_cap, uint16_t& out_len);
+  ErrorCode HandleJTAGSequence(bool in_isr, const uint8_t* req, uint16_t req_len,
+                               uint8_t* resp, uint16_t resp_cap, uint16_t& out_len);
+  ErrorCode HandleJTAGConfigure(bool in_isr, const uint8_t* req, uint16_t req_len,
+                                uint8_t* resp, uint16_t resp_cap, uint16_t& out_len);
+  ErrorCode HandleJTAGIdCode(bool in_isr, const uint8_t* req, uint16_t req_len,
+                             uint8_t* resp, uint16_t resp_cap, uint16_t& out_len);
+  ErrorCode HandleQueueCommands(bool in_isr, const uint8_t* req, uint16_t req_len,
+                                uint8_t* resp, uint16_t resp_cap, uint16_t& out_len);
+  ErrorCode HandleExecuteCommands(bool in_isr, const uint8_t* req, uint16_t req_len,
+                                  uint8_t* resp, uint16_t resp_cap, uint16_t& out_len);
 
   ErrorCode BuildInfoStringResponse(uint8_t cmd, const char* str, uint8_t* resp,
                                     uint16_t resp_cap, uint16_t& out_len);
@@ -156,14 +145,21 @@ class DapLinkV1Class
                                  uint16_t resp_cap, uint16_t& out_len);
 
   uint8_t MapAckToDapResp(LibXR::Debug::SwdProtocol::Ack ack) const;
+  uint8_t MapAckToDapResp(LibXR::Debug::JtagProtocol::Ack ack) const;
+  ErrorCode HandleJtagTransfer(bool in_isr, const uint8_t* req, uint16_t req_len,
+                               uint8_t* resp, uint16_t resp_cap, uint16_t& out_len);
+  ErrorCode HandleJtagTransferBlock(bool in_isr, const uint8_t* req, uint16_t req_len,
+                                    uint8_t* resp, uint16_t resp_cap, uint16_t& out_len);
+  ErrorCode HandleJtagWriteAbort(bool in_isr, const uint8_t* req, uint16_t req_len,
+                                 uint8_t* resp, uint16_t resp_cap, uint16_t& out_len);
   void SetTransferAbortFlag(bool on);
 
-  void DriveReset(bool release);
+ void DriveReset(bool release);
   void DelayUsIfAllowed(bool in_isr, uint32_t us);
 
  private:
   template <typename E>
-  static constexpr uint8_t ToU8(E e)
+  static constexpr uint8_t to_u8(E e)
   {
     return static_cast<uint8_t>(e);
   }
@@ -171,8 +167,8 @@ class DapLinkV1Class
   static constexpr uint8_t DAP_OK = 0x00u;
   static constexpr uint8_t DAP_ERROR = 0xFFu;
 
-  static inline ErrorCode BuildUnknowCmdResponse(uint8_t* resp, uint16_t cap,
-                                                 uint16_t& out_len)
+  static inline ErrorCode build_unknown_cmd_response(uint8_t* resp, uint16_t cap,
+                                                     uint16_t& out_len)
   {
     if (!resp || cap < 1u)
     {
@@ -184,26 +180,31 @@ class DapLinkV1Class
     return ErrorCode::OK;
   }
 
+  static inline ErrorCode build_cmd_status_response(uint8_t cmd, uint8_t status,
+                                                    uint8_t* resp, uint16_t cap,
+                                                    uint16_t& out_len)
+  {
+    if (!resp || cap < 2u)
+    {
+      out_len = 0u;
+      return ErrorCode::NOT_FOUND;
+    }
+    resp[0] = cmd;
+    resp[1] = status;
+    out_len = 2u;
+    return ErrorCode::OK;
+  }
+
   static constexpr uint16_t MAX_REQ = DapLinkV1Def::MAX_REQUEST_SIZE;
   static constexpr uint16_t MAX_RESP = DapLinkV1Def::MAX_RESPONSE_SIZE;
-  static constexpr uint16_t DEFAULT_DAP_PACKET_SIZE = MAX_RESP;
-  static constexpr uint8_t PACKET_COUNT_ADVERTISED = 1u;
-  static constexpr uint8_t MAX_OUTSTANDING_RESPONSES = PACKET_COUNT_ADVERTISED;
-  static constexpr uint16_t MAX_DAP_PACKET_SIZE = MAX_RESP;
-  static constexpr uint16_t RESP_SLOT_SIZE = MAX_DAP_PACKET_SIZE;
-  static constexpr uint8_t RESP_QUEUE_DEPTH = PACKET_COUNT_ADVERTISED;
-  static_assert(RESP_SLOT_SIZE >= DEFAULT_DAP_PACKET_SIZE,
-                "RESP_SLOT_SIZE must cover HID packet size");
-  static_assert((RESP_QUEUE_DEPTH & (RESP_QUEUE_DEPTH - 1u)) == 0u,
-                "Response queue depth must be power-of-two");
-
-  struct ResponseSlot
-  {
-    uint16_t len = 0u;
-    uint8_t payload[RESP_SLOT_SIZE] = {};
-  };
+  static constexpr uint8_t JTAG_MAX_DEVICES = 16u;
 
   SwdPort& swd_;
+  LibXR::Debug::Jtag* jtag_ = nullptr;
+  LibXR::Debug::JtagProtocol::ChainConfig jtag_chain_{};
+  uint8_t jtag_ir_len_[JTAG_MAX_DEVICES] = {};
+  uint16_t jtag_ir_before_[JTAG_MAX_DEVICES] = {};
+  uint16_t jtag_ir_after_[JTAG_MAX_DEVICES] = {};
   LibXR::GPIO* nreset_gpio_ = nullptr;
 
   uint8_t swj_shadow_ = static_cast<uint8_t>(DapLinkV1Def::DAP_SWJ_SWDIO_TMS |
@@ -226,29 +227,29 @@ class DapLinkV1Class
       LibXR::Callback<LibXR::ConstRawData&>::Create(OnDataInCompleteStatic, this);
 
   bool inited_ = false;
-  ResponseSlot resp_q_[RESP_QUEUE_DEPTH] = {};
-  uint8_t resp_q_head_ = 0u;
-  uint8_t resp_q_tail_ = 0u;
-  uint8_t resp_q_count_ = 0u;
-  bool deferred_in_resp_valid_ = false;
-  uint16_t deferred_in_resp_len_ = 0u;
-  uint8_t control_input_report_[MAX_DAP_PACKET_SIZE] = {};
-  uint16_t control_input_report_len_ = DEFAULT_DAP_PACKET_SIZE;
 };
 
 template <typename SwdPort>
 DapLinkV1Class<SwdPort>::DapLinkV1Class(SwdPort& swd_link, LibXR::GPIO* nreset_gpio,
-                                        Endpoint::EPNumber in_ep_num,
-                                        Endpoint::EPNumber out_ep_num)
+                               Endpoint::EPNumber in_ep_num,
+                               Endpoint::EPNumber out_ep_num)
     : HID(true, 1, 1, in_ep_num, out_ep_num), swd_(swd_link), nreset_gpio_(nreset_gpio)
 {
+  jtag_chain_.ir_length = jtag_ir_len_;
+  jtag_chain_.ir_before = jtag_ir_before_;
+  jtag_chain_.ir_after = jtag_ir_after_;
+  jtag_chain_.count = 0u;
+  jtag_chain_.index = 0u;
   (void)swd_.SetClockHz(swj_clock_hz_);
 }
 
 template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::SetInfoStrings(const InfoStrings& info)
+void DapLinkV1Class<SwdPort>::SetInfoStrings(const InfoStrings& info) { info_ = info; }
+
+template <typename SwdPort>
+void DapLinkV1Class<SwdPort>::SetJtag(LibXR::Debug::Jtag* jtag)
 {
-  info_ = info;
+  jtag_ = jtag;
 }
 
 template <typename SwdPort>
@@ -258,15 +259,12 @@ const LibXR::USB::DapLinkV1Def::State& DapLinkV1Class<SwdPort>::GetState() const
 }
 
 template <typename SwdPort>
-bool DapLinkV1Class<SwdPort>::IsInited() const
-{
-  return inited_;
-}
+bool DapLinkV1Class<SwdPort>::IsInited() const { return inited_; }
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::WriteDeviceDescriptor(DeviceDescriptor& header)
 {
-  header.data_.bDeviceClass = DeviceDescriptor::ClassID::PER_INTERFACE;
+  header.data_.bDeviceClass = DeviceDescriptor::ClassID::HID;
   header.data_.bDeviceSubClass = 0;
   header.data_.bDeviceProtocol = 0;
   return ErrorCode::OK;
@@ -279,16 +277,16 @@ ConstRawData DapLinkV1Class<SwdPort>::GetReportDesc()
 }
 
 template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::BindEndpoints(EndpointPool& endpoint_pool,
-                                            uint8_t start_itf_num, bool in_isr)
+void DapLinkV1Class<SwdPort>::BindEndpoints(EndpointPool& endpoint_pool, uint8_t start_itf_num)
 {
-  HID::BindEndpoints(endpoint_pool, start_itf_num, in_isr);
+  HID::BindEndpoints(endpoint_pool, start_itf_num);
 
   ep_in_ = GetInEndpoint();
   ep_out_ = GetOutEndpoint();
 
   if (ep_in_ != nullptr)
   {
+    // Double buffer splits RawData into two halves; ensure EP IN buffer >= 2 * MAX_RESP.
     ep_in_->Configure(
         {Endpoint::Direction::IN, Endpoint::Type::INTERRUPT, MAX_RESP, true});
     ep_in_->SetOnTransferCompleteCallback(on_data_in_cb_);
@@ -296,6 +294,7 @@ void DapLinkV1Class<SwdPort>::BindEndpoints(EndpointPool& endpoint_pool,
 
   if (ep_out_ != nullptr)
   {
+    // Double buffer splits RawData into two halves; ensure EP OUT buffer >= 2 * MAX_REQ.
     ep_out_->Configure(
         {Endpoint::Direction::OUT, Endpoint::Type::INTERRUPT, MAX_REQ, true});
     ep_out_->SetOnTransferCompleteCallback(on_data_out_cb_);
@@ -307,14 +306,23 @@ void DapLinkV1Class<SwdPort>::BindEndpoints(EndpointPool& endpoint_pool,
   dap_state_ = {};
   dap_state_.debug_port = LibXR::USB::DapLinkV1Def::DebugPort::DISABLED;
   dap_state_.transfer_abort = false;
-  ResetResponseQueue();
-  if (ep_in_ != nullptr)
-  {
-    ep_in_->SetActiveLength(0);
-  }
 
   swj_clock_hz_ = 1000000u;
   (void)swd_.SetClockHz(swj_clock_hz_);
+  if (jtag_ != nullptr)
+  {
+    (void)jtag_->SetClockHz(swj_clock_hz_);
+  }
+
+  jtag_chain_.count = 0u;
+  jtag_chain_.index = 0u;
+  jtag_chain_.ir_before_bits_len = 0u;
+  jtag_chain_.ir_after_bits_len = 0u;
+  jtag_chain_.dr_before_bits_len = 0u;
+  jtag_chain_.dr_after_bits_len = 0u;
+  Memory::FastSet(jtag_ir_len_, 0, sizeof(jtag_ir_len_));
+  Memory::FastSet(jtag_ir_before_, 0, sizeof(jtag_ir_before_));
+  Memory::FastSet(jtag_ir_after_, 0, sizeof(jtag_ir_after_));
 
   last_nreset_level_high_ = true;
   swj_shadow_ = static_cast<uint8_t>(DapLinkV1Def::DAP_SWJ_SWDIO_TMS |
@@ -324,29 +332,23 @@ void DapLinkV1Class<SwdPort>::BindEndpoints(EndpointPool& endpoint_pool,
 }
 
 template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::UnbindEndpoints(EndpointPool& endpoint_pool, bool in_isr)
+void DapLinkV1Class<SwdPort>::UnbindEndpoints(EndpointPool& endpoint_pool)
 {
   inited_ = false;
-  ResetResponseQueue();
 
   dap_state_.debug_port = LibXR::USB::DapLinkV1Def::DebugPort::DISABLED;
   dap_state_.transfer_abort = false;
 
-  if (ep_in_ != nullptr)
-  {
-    ep_in_->SetActiveLength(0);
-  }
-  if (ep_out_ != nullptr)
-  {
-    ep_out_->SetActiveLength(0);
-  }
-
-  HID::UnbindEndpoints(endpoint_pool, in_isr);
+  HID::UnbindEndpoints(endpoint_pool);
 
   ep_in_ = nullptr;
   ep_out_ = nullptr;
 
   swd_.Close();
+  if (jtag_ != nullptr)
+  {
+    jtag_->Close();
+  }
 
   last_nreset_level_high_ = true;
   swj_shadow_ = static_cast<uint8_t>(DapLinkV1Def::DAP_SWJ_SWDIO_TMS |
@@ -354,7 +356,8 @@ void DapLinkV1Class<SwdPort>::UnbindEndpoints(EndpointPool& endpoint_pool, bool 
 }
 
 template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::OnDataOutCompleteStatic(bool in_isr, DapLinkV1Class* self,
+void DapLinkV1Class<SwdPort>::OnDataOutCompleteStatic(bool in_isr,
+                                                      DapLinkV1Class* self,
                                                       LibXR::ConstRawData& data)
 {
   if (self && self->inited_)
@@ -364,7 +367,8 @@ void DapLinkV1Class<SwdPort>::OnDataOutCompleteStatic(bool in_isr, DapLinkV1Clas
 }
 
 template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::OnDataInCompleteStatic(bool in_isr, DapLinkV1Class* self,
+void DapLinkV1Class<SwdPort>::OnDataInCompleteStatic(bool in_isr,
+                                                     DapLinkV1Class* self,
                                                      LibXR::ConstRawData& data)
 {
   if (self && self->inited_)
@@ -381,439 +385,57 @@ void DapLinkV1Class<SwdPort>::OnDataOutComplete(bool in_isr, LibXR::ConstRawData
     return;
   }
 
-  ArmOutTransferIfIdle();
-  HandleHostRequest(in_isr, static_cast<const uint8_t*>(data.addr_),
-                    static_cast<uint16_t>(data.size_));
-}
+  const auto* REQ = static_cast<const uint8_t*>(data.addr_);
+  const uint16_t REQ_LEN = static_cast<uint16_t>(data.size_);
 
-template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::OnDataInComplete(bool /*in_isr*/,
-                                               LibXR::ConstRawData& /*data*/)
-{
-  (void)SubmitDeferredResponseIfIdle();
-  (void)SubmitNextQueuedResponseIfIdle();
-  ArmOutTransferIfIdle();
-}
+  auto tx_buff = ep_in_->GetBuffer();
+  const uint16_t RESP_CAP = static_cast<uint16_t>(tx_buff.size_);
+  const uint16_t TX_LEN = (RESP_CAP < MAX_RESP) ? RESP_CAP : MAX_RESP;
 
-template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::OnSetReportData(bool in_isr, LibXR::ConstRawData& data)
-{
-  (void)HID<sizeof(DAPLINK_V1_REPORT_DESC), DapLinkV1Def::MAX_REQUEST_SIZE,
-            DapLinkV1Def::MAX_RESPONSE_SIZE>::OnSetReportData(in_isr, data);
-  const auto* req = static_cast<const uint8_t*>(data.addr_);
-  uint16_t req_len = static_cast<uint16_t>(data.size_);
-  return HandleControlReportRequest(in_isr, req, req_len);
-}
-
-template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleControlReportRequest(bool in_isr,
-                                                              const uint8_t* req,
-                                                              uint16_t req_len)
-{
-  if (!req || req_len == 0u)
+  if (ep_in_->GetState() == Endpoint::State::IDLE)
   {
-    control_input_report_len_ = 0u;
-    return ErrorCode::ARG_ERR;
+    ArmOutTransferIfIdle();
   }
 
+  Memory::FastSet(tx_buff.addr_, 0, RESP_CAP);
   uint16_t out_len = 0u;
-  const ErrorCode ANS = ProcessOneCommand(in_isr, req, req_len, control_input_report_,
-                                          MAX_DAP_PACKET_SIZE, out_len);
+  auto ans = ProcessOneCommand(in_isr, REQ, REQ_LEN,
+                               reinterpret_cast<uint8_t*>(tx_buff.addr_), RESP_CAP,
+                               out_len);
+  UNUSED(ans);
+  UNUSED(out_len);
 
-  out_len = ClipResponseLength(out_len, MAX_DAP_PACKET_SIZE);
-
-  uint16_t tx_len = GetDapPacketSize();
-  if (tx_len == 0u || tx_len > MAX_DAP_PACKET_SIZE)
+  if (ep_in_->GetState() == Endpoint::State::IDLE)
   {
-    tx_len = MAX_DAP_PACKET_SIZE;
-  }
-  if (tx_len < out_len)
-  {
-    tx_len = out_len;
-  }
-  if (tx_len > out_len)
-  {
-    Memory::FastSet(control_input_report_ + out_len, 0, tx_len - out_len);
-  }
-
-  control_input_report_len_ = tx_len;
-  return ANS;
-}
-
-template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::OnGetInputReport(
-    uint8_t /*report_id*/, DeviceClass::ControlTransferResult& result)
-{
-  const uint16_t TX_LEN =
-      (control_input_report_len_ > 0u) ? control_input_report_len_ : GetDapPacketSize();
-  result.write_data = ConstRawData{control_input_report_, TX_LEN};
-  return ErrorCode::OK;
-}
-
-template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::OnGetFeatureReport(
-    uint8_t /*report_id*/, DeviceClass::ControlTransferResult& result)
-{
-  const uint16_t TX_LEN =
-      (control_input_report_len_ > 0u) ? control_input_report_len_ : GetDapPacketSize();
-  result.write_data = ConstRawData{control_input_report_, TX_LEN};
-  return ErrorCode::OK;
-}
-
-template <typename SwdPort>
-uint16_t DapLinkV1Class<SwdPort>::PrepareResponseReport(uint8_t* resp,
-                                                        uint16_t payload_len,
-                                                        uint16_t cap)
-{
-  if (!resp || cap == 0u)
-  {
-    control_input_report_len_ = 0u;
-    return 0u;
-  }
-
-  payload_len = ClipResponseLength(payload_len, cap);
-
-  uint16_t tx_len = GetDapPacketSize();
-  if (tx_len == 0u || tx_len > cap)
-  {
-    tx_len = cap;
-  }
-  if (tx_len < payload_len)
-  {
-    tx_len = payload_len;
-  }
-  if (tx_len > payload_len)
-  {
-    Memory::FastSet(resp + payload_len, 0, tx_len - payload_len);
-  }
-
-  UpdateControlInputReport(resp, tx_len);
-  return tx_len;
-}
-
-template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::UpdateControlInputReport(const uint8_t* resp, uint16_t len)
-{
-  if (!resp)
-  {
-    control_input_report_len_ = 0u;
-    return;
-  }
-
-  if (len > MAX_DAP_PACKET_SIZE)
-  {
-    len = MAX_DAP_PACKET_SIZE;
-  }
-
-  if (len > 0u)
-  {
-    Memory::FastCopy(control_input_report_, resp, len);
-  }
-  if (len < MAX_DAP_PACKET_SIZE)
-  {
-    Memory::FastSet(control_input_report_ + len, 0, MAX_DAP_PACKET_SIZE - len);
-  }
-
-  control_input_report_len_ = len;
-}
-
-template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::HandleHostRequest(bool in_isr, const uint8_t* req,
-                                                uint16_t req_len)
-{
-  if (!inited_ || !ep_in_)
-  {
-    return;
-  }
-
-  if (!req || req_len == 0u)
-  {
-    ArmOutTransferIfIdle();
-    return;
-  }
-
-  if (!HasDeferredResponseInEpBuffer() && IsResponseQueueEmpty() &&
-      ep_in_->GetState() == Endpoint::State::IDLE)
-  {
-    auto tx_buff = ep_in_->GetBuffer();
-    if (tx_buff.addr_ && tx_buff.size_ > 0u)
-    {
-      auto* tx_buf = static_cast<uint8_t*>(tx_buff.addr_);
-      uint16_t out_len = 0u;
-      const auto ANS = ProcessOneCommand(in_isr, req, req_len, tx_buf,
-                                         static_cast<uint16_t>(tx_buff.size_), out_len);
-      UNUSED(ANS);
-
-      out_len = ClipResponseLength(out_len, static_cast<uint16_t>(tx_buff.size_));
-      const uint16_t TX_LEN =
-          PrepareResponseReport(tx_buf, out_len, static_cast<uint16_t>(tx_buff.size_));
-      if (TX_LEN > 0u && ep_in_->Transfer(TX_LEN) == ErrorCode::OK)
-      {
-        return;
-      }
-
-      if (!EnqueueResponse(tx_buf, out_len))
-      {
-        (void)SubmitNextQueuedResponseIfIdle();
-        (void)EnqueueResponse(tx_buf, out_len);
-      }
-
-      (void)SubmitNextQueuedResponseIfIdle();
-      ArmOutTransferIfIdle();
-      return;
-    }
-  }
-
-  if (!HasDeferredResponseInEpBuffer() && IsResponseQueueEmpty() &&
-      ep_in_->GetState() == Endpoint::State::BUSY)
-  {
-    auto tx_buff = ep_in_->GetBuffer();
-    if (tx_buff.addr_ && tx_buff.size_ > 0u)
-    {
-      auto* tx_buf = static_cast<uint8_t*>(tx_buff.addr_);
-      uint16_t out_len = 0u;
-      const auto ANS = ProcessOneCommand(in_isr, req, req_len, tx_buf,
-                                         static_cast<uint16_t>(tx_buff.size_), out_len);
-      UNUSED(ANS);
-
-      out_len = ClipResponseLength(out_len, static_cast<uint16_t>(tx_buff.size_));
-      const uint16_t TX_LEN =
-          PrepareResponseReport(tx_buf, out_len, static_cast<uint16_t>(tx_buff.size_));
-      SetDeferredResponseInEpBuffer(TX_LEN);
-      ArmOutTransferIfIdle();
-      return;
-    }
-  }
-
-  if (TryBuildAndEnqueueResponse(in_isr, req, req_len))
-  {
-    (void)SubmitDeferredResponseIfIdle();
-    (void)SubmitNextQueuedResponseIfIdle();
-    ArmOutTransferIfIdle();
-    return;
-  }
-
-  (void)SubmitNextQueuedResponseIfIdle();
-  (void)TryBuildAndEnqueueResponse(in_isr, req, req_len);
-
-  (void)SubmitDeferredResponseIfIdle();
-  (void)SubmitNextQueuedResponseIfIdle();
-  ArmOutTransferIfIdle();
-}
-
-template <typename SwdPort>
-uint16_t DapLinkV1Class<SwdPort>::GetDapPacketSize() const
-{
-  const uint16_t IN_PS = ep_in_ ? ep_in_->MaxPacketSize() : 0u;
-  const uint16_t OUT_PS = ep_out_ ? ep_out_->MaxPacketSize() : 0u;
-  uint16_t dap_ps = 0u;
-
-  if (IN_PS > 0u && OUT_PS > 0u)
-  {
-    dap_ps = (IN_PS < OUT_PS) ? IN_PS : OUT_PS;
+    ep_in_->Transfer(TX_LEN);
+    ep_in_->SetActiveLength(0);
   }
   else
   {
-    dap_ps = (IN_PS > 0u) ? IN_PS : OUT_PS;
+    ep_in_->SetActiveLength(TX_LEN);
   }
-
-  if (dap_ps == 0u)
-  {
-    dap_ps = DEFAULT_DAP_PACKET_SIZE;
-  }
-  if (dap_ps > MAX_DAP_PACKET_SIZE)
-  {
-    dap_ps = MAX_DAP_PACKET_SIZE;
-  }
-  return dap_ps;
 }
 
 template <typename SwdPort>
-uint16_t DapLinkV1Class<SwdPort>::ClipResponseLength(uint16_t len, uint16_t cap) const
+void DapLinkV1Class<SwdPort>::OnDataInComplete(bool in_isr, LibXR::ConstRawData& data)
 {
-  const uint16_t DAP_PS = GetDapPacketSize();
-  if (len > DAP_PS)
+  UNUSED(in_isr);
+  UNUSED(data);
+
+  auto act_len = ep_in_->GetActiveLength();
+  if (act_len > 0)
   {
-    len = DAP_PS;
-  }
-  if (len > RESP_SLOT_SIZE)
-  {
-    len = RESP_SLOT_SIZE;
-  }
-  if (len > cap)
-  {
-    len = cap;
-  }
-  return len;
-}
-
-template <typename SwdPort>
-constexpr uint8_t DapLinkV1Class<SwdPort>::NextRespQueueIndex(uint8_t idx)
-{
-  return static_cast<uint8_t>((idx + 1u) & (RESP_QUEUE_DEPTH - 1u));
-}
-
-template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::ResetResponseQueue()
-{
-  resp_q_head_ = 0u;
-  resp_q_tail_ = 0u;
-  resp_q_count_ = 0u;
-  deferred_in_resp_valid_ = false;
-  deferred_in_resp_len_ = 0u;
-}
-
-template <typename SwdPort>
-bool DapLinkV1Class<SwdPort>::HasDeferredResponseInEpBuffer() const
-{
-  return deferred_in_resp_valid_;
-}
-
-template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::SetDeferredResponseInEpBuffer(uint16_t len)
-{
-  deferred_in_resp_len_ = len;
-  deferred_in_resp_valid_ = true;
-}
-
-template <typename SwdPort>
-bool DapLinkV1Class<SwdPort>::SubmitDeferredResponseIfIdle()
-{
-  if (!deferred_in_resp_valid_ || !ep_in_ || ep_in_->GetState() != Endpoint::State::IDLE)
-  {
-    return false;
+    ep_in_->Transfer(act_len);
+    ep_in_->SetActiveLength(0);
   }
 
-  const uint16_t TX_LEN = deferred_in_resp_len_;
-  if (ep_in_->Transfer(TX_LEN) != ErrorCode::OK)
-  {
-    return false;
-  }
-
-  deferred_in_resp_valid_ = false;
-  deferred_in_resp_len_ = 0u;
-  return true;
-}
-
-template <typename SwdPort>
-bool DapLinkV1Class<SwdPort>::IsResponseQueueEmpty() const
-{
-  return resp_q_count_ == 0u;
-}
-
-template <typename SwdPort>
-bool DapLinkV1Class<SwdPort>::IsResponseQueueFull() const
-{
-  return resp_q_count_ >= RESP_QUEUE_DEPTH;
-}
-
-template <typename SwdPort>
-bool DapLinkV1Class<SwdPort>::TryBuildAndEnqueueResponse(bool in_isr, const uint8_t* req,
-                                                         uint16_t req_len)
-{
-  if (!req || IsResponseQueueFull())
-  {
-    return false;
-  }
-
-  auto& slot = resp_q_[resp_q_tail_];
-  uint16_t out_len = 0u;
-  auto ans =
-      ProcessOneCommand(in_isr, req, req_len, slot.payload, RESP_SLOT_SIZE, out_len);
-  UNUSED(ans);
-  slot.len = ClipResponseLength(out_len, RESP_SLOT_SIZE);
-  (void)PrepareResponseReport(slot.payload, slot.len, RESP_SLOT_SIZE);
-
-  resp_q_tail_ = NextRespQueueIndex(resp_q_tail_);
-  ++resp_q_count_;
-  return true;
-}
-
-template <typename SwdPort>
-uint8_t DapLinkV1Class<SwdPort>::OutstandingResponseCount() const
-{
-  const uint8_t IN_FLIGHT =
-      (ep_in_ && ep_in_->GetState() == Endpoint::State::BUSY) ? 1u : 0u;
-  const uint8_t DEFERRED = deferred_in_resp_valid_ ? 1u : 0u;
-  return static_cast<uint8_t>(resp_q_count_ + IN_FLIGHT + DEFERRED);
-}
-
-template <typename SwdPort>
-bool DapLinkV1Class<SwdPort>::EnqueueResponse(const uint8_t* data, uint16_t len)
-{
-  if (!data || IsResponseQueueFull())
-  {
-    return false;
-  }
-
-  auto& slot = resp_q_[resp_q_tail_];
-  const uint16_t CLIPPED = ClipResponseLength(len, RESP_SLOT_SIZE);
-  slot.len = CLIPPED;
-  if (CLIPPED > 0u)
-  {
-    Memory::FastCopy(slot.payload, data, CLIPPED);
-  }
-
-  resp_q_tail_ = NextRespQueueIndex(resp_q_tail_);
-  ++resp_q_count_;
-  return true;
-}
-
-template <typename SwdPort>
-bool DapLinkV1Class<SwdPort>::SubmitNextQueuedResponseIfIdle()
-{
-  if (!ep_in_ || ep_in_->GetState() != Endpoint::State::IDLE || IsResponseQueueEmpty())
-  {
-    return false;
-  }
-
-  auto tx_buff = ep_in_->GetBuffer();
-  if (!tx_buff.addr_ || tx_buff.size_ == 0u)
-  {
-    return false;
-  }
-
-  auto& slot = resp_q_[resp_q_head_];
-  uint16_t payload_len = slot.len;
-  if (payload_len > tx_buff.size_)
-  {
-    payload_len = static_cast<uint16_t>(tx_buff.size_);
-  }
-
-  if (payload_len > 0u)
-  {
-    Memory::FastCopy(tx_buff.addr_, slot.payload, payload_len);
-  }
-
-  uint16_t tx_len = GetDapPacketSize();
-  if (tx_len == 0u || tx_len > tx_buff.size_)
-  {
-    tx_len = static_cast<uint16_t>(tx_buff.size_);
-  }
-  if (tx_len < payload_len)
-  {
-    tx_len = payload_len;
-  }
-  if (tx_len > payload_len)
-  {
-    Memory::FastSet(reinterpret_cast<uint8_t*>(tx_buff.addr_) + payload_len, 0,
-                    tx_len - payload_len);
-  }
-
-  if (ep_in_->Transfer(tx_len) != ErrorCode::OK)
-  {
-    return false;
-  }
-
-  resp_q_head_ = NextRespQueueIndex(resp_q_head_);
-  --resp_q_count_;
-  return true;
+  ArmOutTransferIfIdle();
 }
 
 template <typename SwdPort>
 void DapLinkV1Class<SwdPort>::ArmOutTransferIfIdle()
 {
-  if (!inited_ || ep_out_ == nullptr || ep_in_ == nullptr)
+  if (!inited_ || !ep_out_)
   {
     return;
   }
@@ -823,23 +445,13 @@ void DapLinkV1Class<SwdPort>::ArmOutTransferIfIdle()
     return;
   }
 
-  if (OutstandingResponseCount() >= MAX_OUTSTANDING_RESPONSES)
-  {
-    return;
-  }
-
-  uint16_t out_rx_len = ep_out_->MaxPacketSize();
-  if (out_rx_len == 0u)
-  {
-    out_rx_len = ep_out_->MaxTransferSize();
-  }
-  (void)ep_out_->Transfer(out_rx_len);
+  (void)ep_out_->Transfer(ep_out_->MaxTransferSize());
 }
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::ProcessOneCommand(bool in_isr, const uint8_t* req,
-                                                     uint16_t req_len, uint8_t* resp,
-                                                     uint16_t resp_cap, uint16_t& out_len)
+                                            uint16_t req_len, uint8_t* resp,
+                                            uint16_t resp_cap, uint16_t& out_len)
 {
   out_len = 0u;
 
@@ -856,47 +468,57 @@ ErrorCode DapLinkV1Class<SwdPort>::ProcessOneCommand(bool in_isr, const uint8_t*
 
   switch (CMD)
   {
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::INFO):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::INFO):
       return HandleInfo(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::HOST_STATUS):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::HOST_STATUS):
       return HandleHostStatus(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::CONNECT):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::CONNECT):
       return HandleConnect(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::DISCONNECT):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::DISCONNECT):
       return HandleDisconnect(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER_CONFIGURE):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER_CONFIGURE):
       return HandleTransferConfigure(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER):
       return HandleTransfer(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER_BLOCK):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER_BLOCK):
       return HandleTransferBlock(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER_ABORT):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER_ABORT):
       return HandleTransferAbort(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::WRITE_ABORT):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::WRITE_ABORT):
       return HandleWriteABORT(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::DELAY):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::DELAY):
       return HandleDelay(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::RESET_TARGET):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::RESET_TARGET):
       return HandleResetTarget(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::SWJ_PINS):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::SWJ_PINS):
       return HandleSWJPins(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::SWJ_CLOCK):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::SWJ_CLOCK):
       return HandleSWJClock(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::SWJ_SEQUENCE):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::SWJ_SEQUENCE):
       return HandleSWJSequence(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::SWD_CONFIGURE):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::SWD_CONFIGURE):
       return HandleSWDConfigure(in_isr, req, req_len, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::CommandId::SWD_SEQUENCE):
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::SWD_SEQUENCE):
       return HandleSWDSequence(in_isr, req, req_len, resp, resp_cap, out_len);
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::JTAG_SEQUENCE):
+      return HandleJTAGSequence(in_isr, req, req_len, resp, resp_cap, out_len);
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::JTAG_CONFIGURE):
+      return HandleJTAGConfigure(in_isr, req, req_len, resp, resp_cap, out_len);
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::JTAG_IDCODE):
+      return HandleJTAGIdCode(in_isr, req, req_len, resp, resp_cap, out_len);
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::QUEUE_COMMANDS):
+      return HandleQueueCommands(in_isr, req, req_len, resp, resp_cap, out_len);
+    case to_u8(LibXR::USB::DapLinkV1Def::CommandId::EXECUTE_COMMANDS):
+      return HandleExecuteCommands(in_isr, req, req_len, resp, resp_cap, out_len);
     default:
-      (void)BuildUnknowCmdResponse(resp, resp_cap, out_len);
+      (void)build_unknown_cmd_response(resp, resp_cap, out_len);
       return ErrorCode::NOT_SUPPORT;
   }
 }
 
 template <typename SwdPort>
 void DapLinkV1Class<SwdPort>::BuildNotSupportResponse(uint8_t* resp, uint16_t resp_cap,
-                                                      uint16_t& out_len)
+                                             uint16_t& out_len)
 {
   if (!resp || resp_cap < 1u)
   {
@@ -909,12 +531,12 @@ void DapLinkV1Class<SwdPort>::BuildNotSupportResponse(uint8_t* resp, uint16_t re
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleInfo(bool /*in_isr*/, const uint8_t* req,
-                                              uint16_t req_len, uint8_t* resp,
-                                              uint16_t resp_cap, uint16_t& out_len)
+                                     uint16_t req_len, uint8_t* resp, uint16_t resp_cap,
+                                     uint16_t& out_len)
 {
   if (req_len < 2u)
   {
-    resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::INFO);
+    resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::INFO);
     resp[1] = 0u;
     out_len = 2u;
     return ErrorCode::ARG_ERR;
@@ -922,44 +544,46 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleInfo(bool /*in_isr*/, const uint8_t* re
 
   const uint8_t INFO_ID = req[1];
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::INFO);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::INFO);
 
   switch (INFO_ID)
   {
-    case ToU8(LibXR::USB::DapLinkV1Def::InfoId::VENDOR):
+    case to_u8(LibXR::USB::DapLinkV1Def::InfoId::VENDOR):
       return BuildInfoStringResponse(resp[0], info_.vendor, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::InfoId::PRODUCT):
+    case to_u8(LibXR::USB::DapLinkV1Def::InfoId::PRODUCT):
       return BuildInfoStringResponse(resp[0], info_.product, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::InfoId::SERIAL_NUMBER):
+    case to_u8(LibXR::USB::DapLinkV1Def::InfoId::SERIAL_NUMBER):
       return BuildInfoStringResponse(resp[0], info_.serial, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::InfoId::FIRMWARE_VERSION):
+    case to_u8(LibXR::USB::DapLinkV1Def::InfoId::FIRMWARE_VERSION):
       return BuildInfoStringResponse(resp[0], info_.firmware_ver, resp, resp_cap,
                                      out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::InfoId::DEVICE_VENDOR):
+    case to_u8(LibXR::USB::DapLinkV1Def::InfoId::DEVICE_VENDOR):
       return BuildInfoStringResponse(resp[0], info_.device_vendor, resp, resp_cap,
                                      out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::InfoId::DEVICE_NAME):
+    case to_u8(LibXR::USB::DapLinkV1Def::InfoId::DEVICE_NAME):
       return BuildInfoStringResponse(resp[0], info_.device_name, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::InfoId::BOARD_VENDOR):
+    case to_u8(LibXR::USB::DapLinkV1Def::InfoId::BOARD_VENDOR):
       return BuildInfoStringResponse(resp[0], info_.board_vendor, resp, resp_cap,
                                      out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::InfoId::BOARD_NAME):
+    case to_u8(LibXR::USB::DapLinkV1Def::InfoId::BOARD_NAME):
       return BuildInfoStringResponse(resp[0], info_.board_name, resp, resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::InfoId::PRODUCT_FIRMWARE_VERSION):
+    case to_u8(LibXR::USB::DapLinkV1Def::InfoId::PRODUCT_FIRMWARE_VERSION):
       return BuildInfoStringResponse(resp[0], info_.product_fw_ver, resp, resp_cap,
                                      out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::InfoId::CAPABILITIES):
-      return BuildInfoU8Response(resp[0], LibXR::USB::DapLinkV1Def::DAP_CAP_SWD, resp,
-                                 resp_cap, out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::InfoId::PACKET_COUNT):
-      return BuildInfoU8Response(resp[0], PACKET_COUNT_ADVERTISED, resp, resp_cap,
-                                 out_len);
-    case ToU8(LibXR::USB::DapLinkV1Def::InfoId::PACKET_SIZE):
+    case to_u8(LibXR::USB::DapLinkV1Def::InfoId::CAPABILITIES):
     {
-      const uint16_t DAP_PS = GetDapPacketSize();
-      return BuildInfoU16Response(resp[0], DAP_PS, resp, resp_cap, out_len);
+      uint8_t caps = LibXR::USB::DapLinkV1Def::DAP_CAP_SWD;
+      if (jtag_ != nullptr)
+      {
+        caps = static_cast<uint8_t>(caps | LibXR::USB::DapLinkV1Def::DAP_CAP_JTAG);
+      }
+      return BuildInfoU8Response(resp[0], caps, resp, resp_cap, out_len);
     }
-    case ToU8(LibXR::USB::DapLinkV1Def::InfoId::TIMESTAMP_CLOCK):
+    case to_u8(LibXR::USB::DapLinkV1Def::InfoId::PACKET_COUNT):
+      return BuildInfoU8Response(resp[0], 1, resp, resp_cap, out_len);
+    case to_u8(LibXR::USB::DapLinkV1Def::InfoId::PACKET_SIZE):
+      return BuildInfoU16Response(resp[0], MAX_RESP, resp, resp_cap, out_len);
+    case to_u8(LibXR::USB::DapLinkV1Def::InfoId::TIMESTAMP_CLOCK):
       return BuildInfoU32Response(resp[0], 1000000U, resp, resp_cap, out_len);
     default:
       resp[1] = 0u;
@@ -970,9 +594,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleInfo(bool /*in_isr*/, const uint8_t* re
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::BuildInfoStringResponse(uint8_t cmd, const char* str,
-                                                           uint8_t* resp,
-                                                           uint16_t resp_cap,
-                                                           uint16_t& out_len)
+                                                  uint8_t* resp, uint16_t resp_cap,
+                                                  uint16_t& out_len)
 {
   resp[0] = cmd;
   resp[1] = 0u;
@@ -993,16 +616,14 @@ ErrorCode DapLinkV1Class<SwdPort>::BuildInfoStringResponse(uint8_t cmd, const ch
 
   const size_t COPY_N = (N_WITH_NUL > MAX_PAYLOAD) ? MAX_PAYLOAD : N_WITH_NUL;
   Memory::FastCopy(&resp[2], str, COPY_N);
-  resp[2 + COPY_N - 1] = 0x00;
   resp[1] = static_cast<uint8_t>(COPY_N);
   out_len = static_cast<uint16_t>(COPY_N + 2u);
   return ErrorCode::OK;
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU8Response(uint8_t cmd, uint8_t val,
-                                                       uint8_t* resp, uint16_t resp_cap,
-                                                       uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU8Response(uint8_t cmd, uint8_t val, uint8_t* resp,
+                                              uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 3u)
   {
@@ -1017,9 +638,8 @@ ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU8Response(uint8_t cmd, uint8_t val,
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU16Response(uint8_t cmd, uint16_t val,
-                                                        uint8_t* resp, uint16_t resp_cap,
-                                                        uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU16Response(uint8_t cmd, uint16_t val, uint8_t* resp,
+                                               uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 4u)
   {
@@ -1034,9 +654,8 @@ ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU16Response(uint8_t cmd, uint16_t va
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU32Response(uint8_t cmd, uint32_t val,
-                                                        uint8_t* resp, uint16_t resp_cap,
-                                                        uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU32Response(uint8_t cmd, uint32_t val, uint8_t* resp,
+                                               uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 6u)
   {
@@ -1051,26 +670,25 @@ ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU32Response(uint8_t cmd, uint32_t va
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleHostStatus(bool /*in_isr*/,
-                                                    const uint8_t* /*req*/,
-                                                    uint16_t /*req_len*/, uint8_t* resp,
-                                                    uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleHostStatus(bool /*in_isr*/, const uint8_t* /*req*/,
+                                           uint16_t /*req_len*/, uint8_t* resp,
+                                           uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
     out_len = 0u;
     return ErrorCode::NOT_FOUND;
   }
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::HOST_STATUS);
-  resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::OK);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::HOST_STATUS);
+  resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::OK);
   out_len = 2u;
   return ErrorCode::OK;
 }
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleConnect(bool /*in_isr*/, const uint8_t* req,
-                                                 uint16_t req_len, uint8_t* resp,
-                                                 uint16_t resp_cap, uint16_t& out_len)
+                                        uint16_t req_len, uint8_t* resp,
+                                        uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -1078,7 +696,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleConnect(bool /*in_isr*/, const uint8_t*
     return ErrorCode::NOT_FOUND;
   }
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::CONNECT);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::CONNECT);
 
   uint8_t port = 0u;
   if (req_len >= 2u)
@@ -1086,7 +704,12 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleConnect(bool /*in_isr*/, const uint8_t*
     port = req[1];
   }
 
-  if (port == 0u || port == ToU8(LibXR::USB::DapLinkV1Def::Port::SWD))
+  if (port == 0u)
+  {
+    port = to_u8(LibXR::USB::DapLinkV1Def::Port::SWD);
+  }
+
+  if (port == to_u8(LibXR::USB::DapLinkV1Def::Port::SWD))
   {
     (void)swd_.EnterSwd();
     (void)swd_.SetClockHz(swj_clock_hz_);
@@ -1094,11 +717,25 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleConnect(bool /*in_isr*/, const uint8_t*
     dap_state_.debug_port = LibXR::USB::DapLinkV1Def::DebugPort::SWD;
     dap_state_.transfer_abort = false;
 
-    resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Port::SWD);
+    resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Port::SWD);
+  }
+  else if (port == to_u8(LibXR::USB::DapLinkV1Def::Port::JTAG))
+  {
+    if (jtag_ == nullptr)
+    {
+      resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Port::DISABLED);
+    }
+    else
+    {
+      (void)jtag_->SetClockHz(swj_clock_hz_);
+      dap_state_.debug_port = LibXR::USB::DapLinkV1Def::DebugPort::JTAG;
+      dap_state_.transfer_abort = false;
+      resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Port::JTAG);
+    }
   }
   else
   {
-    resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Port::DISABLED);
+    resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Port::DISABLED);
   }
 
   out_len = 2u;
@@ -1106,10 +743,9 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleConnect(bool /*in_isr*/, const uint8_t*
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleDisconnect(bool /*in_isr*/,
-                                                    const uint8_t* /*req*/,
-                                                    uint16_t /*req_len*/, uint8_t* resp,
-                                                    uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleDisconnect(bool /*in_isr*/, const uint8_t* /*req*/,
+                                           uint16_t /*req_len*/, uint8_t* resp,
+                                           uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -1121,16 +757,16 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleDisconnect(bool /*in_isr*/,
   dap_state_.debug_port = LibXR::USB::DapLinkV1Def::DebugPort::DISABLED;
   dap_state_.transfer_abort = false;
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::DISCONNECT);
-  resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::OK);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::DISCONNECT);
+  resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::OK);
   out_len = 2u;
   return ErrorCode::OK;
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleTransferConfigure(
-    bool /*in_isr*/, const uint8_t* req, uint16_t req_len, uint8_t* resp,
-    uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleTransferConfigure(bool /*in_isr*/, const uint8_t* req,
+                                                  uint16_t req_len, uint8_t* resp,
+                                                  uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -1138,11 +774,11 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferConfigure(
     return ErrorCode::NOT_FOUND;
   }
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER_CONFIGURE);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER_CONFIGURE);
 
   if (req_len < 6u)
   {
-    resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::ERROR);
+    resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::ERROR);
     out_len = 2u;
     return ErrorCode::ARG_ERR;
   }
@@ -1163,17 +799,15 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferConfigure(
   pol.wait_retry = wait_retry;
   swd_.SetTransferPolicy(pol);
 
-  resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::OK);
+  resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::OK);
   out_len = 2u;
   return ErrorCode::OK;
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleTransferAbort(bool /*in_isr*/,
-                                                       const uint8_t* /*req*/,
-                                                       uint16_t /*req_len*/,
-                                                       uint8_t* resp, uint16_t resp_cap,
-                                                       uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleTransferAbort(bool /*in_isr*/, const uint8_t* /*req*/,
+                                              uint16_t /*req_len*/, uint8_t* resp,
+                                              uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -1183,16 +817,16 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferAbort(bool /*in_isr*/,
 
   SetTransferAbortFlag(true);
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER_ABORT);
-  resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::OK);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER_ABORT);
+  resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::OK);
   out_len = 2u;
   return ErrorCode::OK;
 }
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleWriteABORT(bool /*in_isr*/, const uint8_t* req,
-                                                    uint16_t req_len, uint8_t* resp,
-                                                    uint16_t resp_cap, uint16_t& out_len)
+                                           uint16_t req_len, uint8_t* resp,
+                                           uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -1200,11 +834,16 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleWriteABORT(bool /*in_isr*/, const uint8
     return ErrorCode::NOT_FOUND;
   }
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::WRITE_ABORT);
+  if (dap_state_.debug_port == LibXR::USB::DapLinkV1Def::DebugPort::JTAG)
+  {
+    return HandleJtagWriteAbort(false, req, req_len, resp, resp_cap, out_len);
+  }
+
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::WRITE_ABORT);
 
   if (req_len < 6u)
   {
-    resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::ERROR);
+    resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::ERROR);
     out_len = 2u;
     return ErrorCode::ARG_ERR;
   }
@@ -1215,8 +854,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleWriteABORT(bool /*in_isr*/, const uint8
   LibXR::Debug::SwdProtocol::Ack ack = LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
   const ErrorCode EC = swd_.WriteAbortTxn(flags, ack);
   resp[1] = (EC == ErrorCode::OK && ack == LibXR::Debug::SwdProtocol::Ack::OK)
-                ? ToU8(LibXR::USB::DapLinkV1Def::Status::OK)
-                : ToU8(LibXR::USB::DapLinkV1Def::Status::ERROR);
+                ? to_u8(LibXR::USB::DapLinkV1Def::Status::OK)
+                : to_u8(LibXR::USB::DapLinkV1Def::Status::ERROR);
 
   out_len = 2u;
   return ErrorCode::OK;
@@ -1224,8 +863,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleWriteABORT(bool /*in_isr*/, const uint8
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleDelay(bool /*in_isr*/, const uint8_t* req,
-                                               uint16_t req_len, uint8_t* resp,
-                                               uint16_t resp_cap, uint16_t& out_len)
+                                      uint16_t req_len, uint8_t* resp, uint16_t resp_cap,
+                                      uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -1233,11 +872,11 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleDelay(bool /*in_isr*/, const uint8_t* r
     return ErrorCode::NOT_FOUND;
   }
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::DELAY);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::DELAY);
 
   if (req_len < 3u)
   {
-    resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::ERROR);
+    resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::ERROR);
     out_len = 2u;
     return ErrorCode::ARG_ERR;
   }
@@ -1247,15 +886,15 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleDelay(bool /*in_isr*/, const uint8_t* r
 
   LibXR::Timebase::DelayMicroseconds(us);
 
-  resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::OK);
+  resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::OK);
   out_len = 2u;
   return ErrorCode::OK;
 }
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleResetTarget(bool in_isr, const uint8_t* /*req*/,
-                                                     uint16_t /*req_len*/, uint8_t* resp,
-                                                     uint16_t resp_cap, uint16_t& out_len)
+                                            uint16_t /*req_len*/, uint8_t* resp,
+                                            uint16_t resp_cap, uint16_t& out_len)
 {
   if (!resp || resp_cap < 3u)
   {
@@ -1263,7 +902,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleResetTarget(bool in_isr, const uint8_t*
     return ErrorCode::NOT_FOUND;
   }
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::RESET_TARGET);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::RESET_TARGET);
 
   uint8_t execute = 0u;
   if (nreset_gpio_ != nullptr)
@@ -1283,8 +922,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleResetTarget(bool in_isr, const uint8_t*
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleSWJPins(bool /*in_isr*/, const uint8_t* req,
-                                                 uint16_t req_len, uint8_t* resp,
-                                                 uint16_t resp_cap, uint16_t& out_len)
+                                        uint16_t req_len, uint8_t* resp,
+                                        uint16_t resp_cap, uint16_t& out_len)
 {
   if (!resp || resp_cap < 2u)
   {
@@ -1292,7 +931,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWJPins(bool /*in_isr*/, const uint8_t*
     return ErrorCode::NOT_FOUND;
   }
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::SWJ_PINS);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::SWJ_PINS);
 
   if (!req || req_len < 7u)
   {
@@ -1312,7 +951,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWJPins(bool /*in_isr*/, const uint8_t*
 
   if ((PIN_SEL & LibXR::USB::DapLinkV1Def::DAP_SWJ_NRESET) != 0u)
   {
-    const bool LEVEL_HIGH = ((PIN_OUT & LibXR::USB::DapLinkV1Def::DAP_SWJ_NRESET) != 0u);
+    const bool LEVEL_HIGH =
+        ((PIN_OUT & LibXR::USB::DapLinkV1Def::DAP_SWJ_NRESET) != 0u);
     DriveReset(LEVEL_HIGH);
   }
 
@@ -1364,8 +1004,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWJPins(bool /*in_isr*/, const uint8_t*
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleSWJClock(bool /*in_isr*/, const uint8_t* req,
-                                                  uint16_t req_len, uint8_t* resp,
-                                                  uint16_t resp_cap, uint16_t& out_len)
+                                         uint16_t req_len, uint8_t* resp,
+                                         uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -1373,11 +1013,11 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWJClock(bool /*in_isr*/, const uint8_t
     return ErrorCode::NOT_FOUND;
   }
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::SWJ_CLOCK);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::SWJ_CLOCK);
 
   if (req_len < 5u)
   {
-    resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::ERROR);
+    resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::ERROR);
     out_len = 2u;
     return ErrorCode::ARG_ERR;
   }
@@ -1387,16 +1027,20 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWJClock(bool /*in_isr*/, const uint8_t
 
   swj_clock_hz_ = hz;
   (void)swd_.SetClockHz(hz);
+  if (jtag_ != nullptr)
+  {
+    (void)jtag_->SetClockHz(hz);
+  }
 
-  resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::OK);
+  resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::OK);
   out_len = 2u;
   return ErrorCode::OK;
 }
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleSWJSequence(bool /*in_isr*/, const uint8_t* req,
-                                                     uint16_t req_len, uint8_t* resp,
-                                                     uint16_t resp_cap, uint16_t& out_len)
+                                            uint16_t req_len, uint8_t* resp,
+                                            uint16_t resp_cap, uint16_t& out_len)
 {
   if (!resp || resp_cap < 2u)
   {
@@ -1404,13 +1048,13 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWJSequence(bool /*in_isr*/, const uint
     return ErrorCode::NOT_FOUND;
   }
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::SWJ_SEQUENCE);
-  resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::OK);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::SWJ_SEQUENCE);
+  resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::OK);
   out_len = 2u;
 
   if (!req || req_len < 2u)
   {
-    resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::ERROR);
+    resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::ERROR);
     return ErrorCode::ARG_ERR;
   }
 
@@ -1423,15 +1067,15 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWJSequence(bool /*in_isr*/, const uint
   const uint32_t BYTE_COUNT = (bit_count + 7u) / 8u;
   if (req_len < (2u + BYTE_COUNT))
   {
-    resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::ERROR);
+    resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::ERROR);
     return ErrorCode::ARG_ERR;
   }
 
-  const uint8_t* data = &req[2];
-  const ErrorCode EC = swd_.SeqWriteBits(bit_count, data);
+  const uint8_t* DATA = &req[2];
+  const ErrorCode EC = swd_.SeqWriteBits(bit_count, DATA);
   if (EC != ErrorCode::OK)
   {
-    resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::ERROR);
+    resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::ERROR);
     return ErrorCode::OK;
   }
 
@@ -1442,7 +1086,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWJSequence(bool /*in_isr*/, const uint
   if (bit_count != 0u)
   {
     const uint32_t LAST_I = bit_count - 1u;
-    last_swdio = (((data[LAST_I / 8u] >> (LAST_I & 7u)) & 0x01u) != 0u);
+    last_swdio = (((DATA[LAST_I / 8u] >> (LAST_I & 7u)) & 0x01u) != 0u);
   }
 
   if (last_swdio)
@@ -1459,11 +1103,9 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWJSequence(bool /*in_isr*/, const uint
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleSWDConfigure(bool /*in_isr*/,
-                                                      const uint8_t* /*req*/,
-                                                      uint16_t /*req_len*/, uint8_t* resp,
-                                                      uint16_t resp_cap,
-                                                      uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleSWDConfigure(bool /*in_isr*/, const uint8_t* /*req*/,
+                                             uint16_t /*req_len*/, uint8_t* resp,
+                                             uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -1471,16 +1113,16 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWDConfigure(bool /*in_isr*/,
     return ErrorCode::NOT_FOUND;
   }
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::SWD_CONFIGURE);
-  resp[1] = ToU8(LibXR::USB::DapLinkV1Def::Status::OK);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::SWD_CONFIGURE);
+  resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::OK);
   out_len = 2u;
   return ErrorCode::OK;
 }
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleSWDSequence(bool /*in_isr*/, const uint8_t* req,
-                                                     uint16_t req_len, uint8_t* resp,
-                                                     uint16_t resp_cap, uint16_t& out_len)
+                                            uint16_t req_len, uint8_t* resp,
+                                            uint16_t resp_cap, uint16_t& out_len)
 {
   if (!req || !resp || resp_cap < 2u)
   {
@@ -1488,7 +1130,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWDSequence(bool /*in_isr*/, const uint
     return ErrorCode::ARG_ERR;
   }
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::SWD_SEQUENCE);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::SWD_SEQUENCE);
   resp[1] = DAP_OK;
   out_len = 2u;
 
@@ -1531,10 +1173,10 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWDSequence(bool /*in_isr*/, const uint
         return ErrorCode::ARG_ERR;
       }
 
-      const uint8_t* data = &req[req_off];
+      const uint8_t* DATA = &req[req_off];
       req_off = static_cast<uint16_t>(req_off + BYTES);
 
-      const ErrorCode EC = swd_.SeqWriteBits(cycles, data);
+      const ErrorCode EC = swd_.SeqWriteBits(cycles, DATA);
       if (EC != ErrorCode::OK)
       {
         resp[1] = DAP_ERROR;
@@ -1569,6 +1211,240 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWDSequence(bool /*in_isr*/, const uint
 }
 
 template <typename SwdPort>
+ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGSequence(bool /*in_isr*/, const uint8_t* req,
+                                             uint16_t req_len, uint8_t* resp,
+                                             uint16_t resp_cap, uint16_t& out_len)
+{
+  if (!req || !resp || resp_cap < 2u)
+  {
+    out_len = 0u;
+    return ErrorCode::ARG_ERR;
+  }
+
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::JTAG_SEQUENCE);
+  resp[1] = DAP_OK;
+  out_len = 2u;
+
+  if (jtag_ == nullptr)
+  {
+    resp[1] = DAP_ERROR;
+    return ErrorCode::OK;
+  }
+
+  if (req_len < 2u)
+  {
+    resp[1] = DAP_ERROR;
+    return ErrorCode::ARG_ERR;
+  }
+
+  const uint8_t SEQ_CNT = req[1];
+  uint16_t req_off = 2u;
+  uint16_t resp_off = 2u;
+
+  for (uint32_t s = 0; s < SEQ_CNT; ++s)
+  {
+    if (req_off >= req_len)
+    {
+      resp[1] = DAP_ERROR;
+      out_len = 2u;
+      return ErrorCode::ARG_ERR;
+    }
+
+    const uint8_t INFO = req[req_off++];
+    uint32_t cycles = static_cast<uint32_t>(INFO & 0x3Fu);
+    if (cycles == 0u)
+    {
+      cycles = 64u;
+    }
+
+    const bool TMS = ((INFO & LibXR::Debug::JtagProtocol::JTAG_SEQUENCE_TMS) != 0u);
+    const bool CAPTURE =
+        ((INFO & LibXR::Debug::JtagProtocol::JTAG_SEQUENCE_TDO) != 0u);
+    const uint16_t BYTES = static_cast<uint16_t>((cycles + 7u) / 8u);
+
+    if (req_off + BYTES > req_len)
+    {
+      resp[1] = DAP_ERROR;
+      out_len = 2u;
+      return ErrorCode::ARG_ERR;
+    }
+
+    if (CAPTURE && (resp_off + BYTES > resp_cap))
+    {
+      resp[1] = DAP_ERROR;
+      out_len = 2u;
+      return ErrorCode::NOT_FOUND;
+    }
+
+    const uint8_t* DATA = &req[req_off];
+    uint8_t* OUT = CAPTURE ? &resp[resp_off] : nullptr;
+    if (CAPTURE)
+    {
+      Memory::FastSet(OUT, 0, BYTES);
+    }
+
+    const ErrorCode EC = jtag_->Sequence(cycles, TMS, DATA, OUT);
+    if (EC != ErrorCode::OK)
+    {
+      resp[1] = DAP_ERROR;
+      out_len = 2u;
+      return ErrorCode::OK;
+    }
+
+    req_off = static_cast<uint16_t>(req_off + BYTES);
+    if (CAPTURE)
+    {
+      resp_off = static_cast<uint16_t>(resp_off + BYTES);
+    }
+  }
+
+  out_len = resp_off;
+  return ErrorCode::OK;
+}
+
+template <typename SwdPort>
+ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGConfigure(bool /*in_isr*/, const uint8_t* req,
+                                              uint16_t req_len, uint8_t* resp,
+                                              uint16_t resp_cap, uint16_t& out_len)
+{
+  if (!req || !resp || resp_cap < 2u)
+  {
+    out_len = 0u;
+    return ErrorCode::ARG_ERR;
+  }
+
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::JTAG_CONFIGURE);
+  resp[1] = DAP_OK;
+  out_len = 2u;
+
+  if (jtag_ == nullptr)
+  {
+    resp[1] = DAP_ERROR;
+    return ErrorCode::OK;
+  }
+
+  if (req_len < 2u)
+  {
+    resp[1] = DAP_ERROR;
+    return ErrorCode::ARG_ERR;
+  }
+
+  const uint8_t COUNT = req[1];
+  if (COUNT > JTAG_MAX_DEVICES || req_len < static_cast<uint16_t>(2u + COUNT))
+  {
+    resp[1] = DAP_ERROR;
+    return ErrorCode::ARG_ERR;
+  }
+
+  Memory::FastSet(jtag_ir_len_, 0, sizeof(jtag_ir_len_));
+  Memory::FastSet(jtag_ir_before_, 0, sizeof(jtag_ir_before_));
+  Memory::FastSet(jtag_ir_after_, 0, sizeof(jtag_ir_after_));
+
+  uint32_t bits = 0u;
+  for (uint32_t i = 0; i < COUNT; ++i)
+  {
+    const uint8_t LEN = req[static_cast<uint16_t>(2u + i)];
+    jtag_ir_len_[i] = LEN;
+    jtag_ir_before_[i] = static_cast<uint16_t>(bits);
+    bits += LEN;
+  }
+  for (uint32_t i = 0; i < COUNT; ++i)
+  {
+    bits -= jtag_ir_len_[i];
+    jtag_ir_after_[i] = static_cast<uint16_t>(bits);
+  }
+
+  jtag_chain_.count = COUNT;
+  if (jtag_chain_.index >= jtag_chain_.count)
+  {
+    jtag_chain_.index = 0u;
+  }
+  jtag_chain_.ir_before_bits_len = 0u;
+  jtag_chain_.ir_after_bits_len = 0u;
+  jtag_chain_.dr_before_bits_len = 0u;
+  jtag_chain_.dr_after_bits_len = 0u;
+
+  return ErrorCode::OK;
+}
+
+template <typename SwdPort>
+ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGIdCode(bool /*in_isr*/, const uint8_t* req,
+                                           uint16_t req_len, uint8_t* resp,
+                                           uint16_t resp_cap, uint16_t& out_len)
+{
+  if (!req || !resp || resp_cap < 2u)
+  {
+    out_len = 0u;
+    return ErrorCode::ARG_ERR;
+  }
+
+  if (resp_cap < 6u)
+  {
+    out_len = 0u;
+    return ErrorCode::NOT_FOUND;
+  }
+
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::JTAG_IDCODE);
+  resp[1] = DAP_ERROR;
+  out_len = 2u;
+
+  if (jtag_ == nullptr || dap_state_.debug_port != LibXR::USB::DapLinkV1Def::DebugPort::JTAG)
+  {
+    return ErrorCode::OK;
+  }
+
+  if (req_len < 2u)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  const uint8_t INDEX = req[1];
+  if (INDEX >= jtag_chain_.count)
+  {
+    return ErrorCode::OK;
+  }
+
+  jtag_chain_.index = INDEX;
+  LibXR::Debug::JtagProtocol::UpdateChainCache(jtag_chain_);
+
+  LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
+  uint32_t idcode = 0u;
+  const ErrorCode EC = dp.ReadIdCode(idcode);
+  if (EC != ErrorCode::OK)
+  {
+    return EC;
+  }
+
+  resp[1] = DAP_OK;
+  resp[2] = static_cast<uint8_t>(idcode & 0xFFu);
+  resp[3] = static_cast<uint8_t>((idcode >> 8) & 0xFFu);
+  resp[4] = static_cast<uint8_t>((idcode >> 16) & 0xFFu);
+  resp[5] = static_cast<uint8_t>((idcode >> 24) & 0xFFu);
+  out_len = 6u;
+  return ErrorCode::OK;
+}
+
+template <typename SwdPort>
+ErrorCode DapLinkV1Class<SwdPort>::HandleQueueCommands(bool /*in_isr*/, const uint8_t* /*req*/,
+                                              uint16_t /*req_len*/, uint8_t* resp,
+                                              uint16_t resp_cap, uint16_t& out_len)
+{
+  return build_cmd_status_response(
+      to_u8(LibXR::USB::DapLinkV1Def::CommandId::QUEUE_COMMANDS), DAP_ERROR, resp,
+      resp_cap, out_len);
+}
+
+template <typename SwdPort>
+ErrorCode DapLinkV1Class<SwdPort>::HandleExecuteCommands(bool /*in_isr*/, const uint8_t* /*req*/,
+                                                uint16_t /*req_len*/, uint8_t* resp,
+                                                uint16_t resp_cap, uint16_t& out_len)
+{
+  return build_cmd_status_response(
+      to_u8(LibXR::USB::DapLinkV1Def::CommandId::EXECUTE_COMMANDS), DAP_ERROR, resp,
+      resp_cap, out_len);
+}
+
+template <typename SwdPort>
 uint8_t DapLinkV1Class<SwdPort>::MapAckToDapResp(LibXR::Debug::SwdProtocol::Ack ack) const
 {
   switch (ack)
@@ -1587,15 +1463,31 @@ uint8_t DapLinkV1Class<SwdPort>::MapAckToDapResp(LibXR::Debug::SwdProtocol::Ack 
 }
 
 template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::SetTransferAbortFlag(bool on)
+uint8_t DapLinkV1Class<SwdPort>::MapAckToDapResp(
+    LibXR::Debug::JtagProtocol::Ack ack) const
 {
-  dap_state_.transfer_abort = on;
+  switch (ack)
+  {
+    case LibXR::Debug::JtagProtocol::Ack::OK:
+      return 1u;
+    case LibXR::Debug::JtagProtocol::Ack::WAIT:
+      return 2u;
+    case LibXR::Debug::JtagProtocol::Ack::FAULT:
+      return 4u;
+    case LibXR::Debug::JtagProtocol::Ack::NO_ACK:
+    case LibXR::Debug::JtagProtocol::Ack::PROTOCOL:
+    default:
+      return 7u;
+  }
 }
 
 template <typename SwdPort>
+void DapLinkV1Class<SwdPort>::SetTransferAbortFlag(bool on) { dap_state_.transfer_abort = on; }
+
+template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t* req,
-                                                  uint16_t req_len, uint8_t* resp,
-                                                  uint16_t resp_cap, uint16_t& out_len)
+                                         uint16_t req_len, uint8_t* resp,
+                                         uint16_t resp_cap, uint16_t& out_len)
 {
   out_len = 0u;
   if (!req || !resp || resp_cap < 3u)
@@ -1603,7 +1495,12 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t
     return ErrorCode::ARG_ERR;
   }
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER);
+  if (dap_state_.debug_port == LibXR::USB::DapLinkV1Def::DebugPort::JTAG)
+  {
+    return HandleJtagTransfer(false, req, req_len, resp, resp_cap, out_len);
+  }
+
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER);
   resp[1] = 0u;
   resp[2] = 0u;
   uint16_t resp_off = 3u;
@@ -1763,7 +1660,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t
     }
 
     LibXR::Debug::SwdProtocol::Ack ack = LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
-    ErrorCode ec = ErrorCode::OK;
+    ErrorCode EC = ErrorCode::OK;
 
     if (!RNW)
     {
@@ -1792,11 +1689,11 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t
 
       if (AP)
       {
-        ec = swd_.ApWriteTxn(ADDR2B, wdata, ack);
+        EC = swd_.ApWriteTxn(ADDR2B, wdata, ack);
       }
       else
       {
-        ec = swd_.DpWriteTxn(static_cast<LibXR::Debug::SwdProtocol::DpWriteReg>(ADDR2B),
+        EC = swd_.DpWriteTxn(static_cast<LibXR::Debug::SwdProtocol::DpWriteReg>(ADDR2B),
                              wdata, ack);
       }
 
@@ -1805,7 +1702,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t
       {
         break;
       }
-      if (ec != ErrorCode::OK)
+      if (EC != ErrorCode::OK)
       {
         response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
         break;
@@ -1850,15 +1747,15 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t
         {
           if (AP)
           {
-            ec = swd_.ApReadTxn(ADDR2B, rdata, ack);
-            if (ec == ErrorCode::OK && ack == LibXR::Debug::SwdProtocol::Ack::OK)
+            EC = swd_.ApReadTxn(ADDR2B, rdata, ack);
+            if (EC == ErrorCode::OK && ack == LibXR::Debug::SwdProtocol::Ack::OK)
             {
               check_write = false;
             }
           }
           else
           {
-            ec = swd_.DpReadTxn(static_cast<LibXR::Debug::SwdProtocol::DpReadReg>(ADDR2B),
+            EC = swd_.DpReadTxn(static_cast<LibXR::Debug::SwdProtocol::DpReadReg>(ADDR2B),
                                 rdata, ack);
           }
 
@@ -1867,7 +1764,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t
           {
             break;
           }
-          if (ec != ErrorCode::OK)
+          if (EC != ErrorCode::OK)
           {
             response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
             break;
@@ -1912,7 +1809,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t
         }
 
         uint32_t rdata = 0u;
-        ec = swd_.DpReadTxn(static_cast<LibXR::Debug::SwdProtocol::DpReadReg>(ADDR2B),
+        EC = swd_.DpReadTxn(static_cast<LibXR::Debug::SwdProtocol::DpReadReg>(ADDR2B),
                             rdata, ack);
 
         response_value = ack_to_dap(ack);
@@ -1920,7 +1817,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t
         {
           break;
         }
-        if (ec != ErrorCode::OK)
+        if (EC != ErrorCode::OK)
         {
           response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
           break;
@@ -1945,14 +1842,14 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t
       if (!pending.valid)
       {
         uint32_t dummy_posted = 0u;
-        ec = swd_.ApReadPostedTxn(ADDR2B, dummy_posted, ack);
+        EC = swd_.ApReadPostedTxn(ADDR2B, dummy_posted, ack);
 
         response_value = ack_to_dap(ack);
         if (response_value != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
         {
           break;
         }
-        if (ec != ErrorCode::OK)
+        if (EC != ErrorCode::OK)
         {
           response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
           break;
@@ -1971,14 +1868,15 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t
         }
 
         uint32_t posted_prev = 0u;
-        ec = swd_.ApReadPostedTxn(ADDR2B, posted_prev, ack);
+        EC = swd_.ApReadPostedTxn(ADDR2B, posted_prev, ack);
 
         const uint8_t CUR_V = ack_to_dap(ack);
-        if (CUR_V != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK || ec != ErrorCode::OK)
+        if (CUR_V != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK || EC != ErrorCode::OK)
         {
-          const uint8_t PRIOR_FAIL = (CUR_V != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
-                                         ? CUR_V
-                                         : LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+          const uint8_t PRIOR_FAIL =
+              (CUR_V != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
+                  ? CUR_V
+                  : LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
 
           if (!complete_pending_by_rdbuff())
           {
@@ -2048,19 +1946,22 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
-                                                       const uint8_t* req,
-                                                       uint16_t req_len, uint8_t* resp,
-                                                       uint16_t resp_cap,
-                                                       uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/, const uint8_t* req,
+                                              uint16_t req_len, uint8_t* resp,
+                                              uint16_t resp_cap, uint16_t& out_len)
 {
+  if (dap_state_.debug_port == LibXR::USB::DapLinkV1Def::DebugPort::JTAG)
+  {
+    return HandleJtagTransferBlock(false, req, req_len, resp, resp_cap, out_len);
+  }
+
   if (!resp || resp_cap < 4u)
   {
     out_len = 0u;
     return ErrorCode::NOT_FOUND;
   }
 
-  resp[0] = ToU8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER_BLOCK);
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER_BLOCK);
   resp[1] = 0u;
   resp[2] = 0u;
   resp[3] = 0u;
@@ -2120,7 +2021,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
     for (uint32_t i = 0; i < count; ++i)
     {
       LibXR::Debug::SwdProtocol::Ack ack = LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
-      ErrorCode ec = ErrorCode::OK;
+      ErrorCode EC = ErrorCode::OK;
 
       if (req_off + 4u > req_len)
       {
@@ -2134,11 +2035,11 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
 
       if (AP)
       {
-        ec = swd_.ApWriteTxn(ADDR2B, wdata, ack);
+        EC = swd_.ApWriteTxn(ADDR2B, wdata, ack);
       }
       else
       {
-        ec = swd_.DpWriteTxn(static_cast<LibXR::Debug::SwdProtocol::DpWriteReg>(ADDR2B),
+        EC = swd_.DpWriteTxn(static_cast<LibXR::Debug::SwdProtocol::DpWriteReg>(ADDR2B),
                              wdata, ack);
       }
 
@@ -2154,7 +2055,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
         break;
       }
 
-      if (ec != ErrorCode::OK)
+      if (EC != ErrorCode::OK)
       {
         xresp |= LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
         break;
@@ -2174,7 +2075,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
     for (uint32_t i = 0; i < count; ++i)
     {
       LibXR::Debug::SwdProtocol::Ack ack = LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
-      ErrorCode ec = ErrorCode::OK;
+      ErrorCode EC = ErrorCode::OK;
       uint32_t rdata = 0u;
 
       if (resp_off + 4u > resp_cap)
@@ -2183,7 +2084,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
         break;
       }
 
-      ec = swd_.DpReadTxn(static_cast<LibXR::Debug::SwdProtocol::DpReadReg>(ADDR2B),
+      EC = swd_.DpReadTxn(static_cast<LibXR::Debug::SwdProtocol::DpReadReg>(ADDR2B),
                           rdata, ack);
 
       xresp = MapAckToDapResp(ack);
@@ -2198,7 +2099,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
         break;
       }
 
-      if (ec != ErrorCode::OK)
+      if (EC != ErrorCode::OK)
       {
         xresp |= LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
         break;
@@ -2217,10 +2118,10 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
 
   {
     LibXR::Debug::SwdProtocol::Ack ack = LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
-    ErrorCode ec = ErrorCode::OK;
+    ErrorCode EC = ErrorCode::OK;
 
     uint32_t dummy_posted = 0u;
-    ec = swd_.ApReadPostedTxn(ADDR2B, dummy_posted, ack);
+    EC = swd_.ApReadPostedTxn(ADDR2B, dummy_posted, ack);
     xresp = MapAckToDapResp(ack);
 
     if (xresp == 0u)
@@ -2232,7 +2133,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
     {
       goto out_ap_read;  // NOLINT
     }
-    if (ec != ErrorCode::OK)
+    if (EC != ErrorCode::OK)
     {
       xresp |= LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
       goto out_ap_read;  // NOLINT
@@ -2247,7 +2148,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
       }
 
       uint32_t posted_prev = 0u;
-      ec = swd_.ApReadPostedTxn(ADDR2B, posted_prev, ack);
+      EC = swd_.ApReadPostedTxn(ADDR2B, posted_prev, ack);
       const uint8_t CUR = MapAckToDapResp(ack);
 
       if (CUR == 0u)
@@ -2256,7 +2157,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
         goto out_ap_read;  // NOLINT
       }
 
-      if (ack != LibXR::Debug::SwdProtocol::Ack::OK || ec != ErrorCode::OK)
+      if (ack != LibXR::Debug::SwdProtocol::Ack::OK || EC != ErrorCode::OK)
       {
         if (resp_off + 4u <= resp_cap)
         {
@@ -2283,7 +2184,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
         }
 
         xresp = CUR;
-        if (ec != ErrorCode::OK)
+        if (EC != ErrorCode::OK)
         {
           xresp |= LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
         }
@@ -2330,6 +2231,707 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
     out_len = resp_off;
     return ErrorCode::OK;
   }
+}
+
+template <typename SwdPort>
+ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransfer(bool /*in_isr*/, const uint8_t* req,
+                                             uint16_t req_len, uint8_t* resp,
+                                             uint16_t resp_cap, uint16_t& out_len)
+{
+  out_len = 0u;
+  if (!req || !resp || resp_cap < 3u)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER);
+  resp[1] = 0u;
+  resp[2] = 0u;
+  uint16_t resp_off = 3u;
+
+  if (req_len < 3u || jtag_ == nullptr || jtag_chain_.count == 0u)
+  {
+    resp[2] = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+    out_len = 3u;
+    return ErrorCode::OK;
+  }
+
+  if (dap_state_.transfer_abort)
+  {
+    dap_state_.transfer_abort = false;
+    resp[2] = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+    out_len = 3u;
+    return ErrorCode::OK;
+  }
+
+  const uint8_t TAP_INDEX = req[1];
+  if (TAP_INDEX >= jtag_chain_.count)
+  {
+    resp[2] = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+    out_len = 3u;
+    return ErrorCode::OK;
+  }
+
+  jtag_chain_.index = TAP_INDEX;
+  LibXR::Debug::JtagProtocol::UpdateChainCache(jtag_chain_);
+
+  LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
+
+  const uint8_t COUNT = req[2];
+  uint16_t req_off = 3u;
+
+  auto push_u32 = [&](uint32_t VALUE) -> bool
+  {
+    if (resp_off + 4u > resp_cap)
+    {
+      return false;
+    }
+    Memory::FastCopy(&resp[resp_off], &VALUE, sizeof(VALUE));
+    resp_off = static_cast<uint16_t>(resp_off + 4u);
+    return true;
+  };
+
+  auto push_timestamp = [&]() -> bool
+  {
+    const uint32_t T = static_cast<uint32_t>(LibXR::Timebase::GetMicroseconds());
+    return push_u32(T);
+  };
+
+  auto ensure_space = [&](uint16_t bytes) -> bool
+  { return (resp_off + bytes) <= resp_cap; };
+
+  auto bytes_for_read = [&](bool need_ts) -> uint16_t
+  { return static_cast<uint16_t>(need_ts ? 8u : 4u); };
+
+  auto idle_after_attempt = [&]() {
+    if (dap_state_.transfer_cfg.idle_cycles != 0u)
+    {
+      jtag_->IdleClocks(dap_state_.transfer_cfg.idle_cycles);
+    }
+  };
+
+  auto dp_read_retry = [&](uint8_t addr2b, uint32_t& val,
+                           LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+  {
+    uint32_t retry = dap_state_.transfer_cfg.retry_count;
+    while (true)
+    {
+      const ErrorCode EC = dp.DpReadTxn(addr2b, val, ack);
+      idle_after_attempt();
+      if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+          dap_state_.transfer_abort)
+      {
+        return EC;
+      }
+      --retry;
+    }
+  };
+
+  auto dp_write_retry = [&](uint8_t addr2b, uint32_t val,
+                            LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+  {
+    uint32_t retry = dap_state_.transfer_cfg.retry_count;
+    while (true)
+    {
+      const ErrorCode EC = dp.DpWriteTxn(addr2b, val, ack);
+      idle_after_attempt();
+      if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+          dap_state_.transfer_abort)
+      {
+        return EC;
+      }
+      --retry;
+    }
+  };
+
+  auto ap_read_retry = [&](uint8_t addr2b, uint32_t& val,
+                           LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+  {
+    uint32_t retry = dap_state_.transfer_cfg.retry_count;
+    while (true)
+    {
+      const ErrorCode EC = dp.ApReadTxn(addr2b, val, ack);
+      idle_after_attempt();
+      if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+          dap_state_.transfer_abort)
+      {
+        return EC;
+      }
+      --retry;
+    }
+  };
+
+  auto ap_write_retry = [&](uint8_t addr2b, uint32_t val,
+                            LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+  {
+    uint32_t retry = dap_state_.transfer_cfg.retry_count;
+    while (true)
+    {
+      const ErrorCode EC = dp.ApWriteTxn(addr2b, val, ack);
+      idle_after_attempt();
+      if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+          dap_state_.transfer_abort)
+      {
+        return EC;
+      }
+      --retry;
+    }
+  };
+
+  uint8_t response_count = 0u;
+  uint8_t response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK;
+  bool check_write = false;
+
+  auto emit_read_with_ts = [&](bool need_ts, uint32_t data) -> bool
+  {
+    if (need_ts)
+    {
+      if (!push_timestamp())
+      {
+        return false;
+      }
+    }
+    if (!push_u32(data))
+    {
+      return false;
+    }
+    response_count++;
+    return true;
+  };
+
+  for (uint32_t i = 0; i < COUNT; ++i)
+  {
+    if (req_off >= req_len)
+    {
+      response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+      break;
+    }
+
+    const uint8_t RQ = req[req_off++];
+    const bool AP = LibXR::USB::DapLinkV1Def::req_is_ap(RQ);
+    const bool RNW = LibXR::USB::DapLinkV1Def::req_is_read(RQ);
+    const uint8_t ADDR2B = LibXR::USB::DapLinkV1Def::req_addr2b(RQ);
+
+    const bool TS = LibXR::USB::DapLinkV1Def::req_need_timestamp(RQ);
+    const bool MATCH_VALUE =
+        ((RQ & LibXR::USB::DapLinkV1Def::DAP_TRANSFER_MATCH_VALUE) != 0u);
+    const bool MATCH_MASK =
+        ((RQ & LibXR::USB::DapLinkV1Def::DAP_TRANSFER_MATCH_MASK) != 0u);
+
+    if (TS && (MATCH_VALUE || MATCH_MASK))
+    {
+      response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+      break;
+    }
+
+    LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+    ErrorCode EC = ErrorCode::OK;
+
+    if (!RNW)
+    {
+      if (req_off + 4u > req_len)
+      {
+        response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+
+      uint32_t wdata = 0u;
+      Memory::FastCopy(&wdata, &req[req_off], sizeof(wdata));
+      req_off = static_cast<uint16_t>(req_off + 4u);
+
+      if (MATCH_MASK)
+      {
+        match_mask_ = wdata;
+        response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK;
+        response_count++;
+        continue;
+      }
+
+      if (AP)
+      {
+        EC = ap_write_retry(ADDR2B, wdata, ack);
+      }
+      else
+      {
+        EC = dp_write_retry(ADDR2B, wdata, ack);
+      }
+
+      response_value = MapAckToDapResp(ack);
+      if (response_value != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
+      {
+        break;
+      }
+      if (EC != ErrorCode::OK)
+      {
+        response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+
+      if (TS)
+      {
+        if (!push_timestamp())
+        {
+          response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+          break;
+        }
+      }
+
+      response_count++;
+      check_write = true;
+    }
+    else
+    {
+      if (MATCH_VALUE)
+      {
+        if (req_off + 4u > req_len)
+        {
+          response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+          break;
+        }
+
+        uint32_t match_val = 0u;
+        Memory::FastCopy(&match_val, &req[req_off], sizeof(match_val));
+        req_off = static_cast<uint16_t>(req_off + 4u);
+
+        uint32_t rdata = 0u;
+        uint32_t retry = dap_state_.transfer_cfg.match_retry;
+        bool matched = false;
+
+        while (true)
+        {
+          if (AP)
+          {
+            EC = ap_read_retry(ADDR2B, rdata, ack);
+          }
+          else
+          {
+            EC = dp_read_retry(ADDR2B, rdata, ack);
+          }
+
+          response_value = MapAckToDapResp(ack);
+          if (response_value != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
+          {
+            break;
+          }
+          if (EC != ErrorCode::OK)
+          {
+            response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+            break;
+          }
+
+          if ((rdata & match_mask_) == (match_val & match_mask_))
+          {
+            matched = true;
+            break;
+          }
+
+          if (retry == 0u)
+          {
+            break;
+          }
+          --retry;
+        }
+
+        if (response_value != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
+        {
+          break;
+        }
+
+        if (!matched)
+        {
+          response_value =
+              static_cast<uint8_t>(LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK |
+                                   LibXR::USB::DapLinkV1Def::DAP_TRANSFER_MISMATCH);
+          break;
+        }
+
+        response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK;
+        response_count++;
+        continue;
+      }
+
+      uint32_t rdata = 0u;
+      if (AP)
+      {
+        EC = ap_read_retry(ADDR2B, rdata, ack);
+      }
+      else
+      {
+        EC = dp_read_retry(ADDR2B, rdata, ack);
+      }
+
+      response_value = MapAckToDapResp(ack);
+      if (response_value != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
+      {
+        break;
+      }
+      if (EC != ErrorCode::OK)
+      {
+        response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+
+      if (!ensure_space(bytes_for_read(TS)))
+      {
+        response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+
+      if (!emit_read_with_ts(TS, rdata))
+      {
+        response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+
+      response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK;
+    }
+
+    if (dap_state_.transfer_abort)
+    {
+      dap_state_.transfer_abort = false;
+      break;
+    }
+  }
+
+  if (response_value == LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK && check_write)
+  {
+    uint32_t dummy = 0u;
+    LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+    const ErrorCode EC = dp_read_retry(3u, dummy, ack);
+    const uint8_t V = MapAckToDapResp(ack);
+
+    if (V != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
+    {
+      response_value = V;
+    }
+    else if (EC != ErrorCode::OK)
+    {
+      response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+    }
+  }
+
+  resp[1] = response_count;
+  resp[2] = response_value;
+  out_len = resp_off;
+  return ErrorCode::OK;
+}
+
+template <typename SwdPort>
+ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransferBlock(bool /*in_isr*/,
+                                                  const uint8_t* req, uint16_t req_len,
+                                                  uint8_t* resp, uint16_t resp_cap,
+                                                  uint16_t& out_len)
+{
+  if (!resp || resp_cap < 4u)
+  {
+    out_len = 0u;
+    return ErrorCode::NOT_FOUND;
+  }
+
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::TRANSFER_BLOCK);
+  resp[1] = 0u;
+  resp[2] = 0u;
+  resp[3] = 0u;
+  out_len = 4u;
+
+  if (!req || req_len < 5u || jtag_ == nullptr || jtag_chain_.count == 0u)
+  {
+    resp[3] = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+    return ErrorCode::ARG_ERR;
+  }
+
+  if (dap_state_.transfer_abort)
+  {
+    dap_state_.transfer_abort = false;
+    resp[3] = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+    return ErrorCode::OK;
+  }
+
+  const uint8_t TAP_INDEX = req[1];
+  if (TAP_INDEX >= jtag_chain_.count)
+  {
+    resp[3] = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+    return ErrorCode::OK;
+  }
+
+  jtag_chain_.index = TAP_INDEX;
+  LibXR::Debug::JtagProtocol::UpdateChainCache(jtag_chain_);
+
+  uint16_t count = 0u;
+  Memory::FastCopy(&count, &req[2], sizeof(count));
+
+  const uint8_t DAP_RQ = req[4];
+
+  if ((DAP_RQ & (LibXR::USB::DapLinkV1Def::DAP_TRANSFER_MATCH_VALUE |
+                 LibXR::USB::DapLinkV1Def::DAP_TRANSFER_MATCH_MASK)) != 0u)
+  {
+    resp[3] = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+    return ErrorCode::NOT_SUPPORT;
+  }
+  if (LibXR::USB::DapLinkV1Def::req_need_timestamp(DAP_RQ))
+  {
+    resp[3] = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+    return ErrorCode::NOT_SUPPORT;
+  }
+
+  if (count == 0u)
+  {
+    const uint16_t DONE0 = 0u;
+    Memory::FastCopy(&resp[1], &DONE0, sizeof(DONE0));
+    resp[3] = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK;
+    out_len = 4u;
+    return ErrorCode::OK;
+  }
+
+  LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
+
+  auto idle_after_attempt = [&]() {
+    if (dap_state_.transfer_cfg.idle_cycles != 0u)
+    {
+      jtag_->IdleClocks(dap_state_.transfer_cfg.idle_cycles);
+    }
+  };
+
+  auto dp_read_retry = [&](uint8_t addr2b, uint32_t& val,
+                           LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+  {
+    uint32_t retry = dap_state_.transfer_cfg.retry_count;
+    while (true)
+    {
+      const ErrorCode EC = dp.DpReadTxn(addr2b, val, ack);
+      idle_after_attempt();
+      if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+          dap_state_.transfer_abort)
+      {
+        return EC;
+      }
+      --retry;
+    }
+  };
+
+  auto dp_write_retry = [&](uint8_t addr2b, uint32_t val,
+                            LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+  {
+    uint32_t retry = dap_state_.transfer_cfg.retry_count;
+    while (true)
+    {
+      const ErrorCode EC = dp.DpWriteTxn(addr2b, val, ack);
+      idle_after_attempt();
+      if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+          dap_state_.transfer_abort)
+      {
+        return EC;
+      }
+      --retry;
+    }
+  };
+
+  auto ap_read_retry = [&](uint8_t addr2b, uint32_t& val,
+                           LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+  {
+    uint32_t retry = dap_state_.transfer_cfg.retry_count;
+    while (true)
+    {
+      const ErrorCode EC = dp.ApReadTxn(addr2b, val, ack);
+      idle_after_attempt();
+      if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+          dap_state_.transfer_abort)
+      {
+        return EC;
+      }
+      --retry;
+    }
+  };
+
+  auto ap_write_retry = [&](uint8_t addr2b, uint32_t val,
+                            LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+  {
+    uint32_t retry = dap_state_.transfer_cfg.retry_count;
+    while (true)
+    {
+      const ErrorCode EC = dp.ApWriteTxn(addr2b, val, ack);
+      idle_after_attempt();
+      if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+          dap_state_.transfer_abort)
+      {
+        return EC;
+      }
+      --retry;
+    }
+  };
+
+  const bool AP = LibXR::USB::DapLinkV1Def::req_is_ap(DAP_RQ);
+  const bool RNW = LibXR::USB::DapLinkV1Def::req_is_read(DAP_RQ);
+  const uint8_t ADDR2B = LibXR::USB::DapLinkV1Def::req_addr2b(DAP_RQ);
+
+  uint16_t done = 0u;
+  uint8_t xresp = 0u;
+
+  uint16_t req_off = 5u;
+  uint16_t resp_off = 4u;
+
+  if (!RNW)
+  {
+    for (uint32_t i = 0; i < count; ++i)
+    {
+      LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+      ErrorCode EC = ErrorCode::OK;
+
+      if (req_off + 4u > req_len)
+      {
+        xresp |= LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+
+      uint32_t wdata = 0u;
+      Memory::FastCopy(&wdata, &req[req_off], sizeof(wdata));
+      req_off = static_cast<uint16_t>(req_off + 4u);
+
+      if (AP)
+      {
+        EC = ap_write_retry(ADDR2B, wdata, ack);
+      }
+      else
+      {
+        EC = dp_write_retry(ADDR2B, wdata, ack);
+      }
+
+      xresp = MapAckToDapResp(ack);
+      if (xresp == 0u)
+      {
+        xresp |= LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+
+      if (ack != LibXR::Debug::JtagProtocol::Ack::OK)
+      {
+        break;
+      }
+
+      if (EC != ErrorCode::OK)
+      {
+        xresp |= LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+
+      done = static_cast<uint16_t>(i + 1u);
+    }
+
+    if (xresp == LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK && done > 0u)
+    {
+      uint32_t dummy = 0u;
+      LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+      const ErrorCode EC = dp_read_retry(3u, dummy, ack);
+      const uint8_t V = MapAckToDapResp(ack);
+      if (V != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
+      {
+        xresp = V;
+      }
+      else if (EC != ErrorCode::OK)
+      {
+        xresp |= LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+      }
+    }
+
+    Memory::FastCopy(&resp[1], &done, sizeof(done));
+    resp[3] = xresp;
+    out_len = resp_off;
+    return ErrorCode::OK;
+  }
+
+  for (uint32_t i = 0; i < count; ++i)
+  {
+    LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+    ErrorCode EC = ErrorCode::OK;
+    uint32_t rdata = 0u;
+
+    if (resp_off + 4u > resp_cap)
+    {
+      xresp |= LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+      break;
+    }
+
+    if (AP)
+    {
+      EC = ap_read_retry(ADDR2B, rdata, ack);
+    }
+    else
+    {
+      EC = dp_read_retry(ADDR2B, rdata, ack);
+    }
+
+    xresp = MapAckToDapResp(ack);
+    if (xresp == 0u)
+    {
+      xresp |= LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+      break;
+    }
+
+    if (ack != LibXR::Debug::JtagProtocol::Ack::OK)
+    {
+      break;
+    }
+
+    if (EC != ErrorCode::OK)
+    {
+      xresp |= LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+      break;
+    }
+
+    Memory::FastCopy(&resp[resp_off], &rdata, sizeof(rdata));
+    resp_off = static_cast<uint16_t>(resp_off + 4u);
+    done = static_cast<uint16_t>(i + 1u);
+  }
+
+  Memory::FastCopy(&resp[1], &done, sizeof(done));
+  resp[3] = xresp;
+  out_len = resp_off;
+  return ErrorCode::OK;
+}
+
+template <typename SwdPort>
+ErrorCode DapLinkV1Class<SwdPort>::HandleJtagWriteAbort(bool /*in_isr*/, const uint8_t* req,
+                                               uint16_t req_len, uint8_t* resp,
+                                               uint16_t resp_cap, uint16_t& out_len)
+{
+  if (!resp || resp_cap < 2u)
+  {
+    out_len = 0u;
+    return ErrorCode::ARG_ERR;
+  }
+
+  resp[0] = to_u8(LibXR::USB::DapLinkV1Def::CommandId::WRITE_ABORT);
+  resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::ERROR);
+  out_len = 2u;
+
+  if (!req || req_len < 6u || jtag_ == nullptr || jtag_chain_.count == 0u)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  const uint8_t TAP_INDEX = req[1];
+  if (TAP_INDEX >= jtag_chain_.count)
+  {
+    return ErrorCode::OK;
+  }
+
+  jtag_chain_.index = TAP_INDEX;
+  LibXR::Debug::JtagProtocol::UpdateChainCache(jtag_chain_);
+
+  uint32_t flags = 0u;
+  Memory::FastCopy(&flags, &req[2], sizeof(flags));
+
+  LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
+  LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+  const ErrorCode EC = dp.WriteAbort(flags, ack);
+  const uint8_t V = MapAckToDapResp(ack);
+
+  if (EC == ErrorCode::OK && V == LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
+  {
+    resp[1] = to_u8(LibXR::USB::DapLinkV1Def::Status::OK);
+  }
+
+  return ErrorCode::OK;
 }
 
 template <typename SwdPort>

--- a/src/driver/usb/device/dap/daplink_v1.hpp
+++ b/src/driver/usb/device/dap/daplink_v1.hpp
@@ -2389,7 +2389,40 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransfer(bool /*in_isr*/, const uin
 
   uint8_t response_count = 0u;
   uint8_t response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK;
-  bool check_write = false;
+  bool pending_ap_write = false;
+
+  auto check_posted_ap_write_if_pending = [&]() -> bool
+  {
+    if (!pending_ap_write)
+    {
+      return true;
+    }
+
+    LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+    const ErrorCode EC = check_posted_ap_write_jtag(ack);
+    const uint8_t V = MapAckToDapResp(ack);
+
+    if (V != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
+    {
+      response_value = V;
+      return false;
+    }
+    if (EC != ErrorCode::OK)
+    {
+      response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+      return false;
+    }
+
+    pending_ap_write = false;
+    return true;
+  };
+
+  auto should_check_pending_ap_write_at_tail = [&]() -> bool
+  {
+    return response_value == LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK ||
+           response_value == static_cast<uint8_t>(LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK |
+                                                  LibXR::USB::DapLinkV1Def::DAP_TRANSFER_MISMATCH);
+  };
 
   auto emit_read_with_ts = [&](bool need_ts, uint32_t data) -> bool
   {
@@ -2488,13 +2521,18 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransfer(bool /*in_isr*/, const uin
       response_count++;
       if (AP)
       {
-        check_write = true;
+        pending_ap_write = true;
       }
     }
     else
     {
       if (MATCH_VALUE)
       {
+        if (!check_posted_ap_write_if_pending())
+        {
+          break;
+        }
+
         if (req_off + 4u > req_len)
         {
           response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
@@ -2563,6 +2601,11 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransfer(bool /*in_isr*/, const uin
       }
 
       uint32_t rdata = 0u;
+      if (!check_posted_ap_write_if_pending())
+      {
+        break;
+      }
+
       if (AP)
       {
         EC = ap_read_retry(ADDR2B, rdata, ack);
@@ -2605,19 +2648,12 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransfer(bool /*in_isr*/, const uin
     }
   }
 
-  if (response_value == LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK && check_write)
+  if (pending_ap_write && should_check_pending_ap_write_at_tail())
   {
-    LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
-    const ErrorCode EC = check_posted_ap_write_jtag(ack);
-    const uint8_t V = MapAckToDapResp(ack);
-
-    if (V != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
+    const uint8_t PRIOR_RESPONSE = response_value;
+    if (check_posted_ap_write_if_pending())
     {
-      response_value = V;
-    }
-    else if (EC != ErrorCode::OK)
-    {
-      response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+      response_value = PRIOR_RESPONSE;
     }
   }
 

--- a/src/driver/usb/device/dap/daplink_v1.hpp
+++ b/src/driver/usb/device/dap/daplink_v1.hpp
@@ -2380,6 +2380,13 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransfer(bool /*in_isr*/, const uin
     }
   };
 
+  auto check_posted_ap_write_jtag = [&](LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+  {
+    uint32_t ctrl_stat = 0u;
+    return dp_read_retry(static_cast<uint8_t>(LibXR::Debug::SwdProtocol::DpReadReg::CTRL_STAT),
+                         ctrl_stat, ack);
+  };
+
   uint8_t response_count = 0u;
   uint8_t response_value = LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK;
   bool check_write = false;
@@ -2600,9 +2607,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransfer(bool /*in_isr*/, const uin
 
   if (response_value == LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK && check_write)
   {
-    uint32_t dummy = 0u;
     LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
-    const ErrorCode EC = dp_read_retry(3u, dummy, ack);
+    const ErrorCode EC = check_posted_ap_write_jtag(ack);
     const uint8_t V = MapAckToDapResp(ack);
 
     if (V != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
@@ -2765,6 +2771,13 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransferBlock(bool /*in_isr*/,
     }
   };
 
+  auto check_posted_ap_write_jtag = [&](LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+  {
+    uint32_t ctrl_stat = 0u;
+    return dp_read_retry(static_cast<uint8_t>(LibXR::Debug::SwdProtocol::DpReadReg::CTRL_STAT),
+                         ctrl_stat, ack);
+  };
+
   const bool AP = LibXR::USB::DapLinkV1Def::req_is_ap(DAP_RQ);
   const bool RNW = LibXR::USB::DapLinkV1Def::req_is_read(DAP_RQ);
   const uint8_t ADDR2B = LibXR::USB::DapLinkV1Def::req_addr2b(DAP_RQ);
@@ -2824,9 +2837,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransferBlock(bool /*in_isr*/,
 
     if (AP && xresp == LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK && done > 0u)
     {
-      uint32_t dummy = 0u;
       LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
-      const ErrorCode EC = dp_read_retry(3u, dummy, ack);
+      const ErrorCode EC = check_posted_ap_write_jtag(ack);
       const uint8_t V = MapAckToDapResp(ack);
       if (V != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
       {

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -3110,8 +3110,6 @@ class DapLinkV2Class : public DeviceClass
       }
 
       auto ap_read_req = LibXR::Debug::SwdProtocol::make_ap_read_req(ADDR2B);
-      const auto rdbuff_req = LibXR::Debug::SwdProtocol::make_dp_read_req(
-          LibXR::Debug::SwdProtocol::DpReadReg::RDBUFF);
       LibXR::Debug::SwdProtocol::Response ap_read_resp = {};
       ErrorCode ec = TransferTxnFast(ap_read_req, ap_read_resp);
       xresp = MapAckToDapResp(ap_read_resp.ack);
@@ -3134,23 +3132,25 @@ class DapLinkV2Class : public DeviceClass
         if (ap_read_resp.ack != LibXR::Debug::SwdProtocol::Ack::OK ||
             ec != ErrorCode::OK || !ap_read_resp.parity_ok)
         {
-          // Current AP read failed; try to flush previous pending data via RDBUFF.
+          // Current AP read failed; try to complete the previous AP read result.
           if (resp_off + 4u <= resp_cap)
           {
-            LibXR::Debug::SwdProtocol::Response rdbuff_resp = {};
-            const ErrorCode EC2 = TransferTxnFast(rdbuff_req, rdbuff_resp);
-            const uint8_t V2 = MapAckToDapResp(rdbuff_resp.ack);
+            uint32_t rdbuff_data = 0u;
+            LibXR::Debug::SwdProtocol::Ack rdbuff_ack =
+                LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
+            const ErrorCode ec2 = CompletePendingApReadFast(rdbuff_data, rdbuff_ack);
+            const uint8_t v2 = MapAckToDapResp(rdbuff_ack);
 
-            if (V2 == 1u && EC2 == ErrorCode::OK && rdbuff_resp.parity_ok)
+            if (v2 == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK && ec2 == ErrorCode::OK)
             {
-              StoreU32Le(&resp[resp_off], rdbuff_resp.rdata);
+              StoreU32Le(&resp[resp_off], rdbuff_data);
               resp_off = static_cast<uint16_t>(resp_off + 4u);
               done = static_cast<uint16_t>(i);  // done includes transfer [0..i-1]
             }
             else
             {
-              xresp = V2;
-              if (EC2 != ErrorCode::OK)
+              xresp = v2;
+              if (ec2 != ErrorCode::OK)
               {
                 xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
               }
@@ -3172,24 +3172,26 @@ class DapLinkV2Class : public DeviceClass
         xresp = CUR;
       }
 
-      // Tail flush: read final posted value from RDBUFF.
+      // Complete the final posted AP read by DP RDBUFF.
       {
-        LibXR::Debug::SwdProtocol::Response rdbuff_resp = {};
-        const ErrorCode EC2 = TransferTxnFast(rdbuff_req, rdbuff_resp);
-        const uint8_t V2 = MapAckToDapResp(rdbuff_resp.ack);
+        uint32_t rdbuff_data = 0u;
+        LibXR::Debug::SwdProtocol::Ack rdbuff_ack =
+            LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
+        const ErrorCode ec2 = CompletePendingApReadFast(rdbuff_data, rdbuff_ack);
+        const uint8_t v2 = MapAckToDapResp(rdbuff_ack);
 
-        xresp = V2;
-        if (V2 != 1u)
+        xresp = v2;
+        if (v2 != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
         {
           goto out_ap_read;  // NOLINT
         }
-        if (EC2 != ErrorCode::OK || !rdbuff_resp.parity_ok)
+        if (ec2 != ErrorCode::OK)
         {
           xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
           goto out_ap_read;  // NOLINT
         }
 
-        StoreU32Le(&resp[resp_off], rdbuff_resp.rdata);
+        StoreU32Le(&resp[resp_off], rdbuff_data);
         resp_off = static_cast<uint16_t>(resp_off + 4u);
         done = count;
       }
@@ -3375,7 +3377,7 @@ class DapLinkV2Class : public DeviceClass
       bool need_ts = false;
     } pending;
 
-    auto complete_pending_by_rdbuff = [&]() -> bool
+    auto complete_pending_ap_read_by_rdbuff = [&]() -> bool
     {
       if (!pending.valid)
       {
@@ -3417,7 +3419,8 @@ class DapLinkV2Class : public DeviceClass
       return true;
     };
 
-    auto flush_pending_if_any = [&]() -> bool { return pending.valid ? complete_pending_by_rdbuff() : true; };
+    auto complete_pending_ap_read_if_any = [&]() -> bool
+    { return pending.valid ? complete_pending_ap_read_by_rdbuff() : true; };
 
     for (uint32_t i = 0; i < COUNT; ++i)
     {
@@ -3446,7 +3449,7 @@ class DapLinkV2Class : public DeviceClass
 
       if (!RNW)
       {
-        if (!flush_pending_if_any())
+        if (!complete_pending_ap_read_if_any())
         {
           break;
         }
@@ -3504,7 +3507,7 @@ class DapLinkV2Class : public DeviceClass
       {
         if (MATCH_VALUE)
         {
-          if (!flush_pending_if_any())
+          if (!complete_pending_ap_read_if_any())
           {
             break;
           }
@@ -3577,7 +3580,7 @@ class DapLinkV2Class : public DeviceClass
 
         if (!AP)
         {
-          if (!flush_pending_if_any())
+          if (!complete_pending_ap_read_if_any())
           {
             break;
           }
@@ -3649,7 +3652,7 @@ class DapLinkV2Class : public DeviceClass
             const uint8_t FAIL = (CUR_V != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
                                      ? CUR_V
                                      : LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-            if (!complete_pending_by_rdbuff())
+            if (!complete_pending_ap_read_by_rdbuff())
             {
               break;
             }
@@ -3679,7 +3682,7 @@ class DapLinkV2Class : public DeviceClass
     if (pending.valid)
     {
       const uint8_t PRIOR_FAIL = response_value;
-      if (!complete_pending_by_rdbuff())
+      if (!complete_pending_ap_read_by_rdbuff())
       {
         // pending failure already recorded in response_value
       }

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -1542,13 +1542,18 @@ class DapLinkV2Class : public DeviceClass
     return ErrorCode::OK;
   }
 
-  ErrorCode HandleWriteABORT(bool /*in_isr*/, const uint8_t* req, uint16_t req_len,
+  ErrorCode HandleWriteABORT(bool in_isr, const uint8_t* req, uint16_t req_len,
                              uint8_t* resp, uint16_t resp_cap, uint16_t& out_len)
   {
     if (resp_cap < 2u)
     {
       out_len = 0;
       return ErrorCode::NOT_FOUND;
+    }
+
+    if (dap_state_.debug_port == LibXR::USB::DapLinkV2Def::DebugPort::JTAG)
+    {
+      return HandleJtagWriteAbort(in_isr, req, req_len, resp, resp_cap, out_len);
     }
 
     resp[0] = ToU8(LibXR::USB::DapLinkV2Def::CommandId::WRITE_ABORT);
@@ -2403,13 +2408,18 @@ class DapLinkV2Class : public DeviceClass
   // Note: The following long functions are kept as-is; no function-level docs in this
   // cpp. HPP will carry API docs.
 
-  ErrorCode HandleTransfer(bool /*in_isr*/, const uint8_t* req, uint16_t req_len,
+  ErrorCode HandleTransfer(bool in_isr, const uint8_t* req, uint16_t req_len,
                            uint8_t* resp, uint16_t resp_cap, uint16_t& out_len)
   {
     out_len = 0u;
     if (!req || !resp || resp_cap < 3u)
     {
       return ErrorCode::ARG_ERR;
+    }
+
+    if (dap_state_.debug_port == LibXR::USB::DapLinkV2Def::DebugPort::JTAG)
+    {
+      return HandleJtagTransfer(in_isr, req, req_len, resp, resp_cap, out_len);
     }
 
     resp[0] = ToU8(LibXR::USB::DapLinkV2Def::CommandId::TRANSFER);
@@ -2910,9 +2920,14 @@ class DapLinkV2Class : public DeviceClass
     out_len = resp_off;
     return ErrorCode::OK;
   }
-  ErrorCode HandleTransferBlock(bool /*in_isr*/, const uint8_t* req, uint16_t req_len,
+  ErrorCode HandleTransferBlock(bool in_isr, const uint8_t* req, uint16_t req_len,
                                 uint8_t* resp, uint16_t resp_cap, uint16_t& out_len)
   {
+    if (dap_state_.debug_port == LibXR::USB::DapLinkV2Def::DebugPort::JTAG)
+    {
+      return HandleJtagTransferBlock(in_isr, req, req_len, resp, resp_cap, out_len);
+    }
+
     // Req:  [0]=0x06 [1]=index [2..3]=count [4]=request [5..]=data(write)
     // Resp: [0]=0x06 [1..2]=done [3]=resp [4..]=data(read)
     if (!resp || resp_cap < 4u)
@@ -3615,61 +3630,33 @@ class DapLinkV2Class : public DeviceClass
           continue;
         }
 
-        if (!pending.valid)
+        uint32_t rdata = 0u;
+        ec = ap_read_retry(ADDR2B, rdata, ack);
+
+        response_value = MapAckToDapResp(ack);
+        if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
         {
-          uint32_t dummy_posted = 0u;
-          ec = ApReadPostedFast(ADDR2B, dummy_posted, ack);
-
-          response_value = MapAckToDapResp(ack);
-          if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
-          {
-            break;
-          }
-          if (ec != ErrorCode::OK)
-          {
-            response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-            break;
-          }
-
-          pending.valid = true;
-          pending.need_ts = TS;
-          response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
+          break;
         }
-        else
+        if (ec != ErrorCode::OK)
         {
-          if (!ensure_space(bytes_for_read(pending.need_ts)))
-          {
-            response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-            break;
-          }
-
-          uint32_t posted_prev = 0u;
-          ec = ApReadPostedFast(ADDR2B, posted_prev, ack);
-
-          const uint8_t CUR_V = MapAckToDapResp(ack);
-          if (CUR_V != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK || ec != ErrorCode::OK)
-          {
-            const uint8_t FAIL = (CUR_V != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
-                                     ? CUR_V
-                                     : LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-            if (!complete_pending_ap_read_by_rdbuff())
-            {
-              break;
-            }
-            response_value = FAIL;
-            break;
-          }
-
-          if (!emit_read_with_ts(pending.need_ts, posted_prev))
-          {
-            response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-            break;
-          }
-
-          pending.valid = true;
-          pending.need_ts = TS;
-          response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
+          response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+          break;
         }
+
+        if (!ensure_space(bytes_for_read(TS)))
+        {
+          response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+          break;
+        }
+
+        if (!emit_read_with_ts(TS, rdata))
+        {
+          response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+          break;
+        }
+
+        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
       }
 
       if (dap_state_.transfer_abort)
@@ -3696,7 +3683,7 @@ class DapLinkV2Class : public DeviceClass
     {
       uint32_t dummy = 0u;
       LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
-      const ErrorCode ec = DpReadRdbuffFast(dummy, ack);
+      const ErrorCode ec = dp_read_retry(3u, dummy, ack);
       const uint8_t v = MapAckToDapResp(ack);
 
       if (v != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -507,10 +507,6 @@ class DapLinkV2Class : public DeviceClass
       return;
     }
 
-    // 尽早 re-arm OUT 以覆盖 host->probe 流水 /
-    // Re-arm OUT early to overlap the host->probe pipeline.
-    ArmOutTransferIfIdle();
-
     const auto* req = static_cast<const uint8_t*>(data.addr_);
     const uint16_t REQ_LEN = static_cast<uint16_t>(data.size_);
 

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -5,6 +5,7 @@
 #include <cstring>
 
 #include "daplink_v2_def.hpp"
+#include "debug/jtag_dp.hpp"
 #include "debug/swd.hpp"
 #include "dev_core.hpp"
 #include "gpio.hpp"
@@ -95,6 +96,19 @@ class DapLinkV2Class : public DeviceClass
    * @param info Info string set
    */
   void SetInfoStrings(const InfoStrings& info) { info_ = info; }
+
+  void SetJtag(LibXR::Debug::Jtag* jtag)
+  {
+    jtag_ = jtag;
+    jtag_chain_.ir_length = jtag_ir_len_;
+    jtag_chain_.ir_before = jtag_ir_before_;
+    jtag_chain_.ir_after = jtag_ir_after_;
+    ResetJtagChainState();
+    if (jtag_ != nullptr)
+    {
+      (void)jtag_->SetClockHz(swj_clock_hz_);
+    }
+  }
 
   /**
    * @brief Get internal state
@@ -202,6 +216,10 @@ class DapLinkV2Class : public DeviceClass
 
     swj_clock_hz_ = 1'000'000u;
     (void)swd_.SetClockHz(swj_clock_hz_);
+    if (jtag_ != nullptr)
+    {
+      (void)jtag_->SetClockHz(swj_clock_hz_);
+    }
 
     // SWJ shadow defaults: SWDIO=1, nRESET=1, SWCLK=0
     last_nreset_level_high_ = true;
@@ -210,6 +228,7 @@ class DapLinkV2Class : public DeviceClass
 
     ResetResponseQueue();
     ResetQueuedCommandState();
+    ResetJtagChainState();
     ep_data_in_->SetActiveLength(0);
 
     inited_ = true;
@@ -247,6 +266,10 @@ class DapLinkV2Class : public DeviceClass
     }
 
     swd_.Close();
+    if (jtag_ != nullptr)
+    {
+      jtag_->Close();
+    }
 
     // Reset shadow defaults
     last_nreset_level_high_ = true;
@@ -1166,6 +1189,13 @@ class DapLinkV2Class : public DeviceClass
       case ToU8(LibXR::USB::DapLinkV2Def::CommandId::SWD_SEQUENCE):
         return HandleSWDSequence(in_isr, req, req_len, resp, resp_cap, out_len);
 
+      case to_u8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_SEQUENCE):
+        return HandleJTAGSequence(in_isr, req, req_len, resp, resp_cap, out_len);
+      case to_u8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_CONFIGURE):
+        return HandleJTAGConfigure(in_isr, req, req_len, resp, resp_cap, out_len);
+      case to_u8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_IDCODE):
+        return HandleJTAGIdCode(in_isr, req, req_len, resp, resp_cap, out_len);
+
       case ToU8(LibXR::USB::DapLinkV2Def::CommandId::QUEUE_COMMANDS):
         return HandleQueueCommands(in_isr, req, req_len, resp, resp_cap, out_len);
       case ToU8(LibXR::USB::DapLinkV2Def::CommandId::EXECUTE_COMMANDS):
@@ -1244,8 +1274,14 @@ class DapLinkV2Class : public DeviceClass
                                        out_len);
 
       case ToU8(LibXR::USB::DapLinkV2Def::InfoId::CAPABILITIES):
-        return BuildInfoU8Response(resp[0], LibXR::USB::DapLinkV2Def::DAP_CAP_SWD, resp,
-                                   resp_cap, out_len);
+      {
+        uint8_t caps = LibXR::USB::DapLinkV2Def::DAP_CAP_SWD;
+        if (jtag_ != nullptr)
+        {
+          caps = static_cast<uint8_t>(caps | LibXR::USB::DapLinkV2Def::DAP_CAP_JTAG);
+        }
+        return BuildInfoU8Response(resp[0], caps, resp, resp_cap, out_len);
+      }
       case ToU8(LibXR::USB::DapLinkV2Def::InfoId::PACKET_COUNT):
         return BuildInfoU8Response(resp[0], PACKET_COUNT_EFFECTIVE, resp, resp_cap,
                                    out_len);
@@ -1383,7 +1419,6 @@ class DapLinkV2Class : public DeviceClass
       port = req[1];
     }
 
-    // SWD-only
     if (port == 0u || port == ToU8(LibXR::USB::DapLinkV2Def::Port::SWD))
     {
       (void)swd_.EnterSwd();
@@ -1394,6 +1429,29 @@ class DapLinkV2Class : public DeviceClass
       ResetQueuedCommandState();
 
       resp[1] = ToU8(LibXR::USB::DapLinkV2Def::Port::SWD);
+    }
+    else if (port == ToU8(LibXR::USB::DapLinkV2Def::Port::JTAG))
+    {
+      if (jtag_ == nullptr)
+      {
+        resp[1] = ToU8(LibXR::USB::DapLinkV2Def::Port::DISABLED);
+      }
+      else
+      {
+        static constexpr uint8_t SWD_TO_JTAG_SEQUENCE[2] = {0x3Cu, 0xE7u};
+        (void)swd_.SetClockHz(swj_clock_hz_);
+        (void)swd_.LineReset();
+        (void)swd_.SeqWriteBits(16u, SWD_TO_JTAG_SEQUENCE);
+        (void)swd_.LineReset();
+        (void)jtag_->SetClockHz(swj_clock_hz_);
+        (void)jtag_->ResetTap();
+
+        dap_state_.debug_port = LibXR::USB::DapLinkV2Def::DebugPort::JTAG;
+        dap_state_.transfer_abort = false;
+        ResetQueuedCommandState();
+        ResetJtagChainState();
+        resp[1] = ToU8(LibXR::USB::DapLinkV2Def::Port::JTAG);
+      }
     }
     else
     {
@@ -1415,6 +1473,10 @@ class DapLinkV2Class : public DeviceClass
     }
 
     swd_.Close();
+    if (jtag_ != nullptr)
+    {
+      jtag_->Close();
+    }
     dap_state_.debug_port = LibXR::USB::DapLinkV2Def::DebugPort::DISABLED;
     dap_state_.transfer_abort = false;
     ResetQueuedCommandState();
@@ -1691,6 +1753,10 @@ class DapLinkV2Class : public DeviceClass
 
     swj_clock_hz_ = hz;
     (void)swd_.SetClockHz(hz);
+    if (jtag_ != nullptr)
+    {
+      (void)jtag_->SetClockHz(hz);
+    }
 
     resp[1] = ToU8(LibXR::USB::DapLinkV2Def::Status::OK);
     out_len = 2u;
@@ -1891,6 +1957,203 @@ class DapLinkV2Class : public DeviceClass
     return ErrorCode::OK;
   }
 
+  ErrorCode HandleJTAGSequence(bool /*in_isr*/, const uint8_t* req, uint16_t req_len,
+                               uint8_t* resp, uint16_t resp_cap, uint16_t& out_len)
+  {
+    if (!req || !resp || resp_cap < 2u)
+    {
+      out_len = 0u;
+      return ErrorCode::ARG_ERR;
+    }
+
+    resp[0] = to_u8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_SEQUENCE);
+    resp[1] = DAP_OK;
+    out_len = 2u;
+
+    if (jtag_ == nullptr)
+    {
+      resp[1] = DAP_ERROR;
+      return ErrorCode::OK;
+    }
+
+    if (req_len < 2u)
+    {
+      resp[1] = DAP_ERROR;
+      return ErrorCode::ARG_ERR;
+    }
+
+    const uint8_t SEQ_CNT = req[1];
+    uint16_t req_off = 2u;
+    uint16_t resp_off = 2u;
+
+    for (uint32_t s = 0; s < SEQ_CNT; ++s)
+    {
+      if (req_off >= req_len)
+      {
+        resp[1] = DAP_ERROR;
+        out_len = 2u;
+        return ErrorCode::ARG_ERR;
+      }
+
+      const uint8_t INFO = req[req_off++];
+      uint32_t cycles = static_cast<uint32_t>(INFO & 0x3Fu);
+      if (cycles == 0u)
+      {
+        cycles = 64u;
+      }
+
+      const bool TMS = ((INFO & LibXR::Debug::JtagProtocol::JTAG_SEQUENCE_TMS) != 0u);
+      const bool CAPTURE = ((INFO & LibXR::Debug::JtagProtocol::JTAG_SEQUENCE_TDO) != 0u);
+      const uint16_t BYTES = static_cast<uint16_t>((cycles + 7u) / 8u);
+
+      if (req_off + BYTES > req_len)
+      {
+        resp[1] = DAP_ERROR;
+        out_len = 2u;
+        return ErrorCode::ARG_ERR;
+      }
+      if (CAPTURE && (resp_off + BYTES > resp_cap))
+      {
+        resp[1] = DAP_ERROR;
+        out_len = 2u;
+        return ErrorCode::NOT_FOUND;
+      }
+
+      const uint8_t* data = &req[req_off];
+      uint8_t* out = CAPTURE ? &resp[resp_off] : nullptr;
+      if (CAPTURE)
+      {
+        Memory::FastSet(out, 0, BYTES);
+      }
+
+      const ErrorCode ec = jtag_->Sequence(cycles, TMS, data, out);
+      if (ec != ErrorCode::OK)
+      {
+        resp[1] = DAP_ERROR;
+        out_len = 2u;
+        return ErrorCode::OK;
+      }
+
+      req_off = static_cast<uint16_t>(req_off + BYTES);
+      if (CAPTURE)
+      {
+        resp_off = static_cast<uint16_t>(resp_off + BYTES);
+      }
+    }
+
+    out_len = resp_off;
+    return ErrorCode::OK;
+  }
+
+  ErrorCode HandleJTAGConfigure(bool /*in_isr*/, const uint8_t* req, uint16_t req_len,
+                                uint8_t* resp, uint16_t resp_cap, uint16_t& out_len)
+  {
+    if (!req || !resp || resp_cap < 2u)
+    {
+      out_len = 0u;
+      return ErrorCode::ARG_ERR;
+    }
+
+    resp[0] = to_u8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_CONFIGURE);
+    resp[1] = DAP_OK;
+    out_len = 2u;
+
+    if (jtag_ == nullptr)
+    {
+      resp[1] = DAP_ERROR;
+      return ErrorCode::OK;
+    }
+
+    if (req_len < 2u)
+    {
+      resp[1] = DAP_ERROR;
+      return ErrorCode::ARG_ERR;
+    }
+
+    const uint8_t count = req[1];
+    if (count > JTAG_MAX_DEVICES || req_len < static_cast<uint16_t>(2u + count))
+    {
+      resp[1] = DAP_ERROR;
+      return ErrorCode::ARG_ERR;
+    }
+
+    Memory::FastSet(jtag_ir_len_, 0, sizeof(jtag_ir_len_));
+    Memory::FastSet(jtag_ir_before_, 0, sizeof(jtag_ir_before_));
+    Memory::FastSet(jtag_ir_after_, 0, sizeof(jtag_ir_after_));
+
+    uint32_t bits = 0u;
+    for (uint32_t i = 0; i < count; ++i)
+    {
+      const uint8_t len = req[static_cast<uint16_t>(2u + i)];
+      jtag_ir_len_[i] = len;
+      jtag_ir_before_[i] = static_cast<uint16_t>(bits);
+      bits += len;
+    }
+    for (uint32_t i = 0; i < count; ++i)
+    {
+      bits -= jtag_ir_len_[i];
+      jtag_ir_after_[i] = static_cast<uint16_t>(bits);
+    }
+
+    jtag_chain_.count = count;
+    if (jtag_chain_.index >= jtag_chain_.count)
+    {
+      jtag_chain_.index = 0u;
+    }
+    jtag_chain_.ir_before_bits_len = 0u;
+    jtag_chain_.ir_after_bits_len = 0u;
+    jtag_chain_.dr_before_bits_len = 0u;
+    jtag_chain_.dr_after_bits_len = 0u;
+    return ErrorCode::OK;
+  }
+
+  ErrorCode HandleJTAGIdCode(bool /*in_isr*/, const uint8_t* req, uint16_t req_len,
+                             uint8_t* resp, uint16_t resp_cap, uint16_t& out_len)
+  {
+    if (!req || !resp || resp_cap < 6u)
+    {
+      out_len = 0u;
+      return ErrorCode::ARG_ERR;
+    }
+
+    resp[0] = to_u8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_IDCODE);
+    resp[1] = DAP_ERROR;
+    out_len = 2u;
+
+    if (jtag_ == nullptr ||
+        dap_state_.debug_port != LibXR::USB::DapLinkV2Def::DebugPort::JTAG)
+    {
+      return ErrorCode::OK;
+    }
+
+    if (req_len < 2u)
+    {
+      return ErrorCode::ARG_ERR;
+    }
+
+    const uint8_t index = req[1];
+    if (index >= jtag_chain_.count)
+    {
+      return ErrorCode::OK;
+    }
+
+    jtag_chain_.index = index;
+    LibXR::Debug::JtagProtocol::UpdateChainCache(jtag_chain_);
+
+    LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
+    uint32_t idcode = 0u;
+    const ErrorCode ec = dp.ReadIdCode(idcode);
+    if (ec != ErrorCode::OK)
+    {
+      return ec;
+    }
+
+    resp[1] = DAP_OK;
+    Memory::FastCopy(&resp[2], &idcode, sizeof(idcode));
+    out_len = 6u;
+    return ErrorCode::OK;
+  }
+
   /**
    * @brief Queue one packed command batch for later EXECUTE_COMMANDS
    */
@@ -1992,6 +2255,23 @@ class DapLinkV2Class : public DeviceClass
   {
     static constexpr uint8_t ACK_MAP[8] = {7u, 1u, 2u, 7u, 4u, 7u, 7u, 7u};
     return ACK_MAP[static_cast<uint8_t>(ack) & 0x07u];
+  }
+
+  uint8_t MapAckToDapResp(LibXR::Debug::JtagProtocol::Ack ack) const
+  {
+    switch (ack)
+    {
+      case LibXR::Debug::JtagProtocol::Ack::OK:
+        return 1u;
+      case LibXR::Debug::JtagProtocol::Ack::WAIT:
+        return 2u;
+      case LibXR::Debug::JtagProtocol::Ack::FAULT:
+        return 4u;
+      case LibXR::Debug::JtagProtocol::Ack::NO_ACK:
+      case LibXR::Debug::JtagProtocol::Ack::PROTOCOL:
+      default:
+        return 7u;
+    }
   }
 
   static inline uint16_t LoadU16Le(const uint8_t* p)
@@ -2871,6 +3151,307 @@ class DapLinkV2Class : public DeviceClass
       out_len = resp_off;
       return ErrorCode::OK;
     }
+  }
+
+  ErrorCode HandleJtagTransfer(bool /*in_isr*/, const uint8_t* req, uint16_t req_len,
+                               uint8_t* resp, uint16_t resp_cap, uint16_t& out_len)
+  {
+    out_len = 0u;
+    if (!req || !resp || resp_cap < 3u)
+    {
+      return ErrorCode::ARG_ERR;
+    }
+
+    resp[0] = to_u8(LibXR::USB::DapLinkV2Def::CommandId::TRANSFER);
+    resp[1] = 0u;
+    resp[2] = 0u;
+    uint16_t resp_off = 3u;
+
+    if (req_len < 3u || jtag_ == nullptr || jtag_chain_.count == 0u)
+    {
+      resp[2] = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+      out_len = 3u;
+      return ErrorCode::OK;
+    }
+
+    if (dap_state_.transfer_abort)
+    {
+      dap_state_.transfer_abort = false;
+      resp[2] = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+      out_len = 3u;
+      return ErrorCode::OK;
+    }
+
+    const uint8_t TAP_INDEX = req[1];
+    if (TAP_INDEX >= jtag_chain_.count)
+    {
+      resp[2] = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+      out_len = 3u;
+      return ErrorCode::OK;
+    }
+
+    jtag_chain_.index = TAP_INDEX;
+    LibXR::Debug::JtagProtocol::UpdateChainCache(jtag_chain_);
+    LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
+
+    const uint8_t COUNT = req[2];
+    uint16_t req_off = 3u;
+    uint8_t response_count = 0u;
+    uint8_t response_value = 0u;
+
+    auto push_u32 = [&](uint32_t v) -> bool
+    {
+      if (resp_off + 4u > resp_cap)
+      {
+        return false;
+      }
+      Memory::FastCopy(&resp[resp_off], &v, sizeof(v));
+      resp_off = static_cast<uint16_t>(resp_off + 4u);
+      return true;
+    };
+
+    for (uint32_t i = 0; i < COUNT; ++i)
+    {
+      if (req_off >= req_len)
+      {
+        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+
+      const uint8_t RQ = req[req_off++];
+      const bool AP = LibXR::USB::DapLinkV2Def::req_is_ap(RQ);
+      const bool RNW = LibXR::USB::DapLinkV2Def::req_is_read(RQ);
+      const uint8_t ADDR2B = LibXR::USB::DapLinkV2Def::req_addr2b(RQ);
+      const bool MATCH_VALUE =
+          ((RQ & LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MATCH_VALUE) != 0u);
+      const bool MATCH_MASK =
+          ((RQ & LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MATCH_MASK) != 0u);
+
+      if (MATCH_VALUE || MATCH_MASK)
+      {
+        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+
+      if (!RNW)
+      {
+        if (req_off + 4u > req_len)
+        {
+          response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+          break;
+        }
+
+        uint32_t wdata = 0u;
+        Memory::FastCopy(&wdata, &req[req_off], sizeof(wdata));
+        req_off = static_cast<uint16_t>(req_off + 4u);
+
+        LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+        ErrorCode ec = ErrorCode::OK;
+        if (AP)
+        {
+          ec = dp.ApWrite(ADDR2B, wdata, ack);
+        }
+        else
+        {
+          ec = dp.DpWrite(ADDR2B, wdata, ack);
+        }
+
+        response_value = MapAckToDapResp(ack);
+        if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+        {
+          break;
+        }
+        if (ec != ErrorCode::OK)
+        {
+          response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+          break;
+        }
+
+        response_count++;
+        continue;
+      }
+
+      uint32_t rdata = 0u;
+      LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+      ErrorCode ec = ErrorCode::OK;
+      if (AP)
+      {
+        ec = dp.ApRead(ADDR2B, rdata, ack);
+      }
+      else
+      {
+        ec = dp.DpRead(ADDR2B, rdata, ack);
+      }
+
+      response_value = MapAckToDapResp(ack);
+      if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+      {
+        break;
+      }
+      if (ec != ErrorCode::OK)
+      {
+        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+      if (!push_u32(rdata))
+      {
+        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+
+      response_count++;
+    }
+
+    resp[1] = response_count;
+    resp[2] = response_value;
+    out_len = resp_off;
+    return ErrorCode::OK;
+  }
+
+  ErrorCode HandleJtagTransferBlock(bool /*in_isr*/, const uint8_t* req, uint16_t req_len,
+                                    uint8_t* resp, uint16_t resp_cap, uint16_t& out_len)
+  {
+    if (!req || !resp || resp_cap < 4u)
+    {
+      out_len = 0u;
+      return ErrorCode::ARG_ERR;
+    }
+
+    resp[0] = ToU8(LibXR::USB::DapLinkV2Def::CommandId::TRANSFER_BLOCK);
+    resp[1] = 0u;
+    resp[2] = 0u;
+    resp[3] = 0u;
+    out_len = 4u;
+
+    if (req_len < 5u || jtag_ == nullptr || jtag_chain_.count == 0u)
+    {
+      resp[3] = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+      return ErrorCode::OK;
+    }
+
+    const uint8_t TAP_INDEX = req[1];
+    if (TAP_INDEX >= jtag_chain_.count)
+    {
+      resp[3] = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+      return ErrorCode::OK;
+    }
+
+    jtag_chain_.index = TAP_INDEX;
+    LibXR::Debug::JtagProtocol::UpdateChainCache(jtag_chain_);
+
+    uint16_t count = 0u;
+    Memory::FastCopy(&count, &req[2], sizeof(count));
+    const uint8_t DAP_RQ = req[4];
+    const bool AP = LibXR::USB::DapLinkV2Def::req_is_ap(DAP_RQ);
+    const bool RNW = LibXR::USB::DapLinkV2Def::req_is_read(DAP_RQ);
+    const uint8_t ADDR2B = LibXR::USB::DapLinkV2Def::req_addr2b(DAP_RQ);
+
+    LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
+    uint16_t done = 0u;
+    uint8_t xresp = 0u;
+    uint16_t req_off = 5u;
+    uint16_t resp_off = 4u;
+
+    if (!RNW)
+    {
+      for (uint32_t i = 0; i < count; ++i)
+      {
+        if (req_off + 4u > req_len)
+        {
+          xresp = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+          break;
+        }
+        uint32_t wdata = 0u;
+        Memory::FastCopy(&wdata, &req[req_off], sizeof(wdata));
+        req_off = static_cast<uint16_t>(req_off + 4u);
+
+        LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+        ErrorCode ec = AP ? dp.ApWrite(ADDR2B, wdata, ack) : dp.DpWrite(ADDR2B, wdata, ack);
+        xresp = MapAckToDapResp(ack);
+        if (xresp != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK || ec != ErrorCode::OK)
+        {
+          if (ec != ErrorCode::OK && xresp == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+          {
+            xresp = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+          }
+          break;
+        }
+        done = static_cast<uint16_t>(i + 1u);
+      }
+      Memory::FastCopy(&resp[1], &done, sizeof(done));
+      resp[3] = xresp;
+      out_len = 4u;
+      return ErrorCode::OK;
+    }
+
+    for (uint32_t i = 0; i < count; ++i)
+    {
+      if (resp_off + 4u > resp_cap)
+      {
+        xresp = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+      uint32_t rdata = 0u;
+      LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+      ErrorCode ec = AP ? dp.ApRead(ADDR2B, rdata, ack) : dp.DpRead(ADDR2B, rdata, ack);
+      xresp = MapAckToDapResp(ack);
+      if (xresp != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK || ec != ErrorCode::OK)
+      {
+        if (ec != ErrorCode::OK && xresp == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+        {
+          xresp = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        }
+        break;
+      }
+      Memory::FastCopy(&resp[resp_off], &rdata, sizeof(rdata));
+      resp_off = static_cast<uint16_t>(resp_off + 4u);
+      done = static_cast<uint16_t>(i + 1u);
+    }
+
+    Memory::FastCopy(&resp[1], &done, sizeof(done));
+    resp[3] = xresp;
+    out_len = resp_off;
+    return ErrorCode::OK;
+  }
+
+  ErrorCode HandleJtagWriteAbort(bool /*in_isr*/, const uint8_t* req, uint16_t req_len,
+                                 uint8_t* resp, uint16_t resp_cap, uint16_t& out_len)
+  {
+    if (!req || !resp || resp_cap < 2u)
+    {
+      out_len = 0u;
+      return ErrorCode::ARG_ERR;
+    }
+
+    resp[0] = ToU8(LibXR::USB::DapLinkV2Def::CommandId::WRITE_ABORT);
+    resp[1] = DAP_ERROR;
+    out_len = 2u;
+
+    if (req_len < 6u || jtag_ == nullptr || jtag_chain_.count == 0u)
+    {
+      return ErrorCode::ARG_ERR;
+    }
+
+    const uint8_t TAP_INDEX = req[1];
+    if (TAP_INDEX >= jtag_chain_.count)
+    {
+      return ErrorCode::OK;
+    }
+
+    jtag_chain_.index = TAP_INDEX;
+    LibXR::Debug::JtagProtocol::UpdateChainCache(jtag_chain_);
+
+    uint32_t flags = 0u;
+    Memory::FastCopy(&flags, &req[2], sizeof(flags));
+
+    LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
+    LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+    const ErrorCode ec = dp.WriteAbort(flags, ack);
+    if (ec == ErrorCode::OK && ack == LibXR::Debug::JtagProtocol::Ack::OK)
+    {
+      resp[1] = DAP_OK;
+    }
+    return ErrorCode::OK;
   }
 
  private:

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -3984,6 +3984,22 @@ class DapLinkV2Class : public DeviceClass
     }
   }
 
+  void ResetJtagChainState()
+  {
+    jtag_chain_.ir_length = jtag_ir_len_;
+    jtag_chain_.ir_before = jtag_ir_before_;
+    jtag_chain_.ir_after = jtag_ir_after_;
+    jtag_chain_.count = 0u;
+    jtag_chain_.index = 0u;
+    jtag_chain_.ir_before_bits_len = 0u;
+    jtag_chain_.ir_after_bits_len = 0u;
+    jtag_chain_.dr_before_bits_len = 0u;
+    jtag_chain_.dr_after_bits_len = 0u;
+    Memory::FastSet(jtag_ir_len_, 0, sizeof(jtag_ir_len_));
+    Memory::FastSet(jtag_ir_before_, 0, sizeof(jtag_ir_before_));
+    Memory::FastSet(jtag_ir_after_, 0, sizeof(jtag_ir_after_));
+  }
+
   void DelayUsIfAllowed(bool /*in_isr*/, uint32_t us)
   {
     LibXR::Timebase::DelayMicroseconds(us);
@@ -4000,6 +4016,7 @@ class DapLinkV2Class : public DeviceClass
   // transfer_count > 255 and "expected X, got Y" mismatch.
   static constexpr uint16_t OPENOCD_SAFE_DAP_PACKET_SIZE =
       static_cast<uint16_t>((255u * 5u) + 4u);
+  static constexpr uint8_t JTAG_MAX_DEVICES = 16u;
   // Host-visible CMSIS-DAP packet size; endpoint MPS limits are handled by
   // TransferMultiBulk segmentation/reassembly.
   static constexpr uint16_t MAX_DAP_PACKET_SIZE = MaxDapPacketSize;
@@ -4087,6 +4104,12 @@ LIBXR_PACKED_END
 
  private:
   SwdPort& swd_;  ///< SWD 链路 / SWD link
+
+  LibXR::Debug::Jtag* jtag_ = nullptr;  ///< JTAG 链路 / JTAG link
+  LibXR::Debug::JtagProtocol::ChainConfig jtag_chain_{};  ///< JTAG 链状态 / JTAG chain state
+  uint8_t jtag_ir_len_[JTAG_MAX_DEVICES] = {};  ///< JTAG IR 长度 / JTAG IR lengths
+  uint16_t jtag_ir_before_[JTAG_MAX_DEVICES] = {};  ///< 目标前 IR 位数 / IR bits before target
+  uint16_t jtag_ir_after_[JTAG_MAX_DEVICES] = {};  ///< 目标后 IR 位数 / IR bits after target
 
   LibXR::GPIO* nreset_gpio_ = nullptr;  ///< Optional nRESET GPIO
 

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -2349,7 +2349,13 @@ class DapLinkV2Class : public DeviceClass
     return ErrorCode::OK;
   }
 
-  ErrorCode RecoverAfterApWriteFast(LibXR::Debug::SwdProtocol::Ack& ack_out)
+  ErrorCode CompletePendingApReadFast(uint32_t& val,
+                                      LibXR::Debug::SwdProtocol::Ack& ack_out)
+  {
+    return DpReadRdbuffFast(val, ack_out);
+  }
+
+  ErrorCode CheckPostedApWriteFast(LibXR::Debug::SwdProtocol::Ack& ack_out)
   {
     LibXR::Debug::SwdProtocol::Response swd_resp = {};
     const auto req = LibXR::Debug::SwdProtocol::make_dp_read_req(
@@ -2457,9 +2463,9 @@ class DapLinkV2Class : public DeviceClass
     // Keep reference behavior: if no transfer executes, response_value remains 0.
     uint8_t response_value = 0u;
 
-    // AP writes are posted by the target.  Keep the write batch fast and
-    // recover once at a transfer boundary instead of after every AP write.
-    bool check_ap_write = false;
+    // AP writes are posted by the target. Keep the write batch fast and check
+    // it once at a transfer boundary with DP CTRL/STAT, not DP RDBUFF.
+    bool pending_ap_write = false;
 
     // -------- posted-read pipeline state (AP read only) --------
     struct PendingApRead
@@ -2485,9 +2491,9 @@ class DapLinkV2Class : public DeviceClass
       return true;
     };
 
-    // Complete a pending AP read by DP_RDBUFF
-    // (used on sequence tail, AP-read interruption, or abnormal tail handling).
-    auto complete_pending_by_rdbuff = [&]() -> bool
+    // Complete a pending AP read by DP RDBUFF.
+    // RDBUFF is the AP read-result pipe outlet, not the AP-write checker.
+    auto complete_pending_ap_read = [&]() -> bool
     {
       if (!pending.valid)
       {
@@ -2502,7 +2508,7 @@ class DapLinkV2Class : public DeviceClass
 
       uint32_t rdata = 0u;
       LibXR::Debug::SwdProtocol::Ack ack = LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
-      const ErrorCode EC = DpReadRdbuffFast(rdata, ack);
+      const ErrorCode EC = CompletePendingApReadFast(rdata, ack);
 
       const uint8_t V = MapAckToDapResp(ack);
       if (V != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
@@ -2525,43 +2531,40 @@ class DapLinkV2Class : public DeviceClass
       pending.valid = false;
       pending.need_ts = false;
 
-      // RDBUFF completes an AP read; it does not validate posted AP writes.
-
       // 成功路径保持 OK
       response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
       return true;
     };
 
-    auto recover_ap_write_if_any = [&]() -> bool
+    auto check_posted_ap_write_if_pending = [&]() -> bool
     {
-      if (!check_ap_write)
+      if (!pending_ap_write)
       {
         return true;
       }
-      LibXR::Debug::SwdProtocol::Ack recover_ack =
+      LibXR::Debug::SwdProtocol::Ack check_ack =
           LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
-      const ErrorCode recover_ec = RecoverAfterApWriteFast(recover_ack);
-      response_value = MapAckToDapResp(recover_ack);
+      const ErrorCode check_ec = CheckPostedApWriteFast(check_ack);
+      response_value = MapAckToDapResp(check_ack);
       if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
       {
         return false;
       }
-      if (recover_ec != ErrorCode::OK)
+      if (check_ec != ErrorCode::OK)
       {
         response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
         return false;
       }
-      check_ap_write = false;
+      pending_ap_write = false;
       return true;
     };
 
-    // Flush pending AP read before handling non-AP normal read
-    // to keep response ordering stable.
-    auto flush_pending_if_any = [&]() -> bool
-    { return pending.valid ? complete_pending_by_rdbuff() : true; };
+    // Complete pending AP read before non-AP operations to keep response order.
+    auto complete_pending_ap_read_if_any = [&]() -> bool
+    { return pending.valid ? complete_pending_ap_read() : true; };
 
     auto close_posted_state = [&]() -> bool
-    { return flush_pending_if_any() && recover_ap_write_if_any(); };
+    { return complete_pending_ap_read_if_any() && check_posted_ap_write_if_pending(); };
 
     // -------- main loop --------
     for (uint32_t i = 0; i < COUNT; ++i)
@@ -2599,7 +2602,7 @@ class DapLinkV2Class : public DeviceClass
         // ---------------- WRITE ----------------
         // A write can follow previous AP writes without forcing a recovery.
         // Only close an AP-read pipeline before consuming write data.
-        if (!flush_pending_if_any())
+        if (!complete_pending_ap_read_if_any())
         {
           break;
         }
@@ -2643,7 +2646,7 @@ class DapLinkV2Class : public DeviceClass
 
         if (AP)
         {
-          check_ap_write = true;
+          pending_ap_write = true;
         }
 
         if (TS)
@@ -2784,7 +2787,7 @@ class DapLinkV2Class : public DeviceClass
 
         // AP reads can observe previous AP writes, so close posted writes
         // before starting or extending the posted-read pipeline.
-        if (!recover_ap_write_if_any())
+        if (!check_posted_ap_write_if_pending())
         {
           break;
         }
@@ -2833,17 +2836,17 @@ class DapLinkV2Class : public DeviceClass
           const uint8_t CUR_V = MapAckToDapResp(ack);
           if (CUR_V != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK || ec != ErrorCode::OK)
           {
-            // Current AP read failed: try best effort to complete pending by RDBUFF.
+            // Current AP read failed: try best effort to complete pending AP read.
             // Otherwise, response_count may miss one and pipeline may remain dirty.
             const uint8_t PROOR_FAIL =
                 (CUR_V != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
                     ? CUR_V
                     : LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
 
-            if (!complete_pending_by_rdbuff())
+            if (!complete_pending_ap_read())
             {
               // Pending itself failed: return earlier failure
-              // (complete_pending_by_rdbuff already wrote response_value).
+              // (complete_pending_ap_read already wrote response_value).
               break;
             }
 
@@ -2882,7 +2885,7 @@ class DapLinkV2Class : public DeviceClass
     {
       const uint8_t PRIOR_FAIL = response_value;
 
-      if (!complete_pending_by_rdbuff())
+      if (!complete_pending_ap_read())
       {
         // Pending failure wins here (response_value already written).
       }
@@ -2898,7 +2901,7 @@ class DapLinkV2Class : public DeviceClass
     }
 
     if (response_value == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK &&
-        !recover_ap_write_if_any())
+        !check_posted_ap_write_if_pending())
     {
       // response_value is already set by the recovery helper.
     }
@@ -3012,11 +3015,11 @@ class DapLinkV2Class : public DeviceClass
         }
         if (xresp == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK && done != 0u)
         {
-          LibXR::Debug::SwdProtocol::Ack recover_ack =
+          LibXR::Debug::SwdProtocol::Ack check_ack =
               LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
-          const ErrorCode recover_ec = RecoverAfterApWriteFast(recover_ack);
-          xresp = MapAckToDapResp(recover_ack);
-          if (recover_ack == LibXR::Debug::SwdProtocol::Ack::OK && recover_ec != ErrorCode::OK)
+          const ErrorCode check_ec = CheckPostedApWriteFast(check_ack);
+          xresp = MapAckToDapResp(check_ack);
+          if (check_ack == LibXR::Debug::SwdProtocol::Ack::OK && check_ec != ErrorCode::OK)
           {
             xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
           }

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -3487,6 +3487,7 @@ class DapLinkV2Class : public DeviceClass
 
         if (MATCH_MASK)
         {
+          match_mask_ = wdata;
           response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
           response_count++;
           continue;
@@ -3522,7 +3523,10 @@ class DapLinkV2Class : public DeviceClass
         }
 
         response_count++;
-        check_write = true;
+        if (AP)
+        {
+          check_write = true;
+        }
       }
       else
       {
@@ -3895,7 +3899,7 @@ class DapLinkV2Class : public DeviceClass
         done = static_cast<uint16_t>(i + 1u);
       }
 
-      if (xresp == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK && done > 0u)
+      if (AP && xresp == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK && done > 0u)
       {
         uint32_t dummy = 0u;
         LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -101,8 +101,6 @@ class DapLinkV2Class : public DeviceClass
   {
     jtag_ = jtag;
     jtag_chain_.ir_length = jtag_ir_len_;
-    jtag_chain_.ir_before = jtag_ir_before_;
-    jtag_chain_.ir_after = jtag_ir_after_;
     ResetJtagChainState();
     if (jtag_ != nullptr)
     {
@@ -2079,21 +2077,13 @@ class DapLinkV2Class : public DeviceClass
     }
 
     Memory::FastSet(jtag_ir_len_, 0, sizeof(jtag_ir_len_));
-    Memory::FastSet(jtag_ir_before_, 0, sizeof(jtag_ir_before_));
-    Memory::FastSet(jtag_ir_after_, 0, sizeof(jtag_ir_after_));
 
     uint32_t bits = 0u;
     for (uint32_t i = 0; i < count; ++i)
     {
       const uint8_t len = req[static_cast<uint16_t>(2u + i)];
       jtag_ir_len_[i] = len;
-      jtag_ir_before_[i] = static_cast<uint16_t>(bits);
       bits += len;
-    }
-    for (uint32_t i = 0; i < count; ++i)
-    {
-      bits -= jtag_ir_len_[i];
-      jtag_ir_after_[i] = static_cast<uint16_t>(bits);
     }
 
     jtag_chain_.count = count;
@@ -2143,7 +2133,23 @@ class DapLinkV2Class : public DeviceClass
 
     LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
     uint32_t idcode = 0u;
-    const ErrorCode ec = dp.ReadIdCode(idcode);
+    ErrorCode ec = dp.ReadIdCode(idcode);
+    if (ec == ErrorCode::OK && (idcode == 0u || idcode == 0xFFFF'FFFFu ||
+                                ((idcode & 0x1u) == 0u)) &&
+        jtag_ir_len_[index] != 4u)
+    {
+      uint32_t fallback_idcode = 0u;
+      ec = dp.ReadIdCodeWithIr(0x01u, fallback_idcode);
+      if (ec != ErrorCode::OK)
+      {
+        return ec;
+      }
+      if (fallback_idcode != 0u && fallback_idcode != 0xFFFF'FFFFu &&
+          ((fallback_idcode & 0x1u) != 0u))
+      {
+        idcode = fallback_idcode;
+      }
+    }
     if (ec != ErrorCode::OK)
     {
       return ec;
@@ -4030,8 +4036,6 @@ class DapLinkV2Class : public DeviceClass
   void ResetJtagChainState()
   {
     jtag_chain_.ir_length = jtag_ir_len_;
-    jtag_chain_.ir_before = jtag_ir_before_;
-    jtag_chain_.ir_after = jtag_ir_after_;
     jtag_chain_.count = 0u;
     jtag_chain_.index = 0u;
     jtag_chain_.ir_before_bits_len = 0u;
@@ -4039,8 +4043,6 @@ class DapLinkV2Class : public DeviceClass
     jtag_chain_.dr_before_bits_len = 0u;
     jtag_chain_.dr_after_bits_len = 0u;
     Memory::FastSet(jtag_ir_len_, 0, sizeof(jtag_ir_len_));
-    Memory::FastSet(jtag_ir_before_, 0, sizeof(jtag_ir_before_));
-    Memory::FastSet(jtag_ir_after_, 0, sizeof(jtag_ir_after_));
   }
 
   void DelayUsIfAllowed(bool /*in_isr*/, uint32_t us)
@@ -4151,8 +4153,6 @@ LIBXR_PACKED_END
   LibXR::Debug::Jtag* jtag_ = nullptr;  ///< JTAG 链路 / JTAG link
   LibXR::Debug::JtagProtocol::ChainConfig jtag_chain_{};  ///< JTAG 链状态 / JTAG chain state
   uint8_t jtag_ir_len_[JTAG_MAX_DEVICES] = {};  ///< JTAG IR 长度 / JTAG IR lengths
-  uint16_t jtag_ir_before_[JTAG_MAX_DEVICES] = {};  ///< 目标前 IR 位数 / IR bits before target
-  uint16_t jtag_ir_after_[JTAG_MAX_DEVICES] = {};  ///< 目标后 IR 位数 / IR bits after target
 
   LibXR::GPIO* nreset_gpio_ = nullptr;  ///< Optional nRESET GPIO
 

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -2457,8 +2457,9 @@ class DapLinkV2Class : public DeviceClass
     // Keep reference behavior: if no transfer executes, response_value remains 0.
     uint8_t response_value = 0u;
 
-    // Whether a final DP_RDBUFF flush is required for write-fault cleanup.
-    bool check_write = false;
+    // AP writes are posted by the target.  Keep the write batch fast and
+    // recover once at a transfer boundary instead of after every AP write.
+    bool check_ap_write = false;
 
     // -------- posted-read pipeline state (AP read only) --------
     struct PendingApRead
@@ -2524,11 +2525,33 @@ class DapLinkV2Class : public DeviceClass
       pending.valid = false;
       pending.need_ts = false;
 
-      // RDBUFF has been read; equivalent to one posted/fault flush.
-      check_write = false;
+      // RDBUFF completes an AP read; it does not validate posted AP writes.
 
       // 成功路径保持 OK
       response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
+      return true;
+    };
+
+    auto recover_ap_write_if_any = [&]() -> bool
+    {
+      if (!check_ap_write)
+      {
+        return true;
+      }
+      LibXR::Debug::SwdProtocol::Ack recover_ack =
+          LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
+      const ErrorCode recover_ec = RecoverAfterApWriteFast(recover_ack);
+      response_value = MapAckToDapResp(recover_ack);
+      if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+      {
+        return false;
+      }
+      if (recover_ec != ErrorCode::OK)
+      {
+        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        return false;
+      }
+      check_ap_write = false;
       return true;
     };
 
@@ -2536,6 +2559,9 @@ class DapLinkV2Class : public DeviceClass
     // to keep response ordering stable.
     auto flush_pending_if_any = [&]() -> bool
     { return pending.valid ? complete_pending_by_rdbuff() : true; };
+
+    auto close_posted_state = [&]() -> bool
+    { return flush_pending_if_any() && recover_ap_write_if_any(); };
 
     // -------- main loop --------
     for (uint32_t i = 0; i < COUNT; ++i)
@@ -2571,8 +2597,8 @@ class DapLinkV2Class : public DeviceClass
       if (!RNW)
       {
         // ---------------- WRITE ----------------
-        // Config-like operations do not participate in AP posted pipeline;
-        // flush pending first.
+        // A write can follow previous AP writes without forcing a recovery.
+        // Only close an AP-read pipeline before consuming write data.
         if (!flush_pending_if_any())
         {
           break;
@@ -2617,17 +2643,7 @@ class DapLinkV2Class : public DeviceClass
 
         if (AP)
         {
-          ec = RecoverAfterApWriteFast(ack);
-          response_value = MapAckToDapResp(ack);
-          if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
-          {
-            break;
-          }
-          if (ec != ErrorCode::OK)
-          {
-            response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-            break;
-          }
+          check_ap_write = true;
         }
 
         if (TS)
@@ -2640,7 +2656,6 @@ class DapLinkV2Class : public DeviceClass
         }
 
         response_count++;
-        check_write = true;
       }
       else
       {
@@ -2648,10 +2663,9 @@ class DapLinkV2Class : public DeviceClass
 
         if (MATCH_VALUE)
         {
-          // MATCH_VALUE does not return read data.
-          // For simpler semantics, flush pending first, then keep using ApReadTxn
-          // for AP reads.
-          if (!flush_pending_if_any())
+          // MATCH_VALUE performs real reads and can observe earlier AP writes,
+          // so close both posted read and posted AP-write state first.
+          if (!close_posted_state())
           {
             break;
           }
@@ -2676,8 +2690,7 @@ class DapLinkV2Class : public DeviceClass
               ec = swd_.ApReadTxn(ADDR2B, rdata, ack);  // 内含 RDBUFF
               if (ec == ErrorCode::OK && ack == LibXR::Debug::SwdProtocol::Ack::OK)
               {
-                // ApReadTxn already reads RDBUFF; equivalent to a flush.
-                check_write = false;
+                // ApReadTxn completes the AP read pipeline only.
               }
             }
             else
@@ -2732,8 +2745,8 @@ class DapLinkV2Class : public DeviceClass
         // ---- Normal read ----
         if (!AP)
         {
-          // DP read：不参与 pipeline；先 flush pending
-          if (!flush_pending_if_any())
+          // DP read does not participate in posted pipelines.
+          if (!close_posted_state())
           {
             break;
           }
@@ -2767,6 +2780,13 @@ class DapLinkV2Class : public DeviceClass
 
           response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
           continue;
+        }
+
+        // AP reads can observe previous AP writes, so close posted writes
+        // before starting or extending the posted-read pipeline.
+        if (!recover_ap_write_if_any())
+        {
+          break;
         }
 
         // AP normal read：posted-read pipeline
@@ -2877,7 +2897,11 @@ class DapLinkV2Class : public DeviceClass
       }
     }
 
-    (void)check_write;
+    if (response_value == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK &&
+        !recover_ap_write_if_any())
+    {
+      // response_value is already set by the recovery helper.
+    }
     resp[1] = response_count;
     resp[2] = response_value;
     out_len = resp_off;
@@ -2984,20 +3008,18 @@ class DapLinkV2Class : public DeviceClass
             xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
             break;
           }
+          done = static_cast<uint16_t>(i + 1u);
+        }
+        if (xresp == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK && done != 0u)
+        {
           LibXR::Debug::SwdProtocol::Ack recover_ack =
               LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
-          const ErrorCode RECOVER_EC = RecoverAfterApWriteFast(recover_ack);
+          const ErrorCode recover_ec = RecoverAfterApWriteFast(recover_ack);
           xresp = MapAckToDapResp(recover_ack);
-          if (recover_ack != LibXR::Debug::SwdProtocol::Ack::OK)
-          {
-            break;
-          }
-          if (RECOVER_EC != ErrorCode::OK)
+          if (recover_ack == LibXR::Debug::SwdProtocol::Ack::OK && recover_ec != ErrorCode::OK)
           {
             xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-            break;
           }
-          done = static_cast<uint16_t>(i + 1u);
         }
       }
       else

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -115,13 +115,13 @@ class DapLinkV2Class : public DeviceClass
   const LibXR::USB::DapLinkV2Def::State& GetState() const { return dap_state_; }
 
   /**
-   * @brief 是否已初始化 / Whether initialized
-   * @return true 已初始化 / Initialized
+   * @brief Whether initialized
+   * @return true if initialized
    */
   bool IsInited() const { return inited_; }
 
   /**
-   * @brief IN 端点是否忙碌 / Whether IN endpoint is busy
+   * @brief Whether IN endpoint is busy
    *
    * @return true
    * @return false
@@ -133,7 +133,7 @@ class DapLinkV2Class : public DeviceClass
   }
 
   /**
-   * @brief OUT 端点是否忙碌 / Whether OUT endpoint is busy
+   * @brief Whether OUT endpoint is busy
    *
    * @return true
    * @return false
@@ -146,10 +146,10 @@ class DapLinkV2Class : public DeviceClass
 
  protected:
   /**
-   * @brief 绑定端点资源 / Bind endpoint resources
+   * @brief Bind endpoint resources
    * @param endpoint_pool Endpoint pool
    * @param start_itf_num Start interface number
-   * @param in_isr 是否在中断中 / Whether in ISR
+   * @param in_isr Whether called from ISR context
    */
   void BindEndpoints(EndpointPool& endpoint_pool, uint8_t start_itf_num, bool) override
   {
@@ -234,9 +234,9 @@ class DapLinkV2Class : public DeviceClass
   }
 
   /**
-   * @brief 解绑端点资源 / Unbind endpoint resources
+   * @brief Unbind endpoint resources
    * @param endpoint_pool Endpoint pool
-   * @param in_isr 是否在中断中 / Whether in ISR
+   * @param in_isr Whether called from ISR context
    */
   void UnbindEndpoints(EndpointPool& endpoint_pool, bool) override
   {
@@ -276,21 +276,21 @@ class DapLinkV2Class : public DeviceClass
   }
 
   /**
-   * @brief 接口数量 / Number of interfaces contributed
-   * @return 接口数量 / Interface count
+   * @brief Number of interfaces contributed
+   * @return Interface count
    */
   size_t GetInterfaceCount() override { return 1; }
 
   /**
-   * @brief 是否包含 IAD / Whether an IAD is used
-   * @return true 使用 IAD / Uses IAD
+   * @brief Whether an IAD is used
+   * @return true if this class uses an IAD
    */
   bool HasIAD() override { return false; }
 
   /**
-   * @brief 端点归属判定 / Endpoint ownership
-   * @param ep_addr 端点地址 / Endpoint address
-   * @return true 属于本类 / Owned by this class
+   * @brief Endpoint ownership check
+   * @param ep_addr Endpoint address
+   * @return true if owned by this class
    */
   bool OwnsEndpoint(uint8_t ep_addr) const override
   {
@@ -303,8 +303,8 @@ class DapLinkV2Class : public DeviceClass
   }
 
   /**
-   * @brief 最大配置描述符占用 / Maximum bytes required in configuration descriptor
-   * @return 最大字节数 / Maximum bytes
+   * @brief Maximum bytes required in configuration descriptor
+   * @return Maximum bytes
    */
   size_t GetMaxConfigSize() override { return sizeof(desc_block_); }
 
@@ -319,15 +319,15 @@ class DapLinkV2Class : public DeviceClass
   }
 
   /**
-   * @brief BOS 能力数量 / BOS capability count
-   * @return 能力数量 / Capability count
+   * @brief BOS capability count
+   * @return Capability count
    */
   size_t GetBosCapabilityCount() override { return 1; }
 
   /**
-   * @brief 获取 BOS 能力对象 / Get BOS capability
-   * @param index 索引 / Index
-   * @return BosCapability* 能力对象指针 / Capability pointer
+   * @brief Get BOS capability
+   * @param index Capability index
+   * @return Capability pointer
    */
   BosCapability* GetBosCapability(size_t index) override
   {
@@ -343,7 +343,7 @@ class DapLinkV2Class : public DeviceClass
   // Local helpers (kept with original comments, moved inside the class)
   // ============================================================================
 
-  // 枚举/整型uint8_t。Cast enum/integer to uint8_t.
+  // Cast enum/integer to uint8_t.
   template <typename E>
   static constexpr uint8_t ToU8(E e)
   {
@@ -354,7 +354,7 @@ class DapLinkV2Class : public DeviceClass
   static constexpr uint8_t DAP_OK = 0x00u;     ///< DAP_OK / DAP_OK
   static constexpr uint8_t DAP_ERROR = 0xFFu;  ///< DAP_ERROR / DAP_ERROR
 
-  // 未知命令响应：单字节 0xFF。Unknown command response: single byte 0xFF.
+  // Unknown command response: single byte 0xFF.
   static inline ErrorCode BuildUnknownCmdResponse(uint8_t* resp, uint16_t cap,
                                                   uint16_t& out_len)
   {
@@ -368,7 +368,7 @@ class DapLinkV2Class : public DeviceClass
     return ErrorCode::OK;
   }
 
-  // 命令状态响应：<cmd, status>。Command status response: <cmd, status>.
+  // Command status response: <cmd, status>.
   static inline ErrorCode BuildCmdStatusResponse(uint8_t cmd, uint8_t status,
                                                  uint8_t* resp, uint16_t cap,
                                                  uint16_t& out_len)
@@ -429,7 +429,7 @@ class DapLinkV2Class : public DeviceClass
                      LibXR::USB::WinUsbMsOs20::PROP_NAME_DEVICE_INTERFACE_GUIDS_BYTES);
 
     // DeviceInterfaceGUIDs: REG_MULTI_SZ UTF-16LE, include double-NUL terminator
-    // 注意：此处为“单 GUID + NUL 结束”的 REG_MULTI_SZ / Single GUID + double-NUL end.
+    // Single GUID plus double-NUL terminator for REG_MULTI_SZ.
     const char GUID_STR[] = "{CDB3B5AD-293B-4663-AA36-1AAE46463776}";
     const size_t GUID_LEN = sizeof(GUID_STR) - 1;
 
@@ -459,7 +459,6 @@ class DapLinkV2Class : public DeviceClass
     // Function subset interface number
     winusb_msos20_.func.bFirstInterface = interface_num_;
 
-    // 内容变化但总长度不变；同步一次保持一致
     // Content changes but total size stays the same; resync for consistency.
     winusb_msos20_cap_.SetDescriptorSet(GetWinUsbMsOs20DescriptorSet());
   }
@@ -470,7 +469,7 @@ class DapLinkV2Class : public DeviceClass
   // ============================================================================
 
   /**
-   * @brief OUT 完成回调静态入口 / OUT complete callback static entry
+   * @brief OUT complete callback static entry
    */
   static void OnDataOutCompleteStatic(bool in_isr, DapLinkV2Class* self,
                                       LibXR::ConstRawData& data)
@@ -482,7 +481,7 @@ class DapLinkV2Class : public DeviceClass
   }
 
   /**
-   * @brief IN 完成回调静态入口 / IN complete callback static entry
+   * @brief IN complete callback static entry
    */
   static void OnDataInCompleteStatic(bool in_isr, DapLinkV2Class* self,
                                      LibXR::ConstRawData& data)
@@ -494,7 +493,7 @@ class DapLinkV2Class : public DeviceClass
   }
 
   /**
-   * @brief OUT 完成回调（实例方法）/ OUT complete callback (instance)
+   * @brief OUT complete callback instance method
    */
   void OnDataOutComplete(bool in_isr, LibXR::ConstRawData& data)
   {
@@ -508,9 +507,8 @@ class DapLinkV2Class : public DeviceClass
     const auto* req = static_cast<const uint8_t*>(data.addr_);
     const uint16_t REQ_LEN = static_cast<uint16_t>(data.size_);
 
-    // 快路径：IN idle 且无积压时，直接在 IN 缓冲构造响应并发包 /
-    // Fast path: build directly
-    // in IN endpoint buffer and submit without extra response copy.
+    // Fast path: when IN is idle and no backlog exists, build directly
+    // in the IN endpoint buffer and submit without extra response copy.
     if (!HasDeferredResponseInEpBuffer() && IsResponseQueueEmpty() &&
         ep_data_in_->GetState() == Endpoint::State::IDLE &&
         CanBuildResponseDirectlyInEpBuffer())
@@ -542,8 +540,8 @@ class DapLinkV2Class : public DeviceClass
       }
     }
 
-    // 延迟快路径：IN busy 且无积压时，直接写入另一IN 双缓/ Deferred fast path:
-    // build next response in the other IN DB buffer to avoid queue copy.
+    // Deferred fast path: when IN is busy and no backlog exists, build the next
+    // response in the alternate IN double buffer to avoid queue copy.
     if (!HasDeferredResponseInEpBuffer() && IsResponseQueueEmpty() &&
         ep_data_in_->GetState() == Endpoint::State::BUSY &&
         CanBuildResponseDirectlyInEpBuffer())
@@ -572,7 +570,6 @@ class DapLinkV2Class : public DeviceClass
       return;
     }
 
-    // 正常背压下不应触发；这里做一best-effort 腾挪后重试队列构建
     // Should not happen with proper backpressure; drain once and retry queue build.
     (void)SubmitNextQueuedResponseIfIdle();
     (void)TryBuildAndEnqueueResponse(in_isr, req, REQ_LEN);
@@ -583,7 +580,7 @@ class DapLinkV2Class : public DeviceClass
   }
 
   /**
-   * @brief IN 完成回调（实例方法）/ IN complete callback (instance)
+   * @brief IN complete callback instance method
    */
   void OnDataInComplete(bool /*in_isr*/, LibXR::ConstRawData& /*data*/)
   {
@@ -594,7 +591,7 @@ class DapLinkV2Class : public DeviceClass
 
  private:
   /**
-   * @brief 获取当前 DAP 有效包长 / Get effective DAP packet size
+   * @brief Get effective DAP packet size
    */
   uint16_t GetDapPacketSize() const
   {
@@ -679,8 +676,7 @@ class DapLinkV2Class : public DeviceClass
   }
 
   /**
-   * @brief 裁剪响应长度DAP 包长与缓冲容/ Clip response length by DAP packet and buffer
-   * cap
+   * @brief Clip response length by DAP packet size and buffer capacity
    */
   uint16_t ClipResponseLength(uint16_t len, uint16_t cap) const
   {
@@ -1074,8 +1070,7 @@ class DapLinkV2Class : public DeviceClass
       return;
     }
 
-    // 对总未完成响应做背压（in-flight + queued Backpressure on total outstanding
-    // responses (in-flight + queued).
+    // Backpressure on total outstanding responses (in-flight + queued).
     if (OutstandingResponseCount() >= MAX_OUTSTANDING_RESPONSES)
     {
       return;
@@ -1121,15 +1116,15 @@ class DapLinkV2Class : public DeviceClass
   // ============================================================================
 
   /**
-   * @brief 处理一条命令 / Process one command
+   * @brief Process one command
    *
-   * @param in_isr   ISR 上下文标志 / ISR context flag
-   * @param req      请求缓冲 / Request buffer
-   * @param req_len  请求长度 / Request length
-   * @param resp     响应缓冲 / Response buffer
-   * @param resp_cap 响应容量 / Response capacity
-   * @param out_len  输出：响应长度 / Output: response length
-   * @return 错误码 / Error code
+   * @param in_isr   ISR context flag
+   * @param req      Request buffer
+   * @param req_len  Request length
+   * @param resp     Response buffer
+   * @param resp_cap Response capacity
+   * @param out_len  Output response length
+   * @return Error code
    */
   ErrorCode ProcessOneCommand(bool in_isr, const uint8_t* req, uint16_t req_len,
                               uint8_t* resp, uint16_t resp_cap, uint16_t& out_len)
@@ -1202,11 +1197,11 @@ class DapLinkV2Class : public DeviceClass
   }
 
   /**
-   * @brief 构建不支持响应 / Build NOT_SUPPORT response
+   * @brief Build NOT_SUPPORT response
    *
-   * @param resp     响应缓冲 / Response buffer
-   * @param resp_cap 响应容量 / Response capacity
-   * @param out_len  输出：响应长度 / Output: response length
+   * @param resp     Response buffer
+   * @param resp_cap Response capacity
+   * @param out_len  Output response length
    */
   void BuildNotSupportResponse(uint8_t* resp, uint16_t resp_cap, uint16_t& out_len)
   {
@@ -1627,8 +1622,7 @@ class DapLinkV2Class : public DeviceClass
       execute = 1u;
     }
 
-    // 关键：无论是否实reset，都返回 DAP_OK；未实现Execute=0
-    // Key: Always return DAP_OK; if not implemented, Execute=0.
+    // Always return DAP_OK; if reset is not implemented, Execute=0.
     resp[1] = DAP_OK;
     resp[2] = execute;
     out_len = 3u;
@@ -2410,9 +2404,7 @@ class DapLinkV2Class : public DeviceClass
   // DAP_Transfer / DAP_TransferBlock
   // ============================================================================
 
-  // 说明：以下长函数保持原样；本 cpp 文件不补充函数级注释，hpp 中再统一给出接口说明
-  // Note: The following long functions are kept as-is; no function-level docs in this
-  // cpp. HPP will carry API docs.
+  // The following long functions are kept as-is; API docs live at the header boundary.
 
   ErrorCode HandleTransfer(bool in_isr, const uint8_t* req, uint16_t req_len,
                            uint8_t* resp, uint16_t resp_cap, uint16_t& out_len)
@@ -2547,7 +2539,7 @@ class DapLinkV2Class : public DeviceClass
       pending.valid = false;
       pending.need_ts = false;
 
-      // 成功路径保持 OK
+      // Successful path keeps OK.
       response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
       return true;
     };
@@ -2636,7 +2628,7 @@ class DapLinkV2Class : public DeviceClass
         {
           match_mask_ = wdata;
           response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
-          response_count++;  // MATCH_MASK 视为成功 transfer
+          response_count++;  // MATCH_MASK counts as a successful transfer.
           continue;
         }
         if (AP)
@@ -2706,7 +2698,7 @@ class DapLinkV2Class : public DeviceClass
           {
             if (AP)
             {
-              ec = swd_.ApReadTxn(ADDR2B, rdata, ack);  // 内含 RDBUFF
+              ec = swd_.ApReadTxn(ADDR2B, rdata, ack);  // Includes RDBUFF.
               if (ec == ErrorCode::OK && ack == LibXR::Debug::SwdProtocol::Ack::OK)
               {
                 // ApReadTxn completes the AP read pipeline only.
@@ -2808,7 +2800,7 @@ class DapLinkV2Class : public DeviceClass
           break;
         }
 
-        // AP normal read：posted-read pipeline
+        // AP normal read: posted-read pipeline.
         if (!pending.valid)
         {
           // First AP read in this contiguous AP-read segment:
@@ -4167,7 +4159,7 @@ class DapLinkV2Class : public DeviceClass
 
 LIBXR_PACKED_BEGIN
   /**
-   * @brief MS OS 2.0 描述符集合布局 / MS OS 2.0 descriptor set layout
+   * @brief MS OS 2.0 descriptor set layout
    */
   struct WinUsbMsOs20DescSet
   {
@@ -4189,19 +4181,19 @@ LIBXR_PACKED_BEGIN
       uint8_t name[LibXR::USB::WinUsbMsOs20::
                        PROP_NAME_DEVICE_INTERFACE_GUIDS_BYTES];  ///< Property name /
                                                                  ///< Property name
-      uint16_t wPropertyDataLength;  ///< UTF-16 字节长度 / UTF-16 byte length
+      uint16_t wPropertyDataLength;  ///< UTF-16 byte length
       uint8_t
-          data[GUID_MULTI_SZ_UTF_16_BYTES];  ///< REG_MULTI_SZ 数据 / REG_MULTI_SZ data
+          data[GUID_MULTI_SZ_UTF_16_BYTES];  ///< REG_MULTI_SZ data
     } prop;
   } winusb_msos20_{};
 LIBXR_PACKED_END
 
  private:
-  SwdPort& swd_;  ///< SWD 链路 / SWD link
+  SwdPort& swd_;  ///< SWD link
 
-  LibXR::Debug::Jtag* jtag_ = nullptr;  ///< JTAG 链路 / JTAG link
-  LibXR::Debug::JtagProtocol::ChainConfig jtag_chain_{};  ///< JTAG 链状态 / JTAG chain state
-  uint8_t jtag_ir_len_[JTAG_MAX_DEVICES] = {};  ///< JTAG IR 长度 / JTAG IR lengths
+  LibXR::Debug::Jtag* jtag_ = nullptr;  ///< JTAG link
+  LibXR::Debug::JtagProtocol::ChainConfig jtag_chain_{};  ///< JTAG chain state
+  uint8_t jtag_ir_len_[JTAG_MAX_DEVICES] = {};  ///< JTAG IR lengths
 
   LibXR::GPIO* nreset_gpio_ = nullptr;  ///< Optional nRESET GPIO
 

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -3391,56 +3391,6 @@ class DapLinkV2Class : public DeviceClass
       return true;
     };
 
-    struct PendingApRead
-    {
-      bool valid = false;
-      bool need_ts = false;
-    } pending;
-
-    auto complete_pending_ap_read_by_rdbuff = [&]() -> bool
-    {
-      if (!pending.valid)
-      {
-        return true;
-      }
-
-      if (!ensure_space(bytes_for_read(pending.need_ts)))
-      {
-        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-        return false;
-      }
-
-      uint32_t rdata = 0u;
-      LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
-      const ErrorCode ec = dp_read_retry(3u, rdata, ack);
-
-      const uint8_t v = MapAckToDapResp(ack);
-      if (v != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
-      {
-        response_value = v;
-        return false;
-      }
-      if (ec != ErrorCode::OK)
-      {
-        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-        return false;
-      }
-
-      if (!emit_read_with_ts(pending.need_ts, rdata))
-      {
-        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-        return false;
-      }
-
-      pending.valid = false;
-      pending.need_ts = false;
-      response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
-      return true;
-    };
-
-    auto complete_pending_ap_read_if_any = [&]() -> bool
-    { return pending.valid ? complete_pending_ap_read_by_rdbuff() : true; };
-
     auto check_posted_ap_write_if_pending = [&]() -> bool
     {
       if (!pending_ap_write)
@@ -3466,9 +3416,6 @@ class DapLinkV2Class : public DeviceClass
       pending_ap_write = false;
       return true;
     };
-
-    auto close_posted_state = [&]() -> bool
-    { return complete_pending_ap_read_if_any() && check_posted_ap_write_if_pending(); };
 
     auto should_check_pending_ap_write_at_tail = [&]() -> bool
     {
@@ -3504,11 +3451,6 @@ class DapLinkV2Class : public DeviceClass
 
       if (!RNW)
       {
-        if (!complete_pending_ap_read_if_any())
-        {
-          break;
-        }
-
         if (req_off + 4u > req_len)
         {
           response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
@@ -3566,7 +3508,7 @@ class DapLinkV2Class : public DeviceClass
       {
         if (MATCH_VALUE)
         {
-          if (!close_posted_state())
+          if (!check_posted_ap_write_if_pending())
           {
             break;
           }
@@ -3639,7 +3581,7 @@ class DapLinkV2Class : public DeviceClass
 
         if (!AP)
         {
-          if (!close_posted_state())
+          if (!check_posted_ap_write_if_pending())
           {
             break;
           }
@@ -3675,7 +3617,7 @@ class DapLinkV2Class : public DeviceClass
         }
 
         uint32_t rdata = 0u;
-        if (!close_posted_state())
+        if (!check_posted_ap_write_if_pending())
         {
           break;
         }
@@ -3712,19 +3654,6 @@ class DapLinkV2Class : public DeviceClass
       {
         dap_state_.transfer_abort = false;
         break;
-      }
-    }
-
-    if (pending.valid)
-    {
-      const uint8_t PRIOR_FAIL = response_value;
-      if (!complete_pending_ap_read_by_rdbuff())
-      {
-        // pending failure already recorded in response_value
-      }
-      else if (PRIOR_FAIL != 0u && PRIOR_FAIL != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
-      {
-        response_value = PRIOR_FAIL;
       }
     }
 

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -1189,11 +1189,11 @@ class DapLinkV2Class : public DeviceClass
       case ToU8(LibXR::USB::DapLinkV2Def::CommandId::SWD_SEQUENCE):
         return HandleSWDSequence(in_isr, req, req_len, resp, resp_cap, out_len);
 
-      case to_u8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_SEQUENCE):
+      case ToU8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_SEQUENCE):
         return HandleJTAGSequence(in_isr, req, req_len, resp, resp_cap, out_len);
-      case to_u8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_CONFIGURE):
+      case ToU8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_CONFIGURE):
         return HandleJTAGConfigure(in_isr, req, req_len, resp, resp_cap, out_len);
-      case to_u8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_IDCODE):
+      case ToU8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_IDCODE):
         return HandleJTAGIdCode(in_isr, req, req_len, resp, resp_cap, out_len);
 
       case ToU8(LibXR::USB::DapLinkV2Def::CommandId::QUEUE_COMMANDS):
@@ -1966,7 +1966,7 @@ class DapLinkV2Class : public DeviceClass
       return ErrorCode::ARG_ERR;
     }
 
-    resp[0] = to_u8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_SEQUENCE);
+    resp[0] = ToU8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_SEQUENCE);
     resp[1] = DAP_OK;
     out_len = 2u;
 
@@ -2054,7 +2054,7 @@ class DapLinkV2Class : public DeviceClass
       return ErrorCode::ARG_ERR;
     }
 
-    resp[0] = to_u8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_CONFIGURE);
+    resp[0] = ToU8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_CONFIGURE);
     resp[1] = DAP_OK;
     out_len = 2u;
 
@@ -2116,7 +2116,7 @@ class DapLinkV2Class : public DeviceClass
       return ErrorCode::ARG_ERR;
     }
 
-    resp[0] = to_u8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_IDCODE);
+    resp[0] = ToU8(LibXR::USB::DapLinkV2Def::CommandId::JTAG_IDCODE);
     resp[1] = DAP_ERROR;
     out_len = 2u;
 
@@ -3162,7 +3162,7 @@ class DapLinkV2Class : public DeviceClass
       return ErrorCode::ARG_ERR;
     }
 
-    resp[0] = to_u8(LibXR::USB::DapLinkV2Def::CommandId::TRANSFER);
+    resp[0] = ToU8(LibXR::USB::DapLinkV2Def::CommandId::TRANSFER);
     resp[1] = 0u;
     resp[2] = 0u;
     uint16_t resp_off = 3u;
@@ -3196,8 +3196,6 @@ class DapLinkV2Class : public DeviceClass
 
     const uint8_t COUNT = req[2];
     uint16_t req_off = 3u;
-    uint8_t response_count = 0u;
-    uint8_t response_value = 0u;
 
     auto push_u32 = [&](uint32_t v) -> bool
     {
@@ -3209,6 +3207,168 @@ class DapLinkV2Class : public DeviceClass
       resp_off = static_cast<uint16_t>(resp_off + 4u);
       return true;
     };
+
+    auto push_timestamp = [&]() -> bool
+    {
+      const uint32_t t = static_cast<uint32_t>(LibXR::Timebase::GetMicroseconds());
+      return push_u32(t);
+    };
+
+    auto ensure_space = [&](uint16_t bytes) -> bool
+    {
+      return (resp_off + bytes) <= resp_cap;
+    };
+
+    auto bytes_for_read = [&](bool need_ts) -> uint16_t
+    {
+      return static_cast<uint16_t>(need_ts ? 8u : 4u);
+    };
+
+    auto idle_after_attempt = [&]() {
+      if (dap_state_.transfer_cfg.idle_cycles != 0u)
+      {
+        jtag_->IdleClocks(dap_state_.transfer_cfg.idle_cycles);
+      }
+    };
+
+    auto dp_read_retry = [&](uint8_t addr2b, uint32_t& val,
+                             LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+    {
+      uint32_t retry = dap_state_.transfer_cfg.retry_count;
+      while (true)
+      {
+        const ErrorCode ec = dp.DpReadTxn(addr2b, val, ack);
+        idle_after_attempt();
+        if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+            dap_state_.transfer_abort)
+        {
+          return ec;
+        }
+        --retry;
+      }
+    };
+
+    auto dp_write_retry = [&](uint8_t addr2b, uint32_t val,
+                              LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+    {
+      uint32_t retry = dap_state_.transfer_cfg.retry_count;
+      while (true)
+      {
+        const ErrorCode ec = dp.DpWriteTxn(addr2b, val, ack);
+        idle_after_attempt();
+        if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+            dap_state_.transfer_abort)
+        {
+          return ec;
+        }
+        --retry;
+      }
+    };
+
+    auto ap_read_retry = [&](uint8_t addr2b, uint32_t& val,
+                             LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+    {
+      uint32_t retry = dap_state_.transfer_cfg.retry_count;
+      while (true)
+      {
+        const ErrorCode ec = dp.ApReadTxn(addr2b, val, ack);
+        idle_after_attempt();
+        if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+            dap_state_.transfer_abort)
+        {
+          return ec;
+        }
+        --retry;
+      }
+    };
+
+    auto ap_write_retry = [&](uint8_t addr2b, uint32_t val,
+                              LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+    {
+      uint32_t retry = dap_state_.transfer_cfg.retry_count;
+      while (true)
+      {
+        const ErrorCode ec = dp.ApWriteTxn(addr2b, val, ack);
+        idle_after_attempt();
+        if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+            dap_state_.transfer_abort)
+        {
+          return ec;
+        }
+        --retry;
+      }
+    };
+
+    uint8_t response_count = 0u;
+    uint8_t response_value = 0u;
+    bool check_write = false;
+
+    auto emit_read_with_ts = [&](bool need_ts, uint32_t data) -> bool
+    {
+      if (need_ts)
+      {
+        if (!push_timestamp())
+        {
+          return false;
+        }
+      }
+      if (!push_u32(data))
+      {
+        return false;
+      }
+      response_count++;
+      return true;
+    };
+
+    struct PendingApRead
+    {
+      bool valid = false;
+      bool need_ts = false;
+    } pending;
+
+    auto complete_pending_by_rdbuff = [&]() -> bool
+    {
+      if (!pending.valid)
+      {
+        return true;
+      }
+
+      if (!ensure_space(bytes_for_read(pending.need_ts)))
+      {
+        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        return false;
+      }
+
+      uint32_t rdata = 0u;
+      LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+      const ErrorCode ec = dp_read_retry(3u, rdata, ack);
+
+      const uint8_t v = MapAckToDapResp(ack);
+      if (v != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+      {
+        response_value = v;
+        return false;
+      }
+      if (ec != ErrorCode::OK)
+      {
+        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        return false;
+      }
+
+      if (!emit_read_with_ts(pending.need_ts, rdata))
+      {
+        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        return false;
+      }
+
+      pending.valid = false;
+      pending.need_ts = false;
+      check_write = false;
+      response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
+      return true;
+    };
+
+    auto flush_pending_if_any = [&]() -> bool { return pending.valid ? complete_pending_by_rdbuff() : true; };
 
     for (uint32_t i = 0; i < COUNT; ++i)
     {
@@ -3222,19 +3382,26 @@ class DapLinkV2Class : public DeviceClass
       const bool AP = LibXR::USB::DapLinkV2Def::req_is_ap(RQ);
       const bool RNW = LibXR::USB::DapLinkV2Def::req_is_read(RQ);
       const uint8_t ADDR2B = LibXR::USB::DapLinkV2Def::req_addr2b(RQ);
-      const bool MATCH_VALUE =
-          ((RQ & LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MATCH_VALUE) != 0u);
-      const bool MATCH_MASK =
-          ((RQ & LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MATCH_MASK) != 0u);
+      const bool TS = LibXR::USB::DapLinkV2Def::req_need_timestamp(RQ);
+      const bool MATCH_VALUE = ((RQ & LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MATCH_VALUE) != 0u);
+      const bool MATCH_MASK = ((RQ & LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MATCH_MASK) != 0u);
 
-      if (MATCH_VALUE || MATCH_MASK)
+      if (TS && (MATCH_VALUE || MATCH_MASK))
       {
         response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
         break;
       }
 
+      LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+      ErrorCode ec = ErrorCode::OK;
+
       if (!RNW)
       {
+        if (!flush_pending_if_any())
+        {
+          break;
+        }
+
         if (req_off + 4u > req_len)
         {
           response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
@@ -3245,15 +3412,20 @@ class DapLinkV2Class : public DeviceClass
         Memory::FastCopy(&wdata, &req[req_off], sizeof(wdata));
         req_off = static_cast<uint16_t>(req_off + 4u);
 
-        LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
-        ErrorCode ec = ErrorCode::OK;
+        if (MATCH_MASK)
+        {
+          response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
+          response_count++;
+          continue;
+        }
+
         if (AP)
         {
-          ec = dp.ApWrite(ADDR2B, wdata, ack);
+          ec = ap_write_retry(ADDR2B, wdata, ack);
         }
         else
         {
-          ec = dp.DpWrite(ADDR2B, wdata, ack);
+          ec = dp_write_retry(ADDR2B, wdata, ack);
         }
 
         response_value = MapAckToDapResp(ack);
@@ -3267,39 +3439,222 @@ class DapLinkV2Class : public DeviceClass
           break;
         }
 
-        response_count++;
-        continue;
-      }
+        if (TS)
+        {
+          if (!push_timestamp())
+          {
+            response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+            break;
+          }
+        }
 
-      uint32_t rdata = 0u;
-      LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
-      ErrorCode ec = ErrorCode::OK;
-      if (AP)
-      {
-        ec = dp.ApRead(ADDR2B, rdata, ack);
+        response_count++;
+        check_write = true;
       }
       else
       {
-        ec = dp.DpRead(ADDR2B, rdata, ack);
+        if (MATCH_VALUE)
+        {
+          if (!flush_pending_if_any())
+          {
+            break;
+          }
+
+          if (req_off + 4u > req_len)
+          {
+            response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+            break;
+          }
+
+          uint32_t match_val = 0u;
+          Memory::FastCopy(&match_val, &req[req_off], sizeof(match_val));
+          req_off = static_cast<uint16_t>(req_off + 4u);
+
+          uint32_t rdata = 0u;
+          uint32_t retry = dap_state_.transfer_cfg.match_retry;
+          bool matched = false;
+
+          while (true)
+          {
+            if (AP)
+            {
+              ec = ap_read_retry(ADDR2B, rdata, ack);
+            }
+            else
+            {
+              ec = dp_read_retry(ADDR2B, rdata, ack);
+            }
+
+            response_value = MapAckToDapResp(ack);
+            if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+            {
+              break;
+            }
+            if (ec != ErrorCode::OK)
+            {
+              response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+              break;
+            }
+
+            if ((rdata & match_mask_) == (match_val & match_mask_))
+            {
+              matched = true;
+              break;
+            }
+
+            if (retry == 0u)
+            {
+              break;
+            }
+            --retry;
+          }
+
+          if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+          {
+            break;
+          }
+
+          if (!matched)
+          {
+            response_value = static_cast<uint8_t>(
+                LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK |
+                LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MISMATCH);
+            break;
+          }
+
+          response_count++;
+          continue;
+        }
+
+        if (!AP)
+        {
+          if (!flush_pending_if_any())
+          {
+            break;
+          }
+
+          uint32_t rdata = 0u;
+          ec = dp_read_retry(ADDR2B, rdata, ack);
+
+          response_value = MapAckToDapResp(ack);
+          if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+          {
+            break;
+          }
+          if (ec != ErrorCode::OK)
+          {
+            response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+            break;
+          }
+
+          if (!ensure_space(bytes_for_read(TS)))
+          {
+            response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+            break;
+          }
+
+          if (!emit_read_with_ts(TS, rdata))
+          {
+            response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+            break;
+          }
+
+          response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
+          continue;
+        }
+
+        if (!pending.valid)
+        {
+          uint32_t dummy_posted = 0u;
+          ec = ApReadPostedFast(ADDR2B, dummy_posted, ack);
+
+          response_value = MapAckToDapResp(ack);
+          if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+          {
+            break;
+          }
+          if (ec != ErrorCode::OK)
+          {
+            response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+            break;
+          }
+
+          pending.valid = true;
+          pending.need_ts = TS;
+          response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
+        }
+        else
+        {
+          if (!ensure_space(bytes_for_read(pending.need_ts)))
+          {
+            response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+            break;
+          }
+
+          uint32_t posted_prev = 0u;
+          ec = ApReadPostedFast(ADDR2B, posted_prev, ack);
+
+          const uint8_t CUR_V = MapAckToDapResp(ack);
+          if (CUR_V != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK || ec != ErrorCode::OK)
+          {
+            const uint8_t FAIL = (CUR_V != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+                                     ? CUR_V
+                                     : LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+            if (!complete_pending_by_rdbuff())
+            {
+              break;
+            }
+            response_value = FAIL;
+            break;
+          }
+
+          if (!emit_read_with_ts(pending.need_ts, posted_prev))
+          {
+            response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+            break;
+          }
+
+          pending.valid = true;
+          pending.need_ts = TS;
+          response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
+        }
       }
 
-      response_value = MapAckToDapResp(ack);
-      if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+      if (dap_state_.transfer_abort)
       {
+        dap_state_.transfer_abort = false;
         break;
       }
-      if (ec != ErrorCode::OK)
-      {
-        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-        break;
-      }
-      if (!push_u32(rdata))
-      {
-        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-        break;
-      }
+    }
 
-      response_count++;
+    if (pending.valid)
+    {
+      const uint8_t PRIOR_FAIL = response_value;
+      if (!complete_pending_by_rdbuff())
+      {
+        // pending failure already recorded in response_value
+      }
+      else if (PRIOR_FAIL != 0u && PRIOR_FAIL != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+      {
+        response_value = PRIOR_FAIL;
+      }
+    }
+
+    if (response_value == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK && check_write)
+    {
+      uint32_t dummy = 0u;
+      LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+      const ErrorCode ec = DpReadRdbuffFast(dummy, ack);
+      const uint8_t v = MapAckToDapResp(ack);
+
+      if (v != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+      {
+        response_value = v;
+      }
+      else if (ec != ErrorCode::OK)
+      {
+        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+      }
     }
 
     resp[1] = response_count;
@@ -3329,6 +3684,13 @@ class DapLinkV2Class : public DeviceClass
       return ErrorCode::OK;
     }
 
+    if (dap_state_.transfer_abort)
+    {
+      dap_state_.transfer_abort = false;
+      resp[3] = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+      return ErrorCode::OK;
+    }
+
     const uint8_t TAP_INDEX = req[1];
     if (TAP_INDEX >= jtag_chain_.count)
     {
@@ -3342,11 +3704,108 @@ class DapLinkV2Class : public DeviceClass
     uint16_t count = 0u;
     Memory::FastCopy(&count, &req[2], sizeof(count));
     const uint8_t DAP_RQ = req[4];
+
+    if ((DAP_RQ & (LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MATCH_VALUE |
+                   LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MATCH_MASK)) != 0u)
+    {
+      resp[3] = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+      return ErrorCode::NOT_SUPPORT;
+    }
+    if (LibXR::USB::DapLinkV2Def::req_need_timestamp(DAP_RQ))
+    {
+      resp[3] = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+      return ErrorCode::NOT_SUPPORT;
+    }
+
+    if (count == 0u)
+    {
+      const uint16_t DONE0 = 0u;
+      Memory::FastCopy(&resp[1], &DONE0, sizeof(DONE0));
+      resp[3] = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
+      out_len = 4u;
+      return ErrorCode::OK;
+    }
+
+    LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
+    auto idle_after_attempt = [&]() {
+      if (dap_state_.transfer_cfg.idle_cycles != 0u)
+      {
+        jtag_->IdleClocks(dap_state_.transfer_cfg.idle_cycles);
+      }
+    };
+
+    auto dp_read_retry = [&](uint8_t addr2b, uint32_t& val,
+                             LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+    {
+      uint32_t retry = dap_state_.transfer_cfg.retry_count;
+      while (true)
+      {
+        const ErrorCode ec = dp.DpReadTxn(addr2b, val, ack);
+        idle_after_attempt();
+        if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+            dap_state_.transfer_abort)
+        {
+          return ec;
+        }
+        --retry;
+      }
+    };
+
+    auto dp_write_retry = [&](uint8_t addr2b, uint32_t val,
+                              LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+    {
+      uint32_t retry = dap_state_.transfer_cfg.retry_count;
+      while (true)
+      {
+        const ErrorCode ec = dp.DpWriteTxn(addr2b, val, ack);
+        idle_after_attempt();
+        if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+            dap_state_.transfer_abort)
+        {
+          return ec;
+        }
+        --retry;
+      }
+    };
+
+    auto ap_read_retry = [&](uint8_t addr2b, uint32_t& val,
+                             LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+    {
+      uint32_t retry = dap_state_.transfer_cfg.retry_count;
+      while (true)
+      {
+        const ErrorCode ec = dp.ApReadTxn(addr2b, val, ack);
+        idle_after_attempt();
+        if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+            dap_state_.transfer_abort)
+        {
+          return ec;
+        }
+        --retry;
+      }
+    };
+
+    auto ap_write_retry = [&](uint8_t addr2b, uint32_t val,
+                              LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+    {
+      uint32_t retry = dap_state_.transfer_cfg.retry_count;
+      while (true)
+      {
+        const ErrorCode ec = dp.ApWriteTxn(addr2b, val, ack);
+        idle_after_attempt();
+        if (ack != LibXR::Debug::JtagProtocol::Ack::WAIT || retry == 0u ||
+            dap_state_.transfer_abort)
+        {
+          return ec;
+        }
+        --retry;
+      }
+    };
+
     const bool AP = LibXR::USB::DapLinkV2Def::req_is_ap(DAP_RQ);
     const bool RNW = LibXR::USB::DapLinkV2Def::req_is_read(DAP_RQ);
     const uint8_t ADDR2B = LibXR::USB::DapLinkV2Def::req_addr2b(DAP_RQ);
 
-    LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
     uint16_t done = 0u;
     uint8_t xresp = 0u;
     uint16_t req_off = 5u;
@@ -3358,29 +3817,58 @@ class DapLinkV2Class : public DeviceClass
       {
         if (req_off + 4u > req_len)
         {
-          xresp = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+          xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
           break;
         }
+
         uint32_t wdata = 0u;
         Memory::FastCopy(&wdata, &req[req_off], sizeof(wdata));
         req_off = static_cast<uint16_t>(req_off + 4u);
 
         LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
-        ErrorCode ec = AP ? dp.ApWrite(ADDR2B, wdata, ack) : dp.DpWrite(ADDR2B, wdata, ack);
+        ErrorCode ec = AP ? ap_write_retry(ADDR2B, wdata, ack)
+                          : dp_write_retry(ADDR2B, wdata, ack);
+
         xresp = MapAckToDapResp(ack);
-        if (xresp != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK || ec != ErrorCode::OK)
+        if (xresp == 0u)
         {
-          if (ec != ErrorCode::OK && xresp == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
-          {
-            xresp = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-          }
+          xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
           break;
         }
+
+        if (ack != LibXR::Debug::JtagProtocol::Ack::OK)
+        {
+          break;
+        }
+
+        if (ec != ErrorCode::OK)
+        {
+          xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+          break;
+        }
+
         done = static_cast<uint16_t>(i + 1u);
       }
+
+      if (xresp == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK && done > 0u)
+      {
+        uint32_t dummy = 0u;
+        LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+        const ErrorCode ec = dp_read_retry(3u, dummy, ack);
+        const uint8_t v = MapAckToDapResp(ack);
+        if (v != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+        {
+          xresp = v;
+        }
+        else if (ec != ErrorCode::OK)
+        {
+          xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        }
+      }
+
       Memory::FastCopy(&resp[1], &done, sizeof(done));
       resp[3] = xresp;
-      out_len = 4u;
+      out_len = resp_off;
       return ErrorCode::OK;
     }
 
@@ -3388,21 +3876,41 @@ class DapLinkV2Class : public DeviceClass
     {
       if (resp_off + 4u > resp_cap)
       {
-        xresp = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
         break;
       }
-      uint32_t rdata = 0u;
+
       LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
-      ErrorCode ec = AP ? dp.ApRead(ADDR2B, rdata, ack) : dp.DpRead(ADDR2B, rdata, ack);
-      xresp = MapAckToDapResp(ack);
-      if (xresp != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK || ec != ErrorCode::OK)
+      ErrorCode ec = ErrorCode::OK;
+      uint32_t rdata = 0u;
+
+      if (AP)
       {
-        if (ec != ErrorCode::OK && xresp == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
-        {
-          xresp = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-        }
+        ec = ap_read_retry(ADDR2B, rdata, ack);
+      }
+      else
+      {
+        ec = dp_read_retry(ADDR2B, rdata, ack);
+      }
+
+      xresp = MapAckToDapResp(ack);
+      if (xresp == 0u)
+      {
+        xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
         break;
       }
+
+      if (ack != LibXR::Debug::JtagProtocol::Ack::OK)
+      {
+        break;
+      }
+
+      if (ec != ErrorCode::OK)
+      {
+        xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        break;
+      }
+
       Memory::FastCopy(&resp[resp_off], &rdata, sizeof(rdata));
       resp_off = static_cast<uint16_t>(resp_off + 4u);
       done = static_cast<uint16_t>(i + 1u);

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -2349,6 +2349,24 @@ class DapLinkV2Class : public DeviceClass
     return ErrorCode::OK;
   }
 
+  ErrorCode RecoverAfterApWriteFast(LibXR::Debug::SwdProtocol::Ack& ack_out)
+  {
+    LibXR::Debug::SwdProtocol::Response swd_resp = {};
+    const auto req = LibXR::Debug::SwdProtocol::make_dp_read_req(
+        LibXR::Debug::SwdProtocol::DpReadReg::CTRL_STAT);
+    const ErrorCode ec = TransferTxnFast(req, swd_resp);
+    ack_out = swd_resp.ack;
+    if (ec != ErrorCode::OK)
+    {
+      return ec;
+    }
+    if (swd_resp.ack != LibXR::Debug::SwdProtocol::Ack::OK || !swd_resp.parity_ok)
+    {
+      return ErrorCode::FAILED;
+    }
+    return ErrorCode::OK;
+  }
+
   ErrorCode ApReadPostedFast(uint8_t addr2b, uint32_t& posted,
                              LibXR::Debug::SwdProtocol::Ack& ack_out)
   {
@@ -2595,6 +2613,21 @@ class DapLinkV2Class : public DeviceClass
         {
           response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
           break;
+        }
+
+        if (AP)
+        {
+          ec = RecoverAfterApWriteFast(ack);
+          response_value = MapAckToDapResp(ack);
+          if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+          {
+            break;
+          }
+          if (ec != ErrorCode::OK)
+          {
+            response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+            break;
+          }
         }
 
         if (TS)
@@ -2844,25 +2877,7 @@ class DapLinkV2Class : public DeviceClass
       }
     }
 
-    // Tail write flush: if all OK and there was a real write, and no RDBUFF
-    // flush happened in between, perform one DP_RDBUFF read (discard).
-    if (response_value == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK && check_write)
-    {
-      uint32_t dummy = 0u;
-      LibXR::Debug::SwdProtocol::Ack ack = LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
-      const ErrorCode EC = DpReadRdbuffFast(dummy, ack);
-      const uint8_t V = MapAckToDapResp(ack);
-
-      if (V != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
-      {
-        response_value = V;
-      }
-      else if (EC != ErrorCode::OK)
-      {
-        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
-      }
-    }
-
+    (void)check_write;
     resp[1] = response_count;
     resp[2] = response_value;
     out_len = resp_off;
@@ -2965,6 +2980,19 @@ class DapLinkV2Class : public DeviceClass
             break;
           }
           if (ec != ErrorCode::OK)
+          {
+            xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+            break;
+          }
+          LibXR::Debug::SwdProtocol::Ack recover_ack =
+              LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
+          const ErrorCode RECOVER_EC = RecoverAfterApWriteFast(recover_ack);
+          xresp = MapAckToDapResp(recover_ack);
+          if (recover_ack != LibXR::Debug::SwdProtocol::Ack::OK)
+          {
+            break;
+          }
+          if (RECOVER_EC != ErrorCode::OK)
           {
             xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
             break;

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -3380,7 +3380,7 @@ class DapLinkV2Class : public DeviceClass
 
     uint8_t response_count = 0u;
     uint8_t response_value = 0u;
-    bool check_write = false;
+    bool pending_ap_write = false;
 
     auto emit_read_with_ts = [&](bool need_ts, uint32_t data) -> bool
     {
@@ -3442,13 +3442,48 @@ class DapLinkV2Class : public DeviceClass
 
       pending.valid = false;
       pending.need_ts = false;
-      check_write = false;
       response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK;
       return true;
     };
 
     auto complete_pending_ap_read_if_any = [&]() -> bool
     { return pending.valid ? complete_pending_ap_read_by_rdbuff() : true; };
+
+    auto check_posted_ap_write_if_pending = [&]() -> bool
+    {
+      if (!pending_ap_write)
+      {
+        return true;
+      }
+
+      LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
+      const ErrorCode ec = check_posted_ap_write_jtag(ack);
+      const uint8_t v = MapAckToDapResp(ack);
+
+      if (v != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+      {
+        response_value = v;
+        return false;
+      }
+      if (ec != ErrorCode::OK)
+      {
+        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        return false;
+      }
+
+      pending_ap_write = false;
+      return true;
+    };
+
+    auto close_posted_state = [&]() -> bool
+    { return complete_pending_ap_read_if_any() && check_posted_ap_write_if_pending(); };
+
+    auto should_check_pending_ap_write_at_tail = [&]() -> bool
+    {
+      return response_value == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK ||
+             response_value == static_cast<uint8_t>(LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK |
+                                                    LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MISMATCH);
+    };
 
     for (uint32_t i = 0; i < COUNT; ++i)
     {
@@ -3532,14 +3567,14 @@ class DapLinkV2Class : public DeviceClass
         response_count++;
         if (AP)
         {
-          check_write = true;
+          pending_ap_write = true;
         }
       }
       else
       {
         if (MATCH_VALUE)
         {
-          if (!complete_pending_ap_read_if_any())
+          if (!close_posted_state())
           {
             break;
           }
@@ -3612,7 +3647,7 @@ class DapLinkV2Class : public DeviceClass
 
         if (!AP)
         {
-          if (!complete_pending_ap_read_if_any())
+          if (!close_posted_state())
           {
             break;
           }
@@ -3648,6 +3683,11 @@ class DapLinkV2Class : public DeviceClass
         }
 
         uint32_t rdata = 0u;
+        if (!close_posted_state())
+        {
+          break;
+        }
+
         ec = ap_read_retry(ADDR2B, rdata, ack);
 
         response_value = MapAckToDapResp(ack);
@@ -3696,19 +3736,12 @@ class DapLinkV2Class : public DeviceClass
       }
     }
 
-    if (response_value == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK && check_write)
+    if (pending_ap_write && should_check_pending_ap_write_at_tail())
     {
-      LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
-      const ErrorCode ec = check_posted_ap_write_jtag(ack);
-      const uint8_t v = MapAckToDapResp(ack);
-
-      if (v != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
+      const uint8_t PRIOR_RESPONSE = response_value;
+      if (check_posted_ap_write_if_pending())
       {
-        response_value = v;
-      }
-      else if (ec != ErrorCode::OK)
-      {
-        response_value = LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
+        response_value = PRIOR_RESPONSE;
       }
     }
 

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -3371,6 +3371,13 @@ class DapLinkV2Class : public DeviceClass
       }
     };
 
+    auto check_posted_ap_write_jtag = [&](LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+    {
+      uint32_t ctrl_stat = 0u;
+      return dp_read_retry(static_cast<uint8_t>(LibXR::Debug::SwdProtocol::DpReadReg::CTRL_STAT),
+                           ctrl_stat, ack);
+    };
+
     uint8_t response_count = 0u;
     uint8_t response_value = 0u;
     bool check_write = false;
@@ -3691,9 +3698,8 @@ class DapLinkV2Class : public DeviceClass
 
     if (response_value == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK && check_write)
     {
-      uint32_t dummy = 0u;
       LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
-      const ErrorCode ec = dp_read_retry(3u, dummy, ack);
+      const ErrorCode ec = check_posted_ap_write_jtag(ack);
       const uint8_t v = MapAckToDapResp(ack);
 
       if (v != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
@@ -3851,6 +3857,13 @@ class DapLinkV2Class : public DeviceClass
       }
     };
 
+    auto check_posted_ap_write_jtag = [&](LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+    {
+      uint32_t ctrl_stat = 0u;
+      return dp_read_retry(static_cast<uint8_t>(LibXR::Debug::SwdProtocol::DpReadReg::CTRL_STAT),
+                           ctrl_stat, ack);
+    };
+
     const bool AP = LibXR::USB::DapLinkV2Def::req_is_ap(DAP_RQ);
     const bool RNW = LibXR::USB::DapLinkV2Def::req_is_read(DAP_RQ);
     const uint8_t ADDR2B = LibXR::USB::DapLinkV2Def::req_addr2b(DAP_RQ);
@@ -3901,9 +3914,8 @@ class DapLinkV2Class : public DeviceClass
 
       if (AP && xresp == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK && done > 0u)
       {
-        uint32_t dummy = 0u;
         LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
-        const ErrorCode ec = dp_read_retry(3u, dummy, ack);
+        const ErrorCode ec = check_posted_ap_write_jtag(ack);
         const uint8_t v = MapAckToDapResp(ack);
         if (v != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
         {

--- a/src/libxr.hpp
+++ b/src/libxr.hpp
@@ -38,9 +38,6 @@
 #include "timebase.hpp"
 #include "timer.hpp"
 #include "transform.hpp"
-#include "driver/debug/jtag.hpp"
-#include "driver/debug/jtag_general_gpio.hpp"
-#include "driver/debug/jtag_protocol.hpp"
 
 /**
  * @brief LibXR 命名空间

--- a/src/libxr.hpp
+++ b/src/libxr.hpp
@@ -40,6 +40,7 @@
 #include "transform.hpp"
 #include "driver/debug/jtag.hpp"
 #include "driver/debug/jtag_general_gpio.hpp"
+#include "driver/debug/jtag_protocol.hpp"
 
 /**
  * @brief LibXR 命名空间

--- a/src/libxr.hpp
+++ b/src/libxr.hpp
@@ -38,6 +38,8 @@
 #include "timebase.hpp"
 #include "timer.hpp"
 #include "transform.hpp"
+#include "driver/debug/jtag.hpp"
+#include "driver/debug/jtag_general_gpio.hpp"
 
 /**
  * @brief LibXR 命名空间


### PR DESCRIPTION
Respun PR 93 onto current master with only the clean JTAG foundation commits migrated so far. DAPLink / dev_core follow-up will be rebuilt separately on this branch.

## Summary by Sourcery

在 DAPLink v1 USB HID 设备实现中集成基于 JTAG 的调试后端，并在对外声明固定数据包大小的同时简化其 USB 端点处理。

新功能：
- 在调试驱动层中新增通用 JTAG 抽象、协议辅助工具，以及基于 GPIO 的“位翻转”（bit-banged）JTAG 实现。
- 扩展 DAPLink v1 设备以支持 JTAG 调试操作，使其与现有的 SWD 功能并存，包括能力上报及 JTAG 专用命令。

增强项：
- 通过移除内部响应队列并在每次传输中使用单一固定大小的数据包，简化 DAPLink v1 HID 传输，并相应调整端点绑定函数签名。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate a JTAG-based debug backend into the DAPLink v1 USB HID device implementation and simplify its USB endpoint handling while advertising fixed packet sizing.

New Features:
- Add a generic JTAG abstraction, protocol helpers, and GPIO-based bit-banged JTAG implementation to the debug driver layer.
- Extend the DAPLink v1 device to support JTAG debug operations alongside existing SWD functionality, including capability reporting and JTAG-specific commands.

Enhancements:
- Simplify DAPLink v1 HID transport by removing internal response queuing and using a single fixed-size packet per transfer, and adjust endpoint binding signatures accordingly.

</details>