### PR TITLE
refactor(assert): hide fatal callback storage

### DIFF
--- a/src/core/assert/diag.hpp
+++ b/src/core/assert/diag.hpp
@@ -12,9 +12,12 @@ namespace LibXR::Assert
  */
 using FatalCallback = LibXR::Callback<const char*, uint32_t>;
 
+namespace Detail
+{
 // Process-global fatal callback storage.
 // 进程级 fatal 回调存根。
 inline FatalCallback fatal_error_callback_;  // NOLINT
+}  // namespace Detail
 
 /**
  * @brief 注册 fatal 错误回调 / Register the fatal error callback
@@ -22,12 +25,29 @@ inline FatalCallback fatal_error_callback_;  // NOLINT
  */
 inline void RegisterFatalErrorCallback(FatalCallback cb)
 {
-  fatal_error_callback_ = std::move(cb);
+  Detail::fatal_error_callback_ = std::move(cb);
 }
 
 /**
  * @brief 返回当前注册的 fatal 错误回调对象 / Return the currently registered fatal error callback object
  * @return 当前注册的 fatal 错误回调对象 / Returns the currently registered fatal error callback object
  */
-[[nodiscard]] inline FatalCallback& FatalErrorCallback() { return fatal_error_callback_; }
+[[nodiscard]] inline FatalCallback FatalErrorCallback()
+{
+  return Detail::fatal_error_callback_;
+}
+
+/**
+ * @brief 执行当前 fatal 错误回调 / Run the currently registered fatal error callback
+ * @param in_isr 当前调用是否来自中断上下文 / Whether the current call is from ISR context
+ * @param file fatal 错误文件名 / Fatal error file name
+ * @param line fatal 错误行号 / Fatal error line number
+ */
+inline void RunFatalErrorCallback(bool in_isr, const char* file, uint32_t line)
+{
+  if (!Detail::fatal_error_callback_.Empty())
+  {
+    Detail::fatal_error_callback_.Run(in_isr, file, line);
+  }
+}
 }  // namespace LibXR::Assert

--- a/src/libxr.cpp
+++ b/src/libxr.cpp
@@ -18,13 +18,10 @@ extern "C" void libxr_fatal_error(const char* file, uint32_t line, bool in_isr)
         LibXR::STDIO::Print<"Fatal error at {}:{}\r\n">(file, static_cast<int>(line));
       }
 
-      if (!LibXR::Assert::FatalErrorCallback().Empty())
-      {
-        // The fatal callback is executed only on the non-ISR fatal path here.
-        // Normalize the user callback to thread context instead of forwarding the
-        // original fault source flag.
-        LibXR::Assert::FatalErrorCallback().Run(false, file, line);
-      }
+      // The fatal callback is executed only on the non-ISR fatal path here.
+      // Normalize the user callback to thread context instead of forwarding the
+      // original fault source flag.
+      LibXR::Assert::RunFatalErrorCallback(false, file, line);
 
       LibXR::Thread::Sleep(500);
     }

--- a/test/base/test_assert.cpp
+++ b/test/base/test_assert.cpp
@@ -55,7 +55,7 @@ void test_assert()
   LibXR::Assert::RegisterFatalErrorCallback(callback);
   ASSERT(!LibXR::Assert::FatalErrorCallback().Empty());
 
-  LibXR::Assert::FatalErrorCallback().Run(false, "test_assert.cpp", 42);
+  LibXR::Assert::RunFatalErrorCallback(false, "test_assert.cpp", 42);
   ASSERT(probe.hit_count == 1);
   ASSERT(!probe.in_isr);
   ASSERT(probe.file == "test_assert.cpp");

--- a/test/base/test_assert.cpp
+++ b/test/base/test_assert.cpp
@@ -4,7 +4,7 @@
  *
  * 测试项目 / Test items:
  * 1. Fatal 回调的注册与替换。 Fatal callback registration and replacement: verify the global fatal callback handle can be installed and restored cleanly.
- * 2. Fatal 回调分发参数透传。 Fatal callback dispatch argument propagation: verify `Run()` forwards the ISR flag, file name and line number to the bound callback.
+ * 2. Fatal 回调分发参数透传。 Fatal callback dispatch argument propagation: verify `RunFatalErrorCallback()` forwards the ISR flag, file name and line number to the bound callback.
  *
  * 测试原理 / Test principles:
  * 1. 只通过公开的 `LibXR::Assert` 回调接口操作，避免把私有存储细节当成契约。 Operate only through the public `LibXR::Assert` callback API, so the test documents the stable contract instead of private storage details.
@@ -37,10 +37,12 @@ struct FatalProbe
  */
 void test_assert()
 {
-  // 测试内容：按文件头列出的测试项目顺序执行当前测试入口。
-  // Test coverage: execute the test items listed in this file header in sequence.
+  // 测试项：保存当前测试框架 fatal 回调，避免本测试污染后续测试。
+  // Test item: preserve the current test-runner fatal callback so this test restores global state before returning.
   auto old_callback = LibXR::Assert::FatalErrorCallback();
 
+  // 测试项：构造探针回调，用副作用记录一次分发传入的全部参数。
+  // Test item: build a probe callback that records every argument passed by one dispatch.
   FatalProbe probe;
   auto callback = LibXR::Assert::FatalCallback::Create(
       [](bool in_isr, FatalProbe* probe, const char* file, uint32_t line)
@@ -52,14 +54,23 @@ void test_assert()
       },
       &probe);
 
+  // 测试项：注册探针回调，并确认公开读取接口能看到非空 fatal 回调。
+  // Test item: register the probe callback and verify the public getter reports a non-empty fatal callback.
   LibXR::Assert::RegisterFatalErrorCallback(callback);
   ASSERT(!LibXR::Assert::FatalErrorCallback().Empty());
 
+  // 测试项：通过封装后的执行入口触发 fatal 回调，而不是直接访问全局存储。
+  // Test item: dispatch through the wrapped run entry instead of reaching into global storage.
   LibXR::Assert::RunFatalErrorCallback(false, "test_assert.cpp", 42);
+
+  // 测试项：确认回调只执行一次，并且 ISR 标志、文件名、行号都原样透传。
+  // Test item: verify one callback hit and exact propagation of ISR flag, file name, and line number.
   ASSERT(probe.hit_count == 1);
   ASSERT(!probe.in_isr);
   ASSERT(probe.file == "test_assert.cpp");
   ASSERT(probe.line == 42);
 
+  // 测试项：恢复进入本测试前的 fatal 回调，保持测试入口的全局状态契约。
+  // Test item: restore the fatal callback that was active before this test to preserve the test runner contract.
   LibXR::Assert::RegisterFatalErrorCallback(old_callback);
 }


### PR DESCRIPTION
## Summary
- move fatal callback storage under `LibXR::Assert::Detail`
- make `FatalErrorCallback()` return a callback copy instead of a mutable global reference
- add `RunFatalErrorCallback()` and route fatal dispatch/test coverage through it
- document each `test_assert()` check inline

## Verification
- Ubuntu24 clean clone/apply/diff-check/cmake/build passed with `LIBXR_SYSTEM=Linux`, `LIBXR_DRIVER=Linux`, `LIBXR_TEST_BUILD=ON`, Debug
- `build/test/test` reached and passed `Test [assert] Passed`
- full test still later fails at existing `terminal_input`; earlier master/control run reproduced that failure, so it is not introduced by this PR

Artifacts:
- `/home/xiao/runs/libxr_assert_restart_master_20260628T125549Z/99_summary.txt`
- `/home/xiao/runs/libxr_assert_test_comments_20260628T140528Z/99_summary.txt`

## Summary by Sourcery

重构断言子系统中的致命错误回调处理，将全局存储隐藏在 detail 命名空间后，并统一回调调用入口。

Enhancements:
- 将进程级的致命错误回调存储隐藏在 `LibXR::Assert::Detail` 命名空间中，并将公共 getter 修改为返回拷贝而不是可变引用。
- 引入 `RunFatalErrorCallback` 入口点，并通过该入口统一调度库中的致命错误，而不是直接访问全局回调存储。

Tests:
- 扩展断言的致命回调测试，使其使用 `RunFatalErrorCallback`，在测试中保存并恢复之前的回调，并对每个测试项进行内联文档说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor fatal error callback handling in the assert subsystem to hide global storage behind a detail namespace and centralize callback invocation.

Enhancements:
- Hide process-global fatal error callback storage in the LibXR::Assert::Detail namespace and change the public getter to return a copy instead of a mutable reference.
- Introduce a RunFatalErrorCallback entry point and route library fatal error dispatch through it to avoid direct access to global callback storage.

Tests:
- Expand the assert fatal-callback test to use RunFatalErrorCallback, preserve and restore the prior callback, and document each test item inline.

</details>