### PR TITLE
refactor(memory): remove nothrow allocation paths

### DIFF
--- a/driver/esp/esp_adc.cpp
+++ b/driver/esp/esp_adc.cpp
@@ -75,11 +75,6 @@ ESP32ADC::ESP32ADC(adc_unit_t unit, const adc_channel_t* channels, uint8_t num_c
   channel_ready_ = new bool[num_channels_];
   latest_values_ = new float[num_channels_];
   latest_raw_ = new uint16_t[num_channels_];
-  REQUIRE(channels_ != nullptr);
-  REQUIRE(channel_ids_ != nullptr);
-  REQUIRE(channel_ready_ != nullptr);
-  REQUIRE(latest_values_ != nullptr);
-  REQUIRE(latest_raw_ != nullptr);
 
   for (uint8_t i = 0; i < SOC_ADC_MAX_CHANNEL_NUM; ++i)
   {

--- a/driver/esp/esp_adc.cpp
+++ b/driver/esp/esp_adc.cpp
@@ -1,7 +1,5 @@
 #include "esp_adc.hpp"
 
-#include <new>
-
 #include "esp_adc/adc_cali_scheme.h"
 #include "esp_clk_tree.h"
 #include "esp_private/adc_private.h"
@@ -72,23 +70,16 @@ ESP32ADC::ESP32ADC(adc_unit_t unit, const adc_channel_t* channels, uint8_t num_c
     return;
   }
 
-  channels_ = new (std::nothrow) Channel[num_channels_];
-  channel_ids_ = new (std::nothrow) adc_channel_t[num_channels_];
-  channel_ready_ = new (std::nothrow) bool[num_channels_];
-  latest_values_ = new (std::nothrow) float[num_channels_];
-  latest_raw_ = new (std::nothrow) uint16_t[num_channels_];
-  ASSERT(channels_ != nullptr);
-  ASSERT(channel_ids_ != nullptr);
-  ASSERT(channel_ready_ != nullptr);
-  ASSERT(latest_values_ != nullptr);
-  ASSERT(latest_raw_ != nullptr);
-  if ((channels_ == nullptr) || (channel_ids_ == nullptr) ||
-      (channel_ready_ == nullptr) || (latest_values_ == nullptr) ||
-      (latest_raw_ == nullptr))
-  {
-    ASSERT(false);
-    return;
-  }
+  channels_ = new Channel[num_channels_];
+  channel_ids_ = new adc_channel_t[num_channels_];
+  channel_ready_ = new bool[num_channels_];
+  latest_values_ = new float[num_channels_];
+  latest_raw_ = new uint16_t[num_channels_];
+  REQUIRE(channels_ != nullptr);
+  REQUIRE(channel_ids_ != nullptr);
+  REQUIRE(channel_ready_ != nullptr);
+  REQUIRE(latest_values_ != nullptr);
+  REQUIRE(latest_raw_ != nullptr);
 
   for (uint8_t i = 0; i < SOC_ADC_MAX_CHANNEL_NUM; ++i)
   {

--- a/driver/esp/esp_adc_continuous.cpp
+++ b/driver/esp/esp_adc_continuous.cpp
@@ -139,7 +139,6 @@ ESP32ADC::ContinuousInitResult ESP32ADC::InitContinuous(uint32_t freq,
 
   continuous_read_buf_ = new uint8_t[frame_size];
   continuous_parsed_buf_ = new adc_continuous_data_t[parsed_capacity];
-  REQUIRE((continuous_read_buf_ != nullptr) && (continuous_parsed_buf_ != nullptr));
 
   adc_continuous_handle_cfg_t handle_cfg = {};
   handle_cfg.max_store_buf_size = store_size;

--- a/driver/esp/esp_adc_continuous.cpp
+++ b/driver/esp/esp_adc_continuous.cpp
@@ -1,5 +1,4 @@
 #include <array>
-#include <new>
 
 #include "esp_adc.hpp"
 
@@ -138,13 +137,9 @@ ESP32ADC::ContinuousInitResult ESP32ADC::InitContinuous(uint32_t freq,
               SOC_ADC_DIGI_DATA_BYTES_PER_CONV);
   const uint32_t parsed_capacity = frame_size / SOC_ADC_DIGI_RESULT_BYTES;
 
-  continuous_read_buf_ = new (std::nothrow) uint8_t[frame_size];
-  continuous_parsed_buf_ = new (std::nothrow) adc_continuous_data_t[parsed_capacity];
-  ASSERT((continuous_read_buf_ != nullptr) && (continuous_parsed_buf_ != nullptr));
-  if ((continuous_read_buf_ == nullptr) || (continuous_parsed_buf_ == nullptr))
-  {
-    return ContinuousInitResult::FAILED;
-  }
+  continuous_read_buf_ = new uint8_t[frame_size];
+  continuous_parsed_buf_ = new adc_continuous_data_t[parsed_capacity];
+  REQUIRE((continuous_read_buf_ != nullptr) && (continuous_parsed_buf_ != nullptr));
 
   adc_continuous_handle_cfg_t handle_cfg = {};
   handle_cfg.max_store_buf_size = store_size;

--- a/driver/esp/esp_adc_oneshot.cpp
+++ b/driver/esp/esp_adc_oneshot.cpp
@@ -25,7 +25,6 @@ bool ESP32ADC::InitOneshot()
   }
 
   oneshot_hal_ = new adc_oneshot_hal_ctx_t{};
-  REQUIRE(oneshot_hal_ != nullptr);
 
   adc_oneshot_hal_cfg_t unit_cfg = {};
   unit_cfg.unit = unit_;

--- a/driver/esp/esp_adc_oneshot.cpp
+++ b/driver/esp/esp_adc_oneshot.cpp
@@ -1,5 +1,3 @@
-#include <new>
-
 #include "esp_adc.hpp"
 #include "esp_clk_tree.h"
 #include "esp_private/adc_share_hw_ctrl.h"
@@ -26,12 +24,8 @@ bool ESP32ADC::InitOneshot()
     return false;
   }
 
-  oneshot_hal_ = new (std::nothrow) adc_oneshot_hal_ctx_t{};
-  ASSERT(oneshot_hal_ != nullptr);
-  if (oneshot_hal_ == nullptr)
-  {
-    return false;
-  }
+  oneshot_hal_ = new adc_oneshot_hal_ctx_t{};
+  REQUIRE(oneshot_hal_ != nullptr);
 
   adc_oneshot_hal_cfg_t unit_cfg = {};
   unit_cfg.unit = unit_;

--- a/driver/esp/esp_cdc_jtag.cpp
+++ b/driver/esp/esp_cdc_jtag.cpp
@@ -37,7 +37,6 @@ ESP32CDCJtag::ESP32CDCJtag(size_t rx_buffer_size, size_t tx_buffer_size,
       _read_port(rx_buffer_size, *this),
       _write_port(tx_queue_size, tx_buffer_size)
 {
-  REQUIRE(tx_slot_storage_ != nullptr);
   ASSERT(tx_buffer_size > 0U);
 
   tx_double_buffer_.Init({tx_slot_storage_, tx_buffer_size * 2U});

--- a/driver/esp/esp_cdc_jtag.cpp
+++ b/driver/esp/esp_cdc_jtag.cpp
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <cstring>
-#include <new>
 
 #include "esp_attr.h"
 #include "hal/usb_serial_jtag_ll.h"
@@ -34,11 +33,11 @@ ESP32CDCJtag::ESP32CDCJtag(size_t rx_buffer_size, size_t tx_buffer_size,
                            uint32_t tx_queue_size, UART::Configuration config)
     : UART(&_read_port, &_write_port),
       config_(config),
-      tx_slot_storage_(new (std::nothrow) uint8_t[tx_buffer_size * 2U]),
+      tx_slot_storage_(new uint8_t[tx_buffer_size * 2U]),
       _read_port(rx_buffer_size, *this),
       _write_port(tx_queue_size, tx_buffer_size)
 {
-  ASSERT(tx_slot_storage_ != nullptr);
+  REQUIRE(tx_slot_storage_ != nullptr);
   ASSERT(tx_buffer_size > 0U);
 
   tx_double_buffer_.Init({tx_slot_storage_, tx_buffer_size * 2U});

--- a/driver/esp/esp_uart.cpp
+++ b/driver/esp/esp_uart.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cstring>
-#include <new>
 
 #include "esp_attr.h"
 #include "esp_clk_tree.h"
@@ -112,7 +111,7 @@ ESP32UART::ESP32UART(uart_port_t uart_num, int tx_pin, int rx_pin, int rts_pin,
       rts_pin_(rts_pin),
       cts_pin_(cts_pin),
       config_(config),
-      rx_isr_buffer_(new (std::nothrow) uint8_t[rx_buffer_size]),
+      rx_isr_buffer_(new uint8_t[rx_buffer_size]),
       rx_isr_buffer_size_(rx_buffer_size),
       tx_storage_(AllocateTxStorage(tx_buffer_size * 2)),
       dma_requested_(enable_dma),
@@ -124,8 +123,8 @@ ESP32UART::ESP32UART(uart_port_t uart_num, int tx_pin, int rx_pin, int rts_pin,
   ASSERT(uart_num_ < SOC_UART_HP_NUM);
   ASSERT(rx_isr_buffer_size_ > 0);
   ASSERT(tx_buffer_size > 0);
-  ASSERT(rx_isr_buffer_ != nullptr);
-  ASSERT(tx_storage_ != nullptr);
+  REQUIRE(rx_isr_buffer_ != nullptr);
+  REQUIRE(tx_storage_ != nullptr);
 
   tx_dma_buffer_.Init({tx_storage_, tx_buffer_size * 2U});
 

--- a/driver/esp/esp_uart.cpp
+++ b/driver/esp/esp_uart.cpp
@@ -123,8 +123,6 @@ ESP32UART::ESP32UART(uart_port_t uart_num, int tx_pin, int rx_pin, int rts_pin,
   ASSERT(uart_num_ < SOC_UART_HP_NUM);
   ASSERT(rx_isr_buffer_size_ > 0);
   ASSERT(tx_buffer_size > 0);
-  REQUIRE(rx_isr_buffer_ != nullptr);
-  REQUIRE(tx_storage_ != nullptr);
 
   tx_dma_buffer_.Init({tx_storage_, tx_buffer_size * 2U});
 

--- a/src/core/libxr_string.hpp
+++ b/src/core/libxr_string.hpp
@@ -451,7 +451,6 @@ class RuntimeStringView
     }
 
     data_ = new char[payload_size + 1U];
-    REQUIRE(data_ != nullptr);
     capacity_ = payload_size;
     return ErrorCode::OK;
   }

--- a/src/core/libxr_string.hpp
+++ b/src/core/libxr_string.hpp
@@ -4,7 +4,6 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
-#include <new>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -424,15 +423,13 @@ class RuntimeStringView
    *
    * RuntimeStringView 的容量策略是一次分配后复用。格式化路径会先从编译格式
    * 元数据计算最大容量，因此已有存储不足表示设计边界被突破，不能在这里静默
-   * new 第二块内存。
-   * 第一次保留分配若失败，开发期应直接暴露问题；发布构建仍保留 `NO_MEM`
-   * 回退状态。
+   * new 第二块内存。首次保留分配失败属于硬资源错误，交给 LibXR 分配边界处理。
    *
    * RuntimeStringView reuses one allocation. The formatted path computes maximum
    * capacity from compiled format metadata first, so an oversized later write is
-   * a boundary error rather than a reason to allocate again.
-   * If the first retained allocation fails, debug builds should surface it
-   * immediately; release builds still keep the `NO_MEM` fallback status.
+   * a boundary error rather than a reason to allocate again. First retained
+   * allocation failure is a hard resource error and is handled at the LibXR
+   * allocation boundary.
    */
   [[nodiscard]] ErrorCode EnsureCapacity(size_t payload_size)
   {
@@ -453,12 +450,8 @@ class RuntimeStringView
       return ErrorCode::OK;
     }
 
-    data_ = new (std::nothrow) char[payload_size + 1U];
-    if (data_ == nullptr)
-    {
-      ASSERT(data_ != nullptr);
-      return ErrorCode::NO_MEM;
-    }
+    data_ = new char[payload_size + 1U];
+    REQUIRE(data_ != nullptr);
     capacity_ = payload_size;
     return ErrorCode::OK;
   }

--- a/src/structure/queue/mpmc_queue_base.cpp
+++ b/src/structure/queue/mpmc_queue_base.cpp
@@ -29,8 +29,8 @@ MPMCQueueBase::MPMCQueueBase(size_t element_size, size_t capacity)
   sequences_ = new (std::align_val_t(alignof(SequenceCell))) SequenceCell[capacity_];
   REQUIRE(sequences_ != nullptr);
 
-  payloads_ = static_cast<std::byte*>(::operator new[](
-      payload_bytes, std::align_val_t(PAYLOAD_ALLOC_ALIGN)));
+  payloads_ = static_cast<std::byte*>(
+      ::operator new[](payload_bytes, std::align_val_t(PAYLOAD_ALLOC_ALIGN)));
   REQUIRE(payloads_ != nullptr);
 
   for (size_t index = 0; index < capacity_; ++index)

--- a/src/structure/queue/mpmc_queue_base.cpp
+++ b/src/structure/queue/mpmc_queue_base.cpp
@@ -26,12 +26,11 @@ MPMCQueueBase::MPMCQueueBase(size_t element_size, size_t capacity)
   REQUIRE(capacity_ <= static_cast<size_t>(std::numeric_limits<SequenceDiffType>::max()));
 
   const size_t payload_bytes = MultiplyChecked(payload_stride_, capacity_);
-  sequences_ =
-      new (std::align_val_t(alignof(SequenceCell)), std::nothrow) SequenceCell[capacity_];
+  sequences_ = new (std::align_val_t(alignof(SequenceCell))) SequenceCell[capacity_];
   REQUIRE(sequences_ != nullptr);
 
   payloads_ = static_cast<std::byte*>(::operator new[](
-      payload_bytes, std::align_val_t(PAYLOAD_ALLOC_ALIGN), std::nothrow));
+      payload_bytes, std::align_val_t(PAYLOAD_ALLOC_ALIGN)));
   REQUIRE(payloads_ != nullptr);
 
   for (size_t index = 0; index < capacity_; ++index)

--- a/src/structure/queue/mpmc_queue_base.cpp
+++ b/src/structure/queue/mpmc_queue_base.cpp
@@ -27,11 +27,9 @@ MPMCQueueBase::MPMCQueueBase(size_t element_size, size_t capacity)
 
   const size_t payload_bytes = MultiplyChecked(payload_stride_, capacity_);
   sequences_ = new (std::align_val_t(alignof(SequenceCell))) SequenceCell[capacity_];
-  REQUIRE(sequences_ != nullptr);
 
   payloads_ = static_cast<std::byte*>(
       ::operator new[](payload_bytes, std::align_val_t(PAYLOAD_ALLOC_ALIGN)));
-  REQUIRE(payloads_ != nullptr);
 
   for (size_t index = 0; index < capacity_; ++index)
   {

--- a/src/structure/queue/spsc_queue_base.hpp
+++ b/src/structure/queue/spsc_queue_base.hpp
@@ -77,7 +77,6 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
     const size_t payload_bytes = MultiplyChecked(payload_stride_, RingCapacity());
     payloads_ = static_cast<std::byte*>(::operator new[](
         payload_bytes, std::align_val_t(payload_alloc_align_)));
-    REQUIRE(payloads_ != nullptr);
   }
 
  public:

--- a/src/structure/queue/spsc_queue_base.hpp
+++ b/src/structure/queue/spsc_queue_base.hpp
@@ -76,7 +76,7 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
 
     const size_t payload_bytes = MultiplyChecked(payload_stride_, RingCapacity());
     payloads_ = static_cast<std::byte*>(::operator new[](
-        payload_bytes, std::align_val_t(payload_alloc_align_), std::nothrow));
+        payload_bytes, std::align_val_t(payload_alloc_align_)));
     REQUIRE(payloads_ != nullptr);
   }
 

--- a/system/freertos/libxr_system.cpp
+++ b/system/freertos/libxr_system.cpp
@@ -52,7 +52,7 @@ void* operator new(std::size_t size)
 #endif
 
   auto ans = pvPortMalloc(size);
-  ASSERT(ans != nullptr);
+  REQUIRE(ans != nullptr);
   return ans;
 }
 
@@ -78,11 +78,7 @@ void* operator new(std::size_t size, std::align_val_t align)
   std::size_t a = static_cast<std::size_t>(align);
   std::size_t space = size + a + sizeof(void*);
   void* raw = pvPortMalloc(space);
-  if (raw == nullptr)
-  {
-    ASSERT(false);
-    return raw;  // NOLINT
-  }
+  REQUIRE(raw != nullptr);
 
   uintptr_t raw_addr = reinterpret_cast<uintptr_t>(raw) + sizeof(void*);
   uintptr_t aligned_addr = (raw_addr + a - 1) & ~(a - 1);


### PR DESCRIPTION
## Summary
- Remove `std::nothrow` allocation usage from LibXR-owned source code.
- Keep third-party Eigen untouched.
- Route retained allocation failures through existing LibXR allocation/require boundaries instead of libc++ nothrow wrappers.
- Replace the queue `std::align_val_t + std::nothrow` allocations that pulled in libc++ `__lcxx_override` start/stop symbols under lld `--gc-sections`.
- Make FreeRTOS global `operator new` allocation failures use `REQUIRE` so the failure boundary is active in release builds too.

## Validation
- Verified LibXR-owned `src/`, `driver/`, and `system/` code has no remaining `std::nothrow` usage.
- Verified PR diff is limited to allocation semantics; third-party Eigen nothrow declarations are unchanged.
- GitHub Actions are running on the updated PR branch.
