### PR TITLE
fix(double_buffer): allow empty nullptr backing storage

### DIFF
--- a/src/structure/double_buffer.cpp
+++ b/src/structure/double_buffer.cpp
@@ -25,15 +25,20 @@ void DoubleBuffer::Reset()
 void DoubleBuffer::Init(const LibXR::RawData& raw_data)
 {
   constexpr size_t ALIGN = alignof(size_t);
+  const bool EMPTY_STORAGE = (raw_data.addr_ == nullptr) && (raw_data.size_ == 0U);
 
-  ASSERT(raw_data.addr_ != nullptr);
-  ASSERT(raw_data.size_ > 0U);
-  ASSERT((reinterpret_cast<uintptr_t>(raw_data.addr_) % ALIGN) == 0U);
-  ASSERT((raw_data.size_ % (2U * ALIGN)) == 0U);
+  ASSERT(EMPTY_STORAGE || (raw_data.addr_ != nullptr));
+
+  if (!EMPTY_STORAGE)
+  {
+    ASSERT(raw_data.size_ > 0U);
+    ASSERT((reinterpret_cast<uintptr_t>(raw_data.addr_) % ALIGN) == 0U);
+    ASSERT((raw_data.size_ % (2U * ALIGN)) == 0U);
+  }
 
   size_ = raw_data.size_ / 2U;
   buffer_[0] = static_cast<uint8_t*>(raw_data.addr_);
-  buffer_[1] = static_cast<uint8_t*>(raw_data.addr_) + size_;
+  buffer_[1] = EMPTY_STORAGE ? nullptr : (static_cast<uint8_t*>(raw_data.addr_) + size_);
   Reset();
 }
 
@@ -84,6 +89,7 @@ bool DoubleBuffer::FillPending(const uint8_t* data, size_t len)
   {
     return false;
   }
+
   LibXR::Memory::FastCopy(PendingBuffer(), data, len);
   pending_len_ = len;
   pending_valid_ = true;
@@ -99,6 +105,7 @@ bool DoubleBuffer::FillActive(const uint8_t* data, size_t len)
   {
     return false;
   }
+
   LibXR::Memory::FastCopy(ActiveBuffer(), data, len);
   return true;
 }

--- a/src/structure/double_buffer.hpp
+++ b/src/structure/double_buffer.hpp
@@ -39,8 +39,10 @@ class DoubleBuffer
    * @brief 绑定连续 backing storage 并重置双缓冲状态
    *        Binds continuous backing storage and resets double-buffer state
    *
-   * @param raw_data 连续内存区，大小必须满足双缓冲对半切分约束
-   * @param raw_data Continuous memory block satisfying the half-split contract
+   * @param raw_data 连续内存区，大小必须满足双缓冲对半切分约束；空双缓冲允许
+   *        传入 `nullptr + 0`
+   * @param raw_data Continuous memory block satisfying the half-split contract;
+   *        an empty double buffer may be initialized with `nullptr + 0`
    */
   void Init(const LibXR::RawData& raw_data);
 

--- a/test/base/structure/test_double_buffer.cpp
+++ b/test/base/structure/test_double_buffer.cpp
@@ -4,8 +4,9 @@
  *
  * 测试项目 / Test items:
  * 1. 初始分块与 pending 初始状态。 Initial split and pending state: verify the raw buffer is divided evenly and starts without pending data.
- * 2. `FillPending()` 的写入与重复写保护。 Pending fill semantics: verify `FillPending()` stores bytes and rejects a second pending fill before switch.
- * 3. `Switch()` 切换和越界长度拒绝。 Switch semantics and bounds: verify active-half toggling and oversized pending writes are rejected.
+ * 2. `nullptr + 0` 空 backing storage。 Empty backing storage: verify an empty raw view can initialize the object without forcing a dummy pointer.
+ * 3. `FillPending()` 的写入与重复写保护。 Pending fill semantics: verify `FillPending()` stores bytes and rejects a second pending fill before switch.
+ * 4. `Switch()` 切换和越界长度拒绝。 Switch semantics and bounds: verify active-half toggling and oversized pending writes are rejected.
  *
  * 测试原理 / Test principles:
  * 1. 使用一个具体后备缓冲区，同时检查地址和长度，因为它是纯存储布局原语。 Use one concrete backing buffer and inspect both addresses and lengths, because this utility is a pure storage-layout primitive.
@@ -33,6 +34,20 @@ void test_double_buffer()
   ASSERT(init_later.Size() == 64);
   ASSERT((reinterpret_cast<uintptr_t>(init_later.ActiveBuffer()) % alignof(size_t)) == 0U);
   ASSERT((reinterpret_cast<uintptr_t>(init_later.PendingBuffer()) % alignof(size_t)) == 0U);
+
+  LibXR::DoubleBuffer empty_buffer;
+  LibXR::RawData empty_raw(nullptr, 0);
+  empty_buffer.Init(empty_raw);
+  ASSERT(empty_buffer.Size() == 0);
+  ASSERT(empty_buffer.ActiveBuffer() == nullptr);
+  ASSERT(empty_buffer.PendingBuffer() == nullptr);
+  ASSERT(empty_buffer.HasPending() == false);
+  ASSERT(empty_buffer.FillPending(nullptr, 0) == true);
+  ASSERT(empty_buffer.HasPending() == true);
+  ASSERT(empty_buffer.GetPendingLength() == 0);
+  empty_buffer.Switch();
+  ASSERT(empty_buffer.ActiveBuffer() == nullptr);
+  ASSERT(empty_buffer.FillActive(nullptr, 0) == true);
 
   LibXR::DoubleBuffer buffer(raw);
 


### PR DESCRIPTION
## Summary
- allow `DoubleBuffer::Init()` to accept empty backing storage as `RawData(nullptr, 0)`
- keep the existing non-empty storage assertions unchanged
- avoid `nullptr + 0` pointer arithmetic when binding the second half-buffer
- keep `FillPending()` and `FillActive()` on their original logic paths

## Verification
- Ubuntu24 run dir: `/home/xiao/runs/libxr_double_buffer_zero_20260616T115145Z`
- result:
  - `extract=PASS`
  - `cmake=PASS`
  - `build=PASS`
  - `test=PASS`

## Summary by Sourcery

允许使用空的底层存储来初始化 DoubleBuffer，并确保在零大小缓冲区上的操作行为正确。

New Features:
- 支持使用空的 RawData 视图（nullptr, 0）作为有效的底层存储来初始化 DoubleBuffer。

Enhancements:
- 在 DoubleBuffer 初始化时绑定内部半缓冲区的过程中，防止对 nullptr 进行指针运算。
- 明确 Init() API 文档，说明其对空底层存储的支持。

Tests:
- 扩展 double buffer 测试，用于覆盖在空缓冲区上的初始化和操作，包括 pending/active 填充以及切换。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow DoubleBuffer to be initialized with empty backing storage and ensure operations behave correctly on a zero-sized buffer.

New Features:
- Support initializing DoubleBuffer with an empty RawData view (nullptr, 0) as valid backing storage.

Enhancements:
- Guard against nullptr pointer arithmetic when binding internal half-buffers in DoubleBuffer initialization.
- Clarify Init() API documentation to describe support for empty backing storage.

Tests:
- Extend double buffer tests to cover initialization and operations on an empty buffer, including pending/active fills and switching.

</details>