### PR TITLE
test(print): add compile-time config matrix

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,40 +5,47 @@ endif()
 add_compile_options(-g)
 
 file(GLOB_RECURSE XR_TEST_BASE_SOURCES CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/base/*.cpp")
+     "${CMAKE_CURRENT_SOURCE_DIR}/base/*.cpp"
+)
 list(SORT XR_TEST_BASE_SOURCES)
 
 file(GLOB_RECURSE XR_TEST_RUNTIME_SOURCES CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/runtime/*.cpp")
+     "${CMAKE_CURRENT_SOURCE_DIR}/runtime/*.cpp"
+)
 list(SORT XR_TEST_RUNTIME_SOURCES)
 
 file(GLOB_RECURSE XR_TEST_LINUX_STDIO_SOURCES CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/linux_stdio/*.cpp")
+     "${CMAKE_CURRENT_SOURCE_DIR}/linux_stdio/*.cpp"
+)
 list(SORT XR_TEST_LINUX_STDIO_SOURCES)
 
 file(GLOB_RECURSE XR_TEST_LINUX_DATABASE_SOURCES CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/linux_database/*.cpp")
+     "${CMAKE_CURRENT_SOURCE_DIR}/linux_database/*.cpp"
+)
 list(SORT XR_TEST_LINUX_DATABASE_SOURCES)
 
 file(GLOB_RECURSE XR_TEST_LINUX_SHM_SOURCES CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/linux_shm/*.cpp")
+     "${CMAKE_CURRENT_SOURCE_DIR}/linux_shm/*.cpp"
+)
 list(SORT XR_TEST_LINUX_SHM_SOURCES)
 
 file(GLOB_RECURSE XR_TEST_LINUX_BENCH_SOURCES CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/linux_bench/*.cpp")
+     "${CMAKE_CURRENT_SOURCE_DIR}/linux_bench/*.cpp"
+)
 list(SORT XR_TEST_LINUX_BENCH_SOURCES)
 
-set(XR_TEST_HARNESS_SOURCES
-    "${CMAKE_CURRENT_SOURCE_DIR}/framework/main.cpp")
+set(XR_TEST_HARNESS_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/framework/main.cpp")
 
-add_executable(test
+add_executable(
+  test
   ${XR_TEST_HARNESS_SOURCES}
   ${XR_TEST_BASE_SOURCES}
   ${XR_TEST_RUNTIME_SOURCES}
   ${XR_TEST_LINUX_STDIO_SOURCES}
   ${XR_TEST_LINUX_DATABASE_SOURCES}
   ${XR_TEST_LINUX_SHM_SOURCES}
-  ${XR_TEST_LINUX_BENCH_SOURCES})
+  ${XR_TEST_LINUX_BENCH_SOURCES}
+)
 add_dependencies(test xr)
 
 target_link_libraries(test PUBLIC xr)
@@ -47,19 +54,25 @@ target_include_directories(
   test
   PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/framework"
   PUBLIC $<TARGET_PROPERTY:xr,INTERFACE_INCLUDE_DIRECTORIES>
-  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../lib/Eigen)
+  PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../lib/Eigen
+)
 
 file(GLOB_RECURSE XR_TEST_PRINT_CONFIG_SOURCES CONFIGURE_DEPENDS
-     "${CMAKE_CURRENT_SOURCE_DIR}/print_config/*.cpp")
+     "${CMAKE_CURRENT_SOURCE_DIR}/print_config/*.cpp"
+)
 list(SORT XR_TEST_PRINT_CONFIG_SOURCES)
 
 add_library(test_print_config_matrix OBJECT ${XR_TEST_PRINT_CONFIG_SOURCES})
 add_dependencies(test_print_config_matrix xr)
 
 target_compile_features(test_print_config_matrix PRIVATE cxx_std_20)
+target_compile_definitions(
+  test_print_config_matrix PRIVATE $<TARGET_PROPERTY:xr,INTERFACE_COMPILE_DEFINITIONS>
+)
 
 target_include_directories(
   test_print_config_matrix
   PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/print_config"
   PRIVATE $<TARGET_PROPERTY:xr,INTERFACE_INCLUDE_DIRECTORIES>
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/Eigen)
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/Eigen
+)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,3 +48,18 @@ target_include_directories(
   PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/framework"
   PUBLIC $<TARGET_PROPERTY:xr,INTERFACE_INCLUDE_DIRECTORIES>
   PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../lib/Eigen)
+
+file(GLOB_RECURSE XR_TEST_PRINT_CONFIG_SOURCES CONFIGURE_DEPENDS
+     "${CMAKE_CURRENT_SOURCE_DIR}/print_config/*.cpp")
+list(SORT XR_TEST_PRINT_CONFIG_SOURCES)
+
+add_library(test_print_config_matrix OBJECT ${XR_TEST_PRINT_CONFIG_SOURCES})
+add_dependencies(test_print_config_matrix xr)
+
+target_compile_features(test_print_config_matrix PRIVATE cxx_std_20)
+
+target_include_directories(
+  test_print_config_matrix
+  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/print_config"
+  PRIVATE $<TARGET_PROPERTY:xr,INTERFACE_INCLUDE_DIRECTORIES>
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../lib/Eigen)

--- a/test/base/print/print_compare_test_common.hpp
+++ b/test/base/print/print_compare_test_common.hpp
@@ -1,12 +1,11 @@
 /**
  * @file print_compare_test_common.hpp
- * @brief `print` 文本对照与失败断言 helper。 Shared comparison and failure helpers for `print` tests.
- * @details 测试项目：
- *          1. 提供 `snprintf` / `Format` / `Printf` 的文本对照 helper。
- *          2. 提供指针、无符号进制文本和失败退出 helper。
- *          Test items:
- *          1. Provide text-comparison helpers for `snprintf`, `Format`, and `Printf`.
- *          2. Provide pointer/base-string helpers and the shared failure exit helper.
+ * @brief `print` 输出对照和失败报告 helper。 Output comparison and failure-report helpers
+ * for `print` tests.
+ * @details
+ * 1. `SameAsSnprintf` 对照 host `snprintf`。
+ * 2. Expected-text helpers cover brace formats.
+ * 3. Expected-text helpers also cover LibXR extensions.
  */
 #pragma once
 
@@ -108,8 +107,7 @@ std::string UnsignedBaseText(UInt value, uint8_t base, bool upper_case = false)
   std::string reversed;
   while (value != 0)
   {
-    reversed.push_back(
-        digits[static_cast<size_t>(value % static_cast<UInt>(base))]);
+    reversed.push_back(digits[static_cast<size_t>(value % static_cast<UInt>(base))]);
     value /= static_cast<UInt>(base);
   }
 

--- a/test/base/print/print_literal_test_common.hpp
+++ b/test/base/print/print_literal_test_common.hpp
@@ -1,12 +1,10 @@
 /**
  * @file print_literal_test_common.hpp
- * @brief `print` 前端字面量解析测试共用约束。 Shared literal-resolution constraints for `print` frontend tests.
- * @details 测试项目：
- *          1. 固化 `Format` 参数匹配的编译期约束。
- *          2. 固化 logger 字面量前端自动判定的编译期约束。
- *          Test items:
- *          1. Lock in compile-time argument-matching constraints for `Format`.
- *          2. Lock in compile-time auto-frontend resolution constraints for logger literals.
+ * @brief `print` 字面量前端的编译期约束。 Compile-time constraints for `print`
+ * literal frontends.
+ * @details
+ * 1. 固化 brace `Format` 的参数匹配规则。
+ * 2. 固化 logger 自动选择 brace/printf/None/Ambiguous 的边界。
  */
 #pragma once
 

--- a/test/base/print/print_sink_test_common.hpp
+++ b/test/base/print/print_sink_test_common.hpp
@@ -1,12 +1,11 @@
 /**
  * @file print_sink_test_common.hpp
- * @brief `print` sink 与坏格式探针。 Shared sinks and malformed-format probes for `print` tests.
- * @details 测试项目：
- *          1. 提供字符串 sink 和限长 sink。
- *          2. 提供用于失败路径的坏格式探针对象。
- *          Test items:
- *          1. Provide string sinks and bounded sinks.
- *          2. Provide malformed-format probe objects for failure-path tests.
+ * @brief `print` 测试用 sink 和坏格式探针。 Test sinks and malformed-format probes
+ * for `print` tests.
+ * @details
+ * 1. `StringSink` 收集完整输出，`LimitedSink` 模拟 sink 写满。
+ * 2. `BrokenGenericFormat` 测 wrapper 错误返回。
+ * 3. `PrefixThenBrokenFormat` 测 stream 前缀保留。
  */
 #pragma once
 

--- a/test/base/print/print_test_common.hpp
+++ b/test/base/print/print_test_common.hpp
@@ -1,12 +1,11 @@
 /**
  * @file print_test_common.hpp
- * @brief `print` 测试聚合 helper 入口。 Aggregation helper entry for `print` tests.
- * @details 作用：
- *          1. 聚合字面量解析约束、sink/坏格式探针和字符串对照 helper。
- *          2. 让各个 `print` 子测试文件只依赖一个薄包装头。
- *          Purpose:
- *          1. Aggregate literal-resolution constraints, sink/malformed-format probes, and comparison helpers.
- *          2. Keep split `print` test files depending on one thin wrapper header.
+ * @brief 默认 profile `print` 测试的共用 helper 入口。 Shared helper entry for
+ * default-profile `print` tests.
+ * @details
+ * 1. 聚合字面量编译期约束。
+ * 2. 聚合 sink/坏格式探针。
+ * 3. 聚合文本对照 helper。
  */
 #pragma once
 

--- a/test/base/print/test_format_frontend.cpp
+++ b/test/base/print/test_format_frontend.cpp
@@ -1,20 +1,25 @@
 /**
  * @file test_format_frontend.cpp
- * @brief `print` format 前端语义子测试。 Split test unit for `print` format frontend semantics.
+ * @brief 默认 profile 的 brace `Format` 运行时输出测试。 Default-profile brace
+ * `Format` runtime output tests.
+ * @details
+ * 1. 覆盖 `{}` 字面量编译后的 writer 输出。
+ * 2. 覆盖转义、显式索引、整数进制、字符串、浮点和指针。
+ * 3. 覆盖 `WriteTo` 直接写入路径。
  */
 #include "print_test_common.hpp"
 
 namespace LibXRPrintTest
 {
 /**
- * @brief 测试项函数 `TestFormatFrontendSemantics`。 Test-item function `TestFormatFrontendSemantics`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 覆盖默认 brace `Format` profile 下的输出语义。 Cover output semantics under the
+ * default brace `Format` profile.
+ * @details 期望文本写在测试内；brace 格式不是 host `snprintf` 方言。
  */
 void TestFormatFrontendSemantics()
 {
-  // 测试内容：执行当前辅助测试项，对应文件头中的一个具体项目。
-  // Test coverage: execute the current helper-scoped test item from this file.
+  // 文本、转义和索引：确认 `{}` 前端最基础的 source 解析和参数重排。
+  // Text, escapes, and indexing: basic source parsing plus argument reordering.
   if (!SameFormatAsExpected<"abc">("abc"))
   {
     Fail("format frontend plain text mismatch");
@@ -31,6 +36,9 @@ void TestFormatFrontendSemantics()
     Fail("format frontend mixed mismatch");
   }
 
+  // 整数进制：二/八/十六进制和 64 位最大值覆盖 base writer 的宽路径。
+  // Integer bases: binary/octal/hex plus max 64-bit values cover the wider base-writer
+  // path.
   if (!SameFormatAsExpected<"{:#b} {:#B} {:#o}">("0b101 0B101 010", 5U, 5U, 8U))
   {
     Fail("format frontend non-decimal mismatch");
@@ -42,8 +50,8 @@ void TestFormatFrontendSemantics()
     std::string octal = UnsignedBaseText(max_value, 8);
     std::string hex_lower = UnsignedBaseText(max_value, 16);
     std::string hex_upper = UnsignedBaseText(max_value, 16, true);
-    std::string expected = binary + "|0b" + binary + "|0" + octal + "|" + hex_lower +
-                           "|" + hex_upper;
+    std::string expected =
+        binary + "|0b" + binary + "|0" + octal + "|" + hex_lower + "|" + hex_upper;
     if (!SameFormatAsExpected<"{:b}|{:#b}|{:#o}|{:x}|{:X}">(
             expected, max_value, max_value, max_value, max_value, max_value))
     {
@@ -51,6 +59,8 @@ void TestFormatFrontendSemantics()
     }
   }
 
+  // 文本族：字符串精度/填充、字符输出和默认左对齐。
+  // Text family: string precision/fill, character output, and default left alignment.
   if (!SameFormatAsExpected<"[{:.3s}] [{:_>6s}] [{:*^7s}]">("[abc] [___abc] [**abc**]",
                                                             "abcdef", "abc", "abc"))
   {
@@ -73,6 +83,9 @@ void TestFormatFrontendSemantics()
     Fail("format frontend integer flag mismatch");
   }
 
+  // 显式索引和浮点边界：参数重排、负零、inf/nan 文本。
+  // Explicit indexes and float boundaries: argument reorder, negative zero, and inf/nan
+  // text.
   if (!SameFormatAsExpected<"{1:+08d} {0:#x} {1}">("-0000012 0x2a -12", 42U, -12))
   {
     Fail("format frontend indexed spec mismatch");
@@ -92,6 +105,8 @@ void TestFormatFrontendSemantics()
     Fail("format frontend inf nan mismatch");
   }
 
+  // LibXR 参数适配：对象字符串、定长 char 数组和空 C 字符串。
+  // LibXR argument adapters: object strings, bounded char arrays, and null C strings.
   if (!SameFormatAsExpected<"[{:3}] [{:6}]">("[A  ] [abc   ]", 'A', "abc"))
   {
     Fail("format frontend default text alignment mismatch");
@@ -120,6 +135,8 @@ void TestFormatFrontendSemantics()
     Fail("format frontend null string mismatch");
   }
 
+  // 直接 writer 路径和指针默认格式：不经过 helper 包装也应生成同一类输出。
+  // Direct writer path and pointer defaults: output should match without helper wrappers.
   {
     constexpr LibXR::Format<"{:c} {:.3s} {:p}"> format{};
     int value = 7;

--- a/test/base/print/test_print.cpp
+++ b/test/base/print/test_print.cpp
@@ -1,24 +1,32 @@
 /**
  * @file test_print.cpp
- * @brief `print` 测试聚合入口。 Aggregation entry for split `print` tests.
+ * @brief 默认 profile 的 `print` 运行时输出测试入口。 Entry point for default-profile
+ * `print` runtime output tests.
  *
- * 测试项目 / Test items:
- * 1. printf 前端语义。 `printf` frontend semantics.
- * 2. format 前端语义。 `format` frontend semantics.
- * 3. 公开 API 包装层。 Public print API wrappers.
- * 4. 失败路径前缀保留语义。 Failure-path prefix retention.
+ * 分类 / Categories:
+ * 1. `printf` 前端：字面量解析后写入 writer，并与 host `snprintf` 或固定期望文本对照。
+ *    `printf` frontend: parse literals, write through the writer, and compare with host
+ *    `snprintf` or fixed expected text.
+ * 2. brace `Format` 前端：验证 `{}` 风格语法的编译结果和输出文本。
+ *    Brace `Format` frontend: verify compiled `{}`-style formats and produced text.
+ * 3. `Print::*` 公开 API：覆盖 sink、字面量、bounded-buffer、`SNPrintf` 和错误返回契约。
+ *    Public `Print::*` API: cover sink, literal, bounded-buffer, `SNPrintf`, and error
+ *    contracts.
+ * 4. 失败路径：stream-backed writer 遇到后续错误时已经写出的前缀不回滚。
+ *    Failure path: a stream-backed writer keeps the prefix emitted before a later error.
  */
 #include "print_test_common.hpp"
 
 /**
- * @brief 测试入口函数 `test_print`。 Test entry function `test_print`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 执行默认 profile 的四组 `print` 运行时测试。 Run the four default-profile
+ * `print` runtime groups.
+ * @details 入口只负责调度；断言分别放在各子文件中。
+ *          This entry only dispatches.
  */
 void test_print()
 {
-  // 测试内容：按文件头列出的测试项目顺序执行当前测试入口。
-  // Test coverage: execute the test items listed in this file header in sequence.
+  // 按分类顺序执行，便于失败时先定位到子系统再看具体断言。
+  // Keep the category order explicit so failures point at the affected subsystem first.
   LibXRPrintTest::TestPrintfFrontendSemantics();
   LibXRPrintTest::TestFormatFrontendSemantics();
   LibXRPrintTest::TestPrintApiWrappers();

--- a/test/base/print/test_print_api.cpp
+++ b/test/base/print/test_print_api.cpp
@@ -1,20 +1,25 @@
 /**
  * @file test_print_api.cpp
- * @brief `print` 公开 API 包装层子测试。 Split test unit for `print` public API wrappers.
+ * @brief `Print::*` 公开 API wrapper 的运行时契约测试。 Runtime contract tests for
+ * public `Print::*` API wrappers.
+ * @details
+ * 1. 不重复扩大格式语法覆盖。
+ * 2. 验证已编译格式写入 sink、bounded buffer 和 `SNPrintf` 风格接口。
+ * 3. 验证截断长度和错误返回。
  */
 #include "print_test_common.hpp"
 
 namespace LibXRPrintTest
 {
 /**
- * @brief 测试项函数 `TestPrintApiWrappers`。 Test-item function `TestPrintApiWrappers`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 覆盖 public print wrapper 的 sink、buffer、截断和错误传播路径。 Cover sink,
+ * buffer, truncation, and error-propagation paths in the public print wrappers.
  */
 void TestPrintApiWrappers()
 {
-  // 测试内容：执行当前辅助测试项，对应文件头中的一个具体项目。
-  // Test coverage: execute the current helper-scoped test item from this file.
+  // Sink wrapper：已构造 format 对象和字面量模板两种入口都应写入同一 sink 合约。
+  // Sink wrappers: object-based and literal-template entry points share the same sink
+  // contract.
   {
     constexpr LibXR::Format<"x={:+05d} {:#x} {}"> format{};
     StringSink sink;
@@ -53,6 +58,9 @@ void TestPrintApiWrappers()
     }
   }
 
+  // Bounded buffer：返回完整逻辑长度，实际内容按容量写入并保持 C 字符串结尾语义。
+  // Bounded buffers: return full logical length while writing only what fits as a C
+  // string.
   {
     constexpr LibXR::Format<"x={:+05d} {:#x} {}"> format{};
     char buffer[32] = {};
@@ -99,6 +107,9 @@ void TestPrintApiWrappers()
     }
   }
 
+  // 边界容量：零容量、单字节容量和空指针计数模式不应越界写入。
+  // Capacity edges: zero-capacity, single-byte, and null-counting modes must not
+  // over-write.
   {
     constexpr LibXR::Format<"{} {}"> format{};
     char buffer[8] = {'x', 'x', 'x', 'x', 'x', 'x', 'x', '\0'};
@@ -127,6 +138,9 @@ void TestPrintApiWrappers()
     }
   }
 
+  // `SNPrintf` wrapper：保留 snprintf 风格的返回值和截断后的可见内容。
+  // `SNPrintf` wrappers preserve snprintf-style return values and truncated visible
+  // content.
   {
     constexpr LibXR::Format<"{} {}"> format{};
     char buffer[6] = {};
@@ -148,6 +162,9 @@ void TestPrintApiWrappers()
     }
   }
 
+  // 错误传播：sink 写入失败或格式运行期失败时，wrapper 返回错误并清理 buffer 开头。
+  // Error propagation: sink and runtime-format failures are surfaced and buffers are
+  // cleared.
   {
     constexpr LibXR::Format<"hello {}"> format{};
     LimitedSink sink{.limit = 6};
@@ -169,7 +186,8 @@ void TestPrintApiWrappers()
 
   {
     char buffer[8] = {'x', 'x', 'x', '\0'};
-    int written = LibXR::Print::FormatIntoBuffer(buffer, sizeof(buffer), BrokenGenericFormat{});
+    int written =
+        LibXR::Print::FormatIntoBuffer(buffer, sizeof(buffer), BrokenGenericFormat{});
     if (written != -1 || buffer[0] != '\0')
     {
       Fail("format bounded buffer runtime error mismatch");
@@ -185,6 +203,8 @@ void TestPrintApiWrappers()
     }
   }
 
+  // 空输出：成功写入空字符串时返回 0，buffer 仍保持 NUL 开头。
+  // Empty output returns zero and leaves the buffer NUL-terminated at the first byte.
   {
     constexpr LibXR::Format<""> format{};
     char buffer[4] = {'x', 'x', 'x', '\0'};

--- a/test/base/print/test_print_failure.cpp
+++ b/test/base/print/test_print_failure.cpp
@@ -1,22 +1,24 @@
 /**
  * @file test_print_failure.cpp
- * @brief `print` 失败路径语义子测试。 Split test unit for `print` failure-path semantics.
+ * @brief `print` stream-backed writer 的失败路径测试。 Failure-path tests for the
+ * `print` stream-backed writer.
+ * @details 格式对象在写出前缀后失败时，已经进入 stream 的前缀仍可提交；这和纯
+ *          bounded-buffer 的失败清理语义不同。
  */
 #include "print_test_common.hpp"
 
 namespace LibXRPrintTest
 {
 /**
- * @brief 测试项函数 `TestStreamBackedPrintFailureKeepsPrefix`。 Test-item function `TestStreamBackedPrintFailureKeepsPrefix`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 确认 stream-backed print 失败后保留已写前缀。 Confirm that stream-backed print
+ * keeps the prefix written before a later failure.
  */
 void TestStreamBackedPrintFailureKeepsPrefix()
 {
-  // 测试内容：执行当前辅助测试项，对应文件头中的一个具体项目。
-  // Test coverage: execute the current helper-scoped test item from this file.
   static constexpr char expected[] = "hello ";
 
+  // Pipe 读端先挂起，写端 stream 只需要提交成功写出的前缀。
+  // Arm the pipe read first; the write stream only has to commit the emitted prefix.
   LibXR::Pipe pipe(64);
   LibXR::ReadPort& read = pipe.GetReadPort();
   LibXR::WritePort& write = pipe.GetWritePort();

--- a/test/base/print/test_printf_frontend.cpp
+++ b/test/base/print/test_printf_frontend.cpp
@@ -1,14 +1,11 @@
 /**
  * @file test_printf_frontend.cpp
- * @brief `print` printf 前端语义聚合入口。 Aggregation entry for split `print` printf frontend semantics.
- * @details 测试项目：
- *          1. 聚合整数族语义子场景。
- *          2. 聚合文本/杂项语义子场景。
- *          3. 聚合浮点族语义子场景。
- *          Test items:
- *          1. Aggregate integer-family semantic sub-scenarios.
- *          2. Aggregate text/misc semantic sub-scenarios.
- *          3. Aggregate floating-point semantic sub-scenarios.
+ * @brief 默认 profile 的 `printf` 前端运行时输出聚合。 Default-profile `printf`
+ * frontend runtime-output aggregation.
+ * @details
+ * 1. 覆盖 `printf` 字面量 -> 编译格式 -> writer 输出。
+ * 2. 只测默认配置运行时输出。
+ * 3. 禁用宏矩阵在 `test/print_config`。
  */
 #include "print_test_common.hpp"
 
@@ -19,14 +16,14 @@ void TestPrintfFrontendTextSemantics();
 void TestPrintfFrontendFloatSemantics();
 
 /**
- * @brief 测试项函数 `TestPrintfFrontendSemantics`。 Test-item function `TestPrintfFrontendSemantics`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 执行 `printf` 默认输出语义的三组子场景。 Run the three default-output
+ * `printf` semantic groups.
+ * @details 整数、文本/杂项、浮点分别成文件，避免一个失败掩盖具体格式族。
  */
 void TestPrintfFrontendSemantics()
 {
-  // 测试内容：聚合执行拆分后的整数、文本和浮点前端语义子场景。
-  // Test coverage: aggregate the split integer, text, and floating-point frontend semantic sub-scenarios.
+  // 默认 profile 下的三类 printf 输出语义。
+  // Three printf output families under the default profile.
   TestPrintfFrontendIntegerSemantics();
   TestPrintfFrontendTextSemantics();
   TestPrintfFrontendFloatSemantics();

--- a/test/base/print/test_printf_frontend_float.cpp
+++ b/test/base/print/test_printf_frontend_float.cpp
@@ -1,19 +1,25 @@
 /**
  * @file test_printf_frontend_float.cpp
- * @brief `print` printf 浮点族前端语义子测试。 Split test unit for `print` printf floating-point frontend semantics.
- * @details 测试项目：
- *          1. long double、大小写浮点和 alternate form 语义。
- *          2. padding、阈值、负零、inf/nan 与全家桶格式语义。
- *          Test items:
- *          1. `long double`, uppercase float, and alternate-form semantics.
- *          2. Padding, threshold, negative-zero, inf/nan, and full-family format semantics.
+ * @brief 默认 profile 的 `printf` 浮点族运行时输出测试。 Default-profile `printf`
+ * floating-point runtime output tests.
+ * @details
+ * 1. 对照 host `snprintf` 的代表性浮点语义点。
+ * 2. 覆盖大小写、alternate form、零填充、`%g` 阈值、负零和 inf/nan。
+ * 3. 完整舍入边界不在本文件展开。
  */
 #include "print_test_common.hpp"
 
 namespace LibXRPrintTest
 {
+/**
+ * @brief 覆盖默认 `printf` profile 下的代表性浮点输出语义。 Cover representative float
+ * output semantics under the default `printf` profile.
+ */
 void TestPrintfFrontendFloatSemantics()
 {
+  // 类型/大小写族：确认 double、long double 和大写说明符都走到对应 writer 入口。
+  // Type and case families: double, long double, and uppercase specifiers reach the right
+  // writers.
   if (!SameAsSnprintf<"%Lg|%Le|%Lf">(1.25L, 1.25L, 1.25L))
   {
     Fail("long double family mismatch");
@@ -24,6 +30,9 @@ void TestPrintfFrontendFloatSemantics()
     Fail("uppercase float family mismatch");
   }
 
+  // 格式标志：alternate form 保留小数点，零填充与符号/空格标志组合。
+  // Format flags: alternate form keeps the radix point; zero padding combines with
+  // sign/space flags.
   if (!SameAsSnprintf<"%#.0f|%#.0e|%#.3g">(12.0, 12.0, 1.2))
   {
     Fail("float alternate form mismatch");
@@ -34,6 +43,8 @@ void TestPrintfFrontendFloatSemantics()
     Fail("float zero padding mismatch");
   }
 
+  // 边界语义：`%g` fixed/scientific 阈值、负零和 inf/nan 文本。
+  // Boundary semantics: `%g` fixed/scientific threshold, negative zero, and inf/nan text.
   if (!SameAsSnprintf<"%g|%g|%.0g|%#.0g">(1000000.0, 999999.0, 12.0, 12.0))
   {
     Fail("float general threshold mismatch");
@@ -51,6 +62,9 @@ void TestPrintfFrontendFloatSemantics()
     Fail("float inf nan mismatch");
   }
 
+  // 全族 smoke：一个格式串同时覆盖已启用的整数、指针、文本和浮点说明符组合。
+  // Full-family smoke: one source string combines enabled integer, pointer, text, and
+  // float specifiers.
   {
     int value = 0;
     if (!SameAsSnprintf<"a%d 0123456789abcdef %u %o %x %X %p %c %s %f %e %g %Lf %Le %Lg">(

--- a/test/base/print/test_printf_frontend_integer.cpp
+++ b/test/base/print/test_printf_frontend_integer.cpp
@@ -1,19 +1,24 @@
 /**
  * @file test_printf_frontend_integer.cpp
- * @brief `print` printf 整数族前端语义子测试。 Split test unit for `print` printf integer-family frontend semantics.
- * @details 测试项目：
- *          1. 纯文本、十进制、有符号/无符号与进制转换语义。
- *          2. 标志位、精度和 64 位整数族语义。
- *          Test items:
- *          1. Plain text, decimal, signed/unsigned, and base-conversion semantics.
- *          2. Flag, precision, and 64-bit integer-family semantics.
+ * @brief 默认 profile 的 `printf` 整数族运行时输出测试。 Default-profile `printf`
+ * integer-family runtime output tests.
+ * @details
+ * 1. 标准 C printf 整数格式对照 host `snprintf`。
+ * 2. LibXR 扩展 `%b/%B` 对照固定期望文本。
+ * 3. 长度修饰符和 enum 参数覆盖参数打包边界。
  */
 #include "print_test_common.hpp"
 
 namespace LibXRPrintTest
 {
+/**
+ * @brief 覆盖默认 `printf` profile 下的整数输出语义。 Cover integer output semantics
+ * under the default `printf` profile.
+ */
 void TestPrintfFrontendIntegerSemantics()
 {
+  // 无参数文本路径：确认字面量文本不会经过格式参数路径后被改写。
+  // No-argument text path: literal text must survive without argument formatting.
   if (!SameAsSnprintf<"abc">())
   {
     Fail("plain text mismatch");
@@ -24,6 +29,8 @@ void TestPrintfFrontendIntegerSemantics()
     Fail("long plain text mismatch");
   }
 
+  // 有符号十进制：符号、空格、零填充、左对齐和零值精度语义。
+  // Signed decimal: sign, space, zero padding, left alignment, and zero-value precision.
   if (!SameAsSnprintf<"%d|%+d|% d|%05d|%-5d|%.0d">(-7, 7, 7, 7, 7, 0))
   {
     Fail("signed integer semantics mismatch");
@@ -39,6 +46,8 @@ void TestPrintfFrontendIntegerSemantics()
     Fail("integer precision precedence mismatch");
   }
 
+  // 无符号十进制和非十进制：标准 `%u/%x/%o` 对照 host，扩展 `%b/%B` 对照固定文本。
+  // Unsigned and bases: standard `%u/%x/%o` compare with host; `%b/%B` use fixed text.
   if (!SameAsSnprintf<"%u|%.0u|%5.3u|%-5u">(7U, 0U, 7U, 7U))
   {
     Fail("unsigned integer semantics mismatch");
@@ -60,14 +69,16 @@ void TestPrintfFrontendIntegerSemantics()
     Fail("binary integer semantics mismatch");
   }
 
+  // 64 位最大值覆盖多进制 writer 循环，避免只测小数值时漏掉高位路径。
+  // Max 64-bit value covers the multi-base writer loops beyond small-value paths.
   {
     unsigned long long max_value = std::numeric_limits<unsigned long long>::max();
     std::string binary = UnsignedBaseText(max_value, 2);
     std::string octal = UnsignedBaseText(max_value, 8);
     std::string hex_lower = UnsignedBaseText(max_value, 16);
     std::string hex_upper = UnsignedBaseText(max_value, 16, true);
-    std::string expected = binary + "|0b" + binary + "|0" + octal + "|" + hex_lower +
-                           "|" + hex_upper;
+    std::string expected =
+        binary + "|0b" + binary + "|0" + octal + "|" + hex_lower + "|" + hex_upper;
     if (!SamePrintfAsExpected<"%llb|%#llb|%#llo|%llx|%llX">(
             expected, max_value, max_value, max_value, max_value, max_value))
     {
@@ -75,6 +86,8 @@ void TestPrintfFrontendIntegerSemantics()
     }
   }
 
+  // 长度修饰符和 enum：确认参数打包类型、整数提升和最终输出一致。
+  // Length modifiers and enum arguments: verify packing, integer promotion, and output.
   {
     signed char tiny_signed = -3;
     unsigned char tiny_unsigned = 4;

--- a/test/base/print/test_printf_frontend_text.cpp
+++ b/test/base/print/test_printf_frontend_text.cpp
@@ -1,24 +1,32 @@
 /**
  * @file test_printf_frontend_text.cpp
- * @brief `print` printf 文本与杂项前端语义子测试。 Split test unit for `print` printf text/misc frontend semantics.
- * @details 测试项目：
- *          1. 混合格式、字符、字符串和指针语义。
- *          2. positional、对象字符串、数组字符串与空字符串语义。
- *          Test items:
- *          1. Mixed-format, character, string, and pointer semantics.
- *          2. Positional, object-string, bounded-array, and null-string semantics.
+ * @brief 默认 profile 的 `printf` 文本/杂项运行时输出测试。 Default-profile `printf`
+ * text/misc runtime output tests.
+ * @details
+ * 1. 覆盖字符、字符串、指针、长度修饰符和 positional 参数。
+ * 2. 覆盖 `std::string` / `std::string_view` / char array 的 LibXR 参数适配。
+ * 3. 这些场景不属于纯整数或纯浮点格式族。
  */
 #include "print_test_common.hpp"
 
 namespace LibXRPrintTest
 {
+/**
+ * @brief 覆盖默认 `printf` profile 下的文本、指针和 positional 输出语义。 Cover text,
+ * pointer, and positional output semantics under the default `printf` profile.
+ */
 void TestPrintfFrontendTextSemantics()
 {
+  // 混合格式 smoke：一个格式串同时经过整数、字符串、转义百分号和浮点 writer。
+  // Mixed-format smoke: one source string crosses integer, string, escaped percent, and
+  // float writers.
   if (!SameAsSnprintf<"x=%+08d y=%-4s z=%#x %% %.2f">(-12, "ok", 42U, 1.25))
   {
     Fail("mixed format mismatch");
   }
 
+  // 字符、字符串、指针：标准 printf 输出与 host `snprintf` 对齐。
+  // Character, string, and pointer formatting should match host `snprintf`.
   {
     int value = 7;
     if (!SameAsSnprintf<"%c %.3s %p">('A', "abcdef", &value))
@@ -42,6 +50,8 @@ void TestPrintfFrontendTextSemantics()
     Fail("string semantics mismatch");
   }
 
+  // 长度修饰符和 positional 参数：验证参数索引、类型修饰和重复引用。
+  // Length modifiers and positional arguments verify indexing, type modifiers, and reuse.
   {
     long signed_value = -12;
     size_t unsigned_value = 34;
@@ -57,6 +67,8 @@ void TestPrintfFrontendTextSemantics()
     Fail("positional argument semantics mismatch");
   }
 
+  // LibXR 扩展参数适配：对象字符串、定长 char 数组和空 C 字符串。
+  // LibXR argument adapters: object strings, bounded char arrays, and null C strings.
   {
     std::string text = "hello";
     std::string_view view = "xy";

--- a/test/linux_stdio/linux_stdio_print_test_common.hpp
+++ b/test/linux_stdio/linux_stdio_print_test_common.hpp
@@ -1,12 +1,13 @@
 /**
  * @file linux_stdio_print_test_common.hpp
- * @brief linux stdio `print` 测试共用 helper。 Shared helpers for linux stdio `print` tests.
+ * @brief Linux STDIO `print` 适配测试共用 helper。 Shared helpers for Linux STDIO
+ * `print` adapter tests.
  *
  * 作用 / Purpose:
- * 1. 集中 STDIO 绑定作用域和失败辅助函数。
- *    Centralize STDIO linux scope and failure helpers.
- * 2. 让 split 后的 linux print 测试文件只保留各自场景。
- *    Keep each split linux-stdio-print test file focused on its own scenario.
+ * 1. 用 `StdioWriteScope` 临时绑定并恢复 `LibXR::STDIO` 的全局写端。
+ *    Temporarily bind and restore the global `LibXR::STDIO` writer.
+ * 2. 提供失败退出 helper，让测试主体只保留适配层场景。
+ *    Provide the failure-exit helper so test bodies stay focused on adapter scenarios.
  */
 #pragma once
 
@@ -25,6 +26,8 @@ namespace LibXRLinuxStdioPrintTest
 
 struct StdioWriteScope
 {
+  // 构造时替换 STDIO 全局写端，析构时恢复为空，避免影响后续测试。
+  // Replace the STDIO global writer during this scope and clear it on destruction.
   explicit StdioWriteScope(LibXR::WritePort& write, LibXR::Mutex& mutex,
                            LibXR::WritePort::Stream* stream = nullptr)
   {
@@ -45,9 +48,8 @@ struct StdioWriteScope
 };
 
 /**
- * @brief 辅助函数 `Fail`。 Helper function `Fail`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @brief 打印失败原因并终止当前测试进程。 Print the failure reason and terminate the
+ * current test process.
  */
 inline int Fail(const char* message)
 {

--- a/test/linux_stdio/test_linux_stdio_print.cpp
+++ b/test/linux_stdio/test_linux_stdio_print.cpp
@@ -1,18 +1,22 @@
 /**
  * @file test_linux_stdio_print.cpp
- * @brief linux stdio `print` 测试聚合入口。 Aggregation entry for split linux stdio `print` tests.
+ * @brief Linux STDIO `print` 适配层测试入口。 Entry point for Linux STDIO `print`
+ * adapter tests.
+ * @details 这组测试不重复覆盖格式语法；它验证 `LibXR::STDIO` 的全局写端绑定、直接写入、
+ *          stream-backed 写入和容量截断契约。 This group does not repeat format-syntax
+ *          coverage; it verifies `LibXR::STDIO` global write binding, direct writes,
+ *          stream-backed writes, and capacity truncation contracts.
  */
 #include "linux_stdio_print_test_common.hpp"
 
 /**
- * @brief 测试入口函数 `test_linux_stdio_print`。 Test entry function `test_linux_stdio_print`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 执行 Linux STDIO `print` wrapper 和截断测试。 Run Linux STDIO `print` wrapper
+ * and truncation tests.
  */
 void test_linux_stdio_print()
 {
-  // 测试内容：按文件头列出的测试项目顺序执行当前测试入口。
-  // Test coverage: execute the test items listed in this file header in sequence.
+  // 先测正常写入路径，再测容量不足时返回值和保留内容。
+  // Check normal write paths first, then truncation return values and retained payload.
   LibXRLinuxStdioPrintTest::TestStdioPrintWrappers();
   LibXRLinuxStdioPrintTest::TestStdioTruncation();
 }

--- a/test/linux_stdio/test_stdio_truncation.cpp
+++ b/test/linux_stdio/test_stdio_truncation.cpp
@@ -1,20 +1,24 @@
 /**
  * @file test_stdio_truncation.cpp
- * @brief linux stdio `print` 截断语义子测试。 Split test unit for linux stdio `print` truncation semantics.
+ * @brief Linux STDIO `print` 容量截断语义测试。 Capacity-truncation tests for Linux
+ * STDIO `print`.
+ * @details
+ * 1. 截断时返回实际保留字节数。
+ * 2. pipe 中只出现被保留的前缀内容。
+ * 3. 覆盖 direct writer、stream-backed writer 和很小 stream 容量。
  */
 #include "linux_stdio_print_test_common.hpp"
 
 namespace LibXRLinuxStdioPrintTest
 {
 /**
- * @brief 测试项函数 `TestStdioTruncation`。 Test-item function `TestStdioTruncation`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 覆盖 direct 和 stream-backed STDIO 写入的截断返回值和保留内容。 Cover truncation
+ * return values and retained payload for direct and stream-backed STDIO writes.
  */
 void TestStdioTruncation()
 {
-  // 测试内容：执行当前辅助测试项，对应文件头中的一个具体项目。
-  // Test coverage: execute the current helper-scoped test item from this file.
+  // Direct writer 容量不足：只保留 pipe 空余容量对应的前缀。
+  // Direct writer with insufficient capacity: retain only the prefix that fits the pipe.
   {
     constexpr size_t pipe_capacity = 64;
     constexpr size_t payload_size = pipe_capacity + 16;
@@ -54,6 +58,9 @@ void TestStdioTruncation()
     }
   }
 
+  // Stream-backed 容量不足：同样按底层写端可用空间截断。
+  // Stream-backed insufficient capacity: truncation still follows the underlying writer
+  // space.
   {
     constexpr size_t stream_capacity = 64;
     constexpr size_t payload_size = stream_capacity + 16;
@@ -95,6 +102,8 @@ void TestStdioTruncation()
     }
   }
 
+  // 很小 stream 容量：覆盖短缓冲区下的返回值和前缀保留。
+  // Very small stream capacity: cover return value and prefix retention for tiny buffers.
   {
     constexpr size_t stream_capacity = 4;
     constexpr size_t payload_size = stream_capacity + 16;

--- a/test/linux_stdio/test_stdio_wrappers.cpp
+++ b/test/linux_stdio/test_stdio_wrappers.cpp
@@ -1,20 +1,24 @@
 /**
  * @file test_stdio_wrappers.cpp
- * @brief linux stdio `print` STDIO 包装层子测试。 Split test unit for linux stdio `print` STDIO wrappers.
+ * @brief Linux STDIO `Print` / `Printf` wrapper 正常写入测试。 Normal-write tests for
+ * Linux STDIO `Print` / `Printf` wrappers.
+ * @details
+ * 1. 每个场景都把 `STDIO::write_` 绑定到 pipe 写端。
+ * 2. 从 pipe 读端确认实际字节。
+ * 3. stream-backed 场景额外验证 `write_stream_` 绑定。
  */
 #include "linux_stdio_print_test_common.hpp"
 
 namespace LibXRLinuxStdioPrintTest
 {
 /**
- * @brief 测试项函数 `TestStdioPrintWrappers`。 Test-item function `TestStdioPrintWrappers`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 覆盖 STDIO 正常写入的 Format/Printf direct 和 stream-backed 路径。 Cover normal
+ * STDIO writes through Format/Printf direct and stream-backed paths.
  */
 void TestStdioPrintWrappers()
 {
-  // 测试内容：执行当前辅助测试项，对应文件头中的一个具体项目。
-  // Test coverage: execute the current helper-scoped test item from this file.
+  // Format direct：`STDIO::Print` 直接写到全局 `write_`。
+  // Format direct: `STDIO::Print` writes directly to global `write_`.
   {
     static constexpr char expected[] = "x=+0007 0x2a ok";
 
@@ -44,6 +48,9 @@ void TestStdioPrintWrappers()
     }
   }
 
+  // Format stream-backed：绑定 stream 后，输出仍应到同一个 pipe，并返回完整长度。
+  // Format stream-backed: with a bound stream, output still reaches the pipe and returns
+  // full length.
   {
     static constexpr char expected[] = "x=+0007 0x2a ok";
 
@@ -75,6 +82,8 @@ void TestStdioPrintWrappers()
     }
   }
 
+  // Printf direct：printf 字面量 wrapper 走同一个全局写端绑定。
+  // Printf direct: printf-literal wrapper uses the same global writer binding.
   {
     static constexpr char expected[] = "+0007 0x2a ok";
 
@@ -104,6 +113,8 @@ void TestStdioPrintWrappers()
     }
   }
 
+  // Printf stream-backed：printf 路径也必须遵守 `write_stream_` 绑定。
+  // Printf stream-backed: printf path must also honor the `write_stream_` binding.
   {
     static constexpr char expected[] = "+0007 0x2a ok";
 

--- a/test/print_config/print_config_probe.hpp
+++ b/test/print_config/print_config_probe.hpp
@@ -1,0 +1,41 @@
+/**
+ * @file print_config_probe.hpp
+ * @brief `print` 配置矩阵的编译期探针。 Compile-time probes for the `print` config
+ * matrix.
+ * @details 测试项目：
+ *          1. 用内部前端分析接口检查禁用语法产生的错误类别。
+ *          2. 用共享编译后端检查源串合法但参数/功能门不匹配的错误类别。
+ *          3. 不执行 writer，不把配置矩阵与运行时文本对照测试混在一起。
+ *          Test items:
+ *          1. Inspect disabled-syntax errors through the internal frontend
+ *             analysis interfaces.
+ *          2. Inspect source-valid argument/gate failures through the shared
+ *             compile backend.
+ *          3. Avoid running the writer so this matrix stays separate from
+ *             runtime text-comparison tests.
+ */
+#pragma once
+
+#include "print.hpp"
+
+namespace LibXRPrintConfigTest
+{
+template <LibXR::Print::Text Source>
+[[nodiscard]] consteval LibXR::Print::Printf::Error PrintfSourceError()
+{
+  return LibXR::Print::Detail::PrintfCompile::Analyze<Source>().error;
+}
+
+template <LibXR::Print::Text Source>
+[[nodiscard]] consteval LibXR::Print::Detail::FormatFrontend::Error FormatSourceError()
+{
+  return LibXR::Print::Detail::FormatFrontend::Analyze<Source>().error;
+}
+
+template <LibXR::Print::Text Source, typename... Args>
+[[nodiscard]] consteval LibXR::Print::Detail::FormatFrontend::Error FormatCompileError()
+{
+  using Frontend = LibXR::Print::Detail::FormatFrontend::Compiler<Source, Args...>;
+  return LibXR::Print::FormatCompiler<Frontend>::Compile().compile_error;
+}
+}  // namespace LibXRPrintConfigTest

--- a/test/print_config/print_config_probe.hpp
+++ b/test/print_config/print_config_probe.hpp
@@ -2,17 +2,10 @@
  * @file print_config_probe.hpp
  * @brief `print` 配置矩阵的编译期探针。 Compile-time probes for the `print` config
  * matrix.
- * @details 测试项目：
- *          1. 用内部前端分析接口检查禁用语法产生的错误类别。
- *          2. 用共享编译后端检查源串合法但参数/功能门不匹配的错误类别。
- *          3. 不执行 writer，不把配置矩阵与运行时文本对照测试混在一起。
- *          Test items:
- *          1. Inspect disabled-syntax errors through the internal frontend
- *             analysis interfaces.
- *          2. Inspect source-valid argument/gate failures through the shared
- *             compile backend.
- *          3. Avoid running the writer so this matrix stays separate from
- *             runtime text-comparison tests.
+ * @details
+ * 1. source analysis 检查被关闭的语法。
+ * 2. compile backend 检查源串合法但参数类型被配置门拒绝的情况。
+ * 3. 不执行 writer，不混入默认 profile 的运行时文本对照测试。
  */
 #pragma once
 

--- a/test/print_config/print_config_reset.hpp
+++ b/test/print_config/print_config_reset.hpp
@@ -1,15 +1,10 @@
 /**
  * @file print_config_reset.hpp
  * @brief 清除 CMake 传入的 print 配置宏。 Clear CMake-provided print config macros.
- * @details 测试项目：
- *          1. 允许每个配置矩阵源文件在 include `print.hpp` 前自行定义
- *             `LIBXR_PRINT_*`。
- *          2. 避免 `xr` target 的 PUBLIC compile definitions 污染本地配置。
- *          Test items:
- *          1. Let each matrix source define its own `LIBXR_PRINT_*` values before
- *             including `print.hpp`.
- *          2. Keep PUBLIC compile definitions from the `xr` target from leaking
- *             into the local profile under test.
+ * @details
+ * 1. 每个矩阵 `.cpp` 先 include 本文件。
+ * 2. 然后该 `.cpp` 定义自己的 `LIBXR_PRINT_*` profile。
+ * 3. 最后 include `print.hpp`，避免继承 `xr` target 的 PUBLIC print 宏。
  */
 #pragma once
 

--- a/test/print_config/print_config_reset.hpp
+++ b/test/print_config/print_config_reset.hpp
@@ -1,0 +1,32 @@
+/**
+ * @file print_config_reset.hpp
+ * @brief 清除 CMake 传入的 print 配置宏。 Clear CMake-provided print config macros.
+ * @details 测试项目：
+ *          1. 允许每个配置矩阵源文件在 include `print.hpp` 前自行定义
+ *             `LIBXR_PRINT_*`。
+ *          2. 避免 `xr` target 的 PUBLIC compile definitions 污染本地配置。
+ *          Test items:
+ *          1. Let each matrix source define its own `LIBXR_PRINT_*` values before
+ *             including `print.hpp`.
+ *          2. Keep PUBLIC compile definitions from the `xr` target from leaking
+ *             into the local profile under test.
+ */
+#pragma once
+
+#undef LIBXR_PRINT_ENABLE_INTEGER
+#undef LIBXR_PRINT_ENABLE_TEXT
+#undef LIBXR_PRINT_ENABLE_POINTER
+#undef LIBXR_PRINT_ENABLE_FLOAT
+#undef LIBXR_PRINT_INTEGER_ENABLE_BASE8_16
+#undef LIBXR_PRINT_INTEGER_ENABLE_64BIT
+#undef LIBXR_PRINT_FLOAT_ENABLE_FIXED
+#undef LIBXR_PRINT_FLOAT_ENABLE_DOUBLE
+#undef LIBXR_PRINT_FLOAT_ENABLE_SCIENTIFIC
+#undef LIBXR_PRINT_FLOAT_ENABLE_GENERAL
+#undef LIBXR_PRINT_FLOAT_ENABLE_LONG_DOUBLE
+#undef LIBXR_PRINT_FLOAT_MAX_PRECISION
+#undef LIBXR_PRINT_FLOAT_MAX_INTEGER_DIGITS
+#undef LIBXR_PRINT_ENABLE_WIDTH
+#undef LIBXR_PRINT_ENABLE_PRECISION
+#undef LIBXR_PRINT_ENABLE_ALTERNATE
+#undef LIBXR_PRINT_ENABLE_EXPLICIT_ARGUMENT_INDEXING

--- a/test/print_config/test_float_disabled.cpp
+++ b/test/print_config/test_float_disabled.cpp
@@ -1,19 +1,11 @@
 /**
  * @file test_float_disabled.cpp
- * @brief 验证浮点总开关关闭时的前端门控。 Verify frontend gates when the float master
- * switch is disabled.
- * @details 测试项目：
- *          1. 子开关定义为开启时，`LIBXR_PRINT_ENABLE_FLOAT=0` 仍会关闭所有浮点族。
- *          2. brace 前端拒绝 fixed、scientific 和 general 浮点展示。
- *          3. printf 前端把 `%f`、`%e`、`%g` 识别为被禁用的说明符。
- *          4. 整数、文本和指针仍可通过，确认不是整体配置失效。
- *          Test items:
- *          1. `LIBXR_PRINT_ENABLE_FLOAT=0` disables every float family even when
- *             the individual float switches are set to one.
- *          2. Brace formatting rejects fixed, scientific, and general float
- * presentations.
- *          3. Printf analysis reports `%f`, `%e`, and `%g` as disabled specifiers.
- *          4. Integer, text, and pointer conversions remain accepted.
+ * @brief 浮点总开关关闭 profile 的编译期门控测试。 Compile-time gate test for the
+ * float-master-disabled profile.
+ * @details
+ * 1. `LIBXR_PRINT_ENABLE_FLOAT=0` 关闭所有浮点格式。
+ * 2. fixed/scientific/general 子开关显式设为 1 也不能绕过总开关。
+ * 3. 整数、文本和指针保留为非目标开关 sanity check。
  */
 #include "print_config_reset.hpp"
 
@@ -48,6 +40,8 @@ static_assert(!enable_float_fixed);
 static_assert(!enable_float_scientific);
 static_assert(!enable_float_general);
 
+// Brace 前端：所有浮点 presentation 都被总开关挡住。
+// Brace frontend: every float presentation is blocked by the master switch.
 static_assert(!LibXR::Format<"{}">::Matches<float>());
 static_assert(!LibXR::Format<"{:.1f}">::Matches<float>());
 static_assert(!LibXR::Format<"{:.1e}">::Matches<double>());
@@ -56,11 +50,15 @@ static_assert(FormatCompileError<"{:.1f}", float>() == Error::ArgumentTypeMismat
 static_assert(FormatCompileError<"{:.1e}", double>() == Error::ArgumentTypeMismatch);
 static_assert(FormatCompileError<"{:g}", double>() == Error::ArgumentTypeMismatch);
 
+// Printf 前端：浮点说明符在 source analysis 阶段即不可用。
+// Printf frontend: float specifiers are unavailable during source analysis.
 static_assert(PrintfSourceError<"%f">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%e">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%g">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%Lf">() == Printf::Error::InvalidSpecifier);
 
+// 非浮点格式仍可用，确认不是探针或 include 配置整体坏掉。
+// Non-float formats remain usable, proving the profile and probes are otherwise live.
 static_assert(LibXR::Format<"{}">::Matches<int>());
 static_assert(LibXR::Format<"{:s}">::Matches<const char*>());
 static_assert(LibXR::Format<"{:p}">::Matches<const void*>());

--- a/test/print_config/test_float_disabled.cpp
+++ b/test/print_config/test_float_disabled.cpp
@@ -1,0 +1,67 @@
+/**
+ * @file test_float_disabled.cpp
+ * @brief 验证浮点总开关关闭时的前端门控。 Verify frontend gates when the float master
+ * switch is disabled.
+ * @details 测试项目：
+ *          1. 子开关定义为开启时，`LIBXR_PRINT_ENABLE_FLOAT=0` 仍会关闭所有浮点族。
+ *          2. brace 前端拒绝 fixed、scientific 和 general 浮点展示。
+ *          3. printf 前端把 `%f`、`%e`、`%g` 识别为被禁用的说明符。
+ *          4. 整数、文本和指针仍可通过，确认不是整体配置失效。
+ *          Test items:
+ *          1. `LIBXR_PRINT_ENABLE_FLOAT=0` disables every float family even when
+ *             the individual float switches are set to one.
+ *          2. Brace formatting rejects fixed, scientific, and general float
+ * presentations.
+ *          3. Printf analysis reports `%f`, `%e`, and `%g` as disabled specifiers.
+ *          4. Integer, text, and pointer conversions remain accepted.
+ */
+#include "print_config_reset.hpp"
+
+#define LIBXR_PRINT_ENABLE_INTEGER 1
+#define LIBXR_PRINT_ENABLE_TEXT 1
+#define LIBXR_PRINT_ENABLE_POINTER 1
+#define LIBXR_PRINT_ENABLE_FLOAT 0
+#define LIBXR_PRINT_INTEGER_ENABLE_BASE8_16 1
+#define LIBXR_PRINT_INTEGER_ENABLE_64BIT 1
+#define LIBXR_PRINT_FLOAT_ENABLE_FIXED 1
+#define LIBXR_PRINT_FLOAT_ENABLE_DOUBLE 1
+#define LIBXR_PRINT_FLOAT_ENABLE_SCIENTIFIC 1
+#define LIBXR_PRINT_FLOAT_ENABLE_GENERAL 1
+#define LIBXR_PRINT_FLOAT_ENABLE_LONG_DOUBLE 1
+#define LIBXR_PRINT_ENABLE_WIDTH 1
+#define LIBXR_PRINT_ENABLE_PRECISION 1
+#define LIBXR_PRINT_ENABLE_ALTERNATE 1
+#define LIBXR_PRINT_ENABLE_EXPLICIT_ARGUMENT_INDEXING 1
+
+#include "print_config_probe.hpp"
+
+using LibXR::Print::Printf;
+using LibXR::Print::Config::enable_float;
+using LibXR::Print::Config::enable_float_fixed;
+using LibXR::Print::Config::enable_float_general;
+using LibXR::Print::Config::enable_float_scientific;
+using LibXR::Print::Detail::FormatFrontend::Error;
+using namespace LibXRPrintConfigTest;
+
+static_assert(!enable_float);
+static_assert(!enable_float_fixed);
+static_assert(!enable_float_scientific);
+static_assert(!enable_float_general);
+
+static_assert(!LibXR::Format<"{}">::Matches<float>());
+static_assert(!LibXR::Format<"{:.1f}">::Matches<float>());
+static_assert(!LibXR::Format<"{:.1e}">::Matches<double>());
+static_assert(!LibXR::Format<"{:g}">::Matches<double>());
+static_assert(FormatCompileError<"{:.1f}", float>() == Error::ArgumentTypeMismatch);
+static_assert(FormatCompileError<"{:.1e}", double>() == Error::ArgumentTypeMismatch);
+static_assert(FormatCompileError<"{:g}", double>() == Error::ArgumentTypeMismatch);
+
+static_assert(PrintfSourceError<"%f">() == Printf::Error::InvalidSpecifier);
+static_assert(PrintfSourceError<"%e">() == Printf::Error::InvalidSpecifier);
+static_assert(PrintfSourceError<"%g">() == Printf::Error::InvalidSpecifier);
+static_assert(PrintfSourceError<"%Lf">() == Printf::Error::InvalidSpecifier);
+
+static_assert(LibXR::Format<"{}">::Matches<int>());
+static_assert(LibXR::Format<"{:s}">::Matches<const char*>());
+static_assert(LibXR::Format<"{:p}">::Matches<const void*>());
+static_assert(PrintfSourceError<"%d %s %p">() == Printf::Error::None);

--- a/test/print_config/test_float_fixed_only.cpp
+++ b/test/print_config/test_float_fixed_only.cpp
@@ -1,16 +1,11 @@
 /**
  * @file test_float_fixed_only.cpp
- * @brief 验证仅 fixed 浮点族开启时的前端门控。 Verify frontend gates when only fixed
- * float formatting is enabled.
- * @details 测试项目：
- *          1. brace 与 printf 都接受 fixed 浮点格式。
- *          2. scientific 与 general 浮点族被拒绝。
- *          3. `double` 存储关闭时，brace 的 `double` 参数仍走 F32 打包路径。
- *          Test items:
- *          1. Brace and printf frontends both accept fixed float formatting.
- *          2. Scientific and general float families are rejected.
- *          3. With double-backed storage disabled, brace `double` arguments lower
- *             through the F32 pack path.
+ * @brief 仅 fixed 浮点开启 profile 的编译期门控测试。 Compile-time gate test for the
+ * fixed-only float profile.
+ * @details
+ * 1. `%f` / `{:f}` 可用。
+ * 2. scientific、general 和 long double 被拒绝。
+ * 3. `LIBXR_PRINT_FLOAT_ENABLE_DOUBLE=0` 时 brace `double` 降到 F32 打包。
  */
 #include "print_config_reset.hpp"
 
@@ -40,6 +35,8 @@ using namespace LibXRPrintConfigTest;
 
 static_assert(!enable_float_double);
 
+// Brace 前端：fixed 可用，scientific/general/long double 被 profile 拒绝。
+// Brace frontend: fixed is accepted; scientific/general/long double are rejected.
 static_assert(LibXR::Format<"{}">::Matches<float>());
 static_assert(LibXR::Format<"{:.2f}">::Matches<float>());
 static_assert(LibXR::Format<"{:.2F}">::Matches<double>());
@@ -50,11 +47,15 @@ static_assert(FormatCompileError<"{:.2e}", float>() == Error::ArgumentTypeMismat
 static_assert(FormatCompileError<"{:g}", double>() == Error::ArgumentTypeMismatch);
 static_assert(FormatCompileError<"{:.2f}", long double>() == Error::ArgumentTypeMismatch);
 
+// Printf 前端：fixed 说明符存在，其它浮点族在 source analysis 阶段不可用。
+// Printf frontend: fixed specifiers exist; other float families are unavailable.
 static_assert(PrintfSourceError<"%f">() == Printf::Error::None);
 static_assert(PrintfSourceError<"%F">() == Printf::Error::None);
 static_assert(PrintfSourceError<"%e">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%g">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%Lf">() == Printf::Error::InvalidSpecifier);
 
+// double 存储关闭时，brace `double` 参数仍可用，但按 F32 打包。
+// With double storage disabled, brace `double` remains accepted but packs as F32.
 using DoubleFixed = LibXR::Format<"{:.2f}">::Compiled<double>;
 static_assert(DoubleFixed::ArgumentList()[0].pack == FormatPackKind::F32);

--- a/test/print_config/test_float_fixed_only.cpp
+++ b/test/print_config/test_float_fixed_only.cpp
@@ -1,0 +1,60 @@
+/**
+ * @file test_float_fixed_only.cpp
+ * @brief 验证仅 fixed 浮点族开启时的前端门控。 Verify frontend gates when only fixed
+ * float formatting is enabled.
+ * @details 测试项目：
+ *          1. brace 与 printf 都接受 fixed 浮点格式。
+ *          2. scientific 与 general 浮点族被拒绝。
+ *          3. `double` 存储关闭时，brace 的 `double` 参数仍走 F32 打包路径。
+ *          Test items:
+ *          1. Brace and printf frontends both accept fixed float formatting.
+ *          2. Scientific and general float families are rejected.
+ *          3. With double-backed storage disabled, brace `double` arguments lower
+ *             through the F32 pack path.
+ */
+#include "print_config_reset.hpp"
+
+#define LIBXR_PRINT_ENABLE_INTEGER 1
+#define LIBXR_PRINT_ENABLE_TEXT 1
+#define LIBXR_PRINT_ENABLE_POINTER 1
+#define LIBXR_PRINT_ENABLE_FLOAT 1
+#define LIBXR_PRINT_INTEGER_ENABLE_BASE8_16 1
+#define LIBXR_PRINT_INTEGER_ENABLE_64BIT 1
+#define LIBXR_PRINT_FLOAT_ENABLE_FIXED 1
+#define LIBXR_PRINT_FLOAT_ENABLE_DOUBLE 0
+#define LIBXR_PRINT_FLOAT_ENABLE_SCIENTIFIC 0
+#define LIBXR_PRINT_FLOAT_ENABLE_GENERAL 0
+#define LIBXR_PRINT_FLOAT_ENABLE_LONG_DOUBLE 0
+#define LIBXR_PRINT_ENABLE_WIDTH 1
+#define LIBXR_PRINT_ENABLE_PRECISION 1
+#define LIBXR_PRINT_ENABLE_ALTERNATE 1
+#define LIBXR_PRINT_ENABLE_EXPLICIT_ARGUMENT_INDEXING 1
+
+#include "print_config_probe.hpp"
+
+using LibXR::Print::FormatPackKind;
+using LibXR::Print::Printf;
+using LibXR::Print::Config::enable_float_double;
+using LibXR::Print::Detail::FormatFrontend::Error;
+using namespace LibXRPrintConfigTest;
+
+static_assert(!enable_float_double);
+
+static_assert(LibXR::Format<"{}">::Matches<float>());
+static_assert(LibXR::Format<"{:.2f}">::Matches<float>());
+static_assert(LibXR::Format<"{:.2F}">::Matches<double>());
+static_assert(!LibXR::Format<"{:.2e}">::Matches<float>());
+static_assert(!LibXR::Format<"{:g}">::Matches<double>());
+static_assert(!LibXR::Format<"{:.2f}">::Matches<long double>());
+static_assert(FormatCompileError<"{:.2e}", float>() == Error::ArgumentTypeMismatch);
+static_assert(FormatCompileError<"{:g}", double>() == Error::ArgumentTypeMismatch);
+static_assert(FormatCompileError<"{:.2f}", long double>() == Error::ArgumentTypeMismatch);
+
+static_assert(PrintfSourceError<"%f">() == Printf::Error::None);
+static_assert(PrintfSourceError<"%F">() == Printf::Error::None);
+static_assert(PrintfSourceError<"%e">() == Printf::Error::InvalidSpecifier);
+static_assert(PrintfSourceError<"%g">() == Printf::Error::InvalidSpecifier);
+static_assert(PrintfSourceError<"%Lf">() == Printf::Error::InvalidSpecifier);
+
+using DoubleFixed = LibXR::Format<"{:.2f}">::Compiled<double>;
+static_assert(DoubleFixed::ArgumentList()[0].pack == FormatPackKind::F32);

--- a/test/print_config/test_float_precision_limit.cpp
+++ b/test/print_config/test_float_precision_limit.cpp
@@ -1,0 +1,69 @@
+/**
+ * @file test_float_precision_limit.cpp
+ * @brief 验证浮点精度上限配置的前端门控。 Verify frontend gates for the float precision
+ * limit.
+ * @details 测试项目：
+ *          1. brace 与 printf 都接受不超过上限的显式浮点精度。
+ *          2. brace 与 printf 都拒绝超过 `LIBXR_PRINT_FLOAT_MAX_PRECISION` 的精度。
+ *          3. `LIBXR_PRINT_FLOAT_MAX_INTEGER_DIGITS` 只确认配置值传递，不在这里测试
+ *             writer 运行时边界。
+ *          Test items:
+ *          1. Brace and printf frontends accept explicit float precision at or
+ *             below the configured limit.
+ *          2. Brace and printf frontends reject precision above
+ *             `LIBXR_PRINT_FLOAT_MAX_PRECISION`.
+ *          3. `LIBXR_PRINT_FLOAT_MAX_INTEGER_DIGITS` is checked only as config
+ *             propagation; writer runtime boundaries stay outside this matrix.
+ */
+#include "print_config_reset.hpp"
+
+#define LIBXR_PRINT_ENABLE_INTEGER 1
+#define LIBXR_PRINT_ENABLE_TEXT 1
+#define LIBXR_PRINT_ENABLE_POINTER 1
+#define LIBXR_PRINT_ENABLE_FLOAT 1
+#define LIBXR_PRINT_INTEGER_ENABLE_BASE8_16 1
+#define LIBXR_PRINT_INTEGER_ENABLE_64BIT 1
+#define LIBXR_PRINT_FLOAT_ENABLE_FIXED 1
+#define LIBXR_PRINT_FLOAT_ENABLE_DOUBLE 1
+#define LIBXR_PRINT_FLOAT_ENABLE_SCIENTIFIC 1
+#define LIBXR_PRINT_FLOAT_ENABLE_GENERAL 1
+#define LIBXR_PRINT_FLOAT_ENABLE_LONG_DOUBLE 1
+#define LIBXR_PRINT_FLOAT_MAX_PRECISION 2
+#define LIBXR_PRINT_FLOAT_MAX_INTEGER_DIGITS 5
+#define LIBXR_PRINT_ENABLE_WIDTH 1
+#define LIBXR_PRINT_ENABLE_PRECISION 1
+#define LIBXR_PRINT_ENABLE_ALTERNATE 1
+#define LIBXR_PRINT_ENABLE_EXPLICIT_ARGUMENT_INDEXING 1
+
+#include "print_config_probe.hpp"
+
+using LibXR::Print::Printf;
+using LibXR::Print::Config::max_float_integer_digits;
+using LibXR::Print::Config::max_float_precision;
+using LibXR::Print::Detail::FormatFrontend::Error;
+using namespace LibXRPrintConfigTest;
+
+static_assert(max_float_precision == 2);
+static_assert(max_float_integer_digits == 5);
+
+static_assert(LibXR::Format<"{:.0f}">::Matches<float>());
+static_assert(LibXR::Format<"{:.2f}">::Matches<float>());
+static_assert(LibXR::Format<"{:.2e}">::Matches<double>());
+static_assert(LibXR::Format<"{:.2g}">::Matches<double>());
+static_assert(!LibXR::Format<"{:.3f}">::Matches<float>());
+static_assert(!LibXR::Format<"{:.3e}">::Matches<double>());
+static_assert(!LibXR::Format<"{:.3g}">::Matches<double>());
+static_assert(FormatCompileError<"{:.3f}", float>() ==
+              Error::FloatPrecisionLimitExceeded);
+static_assert(FormatCompileError<"{:.3e}", double>() ==
+              Error::FloatPrecisionLimitExceeded);
+static_assert(FormatCompileError<"{:.3g}", double>() ==
+              Error::FloatPrecisionLimitExceeded);
+
+static_assert(PrintfSourceError<"%.0f">() == Printf::Error::None);
+static_assert(PrintfSourceError<"%.2f">() == Printf::Error::None);
+static_assert(PrintfSourceError<"%.2e">() == Printf::Error::None);
+static_assert(PrintfSourceError<"%.2g">() == Printf::Error::None);
+static_assert(PrintfSourceError<"%.3f">() == Printf::Error::FloatPrecisionLimitExceeded);
+static_assert(PrintfSourceError<"%.3e">() == Printf::Error::FloatPrecisionLimitExceeded);
+static_assert(PrintfSourceError<"%.3g">() == Printf::Error::FloatPrecisionLimitExceeded);

--- a/test/print_config/test_float_precision_limit.cpp
+++ b/test/print_config/test_float_precision_limit.cpp
@@ -1,19 +1,12 @@
 /**
  * @file test_float_precision_limit.cpp
- * @brief 验证浮点精度上限配置的前端门控。 Verify frontend gates for the float precision
- * limit.
- * @details 测试项目：
- *          1. brace 与 printf 都接受不超过上限的显式浮点精度。
- *          2. brace 与 printf 都拒绝超过 `LIBXR_PRINT_FLOAT_MAX_PRECISION` 的精度。
- *          3. `LIBXR_PRINT_FLOAT_MAX_INTEGER_DIGITS` 只确认配置值传递，不在这里测试
- *             writer 运行时边界。
- *          Test items:
- *          1. Brace and printf frontends accept explicit float precision at or
- *             below the configured limit.
- *          2. Brace and printf frontends reject precision above
- *             `LIBXR_PRINT_FLOAT_MAX_PRECISION`.
- *          3. `LIBXR_PRINT_FLOAT_MAX_INTEGER_DIGITS` is checked only as config
- *             propagation; writer runtime boundaries stay outside this matrix.
+ * @brief 浮点精度上限 profile 的编译期门控测试。 Compile-time gate test for the float
+ * precision-limit profile.
+ * @details
+ * 1. 显式精度小于等于 `LIBXR_PRINT_FLOAT_MAX_PRECISION` 时允许编译。
+ * 2. 超过上限时返回精度上限错误。
+ * 3. `LIBXR_PRINT_FLOAT_MAX_INTEGER_DIGITS` 这里只确认配置值传递。
+ * 4. writer 运行时边界不在本矩阵源里测试。
  */
 #include "print_config_reset.hpp"
 
@@ -46,6 +39,8 @@ using namespace LibXRPrintConfigTest;
 static_assert(max_float_precision == 2);
 static_assert(max_float_integer_digits == 5);
 
+// Brace 前端：0..2 位精度可用，3 位精度被配置上限拒绝。
+// Brace frontend: precision 0..2 is accepted; precision 3 exceeds the configured limit.
 static_assert(LibXR::Format<"{:.0f}">::Matches<float>());
 static_assert(LibXR::Format<"{:.2f}">::Matches<float>());
 static_assert(LibXR::Format<"{:.2e}">::Matches<double>());
@@ -60,6 +55,9 @@ static_assert(FormatCompileError<"{:.3e}", double>() ==
 static_assert(FormatCompileError<"{:.3g}", double>() ==
               Error::FloatPrecisionLimitExceeded);
 
+// Printf 前端：同一上限应在 printf source analysis 中得到相同错误类别。
+// Printf frontend: the same limit should surface as the corresponding source-analysis
+// error.
 static_assert(PrintfSourceError<"%.0f">() == Printf::Error::None);
 static_assert(PrintfSourceError<"%.2f">() == Printf::Error::None);
 static_assert(PrintfSourceError<"%.2e">() == Printf::Error::None);

--- a/test/print_config/test_integer_base_disabled.cpp
+++ b/test/print_config/test_integer_base_disabled.cpp
@@ -1,0 +1,51 @@
+/**
+ * @file test_integer_base_disabled.cpp
+ * @brief 验证非十进制整数族关闭时的前端门控。 Verify frontend gates when non-decimal
+ * integer formats are disabled.
+ * @details 测试项目：
+ *          1. 十进制整数继续可用。
+ *          2. brace 前端拒绝二进制、八进制和十六进制展示。
+ *          3. printf 前端把 `%b`、`%o`、`%x` 识别为被禁用的说明符。
+ *          Test items:
+ *          1. Decimal integer formatting remains enabled.
+ *          2. Brace formatting rejects binary, octal, and hexadecimal presentations.
+ *          3. Printf analysis reports `%b`, `%o`, and `%x` as disabled specifiers.
+ */
+#include "print_config_reset.hpp"
+
+#define LIBXR_PRINT_ENABLE_INTEGER 1
+#define LIBXR_PRINT_ENABLE_TEXT 1
+#define LIBXR_PRINT_ENABLE_POINTER 1
+#define LIBXR_PRINT_ENABLE_FLOAT 1
+#define LIBXR_PRINT_INTEGER_ENABLE_BASE8_16 0
+#define LIBXR_PRINT_INTEGER_ENABLE_64BIT 1
+#define LIBXR_PRINT_FLOAT_ENABLE_FIXED 1
+#define LIBXR_PRINT_FLOAT_ENABLE_DOUBLE 1
+#define LIBXR_PRINT_FLOAT_ENABLE_SCIENTIFIC 1
+#define LIBXR_PRINT_FLOAT_ENABLE_GENERAL 1
+#define LIBXR_PRINT_FLOAT_ENABLE_LONG_DOUBLE 1
+#define LIBXR_PRINT_ENABLE_WIDTH 1
+#define LIBXR_PRINT_ENABLE_PRECISION 1
+#define LIBXR_PRINT_ENABLE_ALTERNATE 1
+#define LIBXR_PRINT_ENABLE_EXPLICIT_ARGUMENT_INDEXING 1
+
+#include "print_config_probe.hpp"
+
+using LibXR::Print::Printf;
+using LibXR::Print::Detail::FormatFrontend::Error;
+using namespace LibXRPrintConfigTest;
+
+static_assert(LibXR::Format<"{}">::Matches<int>());
+static_assert(LibXR::Format<"{:d}">::Matches<unsigned int>());
+static_assert(!LibXR::Format<"{:b}">::Matches<unsigned int>());
+static_assert(!LibXR::Format<"{:o}">::Matches<unsigned int>());
+static_assert(!LibXR::Format<"{:x}">::Matches<unsigned int>());
+static_assert(FormatCompileError<"{:b}", unsigned int>() == Error::ArgumentTypeMismatch);
+static_assert(FormatCompileError<"{:o}", unsigned int>() == Error::ArgumentTypeMismatch);
+static_assert(FormatCompileError<"{:x}", unsigned int>() == Error::ArgumentTypeMismatch);
+
+static_assert(PrintfSourceError<"%d">() == Printf::Error::None);
+static_assert(PrintfSourceError<"%u">() == Printf::Error::None);
+static_assert(PrintfSourceError<"%b">() == Printf::Error::InvalidSpecifier);
+static_assert(PrintfSourceError<"%o">() == Printf::Error::InvalidSpecifier);
+static_assert(PrintfSourceError<"%x">() == Printf::Error::InvalidSpecifier);

--- a/test/print_config/test_integer_base_disabled.cpp
+++ b/test/print_config/test_integer_base_disabled.cpp
@@ -1,15 +1,10 @@
 /**
  * @file test_integer_base_disabled.cpp
- * @brief 验证非十进制整数族关闭时的前端门控。 Verify frontend gates when non-decimal
- * integer formats are disabled.
- * @details 测试项目：
- *          1. 十进制整数继续可用。
- *          2. brace 前端拒绝二进制、八进制和十六进制展示。
- *          3. printf 前端把 `%b`、`%o`、`%x` 识别为被禁用的说明符。
- *          Test items:
- *          1. Decimal integer formatting remains enabled.
- *          2. Brace formatting rejects binary, octal, and hexadecimal presentations.
- *          3. Printf analysis reports `%b`, `%o`, and `%x` as disabled specifiers.
+ * @brief 非十进制整数关闭 profile 的编译期门控测试。 Compile-time gate test for the
+ * non-decimal-integer-disabled profile.
+ * @details
+ * 1. `LIBXR_PRINT_INTEGER_ENABLE_BASE8_16=0` 关闭二/八/十六进制整数格式。
+ * 2. 十进制整数必须继续可用。
  */
 #include "print_config_reset.hpp"
 
@@ -35,6 +30,9 @@ using LibXR::Print::Printf;
 using LibXR::Print::Detail::FormatFrontend::Error;
 using namespace LibXRPrintConfigTest;
 
+// Brace 前端：十进制可用，非十进制 presentation 被参数门拒绝。
+// Brace frontend: decimal works; non-decimal presentations are rejected by the argument
+// gate.
 static_assert(LibXR::Format<"{}">::Matches<int>());
 static_assert(LibXR::Format<"{:d}">::Matches<unsigned int>());
 static_assert(!LibXR::Format<"{:b}">::Matches<unsigned int>());
@@ -44,6 +42,8 @@ static_assert(FormatCompileError<"{:b}", unsigned int>() == Error::ArgumentTypeM
 static_assert(FormatCompileError<"{:o}", unsigned int>() == Error::ArgumentTypeMismatch);
 static_assert(FormatCompileError<"{:x}", unsigned int>() == Error::ArgumentTypeMismatch);
 
+// Printf 前端：对应说明符在 source analysis 阶段不可用。
+// Printf frontend: matching specifiers are unavailable during source analysis.
 static_assert(PrintfSourceError<"%d">() == Printf::Error::None);
 static_assert(PrintfSourceError<"%u">() == Printf::Error::None);
 static_assert(PrintfSourceError<"%b">() == Printf::Error::InvalidSpecifier);

--- a/test/print_config/test_integer_text_disabled.cpp
+++ b/test/print_config/test_integer_text_disabled.cpp
@@ -1,16 +1,12 @@
 /**
  * @file test_integer_text_disabled.cpp
- * @brief 验证整数与文本总开关关闭时的前端门控。 Verify frontend gates when integer and
- * text support are disabled.
- * @details 测试项目：
- *          1. brace 前端拒绝整数、字符和字符串参数。
- *          2. printf 前端把 `%d`、`%c`、`%s` 识别为被禁用的说明符。
- *          3. 同一配置下指针和定点浮点仍可通过，确认测试只覆盖目标开关。
- *          Test items:
- *          1. Brace formatting rejects integer, character, and string arguments.
- *          2. Printf analysis reports `%d`, `%c`, and `%s` as disabled specifiers.
- *          3. Pointer and fixed-float conversions still pass in this profile, so
- *             the assertions stay scoped to the targeted switches.
+ * @brief 整数与文本总开关关闭 profile 的编译期门控测试。 Compile-time gate test for the
+ * integer/text-master-disabled profile.
+ * @details `LIBXR_PRINT_ENABLE_INTEGER=0` 和 `LIBXR_PRINT_ENABLE_TEXT=0` 应分别关闭整数、
+ *          字符和字符串格式；指针与 fixed float 保持开启，用来证明只测目标开关。 The
+ *          integer and text master switches should disable integer, character, and string
+ *          formats; pointer and fixed-float formats stay enabled to prove the test is
+ * scoped to the targeted gates.
  */
 #include "print_config_reset.hpp"
 
@@ -36,6 +32,9 @@ using LibXR::Print::Printf;
 using LibXR::Print::Detail::FormatFrontend::Error;
 using namespace LibXRPrintConfigTest;
 
+// Brace 前端：整数、字符、字符串都被各自总开关挡住。
+// Brace frontend: integer, character, and string arguments are blocked by their master
+// gates.
 static_assert(!LibXR::Format<"{}">::Matches<int>());
 static_assert(!LibXR::Format<"{:c}">::Matches<char>());
 static_assert(!LibXR::Format<"{:s}">::Matches<const char*>());
@@ -43,10 +42,15 @@ static_assert(FormatCompileError<"{}", int>() == Error::ArgumentTypeMismatch);
 static_assert(FormatCompileError<"{:c}", char>() == Error::ArgumentTypeMismatch);
 static_assert(FormatCompileError<"{:s}", const char*>() == Error::ArgumentTypeMismatch);
 
+// Printf 前端：对应说明符在 source analysis 阶段不可用。
+// Printf frontend: matching specifiers are unavailable during source analysis.
 static_assert(PrintfSourceError<"%d">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%c">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%s">() == Printf::Error::InvalidSpecifier);
 
+// 非目标格式继续可用，防止把 include/配置失效误判成门控正确。
+// Untargeted formats remain accepted to avoid mistaking a broken profile for correct
+// gating.
 static_assert(LibXR::Format<"{:p}">::Matches<const void*>());
 static_assert(LibXR::Format<"{:.1f}">::Matches<float>());
 static_assert(PrintfSourceError<"%p">() == Printf::Error::None);

--- a/test/print_config/test_integer_text_disabled.cpp
+++ b/test/print_config/test_integer_text_disabled.cpp
@@ -1,0 +1,53 @@
+/**
+ * @file test_integer_text_disabled.cpp
+ * @brief 验证整数与文本总开关关闭时的前端门控。 Verify frontend gates when integer and
+ * text support are disabled.
+ * @details 测试项目：
+ *          1. brace 前端拒绝整数、字符和字符串参数。
+ *          2. printf 前端把 `%d`、`%c`、`%s` 识别为被禁用的说明符。
+ *          3. 同一配置下指针和定点浮点仍可通过，确认测试只覆盖目标开关。
+ *          Test items:
+ *          1. Brace formatting rejects integer, character, and string arguments.
+ *          2. Printf analysis reports `%d`, `%c`, and `%s` as disabled specifiers.
+ *          3. Pointer and fixed-float conversions still pass in this profile, so
+ *             the assertions stay scoped to the targeted switches.
+ */
+#include "print_config_reset.hpp"
+
+#define LIBXR_PRINT_ENABLE_INTEGER 0
+#define LIBXR_PRINT_ENABLE_TEXT 0
+#define LIBXR_PRINT_ENABLE_POINTER 1
+#define LIBXR_PRINT_ENABLE_FLOAT 1
+#define LIBXR_PRINT_INTEGER_ENABLE_BASE8_16 1
+#define LIBXR_PRINT_INTEGER_ENABLE_64BIT 1
+#define LIBXR_PRINT_FLOAT_ENABLE_FIXED 1
+#define LIBXR_PRINT_FLOAT_ENABLE_DOUBLE 1
+#define LIBXR_PRINT_FLOAT_ENABLE_SCIENTIFIC 1
+#define LIBXR_PRINT_FLOAT_ENABLE_GENERAL 1
+#define LIBXR_PRINT_FLOAT_ENABLE_LONG_DOUBLE 1
+#define LIBXR_PRINT_ENABLE_WIDTH 1
+#define LIBXR_PRINT_ENABLE_PRECISION 1
+#define LIBXR_PRINT_ENABLE_ALTERNATE 1
+#define LIBXR_PRINT_ENABLE_EXPLICIT_ARGUMENT_INDEXING 1
+
+#include "print_config_probe.hpp"
+
+using LibXR::Print::Printf;
+using LibXR::Print::Detail::FormatFrontend::Error;
+using namespace LibXRPrintConfigTest;
+
+static_assert(!LibXR::Format<"{}">::Matches<int>());
+static_assert(!LibXR::Format<"{:c}">::Matches<char>());
+static_assert(!LibXR::Format<"{:s}">::Matches<const char*>());
+static_assert(FormatCompileError<"{}", int>() == Error::ArgumentTypeMismatch);
+static_assert(FormatCompileError<"{:c}", char>() == Error::ArgumentTypeMismatch);
+static_assert(FormatCompileError<"{:s}", const char*>() == Error::ArgumentTypeMismatch);
+
+static_assert(PrintfSourceError<"%d">() == Printf::Error::InvalidSpecifier);
+static_assert(PrintfSourceError<"%c">() == Printf::Error::InvalidSpecifier);
+static_assert(PrintfSourceError<"%s">() == Printf::Error::InvalidSpecifier);
+
+static_assert(LibXR::Format<"{:p}">::Matches<const void*>());
+static_assert(LibXR::Format<"{:.1f}">::Matches<float>());
+static_assert(PrintfSourceError<"%p">() == Printf::Error::None);
+static_assert(PrintfSourceError<"%.1f">() == Printf::Error::None);

--- a/test/print_config/test_pointer_64bit_disabled.cpp
+++ b/test/print_config/test_pointer_64bit_disabled.cpp
@@ -1,16 +1,13 @@
 /**
  * @file test_pointer_64bit_disabled.cpp
- * @brief 验证指针与 64 位整数关闭时的前端门控。 Verify frontend gates when pointer and
- * 64-bit integer support are disabled.
- * @details 测试项目：
- *          1. brace 与 printf 都拒绝指针格式。
- *          2. brace 与 printf 都拒绝需要 64 位存储的整数格式。
- *          3. 32 位整数格式继续可用，确认没有误关整数总开关。
- *          Test items:
- *          1. Brace and printf frontends both reject pointer formatting.
- *          2. Brace and printf frontends both reject integer formats requiring
- *             64-bit packed storage.
- *          3. 32-bit integer formats remain accepted.
+ * @brief 指针与 64 位整数关闭 profile 的编译期门控测试。 Compile-time gate test for the
+ * pointer/64-bit-integer-disabled profile.
+ * @details 指针格式由 `LIBXR_PRINT_ENABLE_POINTER=0` 拒绝，`long long` 整数格式由
+ *          `LIBXR_PRINT_INTEGER_ENABLE_64BIT=0` 拒绝；32 位整数仍可用，证明没有误关整数总
+ *          开关。 Pointer formats are rejected by `LIBXR_PRINT_ENABLE_POINTER=0`; `long
+ * long` integer formats are rejected by `LIBXR_PRINT_INTEGER_ENABLE_64BIT=0`; 32-bit
+ *          integer formats stay accepted so the integer master gate is not being tested
+ * here.
  */
 #include "print_config_reset.hpp"
 
@@ -40,6 +37,8 @@ using namespace LibXRPrintConfigTest;
 
 static_assert(sizeof(unsigned long long) > sizeof(uint32_t));
 
+// Brace 前端：指针和需要 64 位打包的整数参数都不匹配。
+// Brace frontend: pointers and integer arguments requiring 64-bit packing do not match.
 static_assert(!LibXR::Format<"{}">::Matches<const void*>());
 static_assert(!LibXR::Format<"{:p}">::Matches<const void*>());
 static_assert(!LibXR::Format<"{}">::Matches<unsigned long long>());
@@ -51,10 +50,14 @@ static_assert(FormatCompileError<"{}", unsigned long long>() ==
 static_assert(FormatCompileError<"{:x}", unsigned long long>() ==
               Error::ArgumentTypeMismatch);
 
+// Printf 前端：指针是禁用说明符，`ll` 长度修饰符是禁用长度族。
+// Printf frontend: pointer is a disabled specifier; `ll` is a disabled length family.
 static_assert(PrintfSourceError<"%p">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%llu">() == Printf::Error::InvalidLength);
 static_assert(PrintfSourceError<"%llx">() == Printf::Error::InvalidLength);
 
+// 32 位整数仍可用，确认不是整数总开关被关闭。
+// 32-bit integers remain accepted, proving the integer master gate is still enabled.
 static_assert(LibXR::Format<"{}">::Matches<int32_t>());
 static_assert(LibXR::Format<"{:x}">::Matches<uint32_t>());
 static_assert(PrintfSourceError<"%d %u %x">() == Printf::Error::None);

--- a/test/print_config/test_pointer_64bit_disabled.cpp
+++ b/test/print_config/test_pointer_64bit_disabled.cpp
@@ -1,0 +1,60 @@
+/**
+ * @file test_pointer_64bit_disabled.cpp
+ * @brief 验证指针与 64 位整数关闭时的前端门控。 Verify frontend gates when pointer and
+ * 64-bit integer support are disabled.
+ * @details 测试项目：
+ *          1. brace 与 printf 都拒绝指针格式。
+ *          2. brace 与 printf 都拒绝需要 64 位存储的整数格式。
+ *          3. 32 位整数格式继续可用，确认没有误关整数总开关。
+ *          Test items:
+ *          1. Brace and printf frontends both reject pointer formatting.
+ *          2. Brace and printf frontends both reject integer formats requiring
+ *             64-bit packed storage.
+ *          3. 32-bit integer formats remain accepted.
+ */
+#include "print_config_reset.hpp"
+
+#define LIBXR_PRINT_ENABLE_INTEGER 1
+#define LIBXR_PRINT_ENABLE_TEXT 1
+#define LIBXR_PRINT_ENABLE_POINTER 0
+#define LIBXR_PRINT_ENABLE_FLOAT 1
+#define LIBXR_PRINT_INTEGER_ENABLE_BASE8_16 1
+#define LIBXR_PRINT_INTEGER_ENABLE_64BIT 0
+#define LIBXR_PRINT_FLOAT_ENABLE_FIXED 1
+#define LIBXR_PRINT_FLOAT_ENABLE_DOUBLE 1
+#define LIBXR_PRINT_FLOAT_ENABLE_SCIENTIFIC 1
+#define LIBXR_PRINT_FLOAT_ENABLE_GENERAL 1
+#define LIBXR_PRINT_FLOAT_ENABLE_LONG_DOUBLE 1
+#define LIBXR_PRINT_ENABLE_WIDTH 1
+#define LIBXR_PRINT_ENABLE_PRECISION 1
+#define LIBXR_PRINT_ENABLE_ALTERNATE 1
+#define LIBXR_PRINT_ENABLE_EXPLICIT_ARGUMENT_INDEXING 1
+
+#include <cstdint>
+
+#include "print_config_probe.hpp"
+
+using LibXR::Print::Printf;
+using LibXR::Print::Detail::FormatFrontend::Error;
+using namespace LibXRPrintConfigTest;
+
+static_assert(sizeof(unsigned long long) > sizeof(uint32_t));
+
+static_assert(!LibXR::Format<"{}">::Matches<const void*>());
+static_assert(!LibXR::Format<"{:p}">::Matches<const void*>());
+static_assert(!LibXR::Format<"{}">::Matches<unsigned long long>());
+static_assert(!LibXR::Format<"{:x}">::Matches<unsigned long long>());
+static_assert(FormatCompileError<"{}", const void*>() == Error::ArgumentTypeMismatch);
+static_assert(FormatCompileError<"{:p}", const void*>() == Error::ArgumentTypeMismatch);
+static_assert(FormatCompileError<"{}", unsigned long long>() ==
+              Error::ArgumentTypeMismatch);
+static_assert(FormatCompileError<"{:x}", unsigned long long>() ==
+              Error::ArgumentTypeMismatch);
+
+static_assert(PrintfSourceError<"%p">() == Printf::Error::InvalidSpecifier);
+static_assert(PrintfSourceError<"%llu">() == Printf::Error::InvalidLength);
+static_assert(PrintfSourceError<"%llx">() == Printf::Error::InvalidLength);
+
+static_assert(LibXR::Format<"{}">::Matches<int32_t>());
+static_assert(LibXR::Format<"{:x}">::Matches<uint32_t>());
+static_assert(PrintfSourceError<"%d %u %x">() == Printf::Error::None);

--- a/test/print_config/test_syntax_switches_disabled.cpp
+++ b/test/print_config/test_syntax_switches_disabled.cpp
@@ -1,0 +1,53 @@
+/**
+ * @file test_syntax_switches_disabled.cpp
+ * @brief 验证宽度、精度、备用格式和显式索引语法关闭时的前端门控。 Verify frontend gates
+ * for disabled width, precision, alternate, and explicit-index syntax.
+ * @details 测试项目：
+ *          1. 无宽度/精度/备用格式/显式索引的基础格式继续可用。
+ *          2. brace 前端 source analysis 拒绝被关闭的语法。
+ *          3. printf 前端 source analysis 拒绝被关闭的语法。
+ *          Test items:
+ *          1. Basic formats without width, precision, alternate form, or
+ *             explicit indexing remain accepted.
+ *          2. Brace source analysis rejects disabled syntax.
+ *          3. Printf source analysis rejects disabled syntax.
+ */
+#include "print_config_reset.hpp"
+
+#define LIBXR_PRINT_ENABLE_INTEGER 1
+#define LIBXR_PRINT_ENABLE_TEXT 1
+#define LIBXR_PRINT_ENABLE_POINTER 1
+#define LIBXR_PRINT_ENABLE_FLOAT 1
+#define LIBXR_PRINT_INTEGER_ENABLE_BASE8_16 1
+#define LIBXR_PRINT_INTEGER_ENABLE_64BIT 1
+#define LIBXR_PRINT_FLOAT_ENABLE_FIXED 1
+#define LIBXR_PRINT_FLOAT_ENABLE_DOUBLE 1
+#define LIBXR_PRINT_FLOAT_ENABLE_SCIENTIFIC 1
+#define LIBXR_PRINT_FLOAT_ENABLE_GENERAL 1
+#define LIBXR_PRINT_FLOAT_ENABLE_LONG_DOUBLE 1
+#define LIBXR_PRINT_ENABLE_WIDTH 0
+#define LIBXR_PRINT_ENABLE_PRECISION 0
+#define LIBXR_PRINT_ENABLE_ALTERNATE 0
+#define LIBXR_PRINT_ENABLE_EXPLICIT_ARGUMENT_INDEXING 0
+
+#include "print_config_probe.hpp"
+
+using LibXR::Print::Printf;
+using LibXR::Print::Detail::FormatFrontend::Error;
+using namespace LibXRPrintConfigTest;
+
+static_assert(LibXR::Format<"{}">::Matches<int>());
+static_assert(LibXR::Format<"{:d}">::Matches<int>());
+static_assert(LibXR::Format<"{:f}">::Matches<float>());
+static_assert(PrintfSourceError<"%d %f %%">() == Printf::Error::None);
+
+static_assert(FormatSourceError<"{:5d}">() == Error::InvalidSpecifier);
+static_assert(FormatSourceError<"{:.2f}">() == Error::InvalidSpecifier);
+static_assert(FormatSourceError<"{:#x}">() == Error::InvalidSpecifier);
+static_assert(FormatSourceError<"{0}">() == Error::ManualIndexingDisabled);
+static_assert(FormatSourceError<"{1:d}">() == Error::ManualIndexingDisabled);
+
+static_assert(PrintfSourceError<"%5d">() == Printf::Error::InvalidSpecifier);
+static_assert(PrintfSourceError<"%.2f">() == Printf::Error::InvalidSpecifier);
+static_assert(PrintfSourceError<"%#x">() == Printf::Error::InvalidSpecifier);
+static_assert(PrintfSourceError<"%1$d">() == Printf::Error::PositionalArgumentDisabled);

--- a/test/print_config/test_syntax_switches_disabled.cpp
+++ b/test/print_config/test_syntax_switches_disabled.cpp
@@ -1,16 +1,12 @@
 /**
  * @file test_syntax_switches_disabled.cpp
- * @brief 验证宽度、精度、备用格式和显式索引语法关闭时的前端门控。 Verify frontend gates
- * for disabled width, precision, alternate, and explicit-index syntax.
- * @details 测试项目：
- *          1. 无宽度/精度/备用格式/显式索引的基础格式继续可用。
- *          2. brace 前端 source analysis 拒绝被关闭的语法。
- *          3. printf 前端 source analysis 拒绝被关闭的语法。
- *          Test items:
- *          1. Basic formats without width, precision, alternate form, or
- *             explicit indexing remain accepted.
- *          2. Brace source analysis rejects disabled syntax.
- *          3. Printf source analysis rejects disabled syntax.
+ * @brief 宽度、精度、备用格式和显式索引关闭 profile 的编译期门控测试。 Compile-time gate
+ * test for the width/precision/alternate/explicit-index-disabled profile.
+ * @details 这些开关关闭的是源字符串语法，不是参数类型；因此本文件直接检查 brace 和 printf
+ *          source analysis 的错误类别，同时保留无这些语法的基础格式作为 sanity check。
+ * These switches disable source syntax rather than argument types, so this file checks
+ * brace and printf source-analysis errors directly while keeping basic formats without
+ * these syntax features as sanity checks.
  */
 #include "print_config_reset.hpp"
 
@@ -36,17 +32,23 @@ using LibXR::Print::Printf;
 using LibXR::Print::Detail::FormatFrontend::Error;
 using namespace LibXRPrintConfigTest;
 
+// 基础格式不依赖宽度、精度、alternate 或显式索引，仍应可用。
+// Basic formats do not require width, precision, alternate form, or explicit indexing.
 static_assert(LibXR::Format<"{}">::Matches<int>());
 static_assert(LibXR::Format<"{:d}">::Matches<int>());
 static_assert(LibXR::Format<"{:f}">::Matches<float>());
 static_assert(PrintfSourceError<"%d %f %%">() == Printf::Error::None);
 
+// Brace source analysis：被关闭的语法在参数匹配前就应返回对应错误。
+// Brace source analysis: disabled syntax should fail before argument matching.
 static_assert(FormatSourceError<"{:5d}">() == Error::InvalidSpecifier);
 static_assert(FormatSourceError<"{:.2f}">() == Error::InvalidSpecifier);
 static_assert(FormatSourceError<"{:#x}">() == Error::InvalidSpecifier);
 static_assert(FormatSourceError<"{0}">() == Error::ManualIndexingDisabled);
 static_assert(FormatSourceError<"{1:d}">() == Error::ManualIndexingDisabled);
 
+// Printf source analysis：宽度、精度、alternate 和 positional 各自返回禁用错误。
+// Printf source analysis: width, precision, alternate, and positional syntax each fail.
 static_assert(PrintfSourceError<"%5d">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%.2f">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%#x">() == Printf::Error::InvalidSpecifier);


### PR DESCRIPTION
## Summary
- add a compile-only `test_print_config_matrix` object target for `print` configuration profiles
- add independent `test/print_config/*.cpp` translation units that `#undef` CMake-provided `LIBXR_PRINT_*`, define one local profile, then include `print.hpp`
- cover integer/text, non-decimal integer, float master/fixed-only/precision-limit, pointer/64-bit, and width/precision/alternate/indexing gates

## Validation
- local `git diff --check`
- local clang-format dry-run on `test/print_config/*.{cpp,hpp}` with clang-format 21.1.8
- local `tools/format_cmake_files.sh --check`
- Ubuntu24 clean clone/apply/configure/build passed from base `b424e5801406750e720a30d96b2aedc6499883c8`
- Ubuntu24 explicit `cmake --build build --target test_print_config_matrix` passed
- Ubuntu24 built 7 print_config object files
- Ubuntu24 main `build/test/test` observed `Test [print] Passed`; full run later exited 139 at `linux_shm_bench`, outside this compile-only print matrix

Artifact: `/root/codex/runs/libxr_print_config_matrix_20260628/99_summary_current.txt`
Patch sha256: `5211bbc248f7b57a9935e2dae19e48ea2ebfe4b619c6dd74f7fce9539f816fa3`

## Summary by Sourcery

为打印子系统添加一个编译期配置矩阵，并以独立对象目标的形式接入测试构建。

增强功能：
- 提供共享的编译期探测辅助工具，用于在不运行运行时写入器的情况下分析 print 和 printf 格式源，以及基于配置驱动的错误。

构建：
- 添加 `test_print_config_matrix` OBJECT 库目标，对所有 `print_config` 配置概要源文件进行编译，并与 xr 进行适当的包含和链接。

测试：
- 引入多个只编译（compile-only）的配置概要，用于在不同特性组合和限制下验证打印前端的门控逻辑（整数/文本、非十进制进制、浮点数、指针/64 位，以及语法开关）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a compile-time configuration matrix for the print subsystem and wire it into the test build as a dedicated object target.

Enhancements:
- Provide shared compile-time probe helpers to analyze print and printf format sources and configuration-driven errors without running runtime writers.

Build:
- Add the test_print_config_matrix OBJECT library target that compiles all print_config profile sources with appropriate includes and linkage to xr.

Tests:
- Introduce multiple compile-only config profiles that validate print frontend gates for different feature combinations and limits (integer/text, non-decimal bases, floats, pointers/64-bit, and syntax switches).

</details>