### PR TITLE
[codex] feat(hpm): add HPM EWDG watchdog driver

### DIFF
--- a/driver/hpm/hpm_watchdog.cpp
+++ b/driver/hpm/hpm_watchdog.cpp
@@ -3,6 +3,7 @@
 #if LIBXR_HPM_EWDG_SUPPORTED
 
 #include <limits>
+#include <type_traits>
 
 using namespace LibXR;
 
@@ -65,6 +66,38 @@ constexpr uint32_t EWDG_CLOCK_DIV_POWER_MAX =
         ? EWDG_SOC_CLOCK_DIV_POWER_MAX
         : EWDG_REGISTER_CLOCK_DIV_POWER_MAX;
 
+ErrorCode ConvertSdkStatus(hpm_stat_t status)
+{
+  switch (status)
+  {
+    case status_success:
+      return ErrorCode::OK;
+    case status_invalid_argument:
+      return ErrorCode::ARG_ERR;
+    case status_ewdg_tick_out_of_range:
+    case status_ewdg_div_out_of_range:
+      return ErrorCode::OUT_OF_RANGE;
+    case status_ewdg_feature_unsupported:
+      return ErrorCode::NOT_SUPPORT;
+    default:
+      return ErrorCode::FAILED;
+  }
+}
+
+template <typename Callable>
+ErrorCode InvokeSdk(Callable callable)
+{
+  if constexpr (std::is_void_v<decltype(callable())>)
+  {
+    callable();
+    return ErrorCode::OK;
+  }
+  else
+  {
+    return ConvertSdkStatus(static_cast<hpm_stat_t>(callable()));
+  }
+}
+
 uint64_t DivCeil(uint64_t value, uint64_t divisor)
 {
   if (divisor == 0u)
@@ -122,35 +155,17 @@ ErrorCode ValidateClockSource(clock_name_t clock, clk_src_t source)
 }  // namespace
 
 HPMWatchdog::HPMWatchdog(EWDG_Type* ewdg, clock_name_t clock, uint32_t timeout_ms,
-                         uint32_t feed_ms, clk_src_t clock_source, bool auto_start)
+                         uint32_t feed_ms, clk_src_t clock_source)
     : ewdg_(ewdg),
       clock_(clock),
       clock_source_(clock_source),
       current_config_{timeout_ms, feed_ms}
 {
-  if (auto_start)
-  {
-    const ErrorCode ans = Start();
-    ASSERT(ans == ErrorCode::OK);
-  }
 }
 
 ErrorCode HPMWatchdog::ConvertStatus(hpm_stat_t status)
 {
-  switch (status)
-  {
-    case status_success:
-      return ErrorCode::OK;
-    case status_invalid_argument:
-      return ErrorCode::ARG_ERR;
-    case status_ewdg_tick_out_of_range:
-    case status_ewdg_div_out_of_range:
-      return ErrorCode::OUT_OF_RANGE;
-    case status_ewdg_feature_unsupported:
-      return ErrorCode::NOT_SUPPORT;
-    default:
-      return ErrorCode::FAILED;
-  }
+  return ConvertSdkStatus(status);
 }
 
 ErrorCode HPMWatchdog::SetConfig(const Configuration& config)
@@ -249,9 +264,19 @@ ErrorCode HPMWatchdog::EnsureClockReady()
     return ans;
   }
 
-  clock_add_to_group(clock_, EWDG_SDK_DEFAULT_CLOCK_GROUP);
+  ans = InvokeSdk([&]()
+                  { return clock_add_to_group(clock_, EWDG_SDK_DEFAULT_CLOCK_GROUP); });
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
 
-  ewdg_switch_clock_source(ewdg_, ResolveEwdgClockSelect());
+  ans = InvokeSdk([&]()
+                  { return ewdg_switch_clock_source(ewdg_, ResolveEwdgClockSelect()); });
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
 
   ans = ResolveCounterClockFrequency(clock_source, &counter_clock_hz_);
   if (ans == ErrorCode::OK)

--- a/driver/hpm/hpm_watchdog.cpp
+++ b/driver/hpm/hpm_watchdog.cpp
@@ -1,5 +1,7 @@
 #include "hpm_watchdog.hpp"
 
+#if LIBXR_HPM_EWDG_SUPPORTED
+
 #include <limits>
 
 using namespace LibXR;
@@ -17,49 +19,49 @@ ErrorCode ValidateConfiguration(const Watchdog::Configuration& config)
   return ErrorCode::OK;
 }
 
-#if LIBXR_HPM_EWDG_SUPPORTED
-constexpr uint32_t kMillisecondsPerSecond = 1000u;
-constexpr uint32_t kEwdgOsc32kHz = 32768u;
-constexpr uint32_t kEwdgOsc24mHz = 24000000u;
-constexpr uint32_t kEwdgBusClockSourceIndex = 0u;
-constexpr uint32_t kEwdgExternalClockSourceIndex = 1u;
-constexpr uint32_t kEwdgSdkDefaultClockGroup = 0u;
+constexpr uint32_t MILLISECONDS_PER_SECOND = 1000u;
+constexpr uint32_t EWDG_OSC_32KHZ = 32768u;
+constexpr uint32_t EWDG_OSC_24MHZ = 24000000u;
+constexpr uint32_t EWDG_BUS_CLOCK_SOURCE_INDEX = 0u;
+constexpr uint32_t EWDG_EXTERNAL_CLOCK_SOURCE_INDEX = 1u;
+constexpr uint32_t EWDG_SDK_DEFAULT_CLOCK_GROUP = 0u;
 
 #if defined(EWDG_SOC_OVERTIME_REG_WIDTH) && (EWDG_SOC_OVERTIME_REG_WIDTH == 16)
-constexpr uint64_t kEwdgSocTimeoutTickMax = 0xFFFFULL;
+constexpr uint64_t EWDG_SOC_TIMEOUT_TICK_MAX = 0xFFFFULL;
 #else
-constexpr uint64_t kEwdgSocTimeoutTickMax = 0xFFFFFFFFULL;
+constexpr uint64_t EWDG_SOC_TIMEOUT_TICK_MAX = 0xFFFFFFFFULL;
 #endif
 
 #if defined(EWDG_OT_RST_VAL_OT_RST_VAL_MASK) && defined(EWDG_OT_RST_VAL_OT_RST_VAL_SHIFT)
-constexpr uint64_t kEwdgRegisterTimeoutTickMax =
+constexpr uint64_t EWDG_REGISTER_TIMEOUT_TICK_MAX =
     EWDG_OT_RST_VAL_OT_RST_VAL_MASK >> EWDG_OT_RST_VAL_OT_RST_VAL_SHIFT;
 #else
-constexpr uint64_t kEwdgRegisterTimeoutTickMax = kEwdgSocTimeoutTickMax;
+constexpr uint64_t EWDG_REGISTER_TIMEOUT_TICK_MAX = EWDG_SOC_TIMEOUT_TICK_MAX;
 #endif
 
-constexpr uint64_t kEwdgTimeoutTickMax =
-    kEwdgSocTimeoutTickMax < kEwdgRegisterTimeoutTickMax ? kEwdgSocTimeoutTickMax
-                                                         : kEwdgRegisterTimeoutTickMax;
+constexpr uint64_t EWDG_TIMEOUT_TICK_MAX =
+    EWDG_SOC_TIMEOUT_TICK_MAX < EWDG_REGISTER_TIMEOUT_TICK_MAX
+        ? EWDG_SOC_TIMEOUT_TICK_MAX
+        : EWDG_REGISTER_TIMEOUT_TICK_MAX;
 
 #if defined(EWDG_SOC_CLK_DIV_VAL_MAX)
-constexpr uint32_t kEwdgSocClockDivPowerMax = EWDG_SOC_CLK_DIV_VAL_MAX;
+constexpr uint32_t EWDG_SOC_CLOCK_DIV_POWER_MAX = EWDG_SOC_CLK_DIV_VAL_MAX;
 #else
-constexpr uint32_t kEwdgSocClockDivPowerMax =
+constexpr uint32_t EWDG_SOC_CLOCK_DIV_POWER_MAX =
     EWDG_CTRL0_DIV_VALUE_MASK >> EWDG_CTRL0_DIV_VALUE_SHIFT;
 #endif
 
 #if defined(EWDG_CTRL0_DIV_VALUE_MASK) && defined(EWDG_CTRL0_DIV_VALUE_SHIFT)
-constexpr uint32_t kEwdgRegisterClockDivPowerMax =
+constexpr uint32_t EWDG_REGISTER_CLOCK_DIV_POWER_MAX =
     EWDG_CTRL0_DIV_VALUE_MASK >> EWDG_CTRL0_DIV_VALUE_SHIFT;
 #else
-constexpr uint32_t kEwdgRegisterClockDivPowerMax = kEwdgSocClockDivPowerMax;
+constexpr uint32_t EWDG_REGISTER_CLOCK_DIV_POWER_MAX = EWDG_SOC_CLOCK_DIV_POWER_MAX;
 #endif
 
-constexpr uint32_t kEwdgClockDivPowerMax =
-    kEwdgSocClockDivPowerMax < kEwdgRegisterClockDivPowerMax
-        ? kEwdgSocClockDivPowerMax
-        : kEwdgRegisterClockDivPowerMax;
+constexpr uint32_t EWDG_CLOCK_DIV_POWER_MAX =
+    EWDG_SOC_CLOCK_DIV_POWER_MAX < EWDG_REGISTER_CLOCK_DIV_POWER_MAX
+        ? EWDG_SOC_CLOCK_DIV_POWER_MAX
+        : EWDG_REGISTER_CLOCK_DIV_POWER_MAX;
 
 uint64_t DivCeil(uint64_t value, uint64_t divisor)
 {
@@ -85,7 +87,7 @@ ErrorCode ConvertTimeoutMsToTicks(uint32_t counter_clock_hz, uint32_t timeout_ms
 
   const uint64_t timeout_clock_cycles =
       timeout_ms_64 * static_cast<uint64_t>(counter_clock_hz);
-  *timeout_ticks = DivCeil(timeout_clock_cycles, kMillisecondsPerSecond);
+  *timeout_ticks = DivCeil(timeout_clock_cycles, MILLISECONDS_PER_SECOND);
   return ErrorCode::OK;
 }
 
@@ -101,40 +103,31 @@ ErrorCode ValidateClockSource(clock_name_t clock, clk_src_t source)
     return ErrorCode::ARG_ERR;
   }
 
-  if (source_index == kEwdgExternalClockSourceIndex ||
-      source_index == kEwdgBusClockSourceIndex)
+  if (source_index == EWDG_EXTERNAL_CLOCK_SOURCE_INDEX ||
+      source_index == EWDG_BUS_CLOCK_SOURCE_INDEX)
   {
     return ErrorCode::OK;
   }
 
   return ErrorCode::ARG_ERR;
 }
-#endif
 }  // namespace
 
-HPMWatchdog::HPMWatchdog(LibXRHpmEwdgType* ewdg, clock_name_t clock, uint32_t timeout_ms,
+HPMWatchdog::HPMWatchdog(EWDG_Type* ewdg, clock_name_t clock, uint32_t timeout_ms,
                          uint32_t feed_ms, clk_src_t clock_source, bool auto_start)
     : ewdg_(ewdg),
       clock_(clock),
       clock_source_(clock_source),
       current_config_{timeout_ms, feed_ms}
 {
-#if LIBXR_HPM_EWDG_SUPPORTED
   if (auto_start)
   {
     (void)Start();
   }
-#else
-  (void)ewdg_;
-  (void)clock_;
-  (void)clock_source_;
-  (void)auto_start;
-#endif
 }
 
 ErrorCode HPMWatchdog::ConvertStatus(hpm_stat_t status)
 {
-#if LIBXR_HPM_EWDG_SUPPORTED
   switch (status)
   {
     case status_success:
@@ -149,10 +142,6 @@ ErrorCode HPMWatchdog::ConvertStatus(hpm_stat_t status)
     default:
       return ErrorCode::FAILED;
   }
-#else
-  (void)status;
-  return ErrorCode::NOT_SUPPORT;
-#endif
 }
 
 ErrorCode HPMWatchdog::SetConfig(const Configuration& config)
@@ -163,7 +152,6 @@ ErrorCode HPMWatchdog::SetConfig(const Configuration& config)
     return ans;
   }
 
-#if LIBXR_HPM_EWDG_SUPPORTED
   if (ewdg_ == nullptr)
   {
     return ErrorCode::PTR_NULL;
@@ -176,15 +164,10 @@ ErrorCode HPMWatchdog::SetConfig(const Configuration& config)
   }
 
   return ans;
-#else
-  (void)config;
-  return ErrorCode::NOT_SUPPORT;
-#endif
 }
 
 ErrorCode HPMWatchdog::Feed()
 {
-#if LIBXR_HPM_EWDG_SUPPORTED
   if (ewdg_ == nullptr)
   {
     return ErrorCode::PTR_NULL;
@@ -195,14 +178,10 @@ ErrorCode HPMWatchdog::Feed()
   }
 
   return ConvertStatus(ewdg_refresh(ewdg_));
-#else
-  return ErrorCode::NOT_SUPPORT;
-#endif
 }
 
 ErrorCode HPMWatchdog::Start()
 {
-#if LIBXR_HPM_EWDG_SUPPORTED
   if (ewdg_ == nullptr)
   {
     return ErrorCode::PTR_NULL;
@@ -232,14 +211,10 @@ ErrorCode HPMWatchdog::Start()
   this->auto_feed_ = true;
   started_ = true;
   return ErrorCode::OK;
-#else
-  return ErrorCode::NOT_SUPPORT;
-#endif
 }
 
 ErrorCode HPMWatchdog::Stop()
 {
-#if LIBXR_HPM_EWDG_SUPPORTED
   if (ewdg_ == nullptr)
   {
     return ErrorCode::PTR_NULL;
@@ -249,12 +224,8 @@ ErrorCode HPMWatchdog::Stop()
   this->auto_feed_ = false;
   started_ = false;
   return ErrorCode::OK;
-#else
-  return ErrorCode::NOT_SUPPORT;
-#endif
 }
 
-#if LIBXR_HPM_EWDG_SUPPORTED
 ErrorCode HPMWatchdog::EnsureClockReady()
 {
   const clk_src_t clock_source = ResolveClockSource();
@@ -264,12 +235,9 @@ ErrorCode HPMWatchdog::EnsureClockReady()
     return ans;
   }
 
-  clock_add_to_group(clock_, kEwdgSdkDefaultClockGroup);
+  clock_add_to_group(clock_, EWDG_SDK_DEFAULT_CLOCK_GROUP);
 
-  if (ResolveEwdgClockSelect() == ewdg_cnt_clk_src_bus_clk)
-  {
-    ewdg_switch_clock_source(ewdg_, ewdg_cnt_clk_src_bus_clk);
-  }
+  ewdg_switch_clock_source(ewdg_, ResolveEwdgClockSelect());
 
   return ResolveCounterClockFrequency(clock_source, &counter_clock_hz_);
 }
@@ -299,9 +267,9 @@ ErrorCode HPMWatchdog::ResolveTimeoutSetting(uint32_t timeout_ms,
     return ans;
   }
 
-  for (uint32_t div_power = 0u; div_power <= kEwdgClockDivPowerMax; ++div_power)
+  for (uint32_t div_power = 0u; div_power <= EWDG_CLOCK_DIV_POWER_MAX; ++div_power)
   {
-    if (ticks <= kEwdgTimeoutTickMax)
+    if (ticks <= EWDG_TIMEOUT_TICK_MAX)
     {
       *timeout_ticks = static_cast<uint32_t>(ticks);
       *clock_div_power = div_power;
@@ -368,7 +336,7 @@ ErrorCode HPMWatchdog::ApplyConfiguration(const Configuration& config,
 
 clk_src_t HPMWatchdog::ResolveClockSource() const
 {
-  if (clock_source_ != kAutoClockSource)
+  if (clock_source_ != AUTO_CLOCK_SOURCE)
   {
     return clock_source_;
   }
@@ -388,7 +356,7 @@ ewdg_cnt_clk_sel_t HPMWatchdog::ResolveEwdgClockSelect() const
   const uint32_t source_index = GET_CLK_SRC_INDEX(resolved_source);
 
   if ((source_group == CLK_SRC_GROUP_EWDG || source_group == CLK_SRC_GROUP_PEWDG) &&
-      source_index == kEwdgBusClockSourceIndex)
+      source_index == EWDG_BUS_CLOCK_SOURCE_INDEX)
   {
     return ewdg_cnt_clk_src_bus_clk;
   }
@@ -417,13 +385,13 @@ ErrorCode HPMWatchdog::ResolveCounterClockFrequency(clk_src_t source,
 
   if (source_group == CLK_SRC_GROUP_EWDG)
   {
-    if (source_index == kEwdgExternalClockSourceIndex)
+    if (source_index == EWDG_EXTERNAL_CLOCK_SOURCE_INDEX)
     {
-      *frequency_hz = kEwdgOsc32kHz;
+      *frequency_hz = EWDG_OSC_32KHZ;
       return ErrorCode::OK;
     }
 
-    if (source_index == kEwdgBusClockSourceIndex)
+    if (source_index == EWDG_BUS_CLOCK_SOURCE_INDEX)
     {
       *frequency_hz = clock_get_frequency(clock_);
       return *frequency_hz == 0u ? ErrorCode::INIT_ERR : ErrorCode::OK;
@@ -434,15 +402,15 @@ ErrorCode HPMWatchdog::ResolveCounterClockFrequency(clk_src_t source,
 
   if (source_group == CLK_SRC_GROUP_PEWDG)
   {
-    if (source_index == kEwdgExternalClockSourceIndex)
+    if (source_index == EWDG_EXTERNAL_CLOCK_SOURCE_INDEX)
     {
-      *frequency_hz = kEwdgOsc32kHz;
+      *frequency_hz = EWDG_OSC_32KHZ;
       return ErrorCode::OK;
     }
 
-    if (source_index == kEwdgBusClockSourceIndex)
+    if (source_index == EWDG_BUS_CLOCK_SOURCE_INDEX)
     {
-      *frequency_hz = kEwdgOsc24mHz;
+      *frequency_hz = EWDG_OSC_24MHZ;
       return ErrorCode::OK;
     }
 
@@ -451,4 +419,5 @@ ErrorCode HPMWatchdog::ResolveCounterClockFrequency(clk_src_t source,
 
   return ErrorCode::ARG_ERR;
 }
-#endif
+
+#endif  // LIBXR_HPM_EWDG_SUPPORTED

--- a/driver/hpm/hpm_watchdog.cpp
+++ b/driver/hpm/hpm_watchdog.cpp
@@ -1,0 +1,454 @@
+#include "hpm_watchdog.hpp"
+
+#include <limits>
+
+using namespace LibXR;
+
+namespace
+{
+ErrorCode ValidateConfiguration(const Watchdog::Configuration& config)
+{
+  if (config.timeout_ms == 0u || config.feed_ms == 0u ||
+      config.feed_ms >= config.timeout_ms)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  return ErrorCode::OK;
+}
+
+#if LIBXR_HPM_EWDG_SUPPORTED
+constexpr uint32_t kMillisecondsPerSecond = 1000u;
+constexpr uint32_t kEwdgOsc32kHz = 32768u;
+constexpr uint32_t kEwdgOsc24mHz = 24000000u;
+constexpr uint32_t kEwdgBusClockSourceIndex = 0u;
+constexpr uint32_t kEwdgExternalClockSourceIndex = 1u;
+constexpr uint32_t kEwdgSdkDefaultClockGroup = 0u;
+
+#if defined(EWDG_SOC_OVERTIME_REG_WIDTH) && (EWDG_SOC_OVERTIME_REG_WIDTH == 16)
+constexpr uint64_t kEwdgSocTimeoutTickMax = 0xFFFFULL;
+#else
+constexpr uint64_t kEwdgSocTimeoutTickMax = 0xFFFFFFFFULL;
+#endif
+
+#if defined(EWDG_OT_RST_VAL_OT_RST_VAL_MASK) && defined(EWDG_OT_RST_VAL_OT_RST_VAL_SHIFT)
+constexpr uint64_t kEwdgRegisterTimeoutTickMax =
+    EWDG_OT_RST_VAL_OT_RST_VAL_MASK >> EWDG_OT_RST_VAL_OT_RST_VAL_SHIFT;
+#else
+constexpr uint64_t kEwdgRegisterTimeoutTickMax = kEwdgSocTimeoutTickMax;
+#endif
+
+constexpr uint64_t kEwdgTimeoutTickMax =
+    kEwdgSocTimeoutTickMax < kEwdgRegisterTimeoutTickMax ? kEwdgSocTimeoutTickMax
+                                                         : kEwdgRegisterTimeoutTickMax;
+
+#if defined(EWDG_SOC_CLK_DIV_VAL_MAX)
+constexpr uint32_t kEwdgSocClockDivPowerMax = EWDG_SOC_CLK_DIV_VAL_MAX;
+#else
+constexpr uint32_t kEwdgSocClockDivPowerMax =
+    EWDG_CTRL0_DIV_VALUE_MASK >> EWDG_CTRL0_DIV_VALUE_SHIFT;
+#endif
+
+#if defined(EWDG_CTRL0_DIV_VALUE_MASK) && defined(EWDG_CTRL0_DIV_VALUE_SHIFT)
+constexpr uint32_t kEwdgRegisterClockDivPowerMax =
+    EWDG_CTRL0_DIV_VALUE_MASK >> EWDG_CTRL0_DIV_VALUE_SHIFT;
+#else
+constexpr uint32_t kEwdgRegisterClockDivPowerMax = kEwdgSocClockDivPowerMax;
+#endif
+
+constexpr uint32_t kEwdgClockDivPowerMax =
+    kEwdgSocClockDivPowerMax < kEwdgRegisterClockDivPowerMax
+        ? kEwdgSocClockDivPowerMax
+        : kEwdgRegisterClockDivPowerMax;
+
+uint64_t DivCeil(uint64_t value, uint64_t divisor)
+{
+  return value / divisor + (value % divisor == 0u ? 0u : 1u);
+}
+
+ErrorCode ConvertTimeoutMsToTicks(uint32_t counter_clock_hz, uint32_t timeout_ms,
+                                  uint64_t* timeout_ticks)
+{
+  if (timeout_ticks == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+
+  *timeout_ticks = 0u;
+
+  const uint64_t timeout_ms_64 = static_cast<uint64_t>(timeout_ms);
+  if (counter_clock_hz != 0u &&
+      timeout_ms_64 > std::numeric_limits<uint64_t>::max() / counter_clock_hz)
+  {
+    return ErrorCode::OUT_OF_RANGE;
+  }
+
+  const uint64_t timeout_clock_cycles =
+      timeout_ms_64 * static_cast<uint64_t>(counter_clock_hz);
+  *timeout_ticks = DivCeil(timeout_clock_cycles, kMillisecondsPerSecond);
+  return ErrorCode::OK;
+}
+
+ErrorCode ValidateClockSource(clock_name_t clock, clk_src_t source)
+{
+  const uint32_t source_group = GET_CLK_SRC_GROUP(source);
+  const uint32_t source_index = GET_CLK_SRC_INDEX(source);
+  const bool is_pwdg_clock = (clock == clock_pwdg);
+
+  if ((is_pwdg_clock && source_group != CLK_SRC_GROUP_PEWDG) ||
+      (!is_pwdg_clock && source_group != CLK_SRC_GROUP_EWDG))
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  if (source_index == kEwdgExternalClockSourceIndex ||
+      source_index == kEwdgBusClockSourceIndex)
+  {
+    return ErrorCode::OK;
+  }
+
+  return ErrorCode::ARG_ERR;
+}
+#endif
+}  // namespace
+
+HPMWatchdog::HPMWatchdog(LibXRHpmEwdgType* ewdg, clock_name_t clock, uint32_t timeout_ms,
+                         uint32_t feed_ms, clk_src_t clock_source, bool auto_start)
+    : ewdg_(ewdg),
+      clock_(clock),
+      clock_source_(clock_source),
+      current_config_{timeout_ms, feed_ms}
+{
+#if LIBXR_HPM_EWDG_SUPPORTED
+  if (auto_start)
+  {
+    (void)Start();
+  }
+#else
+  (void)ewdg_;
+  (void)clock_;
+  (void)clock_source_;
+  (void)auto_start;
+#endif
+}
+
+ErrorCode HPMWatchdog::ConvertStatus(hpm_stat_t status)
+{
+#if LIBXR_HPM_EWDG_SUPPORTED
+  switch (status)
+  {
+    case status_success:
+      return ErrorCode::OK;
+    case status_invalid_argument:
+      return ErrorCode::ARG_ERR;
+    case status_ewdg_tick_out_of_range:
+    case status_ewdg_div_out_of_range:
+      return ErrorCode::OUT_OF_RANGE;
+    case status_ewdg_feature_unsupported:
+      return ErrorCode::NOT_SUPPORT;
+    default:
+      return ErrorCode::FAILED;
+  }
+#else
+  (void)status;
+  return ErrorCode::NOT_SUPPORT;
+#endif
+}
+
+ErrorCode HPMWatchdog::SetConfig(const Configuration& config)
+{
+  ErrorCode ans = ValidateConfiguration(config);
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+
+#if LIBXR_HPM_EWDG_SUPPORTED
+  if (ewdg_ == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+
+  ans = ApplyConfiguration(config, started_);
+  if (ans == ErrorCode::OK)
+  {
+    current_config_ = config;
+  }
+
+  return ans;
+#else
+  (void)config;
+  return ErrorCode::NOT_SUPPORT;
+#endif
+}
+
+ErrorCode HPMWatchdog::Feed()
+{
+#if LIBXR_HPM_EWDG_SUPPORTED
+  if (ewdg_ == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+  if (!started_)
+  {
+    return ErrorCode::INIT_ERR;
+  }
+
+  return ConvertStatus(ewdg_refresh(ewdg_));
+#else
+  return ErrorCode::NOT_SUPPORT;
+#endif
+}
+
+ErrorCode HPMWatchdog::Start()
+{
+#if LIBXR_HPM_EWDG_SUPPORTED
+  if (ewdg_ == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+
+  ErrorCode ans = ValidateConfiguration(current_config_);
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+
+  ans = ApplyConfiguration(current_config_, true);
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+
+  ans = ConvertStatus(ewdg_refresh(ewdg_));
+  if (ans != ErrorCode::OK)
+  {
+    ewdg_disable(ewdg_);
+    this->auto_feed_ = false;
+    started_ = false;
+    return ans;
+  }
+
+  this->auto_feed_ = true;
+  started_ = true;
+  return ErrorCode::OK;
+#else
+  return ErrorCode::NOT_SUPPORT;
+#endif
+}
+
+ErrorCode HPMWatchdog::Stop()
+{
+#if LIBXR_HPM_EWDG_SUPPORTED
+  if (ewdg_ == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+
+  ewdg_disable(ewdg_);
+  this->auto_feed_ = false;
+  started_ = false;
+  return ErrorCode::OK;
+#else
+  return ErrorCode::NOT_SUPPORT;
+#endif
+}
+
+#if LIBXR_HPM_EWDG_SUPPORTED
+ErrorCode HPMWatchdog::EnsureClockReady()
+{
+  const clk_src_t clock_source = ResolveClockSource();
+  ErrorCode ans = ValidateClockSource(clock_, clock_source);
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+
+  clock_add_to_group(clock_, kEwdgSdkDefaultClockGroup);
+
+  if (ResolveEwdgClockSelect() == ewdg_cnt_clk_src_bus_clk)
+  {
+    ewdg_switch_clock_source(ewdg_, ewdg_cnt_clk_src_bus_clk);
+  }
+
+  return ResolveCounterClockFrequency(clock_source, &counter_clock_hz_);
+}
+
+ErrorCode HPMWatchdog::ResolveTimeoutSetting(uint32_t timeout_ms,
+                                             uint32_t counter_clock_hz,
+                                             uint32_t* timeout_ticks,
+                                             uint32_t* clock_div_power) const
+{
+  if (timeout_ticks == nullptr || clock_div_power == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+
+  *timeout_ticks = 0u;
+  *clock_div_power = 0u;
+
+  if (counter_clock_hz == 0u)
+  {
+    return ErrorCode::INIT_ERR;
+  }
+
+  uint64_t ticks = 0u;
+  ErrorCode ans = ConvertTimeoutMsToTicks(counter_clock_hz, timeout_ms, &ticks);
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+
+  for (uint32_t div_power = 0u; div_power <= kEwdgClockDivPowerMax; ++div_power)
+  {
+    if (ticks <= kEwdgTimeoutTickMax)
+    {
+      *timeout_ticks = static_cast<uint32_t>(ticks);
+      *clock_div_power = div_power;
+      return ErrorCode::OK;
+    }
+
+    ticks = DivCeil(ticks, 2u);
+  }
+
+  return ErrorCode::OUT_OF_RANGE;
+}
+
+ErrorCode HPMWatchdog::ApplyConfiguration(const Configuration& config,
+                                          bool enable_watchdog)
+{
+  ErrorCode ans = EnsureClockReady();
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+
+  ewdg_config_t sdk_config{};
+  ewdg_get_default_config(ewdg_, &sdk_config);
+  sdk_config.enable_watchdog = enable_watchdog;
+  sdk_config.cnt_src_freq = counter_clock_hz_;
+
+  uint32_t timeout_ticks = 0u;
+  uint32_t clock_div_power = 0u;
+  ans = ResolveTimeoutSetting(config.timeout_ms, counter_clock_hz_, &timeout_ticks,
+                              &clock_div_power);
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+
+  sdk_config.ctrl_config.cnt_clk_sel = ResolveEwdgClockSelect();
+  sdk_config.ctrl_config.use_lowlevel_timeout = true;
+  sdk_config.ctrl_config.timeout_interrupt_val = 0u;
+  sdk_config.ctrl_config.timeout_reset_val = timeout_ticks;
+  sdk_config.ctrl_config.clock_div_by_power_of_2 = clock_div_power;
+  sdk_config.ctrl_config.enable_window_mode = false;
+  sdk_config.ctrl_config.enable_refresh_period = false;
+  sdk_config.ctrl_config.enable_refresh_lock = false;
+  sdk_config.ctrl_config.enable_config_lock = false;
+
+  sdk_config.int_rst_config.enable_timeout_interrupt = false;
+  sdk_config.int_rst_config.enable_timeout_reset = true;
+  sdk_config.int_rst_config.enable_ctrl_parity_fail_reset = true;
+  sdk_config.int_rst_config.enable_ctrl_unlock_fail_reset = true;
+  sdk_config.int_rst_config.enable_ctrl_update_violation_reset = true;
+  sdk_config.int_rst_config.enable_refresh_unlock_fail_reset = true;
+  sdk_config.int_rst_config.enable_refresh_violation_reset = true;
+
+  ans = ConvertStatus(ewdg_init(ewdg_, &sdk_config));
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+
+  this->timeout_ms_ = config.timeout_ms;
+  this->auto_feed_interval_ms = config.feed_ms;
+  return ErrorCode::OK;
+}
+
+clk_src_t HPMWatchdog::ResolveClockSource() const
+{
+  if (clock_source_ != kAutoClockSource)
+  {
+    return clock_source_;
+  }
+
+  if (clock_ == clock_pwdg)
+  {
+    return clk_pwdg_src_osc32k;
+  }
+
+  return clk_wdg_src_osc32k;
+}
+
+ewdg_cnt_clk_sel_t HPMWatchdog::ResolveEwdgClockSelect() const
+{
+  const clk_src_t resolved_source = ResolveClockSource();
+  const uint32_t source_group = GET_CLK_SRC_GROUP(resolved_source);
+  const uint32_t source_index = GET_CLK_SRC_INDEX(resolved_source);
+
+  if ((source_group == CLK_SRC_GROUP_EWDG || source_group == CLK_SRC_GROUP_PEWDG) &&
+      source_index == kEwdgBusClockSourceIndex)
+  {
+    return ewdg_cnt_clk_src_bus_clk;
+  }
+
+  return ewdg_cnt_clk_src_ext_osc_clk;
+}
+
+ErrorCode HPMWatchdog::ResolveCounterClockFrequency(clk_src_t source,
+                                                    uint32_t* frequency_hz) const
+{
+  if (frequency_hz == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+
+  *frequency_hz = 0u;
+
+  const uint32_t source_group = GET_CLK_SRC_GROUP(source);
+  const uint32_t source_index = GET_CLK_SRC_INDEX(source);
+
+  const ErrorCode ans = ValidateClockSource(clock_, source);
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+
+  if (source_group == CLK_SRC_GROUP_EWDG)
+  {
+    if (source_index == kEwdgExternalClockSourceIndex)
+    {
+      *frequency_hz = kEwdgOsc32kHz;
+      return ErrorCode::OK;
+    }
+
+    if (source_index == kEwdgBusClockSourceIndex)
+    {
+      *frequency_hz = clock_get_frequency(clock_);
+      return *frequency_hz == 0u ? ErrorCode::INIT_ERR : ErrorCode::OK;
+    }
+
+    return ErrorCode::ARG_ERR;
+  }
+
+  if (source_group == CLK_SRC_GROUP_PEWDG)
+  {
+    if (source_index == kEwdgExternalClockSourceIndex)
+    {
+      *frequency_hz = kEwdgOsc32kHz;
+      return ErrorCode::OK;
+    }
+
+    if (source_index == kEwdgBusClockSourceIndex)
+    {
+      *frequency_hz = kEwdgOsc24mHz;
+      return ErrorCode::OK;
+    }
+
+    return ErrorCode::ARG_ERR;
+  }
+
+  return ErrorCode::ARG_ERR;
+}
+#endif

--- a/driver/hpm/hpm_watchdog.cpp
+++ b/driver/hpm/hpm_watchdog.cpp
@@ -130,7 +130,8 @@ HPMWatchdog::HPMWatchdog(EWDG_Type* ewdg, clock_name_t clock, uint32_t timeout_m
 {
   if (auto_start)
   {
-    (void)Start();
+    const ErrorCode ans = Start();
+    ASSERT(ans == ErrorCode::OK);
   }
 }
 

--- a/driver/hpm/hpm_watchdog.cpp
+++ b/driver/hpm/hpm_watchdog.cpp
@@ -377,12 +377,6 @@ ErrorCode HPMWatchdog::ResolveCounterClockFrequency(clk_src_t source,
   const uint32_t source_group = GET_CLK_SRC_GROUP(source);
   const uint32_t source_index = GET_CLK_SRC_INDEX(source);
 
-  const ErrorCode ans = ValidateClockSource(clock_, source);
-  if (ans != ErrorCode::OK)
-  {
-    return ans;
-  }
-
   if (source_group == CLK_SRC_GROUP_EWDG)
   {
     if (source_index == EWDG_EXTERNAL_CLOCK_SOURCE_INDEX)

--- a/driver/hpm/hpm_watchdog.cpp
+++ b/driver/hpm/hpm_watchdog.cpp
@@ -43,6 +43,8 @@ constexpr uint64_t EWDG_TIMEOUT_TICK_MAX =
     EWDG_SOC_TIMEOUT_TICK_MAX < EWDG_REGISTER_TIMEOUT_TICK_MAX
         ? EWDG_SOC_TIMEOUT_TICK_MAX
         : EWDG_REGISTER_TIMEOUT_TICK_MAX;
+static_assert(EWDG_TIMEOUT_TICK_MAX <= std::numeric_limits<uint32_t>::max(),
+              "EWDG_TIMEOUT_TICK_MAX must fit in uint32_t");
 
 #if defined(EWDG_SOC_CLK_DIV_VAL_MAX)
 constexpr uint32_t EWDG_SOC_CLOCK_DIV_POWER_MAX = EWDG_SOC_CLK_DIV_VAL_MAX;

--- a/driver/hpm/hpm_watchdog.cpp
+++ b/driver/hpm/hpm_watchdog.cpp
@@ -67,6 +67,12 @@ constexpr uint32_t EWDG_CLOCK_DIV_POWER_MAX =
 
 uint64_t DivCeil(uint64_t value, uint64_t divisor)
 {
+  if (divisor == 0u)
+  {
+    ASSERT(false);
+    return std::numeric_limits<uint64_t>::max();
+  }
+
   return value / divisor + (value % divisor == 0u ? 0u : 1u);
 }
 
@@ -230,6 +236,11 @@ ErrorCode HPMWatchdog::Stop()
 
 ErrorCode HPMWatchdog::EnsureClockReady()
 {
+  if (clock_ready_)
+  {
+    return ErrorCode::OK;
+  }
+
   const clk_src_t clock_source = ResolveClockSource();
   ErrorCode ans = ValidateClockSource(clock_, clock_source);
   if (ans != ErrorCode::OK)
@@ -241,7 +252,13 @@ ErrorCode HPMWatchdog::EnsureClockReady()
 
   ewdg_switch_clock_source(ewdg_, ResolveEwdgClockSelect());
 
-  return ResolveCounterClockFrequency(clock_source, &counter_clock_hz_);
+  ans = ResolveCounterClockFrequency(clock_source, &counter_clock_hz_);
+  if (ans == ErrorCode::OK)
+  {
+    clock_ready_ = true;
+  }
+
+  return ans;
 }
 
 ErrorCode HPMWatchdog::ResolveTimeoutSetting(uint32_t timeout_ms,
@@ -271,7 +288,8 @@ ErrorCode HPMWatchdog::ResolveTimeoutSetting(uint32_t timeout_ms,
 
   for (uint32_t div_power = 0u; div_power <= EWDG_CLOCK_DIV_POWER_MAX; ++div_power)
   {
-    if (ticks <= EWDG_TIMEOUT_TICK_MAX)
+    if (ticks <= EWDG_TIMEOUT_TICK_MAX &&
+        ticks <= static_cast<uint64_t>(std::numeric_limits<uint32_t>::max()))
     {
       *timeout_ticks = static_cast<uint32_t>(ticks);
       *clock_div_power = div_power;

--- a/driver/hpm/hpm_watchdog.cpp
+++ b/driver/hpm/hpm_watchdog.cpp
@@ -103,7 +103,6 @@ uint64_t DivCeil(uint64_t value, uint64_t divisor)
   if (divisor == 0u)
   {
     ASSERT(false);
-    return std::numeric_limits<uint64_t>::max();
   }
 
   return value / divisor + (value % divisor == 0u ? 0u : 1u);

--- a/driver/hpm/hpm_watchdog.hpp
+++ b/driver/hpm/hpm_watchdog.hpp
@@ -76,11 +76,10 @@ class HPMWatchdog final : public Watchdog
   static constexpr clk_src_t AUTO_CLOCK_SOURCE = static_cast<clk_src_t>(0xFFu);
 #endif
 
-  /** @brief Construct an HPM EWDG watchdog and optionally start it. */
+  /** @brief Construct an HPM EWDG watchdog; call Start() to enable it. */
   explicit HPMWatchdog(EWDG_Type* ewdg = HPM_EWDG0, clock_name_t clock = clock_watchdog0,
                        uint32_t timeout_ms = 1000, uint32_t feed_ms = 250,
-                       clk_src_t clock_source = AUTO_CLOCK_SOURCE,
-                       bool auto_start = true);
+                       clk_src_t clock_source = AUTO_CLOCK_SOURCE);
 
   /**
    * @brief 设置超时和自动喂狗周期，并初始化 EWDG 配置。

--- a/driver/hpm/hpm_watchdog.hpp
+++ b/driver/hpm/hpm_watchdog.hpp
@@ -171,6 +171,7 @@ class HPMWatchdog final : public Watchdog
   clk_src_t clock_source_;         ///< EWDG 时钟源 / EWDG clock source.
   Configuration current_config_;   ///< 当前配置 / Current configuration.
   uint32_t counter_clock_hz_ = 0;  ///< 计数器频率 / Counter clock frequency.
+  bool clock_ready_ = false;       ///< 时钟是否已就绪 / Whether clock is ready.
   bool started_ = false;           ///< 是否已启动 / Whether started.
 };
 

--- a/driver/hpm/hpm_watchdog.hpp
+++ b/driver/hpm/hpm_watchdog.hpp
@@ -53,13 +53,14 @@ namespace LibXR
  * 因此非法 `timeout_ms`/`feed_ms` 会返回参数错误。默认实例为 `HPM_EWDG0`，
  * 默认时钟为 `clock_watchdog0`，自动选择 32 kHz 看门狗时钟源。
  *
- * When the HPM SDK exposes `HPMSOC_HAS_HPMSDK_EWDG` and `hpm_ewdg_drv.h` is
- * available, this driver initializes, starts, feeds, and stops the watchdog
- * through the SDK EWDG API. Otherwise the whole class definition is excluded by
- * `LIBXR_HPM_EWDG_SUPPORTED`. `SetConfig()` performs LibXR argument validation
- * first, so invalid `timeout_ms`/`feed_ms` values return argument errors. The
- * default instance is `HPM_EWDG0` with `clock_watchdog0`, using the 32 kHz
- * watchdog clock source by default.
+ * Supported when `HPM_EWDG0` and `hpm_ewdg_drv.h` are available.
+ * Unsupported targets
+ * exclude this class at compile time.
+ * Invalid `timeout_ms` or `feed_ms` values return
+ * argument errors.
+ * The default instance is `HPM_EWDG0` with `clock_watchdog0`.
+ * The
+ * default clock source is the 32 kHz watchdog clock.
  */
 class HPMWatchdog final : public Watchdog
 {
@@ -76,9 +77,9 @@ class HPMWatchdog final : public Watchdog
 #endif
 
   /** @brief Construct an HPM EWDG watchdog and optionally start it. */
-  explicit HPMWatchdog(EWDG_Type* ewdg = HPM_EWDG0,
-                       clock_name_t clock = clock_watchdog0, uint32_t timeout_ms = 1000,
-                       uint32_t feed_ms = 250, clk_src_t clock_source = AUTO_CLOCK_SOURCE,
+  explicit HPMWatchdog(EWDG_Type* ewdg = HPM_EWDG0, clock_name_t clock = clock_watchdog0,
+                       uint32_t timeout_ms = 1000, uint32_t feed_ms = 250,
+                       clk_src_t clock_source = AUTO_CLOCK_SOURCE,
                        bool auto_start = true);
 
   /**

--- a/driver/hpm/hpm_watchdog.hpp
+++ b/driver/hpm/hpm_watchdog.hpp
@@ -168,7 +168,7 @@ class HPMWatchdog final : public Watchdog
 
   EWDG_Type* ewdg_;                ///< EWDG 寄存器基地址 / EWDG register base.
   clock_name_t clock_;             ///< EWDG 时钟名 / EWDG clock name.
-  clk_src_t clock_source_;         ///< EWDG 时钟源 / EWDG clock source.
+  const clk_src_t clock_source_;   ///< EWDG 时钟源 / EWDG clock source.
   Configuration current_config_;   ///< 当前配置 / Current configuration.
   uint32_t counter_clock_hz_ = 0;  ///< 计数器频率 / Counter clock frequency.
   bool clock_ready_ = false;       ///< 时钟是否已就绪 / Whether clock is ready.

--- a/driver/hpm/hpm_watchdog.hpp
+++ b/driver/hpm/hpm_watchdog.hpp
@@ -29,8 +29,7 @@
 #include "hpm_soc.h"
 #include "watchdog.hpp"
 
-#if (defined(HPMSOC_HAS_HPMSDK_EWDG) || defined(HPM_EWDG0) || defined(HPM_PEWDG)) && \
-    __has_include("hpm_ewdg_drv.h")
+#if defined(HPM_EWDG0) && __has_include("hpm_ewdg_drv.h")
 #include "hpm_ewdg_drv.h"
 #define LIBXR_HPM_EWDG_SUPPORTED 1
 #else

--- a/driver/hpm/hpm_watchdog.hpp
+++ b/driver/hpm/hpm_watchdog.hpp
@@ -33,11 +33,11 @@
     __has_include("hpm_ewdg_drv.h")
 #include "hpm_ewdg_drv.h"
 #define LIBXR_HPM_EWDG_SUPPORTED 1
-using LibXRHpmEwdgType = EWDG_Type;
 #else
 #define LIBXR_HPM_EWDG_SUPPORTED 0
-using LibXRHpmEwdgType = void;
 #endif
+
+#if LIBXR_HPM_EWDG_SUPPORTED
 
 namespace LibXR
 {
@@ -49,19 +49,18 @@ namespace LibXR
  *
  * @details
  * 当 HPM SDK 暴露 `HPMSOC_HAS_HPMSDK_EWDG` 且可以包含 `hpm_ewdg_drv.h`
- * 时，本驱动通过 SDK EWDG 接口完成初始化、启动、喂狗和停止；否则接口保留，
- * 有效配置和启停/喂狗操作返回 `ErrorCode::NOT_SUPPORT`。`SetConfig()` 仍会先执行
- * LibXR 参数校验，因此非法 `timeout_ms`/`feed_ms` 会返回参数错误。默认实例为
- * `HPM_EWDG0`，默认时钟为 `clock_watchdog0`，自动选择 32 kHz 看门狗时钟源。
+ * 时，本驱动通过 SDK EWDG 接口完成初始化、启动、喂狗和停止；否则整个类定义
+ * 会被 `LIBXR_HPM_EWDG_SUPPORTED` 宏排除。`SetConfig()` 会先执行 LibXR 参数校验，
+ * 因此非法 `timeout_ms`/`feed_ms` 会返回参数错误。默认实例为 `HPM_EWDG0`，
+ * 默认时钟为 `clock_watchdog0`，自动选择 32 kHz 看门狗时钟源。
  *
  * When the HPM SDK exposes `HPMSOC_HAS_HPMSDK_EWDG` and `hpm_ewdg_drv.h` is
  * available, this driver initializes, starts, feeds, and stops the watchdog
- * through the SDK EWDG API. Otherwise the class remains available and valid
- * configuration plus start/feed/stop operations return `ErrorCode::NOT_SUPPORT`.
- * `SetConfig()` still performs LibXR argument validation first, so invalid
- * `timeout_ms`/`feed_ms` values return argument errors. The default instance is
- * `HPM_EWDG0` with `clock_watchdog0`, using the 32 kHz watchdog clock source by
- * default.
+ * through the SDK EWDG API. Otherwise the whole class definition is excluded by
+ * `LIBXR_HPM_EWDG_SUPPORTED`. `SetConfig()` performs LibXR argument validation
+ * first, so invalid `timeout_ms`/`feed_ms` values return argument errors. The
+ * default instance is `HPM_EWDG0` with `clock_watchdog0`, using the 32 kHz
+ * watchdog clock source by default.
  */
 class HPMWatchdog final : public Watchdog
 {
@@ -71,51 +70,17 @@ class HPMWatchdog final : public Watchdog
    *        Sentinel value for automatic EWDG clock source selection.
    */
 #if defined(CLK_SRC_GROUP_INVALID) && defined(MAKE_CLK_SRC)
-  static constexpr clk_src_t kAutoClockSource =
+  static constexpr clk_src_t AUTO_CLOCK_SOURCE =
       static_cast<clk_src_t>(MAKE_CLK_SRC(CLK_SRC_GROUP_INVALID, 0x0Fu));
 #else
-  static constexpr clk_src_t kAutoClockSource = static_cast<clk_src_t>(0xFFu);
+  static constexpr clk_src_t AUTO_CLOCK_SOURCE = static_cast<clk_src_t>(0xFFu);
 #endif
 
-#if LIBXR_HPM_EWDG_SUPPORTED && defined(HPM_EWDG0)
   /** @brief Construct an HPM EWDG watchdog and optionally start it. */
-  explicit HPMWatchdog(LibXRHpmEwdgType* ewdg = HPM_EWDG0,
+  explicit HPMWatchdog(EWDG_Type* ewdg = HPM_EWDG0,
                        clock_name_t clock = clock_watchdog0, uint32_t timeout_ms = 1000,
-                       uint32_t feed_ms = 250, clk_src_t clock_source = kAutoClockSource,
+                       uint32_t feed_ms = 250, clk_src_t clock_source = AUTO_CLOCK_SOURCE,
                        bool auto_start = true);
-#else
-  /**
-   * @brief 构造未启用 EWDG 后端的占位看门狗。
-   *        Construct a placeholder watchdog when the EWDG backend is unavailable.
-   *
-   * @details
-   * 该构造函数保留统一类型接口；有效配置、启动、喂狗和停止操作会返回
-   * `ErrorCode::NOT_SUPPORT`。`SetConfig()` 仍会先做 `timeout_ms`/`feed_ms`
-   * 参数校验。
-   *
-   * This constructor preserves the common type interface; valid configuration,
-   * start, feed, and stop operations return `ErrorCode::NOT_SUPPORT`.
-   * `SetConfig()` still validates `timeout_ms`/`feed_ms` first.
-   *
-   * @param ewdg 占位 EWDG 指针；后端不可用时不会解引用。
-   *             Placeholder EWDG pointer; it is not dereferenced when unsupported.
-   * @param clock 占位时钟名；后端不可用时不会使用。
-   *              Placeholder clock name; it is not used when unsupported.
-   * @param timeout_ms 初始超时配置，仅保存到 LibXR 配置路径。
-   *                   Initial timeout configuration, only saved through the LibXR path.
-   * @param feed_ms 初始自动喂狗周期，仅保存到 LibXR 配置路径。
-   *                Initial auto-feed interval, only saved through the LibXR path.
-   * @param clock_source 占位时钟源；后端不可用时不会使用。
-   *                     Placeholder clock source; it is not used when unsupported.
-   * @param auto_start 占位自动启动标志；后端不可用时不会启动硬件。
-   *                   Placeholder auto-start flag; no hardware is started when
-   * unsupported.
-   */
-  explicit HPMWatchdog(LibXRHpmEwdgType* ewdg = nullptr,
-                       clock_name_t clock = static_cast<clock_name_t>(0),
-                       uint32_t timeout_ms = 1000, uint32_t feed_ms = 250,
-                       clk_src_t clock_source = kAutoClockSource, bool auto_start = true);
-#endif
 
   /**
    * @brief 设置超时和自动喂狗周期，并初始化 EWDG 配置。
@@ -124,9 +89,9 @@ class HPMWatchdog final : public Watchdog
    * @param config 看门狗配置，`timeout_ms` 和 `feed_ms` 必须在硬件范围内。
    *               Watchdog configuration; `timeout_ms` and `feed_ms` must fit
    *               the hardware range.
-   * @return `OK` 表示配置成功；参数非法、超出硬件范围或后端不可用时返回对应错误码。
-   *         `OK` on success; otherwise an error for invalid arguments, hardware
-   *         range overflow, or unavailable backend.
+   * @return `OK` 表示配置成功；参数非法或超出硬件范围时返回对应错误码。
+   *         `OK` on success; otherwise an error for invalid arguments or hardware
+   *         range overflow.
    */
   ErrorCode SetConfig(const Configuration& config) override;
 
@@ -134,9 +99,8 @@ class HPMWatchdog final : public Watchdog
    * @brief 立即喂狗。
    *        Feed the watchdog immediately.
    *
-   * @return 已启动时返回 `OK`；未启动、指针为空或后端不可用时返回对应错误码。
-   *         `OK` when started; otherwise an error for not started, null pointer,
-   *         or unavailable backend.
+   * @return 已启动时返回 `OK`；未启动或指针为空时返回对应错误码。
+   *         `OK` when started; otherwise an error for not started or null pointer.
    */
   ErrorCode Feed() override;
 
@@ -153,8 +117,8 @@ class HPMWatchdog final : public Watchdog
    * @brief 停止 EWDG。
    *        Stop EWDG.
    *
-   * @return 操作结果错误码；后端不可用时返回 `NOT_SUPPORT`。
-   *         Operation result error code; returns `NOT_SUPPORT` when unavailable.
+   * @return 操作结果错误码。
+   *         Operation result error code.
    */
   ErrorCode Stop() override;
 
@@ -165,7 +129,6 @@ class HPMWatchdog final : public Watchdog
    */
   static ErrorCode ConvertStatus(hpm_stat_t status);
 
-#if LIBXR_HPM_EWDG_SUPPORTED
   /**
    * @brief Ensure the EWDG clock gate/source are ready and resolve frequency.
    */
@@ -202,9 +165,8 @@ class HPMWatchdog final : public Watchdog
    *        Resolve the EWDG counter frequency from an SDK clock source.
    */
   ErrorCode ResolveCounterClockFrequency(clk_src_t source, uint32_t* frequency_hz) const;
-#endif
 
-  LibXRHpmEwdgType* ewdg_;         ///< EWDG 寄存器基地址 / EWDG register base.
+  EWDG_Type* ewdg_;                ///< EWDG 寄存器基地址 / EWDG register base.
   clock_name_t clock_;             ///< EWDG 时钟名 / EWDG clock name.
   clk_src_t clock_source_;         ///< EWDG 时钟源 / EWDG clock source.
   Configuration current_config_;   ///< 当前配置 / Current configuration.
@@ -213,3 +175,5 @@ class HPMWatchdog final : public Watchdog
 };
 
 }  // namespace LibXR
+
+#endif  // LIBXR_HPM_EWDG_SUPPORTED

--- a/driver/hpm/hpm_watchdog.hpp
+++ b/driver/hpm/hpm_watchdog.hpp
@@ -1,0 +1,215 @@
+#pragma once
+
+/**
+ * @file hpm_watchdog.hpp
+ * @brief HPM EWDG 看门狗适配头文件 / Adapter header for the HPM EWDG watchdog.
+ *
+ * @details
+ * 本文件在 HPM SDK `hpm_ewdg_drv` 之上实现 LibXR `Watchdog` 抽象。当前后端只覆盖
+ * EWDG：配置阶段使用 `ewdg_get_default_config()` 和 `ewdg_init()` 写入低层
+ * tick/div 超时复位策略，`Start()` 使能并刷新，`Feed()` 调用 `ewdg_refresh()`，
+ * `Stop()` 调用 `ewdg_disable()`。超时范围按 `EWDG_SOC_OVERTIME_REG_WIDTH`、
+ * `EWDG_SOC_CLK_DIV_VAL_MAX` 和实际分频寄存器宽度校验，板级复位行为和真实超时时间
+ * 仍需上板确认。
+ *
+ * This file implements the LibXR `Watchdog` abstraction on top of the HPM SDK
+ * `hpm_ewdg_drv` APIs. The current backend covers EWDG only: configuration uses
+ * `ewdg_get_default_config()` and `ewdg_init()` to program low-level tick/div
+ * timeout-reset policy,
+ * `Start()` enables and refreshes the watchdog, `Feed()` calls `ewdg_refresh()`,
+ * and `Stop()` calls `ewdg_disable()`. Timeout range checks use
+ * `EWDG_SOC_OVERTIME_REG_WIDTH`, `EWDG_SOC_CLK_DIV_VAL_MAX`, and the real divider
+ * register width; board-level reset behavior and real timeout timing still require
+ * hardware validation.
+ */
+
+#include <cstdint>
+
+#include "hpm_clock_drv.h"
+#include "hpm_soc.h"
+#include "watchdog.hpp"
+
+#if (defined(HPMSOC_HAS_HPMSDK_EWDG) || defined(HPM_EWDG0) || defined(HPM_PEWDG)) && \
+    __has_include("hpm_ewdg_drv.h")
+#include "hpm_ewdg_drv.h"
+#define LIBXR_HPM_EWDG_SUPPORTED 1
+using LibXRHpmEwdgType = EWDG_Type;
+#else
+#define LIBXR_HPM_EWDG_SUPPORTED 0
+using LibXRHpmEwdgType = void;
+#endif
+
+namespace LibXR
+{
+
+/**
+ * @class HPMWatchdog
+ * @brief HPM EWDG 看门狗适配器 / HPM EWDG watchdog adapter for the LibXR Watchdog
+ * interface.
+ *
+ * @details
+ * 当 HPM SDK 暴露 `HPMSOC_HAS_HPMSDK_EWDG` 且可以包含 `hpm_ewdg_drv.h`
+ * 时，本驱动通过 SDK EWDG 接口完成初始化、启动、喂狗和停止；否则接口保留，
+ * 有效配置和启停/喂狗操作返回 `ErrorCode::NOT_SUPPORT`。`SetConfig()` 仍会先执行
+ * LibXR 参数校验，因此非法 `timeout_ms`/`feed_ms` 会返回参数错误。默认实例为
+ * `HPM_EWDG0`，默认时钟为 `clock_watchdog0`，自动选择 32 kHz 看门狗时钟源。
+ *
+ * When the HPM SDK exposes `HPMSOC_HAS_HPMSDK_EWDG` and `hpm_ewdg_drv.h` is
+ * available, this driver initializes, starts, feeds, and stops the watchdog
+ * through the SDK EWDG API. Otherwise the class remains available and valid
+ * configuration plus start/feed/stop operations return `ErrorCode::NOT_SUPPORT`.
+ * `SetConfig()` still performs LibXR argument validation first, so invalid
+ * `timeout_ms`/`feed_ms` values return argument errors. The default instance is
+ * `HPM_EWDG0` with `clock_watchdog0`, using the 32 kHz watchdog clock source by
+ * default.
+ */
+class HPMWatchdog final : public Watchdog
+{
+ public:
+  /**
+   * @brief 自动选择 EWDG 时钟源的哨兵值。
+   *        Sentinel value for automatic EWDG clock source selection.
+   */
+#if defined(CLK_SRC_GROUP_INVALID) && defined(MAKE_CLK_SRC)
+  static constexpr clk_src_t kAutoClockSource =
+      static_cast<clk_src_t>(MAKE_CLK_SRC(CLK_SRC_GROUP_INVALID, 0x0Fu));
+#else
+  static constexpr clk_src_t kAutoClockSource = static_cast<clk_src_t>(0xFFu);
+#endif
+
+#if LIBXR_HPM_EWDG_SUPPORTED && defined(HPM_EWDG0)
+  /** @brief Construct an HPM EWDG watchdog and optionally start it. */
+  explicit HPMWatchdog(LibXRHpmEwdgType* ewdg = HPM_EWDG0,
+                       clock_name_t clock = clock_watchdog0, uint32_t timeout_ms = 1000,
+                       uint32_t feed_ms = 250, clk_src_t clock_source = kAutoClockSource,
+                       bool auto_start = true);
+#else
+  /**
+   * @brief 构造未启用 EWDG 后端的占位看门狗。
+   *        Construct a placeholder watchdog when the EWDG backend is unavailable.
+   *
+   * @details
+   * 该构造函数保留统一类型接口；有效配置、启动、喂狗和停止操作会返回
+   * `ErrorCode::NOT_SUPPORT`。`SetConfig()` 仍会先做 `timeout_ms`/`feed_ms`
+   * 参数校验。
+   *
+   * This constructor preserves the common type interface; valid configuration,
+   * start, feed, and stop operations return `ErrorCode::NOT_SUPPORT`.
+   * `SetConfig()` still validates `timeout_ms`/`feed_ms` first.
+   *
+   * @param ewdg 占位 EWDG 指针；后端不可用时不会解引用。
+   *             Placeholder EWDG pointer; it is not dereferenced when unsupported.
+   * @param clock 占位时钟名；后端不可用时不会使用。
+   *              Placeholder clock name; it is not used when unsupported.
+   * @param timeout_ms 初始超时配置，仅保存到 LibXR 配置路径。
+   *                   Initial timeout configuration, only saved through the LibXR path.
+   * @param feed_ms 初始自动喂狗周期，仅保存到 LibXR 配置路径。
+   *                Initial auto-feed interval, only saved through the LibXR path.
+   * @param clock_source 占位时钟源；后端不可用时不会使用。
+   *                     Placeholder clock source; it is not used when unsupported.
+   * @param auto_start 占位自动启动标志；后端不可用时不会启动硬件。
+   *                   Placeholder auto-start flag; no hardware is started when
+   * unsupported.
+   */
+  explicit HPMWatchdog(LibXRHpmEwdgType* ewdg = nullptr,
+                       clock_name_t clock = static_cast<clock_name_t>(0),
+                       uint32_t timeout_ms = 1000, uint32_t feed_ms = 250,
+                       clk_src_t clock_source = kAutoClockSource, bool auto_start = true);
+#endif
+
+  /**
+   * @brief 设置超时和自动喂狗周期，并初始化 EWDG 配置。
+   *        Set timeout/feed intervals and initialize the EWDG configuration.
+   *
+   * @param config 看门狗配置，`timeout_ms` 和 `feed_ms` 必须在硬件范围内。
+   *               Watchdog configuration; `timeout_ms` and `feed_ms` must fit
+   *               the hardware range.
+   * @return `OK` 表示配置成功；参数非法、超出硬件范围或后端不可用时返回对应错误码。
+   *         `OK` on success; otherwise an error for invalid arguments, hardware
+   *         range overflow, or unavailable backend.
+   */
+  ErrorCode SetConfig(const Configuration& config) override;
+
+  /**
+   * @brief 立即喂狗。
+   *        Feed the watchdog immediately.
+   *
+   * @return 已启动时返回 `OK`；未启动、指针为空或后端不可用时返回对应错误码。
+   *         `OK` when started; otherwise an error for not started, null pointer,
+   *         or unavailable backend.
+   */
+  ErrorCode Feed() override;
+
+  /**
+   * @brief 启动 EWDG 并执行一次喂狗。
+   *        Start EWDG and feed it once.
+   *
+   * @return 操作结果错误码。
+   *         Operation result error code.
+   */
+  ErrorCode Start() override;
+
+  /**
+   * @brief 停止 EWDG。
+   *        Stop EWDG.
+   *
+   * @return 操作结果错误码；后端不可用时返回 `NOT_SUPPORT`。
+   *         Operation result error code; returns `NOT_SUPPORT` when unavailable.
+   */
+  ErrorCode Stop() override;
+
+ private:
+  /**
+   * @brief 将 HPM SDK 状态码转换为 LibXR 错误码。
+   *        Convert an HPM SDK status code to a LibXR error code.
+   */
+  static ErrorCode ConvertStatus(hpm_stat_t status);
+
+#if LIBXR_HPM_EWDG_SUPPORTED
+  /**
+   * @brief Ensure the EWDG clock gate/source are ready and resolve frequency.
+   */
+  ErrorCode EnsureClockReady();
+
+  /**
+   * @brief 解析可写入 EWDG 的超时 tick 和分频值。
+   *        Resolve writable EWDG timeout ticks and divider value.
+   */
+  ErrorCode ResolveTimeoutSetting(uint32_t timeout_ms, uint32_t counter_clock_hz,
+                                  uint32_t* timeout_ticks,
+                                  uint32_t* clock_div_power) const;
+
+  /**
+   * @brief 将当前配置写入 EWDG SDK。
+   *        Apply the current configuration through the EWDG SDK.
+   */
+  ErrorCode ApplyConfiguration(const Configuration& config, bool enable_watchdog);
+
+  /**
+   * @brief 解析自动或用户指定的 EWDG 时钟源。
+   *        Resolve the automatic or user-specified EWDG clock source.
+   */
+  clk_src_t ResolveClockSource() const;
+
+  /**
+   * @brief 根据时钟源选择 EWDG 内部计数时钟类型。
+   *        Select the EWDG internal counter clock type from the clock source.
+   */
+  ewdg_cnt_clk_sel_t ResolveEwdgClockSelect() const;
+
+  /**
+   * @brief 根据 SDK 时钟源解析 EWDG 计数器频率。
+   *        Resolve the EWDG counter frequency from an SDK clock source.
+   */
+  ErrorCode ResolveCounterClockFrequency(clk_src_t source, uint32_t* frequency_hz) const;
+#endif
+
+  LibXRHpmEwdgType* ewdg_;         ///< EWDG 寄存器基地址 / EWDG register base.
+  clock_name_t clock_;             ///< EWDG 时钟名 / EWDG clock name.
+  clk_src_t clock_source_;         ///< EWDG 时钟源 / EWDG clock source.
+  Configuration current_config_;   ///< 当前配置 / Current configuration.
+  uint32_t counter_clock_hz_ = 0;  ///< 计数器频率 / Counter clock frequency.
+  bool started_ = false;           ///< 是否已启动 / Whether started.
+};
+
+}  // namespace LibXR

--- a/src/driver/watchdog.hpp
+++ b/src/driver/watchdog.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-#include "libxr_def.hpp"
-#include "thread.hpp"
+#include "libxr.hpp"
 
 namespace LibXR
 {

--- a/src/driver/watchdog.hpp
+++ b/src/driver/watchdog.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "libxr.hpp"
+#include "libxr_def.hpp"
+#include "thread.hpp"
 
 namespace LibXR
 {


### PR DESCRIPTION
## Summary

- Add `LibXR::HPMWatchdog final : public Watchdog` backed by the HPM SDK EWDG driver.
- Support `SetConfig`, `Start`, `Feed`, and `Stop`.
- Reject invalid `timeout_ms` / `feed_ms` and timeout settings outside the EWDG tick/divider hardware range.
- Gate the implementation on HPM EWDG SDK/header availability.
- This PR only adds `driver/hpm/hpm_watchdog.hpp` and `driver/hpm/hpm_watchdog.cpp`; it does not modify `src/driver/watchdog.hpp`.

## Validation

- GitHub checks on the current head passed: build, cmake-format, clang-format, Sourcery review, Dependency Quality, License Compliance, and Security Analysis.
- GitHub review threads: `0` unresolved; latest Sourcery review reported the changes look good.
- Local hardware test rebuild passed:
  `cmake --build build --parallel 8`
  in `D:\Codes\HPM\hpm_watchdog_hw_test`.
- HPM5301EVKLite + CMSIS-DAP/OpenOCD default `AUTO_CLOCK_SOURCE` 32 kHz watchdog reset passed 3/3 on the current PR head. Each run cleared the RAM marker and PPOR reset flags, then ran `HPMWatchdog(HPM_EWDG0, clock_watchdog0, 500 ms, 100 ms, AUTO_CLOCK_SOURCE)` until feeds stopped. Observed marker started with `0x58445731 0x2 0x4 0x50415353`, and PPOR was `0x10010`, including the EWDG0 reset bit `0x00010000`.
- Earlier HPM5301EVKLite hardware evidence also covered the explicit bus-clock path using `clk_wdg_src_ahb0` and the `Stop()` path.

## Hardware Notes

- Tested target: HPM5301EVKLite via CMSIS-DAP and HPM OpenOCD.
- The default automatic 32 kHz path is now verified on the connected board; the previous PR note saying it did not reset is stale.
- HPM6E80/HPM6880 hardware reset timing remains untested in this PR.

## Summary by Sourcery

添加一个基于 HPM EWDG 的 LibXR Watchdog 接口实现，并在 SDK 可用时启用，以支持在 HPM 平台上进行硬件看门狗控制。

新特性：
- 引入 `HPMWatchdog`：一个由 HPM SDK 的 EWDG 驱动支持的 Watchdog 实现，支持配置、启动、喂狗和停止看门狗。
- 添加自动和显式的 EWDG 时钟源选择，并在硬件支持范围内进行校验以及将超时时间转换为计数节拍（ticks）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an HPM EWDG-based implementation of the LibXR Watchdog interface, gated on SDK availability, to support hardware watchdog control on HPM platforms.

New Features:
- Introduce HPMWatchdog, a Watchdog implementation backed by the HPM SDK EWDG driver with support for configuring, starting, feeding, and stopping the watchdog.
- Add automatic and explicit EWDG clock source selection with validation and timeout-to-tick conversion within hardware-supported ranges.

</details>