### PR TITLE
fix(print): fully gate float runtime paths

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,3 +57,25 @@ jobs:
       shell: bash
       run: |
         tools/format_cmake_files.sh --check
+
+  no-float-smoke:
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: configure no-float smoke
+      shell: bash
+      run: |
+        cmake -S . -B build-nofloat \
+          -DLIBXR_TEST_BUILD=True \
+          -DLIBXR_PRINT_ENABLE_FLOAT=0 \
+          -DLIBXR_PRINT_FLOAT_ENABLE_FIXED=0 \
+          -DLIBXR_PRINT_FLOAT_ENABLE_DOUBLE=0 \
+          -DLIBXR_PRINT_FLOAT_ENABLE_SCIENTIFIC=0 \
+          -DLIBXR_PRINT_FLOAT_ENABLE_GENERAL=0 \
+          -DLIBXR_PRINT_FLOAT_ENABLE_LONG_DOUBLE=0
+    - name: build no-float smoke
+      shell: bash
+      run: |
+        cmake --build build-nofloat -j"$(nproc)"

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -57,25 +57,3 @@ jobs:
       shell: bash
       run: |
         tools/format_cmake_files.sh --check
-
-  no-float-smoke:
-    needs: build
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - name: configure no-float smoke
-      shell: bash
-      run: |
-        cmake -S . -B build-nofloat \
-          -DLIBXR_TEST_BUILD=True \
-          -DLIBXR_PRINT_ENABLE_FLOAT=0 \
-          -DLIBXR_PRINT_FLOAT_ENABLE_FIXED=0 \
-          -DLIBXR_PRINT_FLOAT_ENABLE_DOUBLE=0 \
-          -DLIBXR_PRINT_FLOAT_ENABLE_SCIENTIFIC=0 \
-          -DLIBXR_PRINT_FLOAT_ENABLE_GENERAL=0 \
-          -DLIBXR_PRINT_FLOAT_ENABLE_LONG_DOUBLE=0
-    - name: build no-float smoke
-      shell: bash
-      run: |
-        cmake --build build-nofloat -j"$(nproc)"

--- a/src/core/print/writer.hpp
+++ b/src/core/print/writer.hpp
@@ -476,6 +476,7 @@ class Writer
   [[nodiscard]] static bool AppendBufferU32ZeroPad(char* buffer, size_t capacity,
                                                    size_t& size, uint32_t value, uint8_t width);
 
+#if LIBXR_PRINT_ENABLE_FLOAT
   /**
    * @brief 基于精确 float32 位模式并按最近偶数处理平局返回 `round(value * scale)` / Return `round(value * scale)` using the exact float32 bit pattern and nearest-even ties
    * @param value 待缩放的 float32 绝对值 / Float32 magnitude to scale
@@ -592,6 +593,7 @@ class Writer
   template <typename Float>
   [[nodiscard]] static bool FormatFloatText(FormatType type, const Spec& spec, Float value,
                                             char* out, size_t& out_size);
+#endif
 
   class CodeReader;
   class ArgumentReader;
@@ -650,10 +652,12 @@ class Writer
 
 #include "writer/writer_argument.hpp"
 #include "writer/writer_integer.hpp"
+#if LIBXR_PRINT_ENABLE_FLOAT
 #include "writer/writer_float_runtime.hpp"
 #include "writer/writer_float_math.hpp"
 #include "writer/writer_float_fixed.hpp"
 #include "writer/writer_float_general.hpp"
+#endif
 #include "writer/writer_reader.hpp"
 #include "writer/writer_executor.hpp"
 }  // namespace LibXR::Print

--- a/src/core/print/writer/writer_executor.hpp
+++ b/src/core/print/writer/writer_executor.hpp
@@ -36,8 +36,10 @@ class Writer::Executor
   template <std::signed_integral Int>
   [[nodiscard]] static char ResolveSignChar(Int value, const Spec& spec);
 
+#if LIBXR_PRINT_ENABLE_FLOAT
   template <typename T>
   [[nodiscard]] static char ResolveFloatSignChar(T value, const Spec& spec);
+#endif
 
   template <std::signed_integral Int>
   [[nodiscard]] ErrorCode WriteSigned(const Spec& spec, Int value);
@@ -64,8 +66,10 @@ class Writer::Executor
   [[nodiscard]] ErrorCode WriteCharacter(const Spec& spec, char ch);
   [[nodiscard]] ErrorCode WriteString(const Spec& spec, std::string_view text);
 
+#if LIBXR_PRINT_ENABLE_FLOAT
   template <typename T>
   [[nodiscard]] ErrorCode WriteFloat(FormatType type, const Spec& spec, T value);
+#endif
 
   /**
    * @brief 单个原始 uint32_t 十进制字段的快路径。 / Fast path for one raw uint32_t decimal field.
@@ -82,6 +86,7 @@ class Writer::Executor
    */
   [[nodiscard]] ErrorCode WriteStringRaw(std::string_view text);
 
+#if LIBXR_PRINT_ENABLE_FLOAT
   /**
    * @brief 单个带显式精度的定点 float 快路径。 / Fast path for one fixed float with explicit precision.
    */
@@ -91,6 +96,7 @@ class Writer::Executor
    * @brief 单个带显式精度的定点 double 快路径。 / Fast path for one fixed double with explicit precision.
    */
   [[nodiscard]] ErrorCode WriteF64FixedPrec(uint8_t precision, double value);
+#endif
 
   // Small bridges that keep GenericField dispatch readable while preserving the
   // existing "read spec -> read next packed argument -> call concrete writer"
@@ -103,8 +109,10 @@ class Writer::Executor
   template <FormatType Type, std::unsigned_integral UInt>
   [[nodiscard]] ErrorCode DispatchUnsignedField();
 
+#if LIBXR_PRINT_ENABLE_FLOAT
   template <FormatType Type, typename Float>
   [[nodiscard]] ErrorCode DispatchFloatField();
+#endif
 
   [[nodiscard]] ErrorCode DispatchPointerField();
 

--- a/src/core/print/writer/writer_executor_generic.hpp
+++ b/src/core/print/writer/writer_executor_generic.hpp
@@ -29,6 +29,7 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchUnsignedField()
   return WriteUnsigned<Type>(codes_.ReadSpec(), args_.Read<UInt>());
 }
 
+#if LIBXR_PRINT_ENABLE_FLOAT
 /**
  * @brief 读取一个浮点载荷并转发给选定的浮点语义写出路径 / Read one float payload and forward it to the selected float semantic writer
  * @tparam Type 运行期浮点语义类型 / Runtime float semantic type
@@ -41,6 +42,7 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchFloatField()
 {
   return WriteFloat(Type, codes_.ReadSpec(), args_.Read<Float>());
 }
+#endif
 
 /**
  * @brief 读取一个指针载荷并走指针字段写出路径 / Read one pointer payload and write it through the pointer field path

--- a/src/core/print/writer/writer_executor_generic.hpp
+++ b/src/core/print/writer/writer_executor_generic.hpp
@@ -176,6 +176,7 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchGenericField(FormatType type)
         return ErrorCode::STATE_ERR;
       }
       return DispatchStringField();
+#if LIBXR_PRINT_ENABLE_FLOAT
     case FormatType::FloatFixed:
       if constexpr (!FloatEnabled(FormatType::FloatFixed))
       {
@@ -230,6 +231,7 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchGenericField(FormatType type)
         return ErrorCode::STATE_ERR;
       }
       return DispatchFloatField<FormatType::LongDoubleGeneral, long double>();
+#endif
     case FormatType::TextInline:
     case FormatType::TextRef:
     case FormatType::TextSpace:

--- a/src/core/print/writer/writer_executor_opcode.hpp
+++ b/src/core/print/writer/writer_executor_opcode.hpp
@@ -82,6 +82,7 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchOp(FormatOp op)
         return ErrorCode::STATE_ERR;
       }
       return WriteStringRaw(args_.Read<std::string_view>());
+#if LIBXR_PRINT_ENABLE_FLOAT
     case FormatOp::F32FixedPrec:
       if constexpr (!HasProfile(Profile, FormatProfile::F32Fixed) ||
                     !FloatEnabled(FormatType::FloatFixed))
@@ -96,6 +97,7 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchOp(FormatOp op)
         return ErrorCode::STATE_ERR;
       }
       return WriteF64FixedPrec(codes_.Read<uint8_t>(), args_.Read<double>());
+#endif
     case FormatOp::GenericField:
       if constexpr (!HasProfile(Profile, FormatProfile::Generic))
       {

--- a/src/core/print/writer/writer_executor_value.hpp
+++ b/src/core/print/writer/writer_executor_value.hpp
@@ -30,6 +30,7 @@ char Writer::Executor<Sink, Profile>::ResolveSignChar(Int value, const Spec& spe
   return '\0';
 }
 
+#if LIBXR_PRINT_ENABLE_FLOAT
 /**
  * @brief 为一个浮点载荷确定最终可见的符号字符 / Resolve the visible sign character for one float payload
  * @tparam T 浮点类型 / Float type
@@ -55,6 +56,7 @@ char Writer::Executor<Sink, Profile>::ResolveFloatSignChar(T value, const Spec& 
   }
   return '\0';
 }
+#endif
 
 /**
  * @brief 通过共享整数字段路径写出一个有符号整数值 / Write one signed integer value through the shared integer-field path
@@ -222,6 +224,7 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteString(const Spec& spec,
  * @param value 待写出的浮点值 / Float value to write
  * @return 返回浮点字段写出结果 / Returns the float-field write result
  */
+#if LIBXR_PRINT_ENABLE_FLOAT
 template <OutputSink Sink, FormatProfile Profile>
 template <typename T>
 ErrorCode Writer::Executor<Sink, Profile>::WriteFloat(FormatType type,
@@ -271,6 +274,7 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteFloat(FormatType type,
 
   return WriteFloatField(sign_char, std::string_view(output_buffer, output_size), spec);
 }
+#endif
 
 /**
  * @brief 写出一个原始 uint32 十进制快路径字段 / Writes one raw uint32 decimal fast-path field.
@@ -322,6 +326,7 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteStringRaw(std::string_view text)
  * @param value 待写出的浮点值 / Float value to write
  * @return 返回该快路径的写出结果 / Returns the fast-path write result
  */
+#if LIBXR_PRINT_ENABLE_FLOAT
 template <OutputSink Sink, FormatProfile Profile>
 ErrorCode Writer::Executor<Sink, Profile>::WriteF32FixedPrec(uint8_t precision,
                                                              float value)
@@ -362,3 +367,4 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteF64FixedPrec(uint8_t precision,
 {
   return WriteFloat(FormatType::DoubleFixed, Spec{.precision = precision}, value);
 }
+#endif

--- a/src/core/print/writer_runtime_os.cpp
+++ b/src/core/print/writer_runtime_os.cpp
@@ -78,6 +78,8 @@ bool Writer::AppendBufferU32ZeroPad(char* buffer, size_t capacity, size_t& size,
   return AppendBufferText(buffer, capacity, size, std::string_view(digits, digit_count));
 }
 
+#if LIBXR_PRINT_ENABLE_FLOAT
+
 uint64_t Writer::RoundScaledF32(float value, uint32_t scale)
 {
   uint32_t bits = std::bit_cast<uint32_t>(value);
@@ -326,4 +328,6 @@ bool Writer::FormatF32FixedPrecText(float value, uint8_t precision, char* out,
 
   return true;
 }
+
+#endif
 }  // namespace LibXR::Print


### PR DESCRIPTION
## Summary
Fix `libxr` print float gating so disabling float support actually removes print-side float runtime paths from the `xr` target.

This PR only contains the `libxr` core-side fix:
- guard float generic-field dispatch in `writer_executor_generic.hpp`
- guard float fixed-precision opcodes in `writer_executor_opcode.hpp`
- guard float runtime implementation bodies in `writer_runtime_os.cpp`

It intentionally does not include the downstream `XRDAP-F103C8` nested-subbuild propagation fix.

## Why
The earlier F103 investigation showed two separate issues:
1. downstream nested clock sub-builds were not propagating `LIBXR_PRINT_*` cache variables consistently
2. even when float-disable flags reached `xr`, a few print implementation paths still compiled float runtime code

This PR addresses only issue 2 inside `libxr` itself.

## Verification
Clean remote verification evidence was collected on Ubuntu24.

Float-disabled verification:
- `libxr.cpp.obj` float refs: `0`
- `writer_runtime_os.cpp.obj` float refs: `0`
- full print-object audit: `BAD_COUNT 0`
- artifact: `/root/codex/runs/repo_closure_dap_start_20260626T055917Z/libxr_float_gate_verify_clean_v2_20260626.tsv`

Float-enabled safety check:
- `XRDAP-F103C8 master + libxr codex/fix-print-float-gate-20260626` still built successfully on Ubuntu24
- resulting size matched prior float-enabled baseline: `text=44232`, `data=124`, `bss=6332`
- artifact: `/root/codex/runs/repo_closure_dap_start_20260626T055917Z/libxr_float_gate_commit_safety_20260627.tsv`

## Scope boundary
The downstream product-side patch that propagates `LIBXR_PRINT_*` variables into nested `XRDAP_F103C8_clock_*` sub-builds is tracked separately and should not be merged into `libxr`.

## Summary by Sourcery

通过 `LIBXR_PRINT_ENABLE_FLOAT` 来控制浮点打印相关的代码路径，这样在禁用浮点支持时，可以将浮点运行时代码路径完全从 `libxr` 中移除。

Bug Fixes:
- 通过在编译期使用宏保护，将浮点打印运行时函数包裹起来，当 `LIBXR_PRINT_ENABLE_FLOAT` 被禁用时，避免这些函数被编译。
- 当浮点打印支持被禁用时，在通用写入执行器中避免分派与浮点相关的格式类型和操作码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate float printing code paths on LIBXR_PRINT_ENABLE_FLOAT so that disabling float support fully removes float runtime paths from libxr.

Bug Fixes:
- Prevent float print runtime functions from being compiled when LIBXR_PRINT_ENABLE_FLOAT is disabled by wrapping them in compile-time guards.
- Avoid dispatching float-related format types and opcodes in the generic writer executor when float printing support is disabled.

</details>