### PR TITLE
fix(mspm0): add GPIO/SPI interrupt support and timing fixes

### DIFF
--- a/driver/mspm0/mspm0_gpio.cpp
+++ b/driver/mspm0/mspm0_gpio.cpp
@@ -1,5 +1,7 @@
 #include "mspm0_gpio.hpp"
 
+#include <ti/driverlib/m0p/dl_interrupt.h>
+
 using namespace LibXR;
 
 MSPM0GPIO* MSPM0GPIO::instance_map_[MAX_PORTS][32] = {{nullptr}};
@@ -237,6 +239,11 @@ ErrorCode MSPM0GPIO::SetConfig(Configuration config)
 
 void MSPM0GPIO::OnInterruptDispatch(GPIO_Regs* port, int port_idx)
 {
+  if (port_idx < 0 || port_idx >= LibXR::MAX_PORTS)
+  {
+    return;
+  }
+
   uint32_t pending_pins = DL_GPIO_getEnabledInterruptStatus(port, 0xFFFFFFFF);
 
   if (pending_pins != 0)
@@ -256,5 +263,29 @@ void MSPM0GPIO::OnInterruptDispatch(GPIO_Regs* port, int port_idx)
     {
       instance->callback_.Run(true);
     }
+  }
+}
+
+extern "C" void GROUP1_IRQHandler(void)  // NOLINT
+{
+  switch (DL_Interrupt_getPendingGroup(DL_INTERRUPT_GROUP_1))
+  {
+#ifdef GPIOA_BASE
+    case DL_INTERRUPT_GROUP1_IIDX_GPIOA:
+      LibXR::MSPM0GPIO::OnInterrupt(GPIOA);
+      break;
+#endif
+#ifdef GPIOB_BASE
+    case DL_INTERRUPT_GROUP1_IIDX_GPIOB:
+      LibXR::MSPM0GPIO::OnInterrupt(GPIOB);
+      break;
+#endif
+#ifdef GPIOC_BASE
+    case DL_INTERRUPT_GROUP1_IIDX_GPIOC:
+      LibXR::MSPM0GPIO::OnInterrupt(GPIOC);
+      break;
+#endif
+    default:
+      break;
   }
 }

--- a/driver/mspm0/mspm0_pwm.cpp
+++ b/driver/mspm0/mspm0_pwm.cpp
@@ -85,10 +85,11 @@ ErrorCode MSPM0PWM::SetConfig(Configuration config)
   }
 
   uint32_t best_load = (SOURCE_CLOCK / (best_div * best_prescaler * config.frequency));
-  if (best_load > 0)
+  if (best_load == 0)
   {
-    best_load -= 1;
+    return ErrorCode::NOT_SUPPORT;  // Frequency too high to represent
   }
+  best_load -= 1;
 
   DL_Timer_ClockConfig clock_config;
   DL_Timer_getClockConfig(timer_, &clock_config);

--- a/driver/mspm0/mspm0_spi.cpp
+++ b/driver/mspm0/mspm0_spi.cpp
@@ -722,3 +722,10 @@ extern "C" void SPI1_IRQHandler(void)  // NOLINT
   LibXR::MSPM0SPI::OnInterrupt(1);
 }
 #endif
+
+#if defined(SPI2_BASE)
+extern "C" void SPI2_IRQHandler(void)  // NOLINT
+{
+  LibXR::MSPM0SPI::OnInterrupt(2);
+}
+#endif

--- a/driver/mspm0/mspm0_spi.hpp
+++ b/driver/mspm0/mspm0_spi.hpp
@@ -57,6 +57,10 @@ class MSPM0SPI : public SPI
       case SPI1_INT_IRQn:
         return 1;
 #endif
+#if defined(SPI2_BASE)
+      case SPI2_INT_IRQn:
+        return 2;
+#endif
       default:
         return INVALID_INSTANCE_INDEX;
     }
@@ -70,7 +74,13 @@ class MSPM0SPI : public SPI
     TX_ONLY
   };
 
+#if defined(SPI2_BASE)
+  static constexpr uint8_t MAX_SPI_INSTANCES = 3;
+#elif defined(SPI1_BASE)
   static constexpr uint8_t MAX_SPI_INSTANCES = 2;
+#else
+  static constexpr uint8_t MAX_SPI_INSTANCES = 1;
+#endif
   static constexpr uint8_t INVALID_INSTANCE_INDEX = 0xFF;
   static constexpr uint32_t RX_ONLY_REPEAT_TX_MAX_FRAMES = 256U;
 

--- a/driver/mspm0/mspm0_timebase.cpp
+++ b/driver/mspm0/mspm0_timebase.cpp
@@ -12,9 +12,9 @@ MicrosecondTimestamp Timebase::GetMicroseconds()
 {
   do
   {
-    uint32_t tick_old = sys_tick_ms;
+    uint32_t tick_old = MSPM0Timebase::sys_tick_ms;
     uint32_t val_old = DL_SYSTICK_getValue();
-    uint32_t tick_new = sys_tick_ms;
+    uint32_t tick_new = MSPM0Timebase::sys_tick_ms;
     uint32_t val_new = DL_SYSTICK_getValue();
 
     auto tick_diff = tick_new - tick_old;
@@ -43,8 +43,8 @@ MicrosecondTimestamp Timebase::GetMicroseconds()
 }
 
 MillisecondTimestamp Timebase::GetMilliseconds() { return MSPM0Timebase::sys_tick_ms; }
-void MSPM0Timebase::OnSysTickInterrupt() { sys_tick_ms++; }
-void MSPM0Timebase::Sync(uint32_t ticks) { sys_tick_ms = ticks; }
+void MSPM0Timebase::OnSysTickInterrupt() { MSPM0Timebase::sys_tick_ms++; }
+void MSPM0Timebase::Sync(uint32_t ticks) { MSPM0Timebase::sys_tick_ms = ticks; }
 
 extern "C" void SysTick_Handler(void)  // NOLINT
 {


### PR DESCRIPTION
## Summary

This PR improves MSPM0 driver interrupt coverage and fixes several edge cases in the MSPM0 platform drivers.

## Changes

- Add `GROUP1_IRQHandler` dispatching for MSPM0 GPIO interrupts
  - Dispatches pending group interrupts to the matching GPIO port handler
  - Supports GPIOA/GPIOB/GPIOC when the corresponding base macros are available
  - Adds a bounds check before accessing the GPIO instance map

- Add MSPM0 SPI2 support
  - Maps `SPI2_INT_IRQn` to SPI instance index `2`
  - Expands `MAX_SPI_INSTANCES` when `SPI2_BASE` is available
  - Adds `SPI2_IRQHandler` and forwards it to the shared MSPM0 SPI interrupt handler

- Fix MSPM0 PWM frequency edge handling
  - Detects an unrepresentable high-frequency configuration when the computed timer load is `0`
  - Returns `ErrorCode::NOT_SUPPORT` instead of allowing an underflow

- Fix MSPM0 timebase static tick counter references
  - Qualifies `sys_tick_ms` access through `MSPM0Timebase`
  - Avoids ambiguous or unqualified static member references in `Timebase` methods
  - Keeps SysTick timestamp reads and synchronization behavior explicit

## Motivation

These changes improve MSPM0 platform coverage for devices with additional GPIO/SPI interrupt sources and make timer-related edge cases safer. They also make the timebase implementation clearer by explicitly referencing the owning class for the static tick counter.

## Summary by Sourcery

扩展 MSPM0 平台驱动的中断覆盖范围，并改进与定时器相关的边界情况处理，涉及 GPIO、SPI、PWM 和时间基准。

New Features:
- 为 MSPM0 GPIO 端口专用中断处理程序添加 GROUP1 中断处理程序分发逻辑。
- 为 MSPM0 添加 SPI2 中断支持，并为暴露 `SPI2_BASE` 的平台增加实例映射。

Bug Fixes:
- 在 MSPM0 GPIO 中断分发逻辑中对端口索引进行边界检查，以避免访问无效的实例映射。
- 在计算出的定时器装载值为 0 时，检测不可表示的高 PWM 频率，并返回 `NOT_SUPPORT`，而不是发生下溢。
- 通过 `MSPM0Timebase` 访问 MSPM0 时间基准的静态滴答计数器，以避免在时间戳计算和 SysTick 处理时出现引用歧义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Expand MSPM0 platform driver interrupt coverage and improve timer-related edge case handling for GPIO, SPI, PWM, and timebase.

New Features:
- Add GROUP1 interrupt handler dispatching to MSPM0 GPIO port-specific interrupt handlers.
- Add MSPM0 SPI2 interrupt support and instance mapping for platforms exposing SPI2_BASE.

Bug Fixes:
- Guard MSPM0 GPIO interrupt dispatch with a bounds check on the port index to avoid invalid instance map access.
- Detect unrepresentable high PWM frequencies when the computed timer load is zero and return NOT_SUPPORT instead of underflowing.
- Qualify MSPM0 timebase static tick counter accesses through MSPM0Timebase to avoid ambiguous references in timestamp calculations and SysTick handling.

</details>

Closes #214