### PR TITLE
[codex] fix(ch32): qualify systick state in timebase

### DIFF
--- a/driver/ch/ch32_timebase.cpp
+++ b/driver/ch/ch32_timebase.cpp
@@ -13,9 +13,9 @@ MicrosecondTimestamp Timebase::GetMicroseconds()
 {
   do
   {
-    uint32_t tick_old = sys_tick_ms_;
+    uint32_t tick_old = CH32Timebase::sys_tick_ms_;
     uint32_t cnt_old = SysTick->CNT;
-    uint32_t tick_new = sys_tick_ms_;
+    uint32_t tick_new = CH32Timebase::sys_tick_ms_;
     uint32_t cnt_new = SysTick->CNT;
 
     auto tick_diff = tick_new - tick_old;


### PR DESCRIPTION
This fixes a CH32 build break in the current `master` timebase implementation.

`driver/ch/ch32_timebase.cpp` implements `Timebase::GetMicroseconds()` as a free `Timebase` method, but it was reading `sys_tick_ms_` without qualifying it through `CH32Timebase`. In this file, `sys_tick_ms_` is a static data member of `CH32Timebase`, so the unqualified lookup does not resolve correctly on the CH32 build path and the file fails to compile with:

`error: 'sys_tick_ms_' was not declared in this scope`

The fix is intentionally minimal: qualify the two reads as `CH32Timebase::sys_tick_ms_`. No behavior or timing logic changes beyond resolving the member lookup correctly.

This was validated through the CH32V305 DAP three-stage build path on Ubuntu24 using the latest `master` source as the embedded `libxr` baseline. Validation artifact:

- `/home/xiao/runs/ch32v305_dap_3stage_mainline_clean_20260615T013333Z/99_summary.txt`

The relevant results were:

- `cmake_app=PASS`
- `build_app=PASS`
- `cmake_full_3stage=PASS`
- `build_full_3stage=PASS`

This change is intended as a direct merge-ready fix for the current CH32 compile gap on `master`.

## 由 Sourcery 提供的总结

错误修复：
- 通过在 `GetMicroseconds()` 中通过 `CH32Timebase` 访问并限定 SysTick 毫秒计数器，解决 CH32 构建失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve CH32 build failure by qualifying SysTick millisecond counter accesses through CH32Timebase in GetMicroseconds().

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

错误修复：
- 通过在 `GetMicroseconds()` 中通过 `CH32Timebase` 访问并限定 SysTick 毫秒计数器，解决 CH32 构建失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve CH32 build failure by qualifying SysTick millisecond counter accesses through CH32Timebase in GetMicroseconds().

</details>

</details>