### PR TITLE
fix(print): narrow raw int/text fast paths

### DIFF
--- a/src/core/print/format_compile.hpp
+++ b/src/core/print/format_compile.hpp
@@ -166,8 +166,14 @@ class FormatCompiler
     {
       case FormatOp::U32Dec:
       case FormatOp::U32ZeroPadWidth:
+      case FormatOp::Signed32Dec:
+      case FormatOp::U32Binary:
+      case FormatOp::U32Octal:
+      case FormatOp::U32HexLower:
+      case FormatOp::U32HexUpper:
         return FormatProfile::U32;
       case FormatOp::StringRaw:
+      case FormatOp::CharacterRaw:
         return FormatProfile::TextArg;
       case FormatOp::F32FixedPrec:
         return FormatProfile::F32Fixed;
@@ -190,11 +196,60 @@ class FormatCompiler
    */
   [[nodiscard]] static consteval FormatOp FastFieldOp(const FormatField& field)
   {
+    const bool raw_integer_field = field.flags == 0 && field.fill == ' ' &&
+                                   field.width == 0 &&
+                                   field.precision == unspecified_precision;
+    const bool raw_text_field =
+        (field.flags == 0 || field.flags == static_cast<uint8_t>(FormatFlag::LeftAlign)) &&
+        field.fill == ' ' && field.width == 0 &&
+        field.precision == unspecified_precision;
+
+    if (raw_integer_field && field.type == FormatType::Signed32 &&
+        field.pack == FormatPackKind::I32)
+    {
+      return FormatOp::Signed32Dec;
+    }
+
     if (field.type == FormatType::Unsigned32 && field.pack == FormatPackKind::U32 &&
-        field.flags == 0 && field.fill == ' ' && field.width == 0 &&
-        field.precision == unspecified_precision)
+        raw_integer_field)
     {
       return FormatOp::U32Dec;
+    }
+
+    if (raw_integer_field && field.type == FormatType::Binary32 &&
+        field.pack == FormatPackKind::U32)
+    {
+      return FormatOp::U32Binary;
+    }
+
+    if (raw_integer_field && field.type == FormatType::Octal32 &&
+        field.pack == FormatPackKind::U32)
+    {
+      return FormatOp::U32Octal;
+    }
+
+    if (raw_integer_field && field.type == FormatType::HexLower32 &&
+        field.pack == FormatPackKind::U32)
+    {
+      return FormatOp::U32HexLower;
+    }
+
+    if (raw_integer_field && field.type == FormatType::HexUpper32 &&
+        field.pack == FormatPackKind::U32)
+    {
+      return FormatOp::U32HexUpper;
+    }
+
+    if (raw_text_field && field.type == FormatType::Character &&
+        field.pack == FormatPackKind::Character)
+    {
+      return FormatOp::CharacterRaw;
+    }
+
+    if (raw_text_field && field.type == FormatType::String &&
+        field.pack == FormatPackKind::StringView)
+    {
+      return FormatOp::StringRaw;
     }
 
     if (field.type == FormatType::Unsigned32 && field.pack == FormatPackKind::U32 &&
@@ -203,14 +258,6 @@ class FormatCompiler
         field.precision == unspecified_precision)
     {
       return FormatOp::U32ZeroPadWidth;
-    }
-
-    if (field.type == FormatType::String &&
-        field.pack == FormatPackKind::StringView && field.flags == 0 &&
-        field.fill == ' ' &&
-        field.width == 0 && field.precision == unspecified_precision)
-    {
-      return FormatOp::StringRaw;
     }
 
     if (field.type == FormatType::FloatFixed && field.pack == FormatPackKind::F32 &&
@@ -315,7 +362,13 @@ class FormatCompiler
       switch (op)
       {
         case FormatOp::U32Dec:
+        case FormatOp::Signed32Dec:
+        case FormatOp::U32Binary:
+        case FormatOp::U32Octal:
+        case FormatOp::U32HexLower:
+        case FormatOp::U32HexUpper:
         case FormatOp::StringRaw:
+        case FormatOp::CharacterRaw:
           break;
         case FormatOp::U32ZeroPadWidth:
           EmitByte(code_scratch, code_bytes, field.width);

--- a/src/core/print/format_compile.hpp
+++ b/src/core/print/format_compile.hpp
@@ -171,7 +171,7 @@ class FormatCompiler
       case FormatOp::U32Octal:
       case FormatOp::U32HexLower:
       case FormatOp::U32HexUpper:
-        return FormatProfile::U32;
+        return FormatProfile::NarrowInt;
       case FormatOp::StringRaw:
       case FormatOp::CharacterRaw:
         return FormatProfile::TextArg;
@@ -196,13 +196,8 @@ class FormatCompiler
    */
   [[nodiscard]] static consteval FormatOp FastFieldOp(const FormatField& field)
   {
-    const bool raw_integer_field = field.flags == 0 && field.fill == ' ' &&
-                                   field.width == 0 &&
-                                   field.precision == unspecified_precision;
-    const bool raw_text_field =
-        (field.flags == 0 || field.flags == static_cast<uint8_t>(FormatFlag::LeftAlign)) &&
-        field.fill == ' ' && field.width == 0 &&
-        field.precision == unspecified_precision;
+    const bool raw_integer_field = IsRawIntegerField(field);
+    const bool raw_text_field = IsRawTextField(field);
 
     if (raw_integer_field && field.type == FormatType::Signed32 &&
         field.pack == FormatPackKind::I32)
@@ -275,6 +270,25 @@ class FormatCompiler
     }
 
     return FormatOp::GenericField;
+  }
+
+  /**
+   * @brief 判断字段是否满足裸整数快路径条件。 / Tests whether one field matches the raw integer fast-path gate.
+   */
+  [[nodiscard]] static consteval bool IsRawIntegerField(const FormatField& field)
+  {
+    return field.flags == 0 && field.fill == ' ' && field.width == 0 &&
+           field.precision == unspecified_precision;
+  }
+
+  /**
+   * @brief 判断字段是否满足裸文本快路径条件。 / Tests whether one field matches the raw text fast-path gate.
+   */
+  [[nodiscard]] static consteval bool IsRawTextField(const FormatField& field)
+  {
+    return (field.flags == 0 || field.flags == static_cast<uint8_t>(FormatFlag::LeftAlign)) &&
+           field.fill == ' ' && field.width == 0 &&
+           field.precision == unspecified_precision;
   }
 
   /**
@@ -455,6 +469,12 @@ class FormatCompiler
           continue;
         }
 
+        const size_t payload_bytes = FormatOpPayloadBytes(op);
+        if (payload_bytes == 0)
+        {
+          continue;
+        }
+
         if (op == FormatOp::TextRef)
         {
           auto relative_offset = ReadNative<uint16_t>(code_scratch, scratch_in);
@@ -470,8 +490,7 @@ class FormatCompiler
           continue;
         }
 
-        if (op == FormatOp::U32ZeroPadWidth || op == FormatOp::F32FixedPrec ||
-            op == FormatOp::F64FixedPrec)
+        if (payload_bytes == 1)
         {
           EmitByte(result.codes, code_out, code_scratch[scratch_in++]);
           continue;
@@ -479,11 +498,10 @@ class FormatCompiler
 
         if (op == FormatOp::GenericField)
         {
-          EmitByte(result.codes, code_out, code_scratch[scratch_in++]);
-          EmitByte(result.codes, code_out, code_scratch[scratch_in++]);
-          EmitByte(result.codes, code_out, code_scratch[scratch_in++]);
-          EmitByte(result.codes, code_out, code_scratch[scratch_in++]);
-          EmitByte(result.codes, code_out, code_scratch[scratch_in++]);
+          for (size_t i = 0; i < payload_bytes; ++i)
+          {
+            EmitByte(result.codes, code_out, code_scratch[scratch_in++]);
+          }
         }
       }
 

--- a/src/core/print/format_protocol.hpp
+++ b/src/core/print/format_protocol.hpp
@@ -276,6 +276,39 @@ enum class FormatOp : uint8_t
 };
 
 /**
+ * @brief 编码后的单个操作码后面跟随的载荷字节数 / Number of payload bytes that follow one encoded opcode.
+ */
+[[nodiscard]] constexpr size_t FormatOpPayloadBytes(FormatOp op)
+{
+  switch (op)
+  {
+    case FormatOp::TextInline:
+      return 0;
+    case FormatOp::TextRef:
+      return 2 * sizeof(uint16_t);
+    case FormatOp::U32ZeroPadWidth:
+    case FormatOp::F32FixedPrec:
+    case FormatOp::F64FixedPrec:
+      return 1;
+    case FormatOp::GenericField:
+      return 5;
+    case FormatOp::TextSpace:
+    case FormatOp::U32Dec:
+    case FormatOp::Signed32Dec:
+    case FormatOp::U32Binary:
+    case FormatOp::U32Octal:
+    case FormatOp::U32HexLower:
+    case FormatOp::U32HexUpper:
+    case FormatOp::StringRaw:
+    case FormatOp::CharacterRaw:
+    case FormatOp::End:
+      return 0;
+  }
+
+  return 0;
+}
+
+/**
  * @brief 编译期分析和运行期分发共用的语义处理类别。 / Semantic handler categories used by compile-time analysis and runtime dispatch.
  */
 enum class FormatType : uint8_t
@@ -341,7 +374,7 @@ enum class FormatPackKind : uint8_t
 enum class FormatProfile : uint8_t
 {
   None = 0,            ///< text-only stream / 只有文本记录的流
-  U32 = 1U << 0,       ///< narrow integer fast path / 窄整数快路径
+  NarrowInt = 1U << 0, ///< signed/unsigned narrow integer fast path family / 有符号/无符号窄整数快路径族
   TextArg = 1U << 1,   ///< raw text argument fast path / 原始文本参数快路径
   F32Fixed = 1U << 2,  ///< fixed float fast path / 定点 float 快路径
   F64Fixed = 1U << 3,  ///< fixed double fast path / 定点 double 快路径

--- a/src/core/print/format_protocol.hpp
+++ b/src/core/print/format_protocol.hpp
@@ -262,7 +262,13 @@ enum class FormatOp : uint8_t
   TextSpace = 0x03,        ///< one literal space / 单个字面空格
   U32Dec = 0x10,           ///< raw uint32_t decimal output / 直接输出 uint32_t 十进制
   U32ZeroPadWidth = 0x11,  ///< uint32_t decimal with zero-pad width byte / 带零填充宽度字节的 uint32_t 十进制
+  Signed32Dec = 0x12,      ///< raw int32_t decimal output / 直接输出 int32_t 十进制
+  U32Binary = 0x13,        ///< raw uint32_t binary output / 直接输出 uint32_t 二进制
+  U32Octal = 0x14,         ///< raw uint32_t octal output / 直接输出 uint32_t 八进制
+  U32HexLower = 0x15,      ///< raw uint32_t lowercase hex output / 直接输出 uint32_t 小写十六进制
+  U32HexUpper = 0x16,      ///< raw uint32_t uppercase hex output / 直接输出 uint32_t 大写十六进制
   StringRaw = 0x20,        ///< raw string_view output / 直接输出 string_view
+  CharacterRaw = 0x21,     ///< raw character output / 直接输出字符
   F32FixedPrec = 0x30,     ///< fixed float with one precision byte / 带一个精度字节的定点 float
   F64FixedPrec = 0x31,     ///< fixed double with one precision byte / 带一个精度字节的定点 double
   GenericField = 0xF0,     ///< wide fallback payload: type, flags, fill, width, precision / 宽回退载荷：type、flags、fill、width、precision
@@ -335,8 +341,8 @@ enum class FormatPackKind : uint8_t
 enum class FormatProfile : uint8_t
 {
   None = 0,            ///< text-only stream / 只有文本记录的流
-  U32 = 1U << 0,       ///< uint32_t decimal fast path / uint32_t 十进制快路径
-  TextArg = 1U << 1,   ///< raw string argument fast path / 原始字符串参数快路径
+  U32 = 1U << 0,       ///< narrow integer fast path / 窄整数快路径
+  TextArg = 1U << 1,   ///< raw text argument fast path / 原始文本参数快路径
   F32Fixed = 1U << 2,  ///< fixed float fast path / 定点 float 快路径
   F64Fixed = 1U << 3,  ///< fixed double fast path / 定点 double 快路径
   Generic = 1U << 7,   ///< at least one field uses generic fallback / 至少有一个字段使用通用回退

--- a/src/core/print/writer/writer_executor.hpp
+++ b/src/core/print/writer/writer_executor.hpp
@@ -77,6 +77,17 @@ class Writer::Executor
   [[nodiscard]] ErrorCode WriteU32Dec(uint32_t value);
 
   /**
+   * @brief 单个原始 int32_t 十进制字段的快路径。 / Fast path for one raw int32_t decimal field.
+   */
+  [[nodiscard]] ErrorCode WriteI32Dec(int32_t value);
+
+  /**
+   * @brief 单个原始 uint32_t 非十进制字段的快路径。 / Fast path for one raw uint32_t non-decimal field.
+   */
+  template <uint8_t Base, bool UpperCase = false>
+  [[nodiscard]] ErrorCode WriteU32Base(uint32_t value);
+
+  /**
    * @brief 单个零填充 uint32_t 十进制字段的快路径。 / Fast path for one zero-padded uint32_t decimal field.
    */
   [[nodiscard]] ErrorCode WriteU32ZeroPadWidth(uint8_t width, uint32_t value);
@@ -85,6 +96,11 @@ class Writer::Executor
    * @brief 单个原始字符串参数的快路径。 / Fast path for one raw string argument.
    */
   [[nodiscard]] ErrorCode WriteStringRaw(std::string_view text);
+
+  /**
+   * @brief 单个原始字符参数的快路径。 / Fast path for one raw character argument.
+   */
+  [[nodiscard]] ErrorCode WriteCharacterRaw(char ch);
 
 #if LIBXR_PRINT_ENABLE_FLOAT
   /**

--- a/src/core/print/writer/writer_executor_opcode.hpp
+++ b/src/core/print/writer/writer_executor_opcode.hpp
@@ -62,49 +62,49 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchOp(FormatOp op)
     case FormatOp::TextSpace:
       return WriteRaw(" ");
     case FormatOp::U32Dec:
-      if constexpr (!HasProfile(Profile, FormatProfile::U32) ||
+      if constexpr (!HasProfile(Profile, FormatProfile::NarrowInt) ||
                     !Config::enable_integer)
       {
         return ErrorCode::STATE_ERR;
       }
       return WriteU32Dec(args_.Read<uint32_t>());
     case FormatOp::Signed32Dec:
-      if constexpr (!HasProfile(Profile, FormatProfile::U32) ||
+      if constexpr (!HasProfile(Profile, FormatProfile::NarrowInt) ||
                     !Config::enable_integer)
       {
         return ErrorCode::STATE_ERR;
       }
       return WriteI32Dec(args_.Read<int32_t>());
     case FormatOp::U32ZeroPadWidth:
-      if constexpr (!HasProfile(Profile, FormatProfile::U32) ||
+      if constexpr (!HasProfile(Profile, FormatProfile::NarrowInt) ||
                     !Config::enable_integer)
       {
         return ErrorCode::STATE_ERR;
       }
       return WriteU32ZeroPadWidth(codes_.Read<uint8_t>(), args_.Read<uint32_t>());
     case FormatOp::U32Binary:
-      if constexpr (!HasProfile(Profile, FormatProfile::U32) ||
+      if constexpr (!HasProfile(Profile, FormatProfile::NarrowInt) ||
                     !Config::enable_integer || !Config::enable_integer_base8_16)
       {
         return ErrorCode::STATE_ERR;
       }
       return WriteU32Base<2>(args_.Read<uint32_t>());
     case FormatOp::U32Octal:
-      if constexpr (!HasProfile(Profile, FormatProfile::U32) ||
+      if constexpr (!HasProfile(Profile, FormatProfile::NarrowInt) ||
                     !Config::enable_integer || !Config::enable_integer_base8_16)
       {
         return ErrorCode::STATE_ERR;
       }
       return WriteU32Base<8>(args_.Read<uint32_t>());
     case FormatOp::U32HexLower:
-      if constexpr (!HasProfile(Profile, FormatProfile::U32) ||
+      if constexpr (!HasProfile(Profile, FormatProfile::NarrowInt) ||
                     !Config::enable_integer || !Config::enable_integer_base8_16)
       {
         return ErrorCode::STATE_ERR;
       }
       return WriteU32Base<16>(args_.Read<uint32_t>());
     case FormatOp::U32HexUpper:
-      if constexpr (!HasProfile(Profile, FormatProfile::U32) ||
+      if constexpr (!HasProfile(Profile, FormatProfile::NarrowInt) ||
                     !Config::enable_integer || !Config::enable_integer_base8_16)
       {
         return ErrorCode::STATE_ERR;

--- a/src/core/print/writer/writer_executor_opcode.hpp
+++ b/src/core/print/writer/writer_executor_opcode.hpp
@@ -68,6 +68,13 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchOp(FormatOp op)
         return ErrorCode::STATE_ERR;
       }
       return WriteU32Dec(args_.Read<uint32_t>());
+    case FormatOp::Signed32Dec:
+      if constexpr (!HasProfile(Profile, FormatProfile::U32) ||
+                    !Config::enable_integer)
+      {
+        return ErrorCode::STATE_ERR;
+      }
+      return WriteI32Dec(args_.Read<int32_t>());
     case FormatOp::U32ZeroPadWidth:
       if constexpr (!HasProfile(Profile, FormatProfile::U32) ||
                     !Config::enable_integer)
@@ -75,6 +82,34 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchOp(FormatOp op)
         return ErrorCode::STATE_ERR;
       }
       return WriteU32ZeroPadWidth(codes_.Read<uint8_t>(), args_.Read<uint32_t>());
+    case FormatOp::U32Binary:
+      if constexpr (!HasProfile(Profile, FormatProfile::U32) ||
+                    !Config::enable_integer || !Config::enable_integer_base8_16)
+      {
+        return ErrorCode::STATE_ERR;
+      }
+      return WriteU32Base<2>(args_.Read<uint32_t>());
+    case FormatOp::U32Octal:
+      if constexpr (!HasProfile(Profile, FormatProfile::U32) ||
+                    !Config::enable_integer || !Config::enable_integer_base8_16)
+      {
+        return ErrorCode::STATE_ERR;
+      }
+      return WriteU32Base<8>(args_.Read<uint32_t>());
+    case FormatOp::U32HexLower:
+      if constexpr (!HasProfile(Profile, FormatProfile::U32) ||
+                    !Config::enable_integer || !Config::enable_integer_base8_16)
+      {
+        return ErrorCode::STATE_ERR;
+      }
+      return WriteU32Base<16>(args_.Read<uint32_t>());
+    case FormatOp::U32HexUpper:
+      if constexpr (!HasProfile(Profile, FormatProfile::U32) ||
+                    !Config::enable_integer || !Config::enable_integer_base8_16)
+      {
+        return ErrorCode::STATE_ERR;
+      }
+      return WriteU32Base<16, true>(args_.Read<uint32_t>());
     case FormatOp::StringRaw:
       if constexpr (!HasProfile(Profile, FormatProfile::TextArg) ||
                     !Config::enable_text)
@@ -82,6 +117,13 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchOp(FormatOp op)
         return ErrorCode::STATE_ERR;
       }
       return WriteStringRaw(args_.Read<std::string_view>());
+    case FormatOp::CharacterRaw:
+      if constexpr (!HasProfile(Profile, FormatProfile::TextArg) ||
+                    !Config::enable_text)
+      {
+        return ErrorCode::STATE_ERR;
+      }
+      return WriteCharacterRaw(args_.Read<char>());
 #if LIBXR_PRINT_ENABLE_FLOAT
     case FormatOp::F32FixedPrec:
       if constexpr (!HasProfile(Profile, FormatProfile::F32Fixed) ||

--- a/src/core/print/writer/writer_executor_value.hpp
+++ b/src/core/print/writer/writer_executor_value.hpp
@@ -297,6 +297,47 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteU32Dec(uint32_t value)
 }
 
 /**
+ * @brief 写出一个原始 int32 十进制快路径字段 / Writes one raw int32 decimal fast-path field.
+ * @param value Signed value to write. / 待写出的有符号值。
+ * @return Returns the sink write result. / 返回 sink 写出结果。
+ */
+template <OutputSink Sink, FormatProfile Profile>
+ErrorCode Writer::Executor<Sink, Profile>::WriteI32Dec(int32_t value)
+{
+  using UInt = std::make_unsigned_t<int32_t>;
+  char digit_buffer[UnsignedDigitCapacity<UInt, 10>()];
+  UInt bits = static_cast<UInt>(value);
+  UInt magnitude = (value < 0) ? (UInt{0} - bits) : bits;
+  size_t digit_count = AppendUnsigned<10>(digit_buffer, magnitude);
+
+  if (value < 0)
+  {
+    if (auto ec = WriteRaw("-"); ec != ErrorCode::OK)
+    {
+      return ec;
+    }
+  }
+
+  return WriteRaw(std::string_view(digit_buffer, digit_count));
+}
+
+/**
+ * @brief 写出一个原始 uint32 多进制快路径字段 / Writes one raw uint32 base-specific fast-path field.
+ * @tparam Base Integer radix. / 整数进制。
+ * @tparam UpperCase Whether hexadecimal digits are uppercase. / 十六进制数字是否大写。
+ * @param value Unsigned value to write. / 待写出的无符号值。
+ * @return Returns the sink write result. / 返回 sink 写出结果。
+ */
+template <OutputSink Sink, FormatProfile Profile>
+template <uint8_t Base, bool UpperCase>
+ErrorCode Writer::Executor<Sink, Profile>::WriteU32Base(uint32_t value)
+{
+  char digit_buffer[UnsignedDigitCapacity<uint32_t, Base>()];
+  size_t digit_count = AppendUnsigned<Base, UpperCase>(digit_buffer, value);
+  return WriteRaw(std::string_view(digit_buffer, digit_count));
+}
+
+/**
  * @brief 写出一个带零填充宽度的 `uint32_t` 十进制快路径字段 / Write one zero-padded `uint32_t` decimal fast-path field
  * @param width 目标零填充宽度 / Target zero-padded width
  * @param value 待写出的无符号值 / Unsigned value to write
@@ -325,6 +366,17 @@ template <OutputSink Sink, FormatProfile Profile>
 ErrorCode Writer::Executor<Sink, Profile>::WriteStringRaw(std::string_view text)
 {
   return WriteRaw(text);
+}
+
+/**
+ * @brief 写出一个原始字符快路径字段 / Writes one raw character fast-path field.
+ * @param ch Character payload to write. / 待写出的字符载荷。
+ * @return Returns the sink write result. / 返回 sink 写出结果。
+ */
+template <OutputSink Sink, FormatProfile Profile>
+ErrorCode Writer::Executor<Sink, Profile>::WriteCharacterRaw(char ch)
+{
+  return WriteRaw(std::string_view(&ch, 1));
 }
 
 /**

--- a/test/base/print/print_literal_test_common.hpp
+++ b/test/base/print/print_literal_test_common.hpp
@@ -8,6 +8,8 @@
  */
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <limits>
 
 #include "libxr.hpp"
@@ -19,6 +21,103 @@ static_assert(LibXR::Format<"{}">::template Matches<int>());
 static_assert(!LibXR::Format<"{}">::template Matches<int, int>());
 static_assert(!LibXR::Format<"abc">::template Matches<int>());
 static_assert(!LibXR::Format<"{:d} {}">::template Matches<const char*, int>());
+
+namespace LibXRPrintTest::CompileProfile
+{
+template <typename Format>
+[[nodiscard]] consteval bool HasOp(LibXR::Print::FormatOp op)
+{
+  auto codes = Format::Codes();
+  size_t pos = 0;
+  while (pos < codes.size())
+  {
+    auto current = static_cast<LibXR::Print::FormatOp>(codes[pos++]);
+    if (current == op)
+    {
+      return true;
+    }
+
+    switch (current)
+    {
+      case LibXR::Print::FormatOp::TextInline:
+        while (pos < codes.size() && codes[pos++] != 0)
+        {
+        }
+        break;
+      case LibXR::Print::FormatOp::TextRef:
+        pos += 2 * sizeof(uint16_t);
+        break;
+      case LibXR::Print::FormatOp::U32ZeroPadWidth:
+      case LibXR::Print::FormatOp::F32FixedPrec:
+      case LibXR::Print::FormatOp::F64FixedPrec:
+        ++pos;
+        break;
+      case LibXR::Print::FormatOp::GenericField:
+        pos += 5;
+        break;
+      case LibXR::Print::FormatOp::End:
+        return false;
+      case LibXR::Print::FormatOp::TextSpace:
+      case LibXR::Print::FormatOp::U32Dec:
+      case LibXR::Print::FormatOp::Signed32Dec:
+      case LibXR::Print::FormatOp::U32Binary:
+      case LibXR::Print::FormatOp::U32Octal:
+      case LibXR::Print::FormatOp::U32HexLower:
+      case LibXR::Print::FormatOp::U32HexUpper:
+      case LibXR::Print::FormatOp::StringRaw:
+      case LibXR::Print::FormatOp::CharacterRaw:
+        break;
+      default:
+        return false;
+    }
+  }
+  return false;
+}
+
+template <typename Format>
+[[nodiscard]] consteval bool HasProfileBit(LibXR::Print::FormatProfile bit)
+{
+  return LibXR::Print::HasProfile(Format::Profile(), bit);
+}
+
+using PrintfRawIntegerFormat =
+    decltype(LibXR::Print::Printf::Build<"%d %u %b %o %x %X">());
+using PrintfIntTextFormat =
+    decltype(LibXR::Print::Printf::Build<"id=%d hex=%x msg=%s ch=%c">());
+using FormatRawIntegerFormat =
+    LibXR::Format<"{} {:x} {:c}">::Compiled<int, unsigned, int>;
+
+// 裁剪边界：常见裸整数/文本字段不能退回 GenericField。
+// 否则 float 默认开启时会留下浮点分发后端。
+// Trimming boundary: raw integer/text fields must not use GenericField.
+// Otherwise the default float-enabled profile retains float dispatch.
+static_assert(
+    !HasProfileBit<PrintfRawIntegerFormat>(LibXR::Print::FormatProfile::Generic));
+static_assert(HasProfileBit<PrintfRawIntegerFormat>(LibXR::Print::FormatProfile::U32));
+static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::Signed32Dec));
+static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::U32Dec));
+static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::U32Binary));
+static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::U32Octal));
+static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::U32HexLower));
+static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::U32HexUpper));
+
+static_assert(!HasProfileBit<PrintfIntTextFormat>(LibXR::Print::FormatProfile::Generic));
+static_assert(HasProfileBit<PrintfIntTextFormat>(LibXR::Print::FormatProfile::U32));
+static_assert(HasProfileBit<PrintfIntTextFormat>(LibXR::Print::FormatProfile::TextArg));
+static_assert(HasOp<PrintfIntTextFormat>(LibXR::Print::FormatOp::Signed32Dec));
+static_assert(HasOp<PrintfIntTextFormat>(LibXR::Print::FormatOp::U32HexLower));
+static_assert(HasOp<PrintfIntTextFormat>(LibXR::Print::FormatOp::StringRaw));
+static_assert(HasOp<PrintfIntTextFormat>(LibXR::Print::FormatOp::CharacterRaw));
+
+static_assert(
+    !HasProfileBit<FormatRawIntegerFormat>(LibXR::Print::FormatProfile::Generic));
+static_assert(HasProfileBit<FormatRawIntegerFormat>(LibXR::Print::FormatProfile::U32));
+static_assert(
+    HasProfileBit<FormatRawIntegerFormat>(LibXR::Print::FormatProfile::TextArg));
+static_assert(HasOp<FormatRawIntegerFormat>(LibXR::Print::FormatOp::Signed32Dec));
+static_assert(HasOp<FormatRawIntegerFormat>(LibXR::Print::FormatOp::U32HexLower));
+static_assert(HasOp<FormatRawIntegerFormat>(LibXR::Print::FormatOp::CharacterRaw));
+}  // namespace LibXRPrintTest::CompileProfile
 
 using LoggerFrontend = LibXR::Detail::LoggerLiteral::Frontend;
 using LoggerResolution = LibXR::Detail::LoggerLiteral::Resolution;

--- a/test/base/print/print_literal_test_common.hpp
+++ b/test/base/print/print_literal_test_common.hpp
@@ -37,38 +37,32 @@ template <typename Format>
       return true;
     }
 
-    switch (current)
+    const size_t payload_bytes = LibXR::Print::FormatOpPayloadBytes(current);
+    if (current == LibXR::Print::FormatOp::TextInline)
     {
-      case LibXR::Print::FormatOp::TextInline:
-        while (pos < codes.size() && codes[pos++] != 0)
-        {
-        }
-        break;
-      case LibXR::Print::FormatOp::TextRef:
-        pos += 2 * sizeof(uint16_t);
-        break;
-      case LibXR::Print::FormatOp::U32ZeroPadWidth:
-      case LibXR::Print::FormatOp::F32FixedPrec:
-      case LibXR::Print::FormatOp::F64FixedPrec:
-        ++pos;
-        break;
-      case LibXR::Print::FormatOp::GenericField:
-        pos += 5;
-        break;
-      case LibXR::Print::FormatOp::End:
-        return false;
-      case LibXR::Print::FormatOp::TextSpace:
-      case LibXR::Print::FormatOp::U32Dec:
-      case LibXR::Print::FormatOp::Signed32Dec:
-      case LibXR::Print::FormatOp::U32Binary:
-      case LibXR::Print::FormatOp::U32Octal:
-      case LibXR::Print::FormatOp::U32HexLower:
-      case LibXR::Print::FormatOp::U32HexUpper:
-      case LibXR::Print::FormatOp::StringRaw:
-      case LibXR::Print::FormatOp::CharacterRaw:
-        break;
-      default:
-        return false;
+      while (pos < codes.size() && codes[pos++] != 0)
+      {
+      }
+    }
+    else if (current == LibXR::Print::FormatOp::End)
+    {
+      return false;
+    }
+    else if (payload_bytes != 0)
+    {
+      pos += payload_bytes;
+    }
+    else if (current != LibXR::Print::FormatOp::TextSpace &&
+             current != LibXR::Print::FormatOp::U32Dec &&
+             current != LibXR::Print::FormatOp::Signed32Dec &&
+             current != LibXR::Print::FormatOp::U32Binary &&
+             current != LibXR::Print::FormatOp::U32Octal &&
+             current != LibXR::Print::FormatOp::U32HexLower &&
+             current != LibXR::Print::FormatOp::U32HexUpper &&
+             current != LibXR::Print::FormatOp::StringRaw &&
+             current != LibXR::Print::FormatOp::CharacterRaw)
+    {
+      return false;
     }
   }
   return false;
@@ -93,7 +87,7 @@ using FormatRawIntegerFormat =
 // Otherwise the default float-enabled profile retains float dispatch.
 static_assert(
     !HasProfileBit<PrintfRawIntegerFormat>(LibXR::Print::FormatProfile::Generic));
-static_assert(HasProfileBit<PrintfRawIntegerFormat>(LibXR::Print::FormatProfile::U32));
+static_assert(HasProfileBit<PrintfRawIntegerFormat>(LibXR::Print::FormatProfile::NarrowInt));
 static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::Signed32Dec));
 static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::U32Dec));
 static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::U32Binary));
@@ -102,7 +96,7 @@ static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::U32HexLower)
 static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::U32HexUpper));
 
 static_assert(!HasProfileBit<PrintfIntTextFormat>(LibXR::Print::FormatProfile::Generic));
-static_assert(HasProfileBit<PrintfIntTextFormat>(LibXR::Print::FormatProfile::U32));
+static_assert(HasProfileBit<PrintfIntTextFormat>(LibXR::Print::FormatProfile::NarrowInt));
 static_assert(HasProfileBit<PrintfIntTextFormat>(LibXR::Print::FormatProfile::TextArg));
 static_assert(HasOp<PrintfIntTextFormat>(LibXR::Print::FormatOp::Signed32Dec));
 static_assert(HasOp<PrintfIntTextFormat>(LibXR::Print::FormatOp::U32HexLower));
@@ -111,7 +105,7 @@ static_assert(HasOp<PrintfIntTextFormat>(LibXR::Print::FormatOp::CharacterRaw));
 
 static_assert(
     !HasProfileBit<FormatRawIntegerFormat>(LibXR::Print::FormatProfile::Generic));
-static_assert(HasProfileBit<FormatRawIntegerFormat>(LibXR::Print::FormatProfile::U32));
+static_assert(HasProfileBit<FormatRawIntegerFormat>(LibXR::Print::FormatProfile::NarrowInt));
 static_assert(
     HasProfileBit<FormatRawIntegerFormat>(LibXR::Print::FormatProfile::TextArg));
 static_assert(HasOp<FormatRawIntegerFormat>(LibXR::Print::FormatOp::Signed32Dec));


### PR DESCRIPTION
Rebased the int/text size-cut line onto the latest master after PR #212 merged and the unrelated HPM master advance landed.

Verification on Ubuntu24:
- Patched rebased run: /home/xiao/runs/libxr_print_fix_rebased_20260629T1748/99_summary.txt
- Base run: /home/xiao/runs/libxr_print_fix_rebased_base_20260629T1810/99_summary.txt
- STM32 int_text: 1680 vs snprintf 2984 (-1304)
- CH32 int_text: 1734 vs snprintf 3160 (-1426)
- STM32 mixed_fixed: 5276 vs snprintf 16104 (-10828)
- CH32 mixed_fixed: 8096 vs snprintf 21888 (-13792)

ESP32 still compares as an app-level increment and remains above snprintf, which matches the earlier conclusion.

## Summary by Sourcery

扩展 LibXR 打印的快速路径，使其覆盖原始窄整型和文本字段，并确保它们不再回退到通用格式化逻辑。

增强内容：
- 添加用于原始 `int32` 和按进制输出的 `uint32` 的新格式操作码和写入执行器，以及原始字符处理，以提升打印性能。
- 扩展格式配置（profile）分类，使窄整型和文本参数能够被归入专用配置，而不是落入通用回退路径。
- 引入编译期测试，验证常见的 `printf`/`format` 模式会使用优化过的整型和文本路径，而非通用字段后端。

测试：
- 为具有代表性的 `printf`/`format` 模式添加 `constexpr` 分析和操作码覆盖断言，以保证它们会被编译为预期的快速路径操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend LibXR print fast paths to cover raw narrow integer and text fields and ensure they no longer fall back to generic formatting.

Enhancements:
- Add new format opcodes and writer executors for raw int32 and base-specific uint32 output, plus raw character handling, to improve print performance.
- Broaden format profile classification so narrow integer and text arguments are captured in dedicated profiles instead of generic fallback.
- Introduce compile-time tests that verify common printf/format patterns use the optimized integer and text paths rather than the generic field backend.

Tests:
- Add constexpr profiling and opcode coverage assertions for representative printf/format patterns to guarantee they compile to the intended fast-path operations.

</details>