### PR TITLE
feat(message): add raw topic callback and packet API

### DIFF
--- a/src/middleware/message/publish.cpp
+++ b/src/middleware/message/publish.cpp
@@ -10,7 +10,8 @@
 using namespace LibXR;
 
 void Topic::DispatchSubscriber(SuberBlock& block, MicrosecondTimestamp timestamp,
-                               void* payload_addr, bool from_callback, bool in_isr)
+                               void* payload_addr, size_t payload_size,
+                               bool from_callback, bool in_isr)
 {
   switch (block.type)
   {
@@ -60,7 +61,7 @@ void Topic::DispatchSubscriber(SuberBlock& block, MicrosecondTimestamp timestamp
     case SuberType::CALLBACK:
     {
       auto cb_block = static_cast<CallbackBlock*>(&block);
-      cb_block->cb.Run(from_callback && in_isr, timestamp, payload_addr);
+      cb_block->cb.Run(from_callback && in_isr, timestamp, payload_addr, payload_size);
       break;
     }
   }
@@ -72,7 +73,8 @@ void Topic::DispatchSubscribers(TopicHandle topic, MicrosecondTimestamp timestam
   topic->data_.subers.Foreach<SuberBlock>(
       [=](SuberBlock& block)
       {
-        DispatchSubscriber(block, timestamp, payload_addr, from_callback, in_isr);
+        DispatchSubscriber(block, timestamp, payload_addr, topic->data_.payload_size,
+                           from_callback, in_isr);
         return ErrorCode::OK;
       });
 }

--- a/src/middleware/message/subscriber/callback.hpp
+++ b/src/middleware/message/subscriber/callback.hpp
@@ -89,13 +89,23 @@ class Topic::Callback
       MessageViewTraits<RemoveCVRef<T>>::VALUE;  ///< 是否为带时间戳的类型化消息视图参数。Whether the argument is a timestamped typed message view.
 
   /**
+   * @brief 是否为只读 raw payload 视图参数 / Whether one callback payload argument is a
+   *        read-only raw payload view
+   * @tparam T 待判断的参数类型 / Argument type to inspect
+   */
+  template <typename T>
+  static constexpr bool IS_RAW_DATA_VIEW =
+      std::same_as<RemoveCVRef<T>, ConstRawData> ||
+      std::same_as<RemoveCVRef<T>, RawMessageView>;
+
+  /**
    * @brief 是否把 payload 直接当成一个对象接收 / Whether one callback payload argument
    *        receives the payload directly as one object
    * @tparam T 待判断的参数类型 / Argument type to inspect
    */
   template <typename T>
   static constexpr bool IS_TYPED_DATA =
-      !IS_MESSAGE_VIEW<T> &&
+      !IS_MESSAGE_VIEW<T> && !IS_RAW_DATA_VIEW<T> &&
       TopicPayload<RemoveCVRef<T>>;  ///< 是否把负载直接当成一个对象来接收。Whether the payload is received directly as one typed object.
 
   /**
@@ -105,7 +115,7 @@ class Topic::Callback
    */
   template <typename T>
   static constexpr bool IS_CALLBACK_PAYLOAD =
-      IS_MESSAGE_VIEW<T> ||
+      IS_MESSAGE_VIEW<T> || IS_RAW_DATA_VIEW<T> ||
       IS_TYPED_DATA<T>;  ///< 是否是这个回调接口允许的负载参数写法。Whether this callback interface accepts this payload argument form.
 
   /**
@@ -133,11 +143,12 @@ class Topic::Callback
    */
   struct BlockHeader
   {
-    using RunFun = void (*)(const BlockHeader*, bool, MicrosecondTimestamp,
-                            void*);  ///< 所有具体回调块共用的执行入口。Shared execution entry used by all concrete callback blocks.
+    using RunFun = void (*)(const BlockHeader*, bool, MicrosecondTimestamp, void*,
+                            size_t);  ///< 所有具体回调块共用的执行入口。Shared execution entry used by all concrete callback blocks.
 
     RunFun run = nullptr;  ///< 当前块的执行函数。Execution function of the current block.
     TypeID::ID payload_type_id = nullptr;  ///< 该回调期望的主题负载类型标识。Expected topic payload type identifier.
+    bool accepts_raw_payload = false;  ///< 是否按 raw payload 视图接收。Whether this callback receives a raw payload view.
   };
 
   /**
@@ -153,7 +164,11 @@ class Topic::Callback
                   "LibXR::Topic::Callback does not accept MessageView<T>&; "
                   "use MessageView<T> or const MessageView<T>& instead.");
 
-    if constexpr (IS_MESSAGE_VIEW<PayloadArg>)
+    if constexpr (IS_RAW_DATA_VIEW<PayloadArg>)
+    {
+      return nullptr;
+    }
+    else if constexpr (IS_MESSAGE_VIEW<PayloadArg>)
     {
       using View = MessageViewTraits<RemoveCVRef<PayloadArg>>;
       return TypeID::GetID<typename View::DataType>();
@@ -162,9 +177,21 @@ class Topic::Callback
     {
       static_assert(IS_TYPED_DATA<PayloadArg>,
                     "LibXR::Topic::Callback payload must be Topic::MessageView<T>, "
-                    "T, T&, or const T&.");
+                    "Topic::RawMessageView, ConstRawData, T, T&, or const T&.");
       return TypeID::GetID<RemoveCVRef<PayloadArg>>();
     }
+  }
+
+  /**
+   * @brief 回调 payload 参数是否是 raw 字节视图 / Whether the callback payload
+   *        argument is a raw byte view
+   * @tparam PayloadArg 回调 payload 参数类型 / Callback payload argument type
+   * @return 是 raw 字节视图则返回 true / Returns true for raw byte view payloads
+   */
+  template <typename PayloadArg>
+  static constexpr bool AcceptsRawPayload()
+  {
+    return IS_RAW_DATA_VIEW<PayloadArg>;
   }
 
   /**
@@ -183,9 +210,20 @@ class Topic::Callback
    */
   template <typename Function, typename BoundArg, typename PayloadArg>
   static void InvokePayload(Function fun, BoundArg& arg, bool in_isr,
-                            MicrosecondTimestamp timestamp, void* payload_addr)
+                            MicrosecondTimestamp timestamp, void* payload_addr,
+                            size_t payload_size)
   {
-    if constexpr (IS_MESSAGE_VIEW<PayloadArg>)
+    if constexpr (std::same_as<RemoveCVRef<PayloadArg>, ConstRawData>)
+    {
+      ConstRawData raw_payload{payload_addr, payload_size};
+      fun(in_isr, arg, raw_payload);
+    }
+    else if constexpr (std::same_as<RemoveCVRef<PayloadArg>, RawMessageView>)
+    {
+      RawMessageView raw_message{timestamp, ConstRawData{payload_addr, payload_size}};
+      fun(in_isr, arg, raw_message);
+    }
+    else if constexpr (IS_MESSAGE_VIEW<PayloadArg>)
     {
       using View = MessageViewTraits<RemoveCVRef<PayloadArg>>;
       using Data = typename View::DataType;
@@ -216,7 +254,8 @@ class Topic::Callback
      * @param arg 绑定到回调中的参数 / Argument bound into the callback
      */
     PayloadOnlyBlock(Function fun, BoundArg&& arg)
-        : BlockHeader{&Run, PayloadTypeID<PayloadArg>()},
+        : BlockHeader{&Run, PayloadTypeID<PayloadArg>(),
+                      AcceptsRawPayload<PayloadArg>()},
           fun_(fun),
           arg_(std::move(arg))
     {
@@ -232,12 +271,13 @@ class Topic::Callback
      *        object
      */
     static void Run(const BlockHeader* header, bool in_isr,
-                    MicrosecondTimestamp timestamp, void* payload_addr)
+                    MicrosecondTimestamp timestamp, void* payload_addr,
+                    size_t payload_size)
     {
       auto* block = static_cast<const PayloadOnlyBlock*>(header);
       InvokePayload<Function, BoundArg, PayloadArg>(
           block->fun_, const_cast<BoundArg&>(block->arg_), in_isr, timestamp,
-          payload_addr);
+          payload_addr, payload_size);
     }
 
     Function fun_;  ///< 目标回调函数。Target callback function.
@@ -262,7 +302,8 @@ class Topic::Callback
      * @param arg 绑定到回调中的参数 / Argument bound into the callback
      */
     TimestampPayloadBlock(Function fun, BoundArg&& arg)
-        : BlockHeader{&Run, PayloadTypeID<PayloadArg>()},
+        : BlockHeader{&Run, PayloadTypeID<PayloadArg>(),
+                      AcceptsRawPayload<PayloadArg>()},
           fun_(fun),
           arg_(std::move(arg))
     {
@@ -278,10 +319,21 @@ class Topic::Callback
      *        object
      */
     static void Run(const BlockHeader* header, bool in_isr,
-                    MicrosecondTimestamp timestamp, void* payload_addr)
+                    MicrosecondTimestamp timestamp, void* payload_addr,
+                    size_t payload_size)
     {
       auto* block = static_cast<const TimestampPayloadBlock*>(header);
-      if constexpr (IS_MESSAGE_VIEW<PayloadArg>)
+      if constexpr (std::same_as<RemoveCVRef<PayloadArg>, ConstRawData>)
+      {
+        ConstRawData raw_payload{payload_addr, payload_size};
+        block->fun_(in_isr, block->arg_, timestamp, raw_payload);
+      }
+      else if constexpr (std::same_as<RemoveCVRef<PayloadArg>, RawMessageView>)
+      {
+        RawMessageView raw_message{timestamp, ConstRawData{payload_addr, payload_size}};
+        block->fun_(in_isr, block->arg_, timestamp, raw_message);
+      }
+      else if constexpr (IS_MESSAGE_VIEW<PayloadArg>)
       {
         using View = MessageViewTraits<RemoveCVRef<PayloadArg>>;
         using Data = typename View::DataType;
@@ -390,17 +442,19 @@ class Topic::Callback
    *        object
    */
   static void EmptyRun(const BlockHeader* header, bool in_isr,
-                       MicrosecondTimestamp timestamp, void* payload_addr)
+                       MicrosecondTimestamp timestamp, void* payload_addr,
+                       size_t payload_size)
   {
     UNUSED(header);
     UNUSED(in_isr);
     UNUSED(timestamp);
     UNUSED(payload_addr);
+    UNUSED(payload_size);
   }
 
   inline static BlockHeader empty_block_{
-      &EmptyRun,
-      nullptr};  ///< 空回调句柄共用的静态空执行块。Shared static empty execution block used by empty callback handles.
+      &EmptyRun, nullptr,
+      false};  ///< 空回调句柄共用的静态空执行块。Shared static empty execution block used by empty callback handles.
 
  public:
   /**
@@ -457,9 +511,10 @@ class Topic::Callback
    * @param payload_addr 当前消息 payload 对象地址 / Address of the current payload
    *        object
    */
-  void Run(bool in_isr, MicrosecondTimestamp timestamp, void* payload_addr) const
+  void Run(bool in_isr, MicrosecondTimestamp timestamp, void* payload_addr,
+           size_t payload_size) const
   {
-    block_->run(block_, in_isr, timestamp, payload_addr);
+    block_->run(block_, in_isr, timestamp, payload_addr, payload_size);
   }
 
   /**
@@ -468,6 +523,13 @@ class Topic::Callback
    * @return payload 类型标识 / Payload type ID
    */
   TypeID::ID PayloadTypeID() const { return block_->payload_type_id; }
+
+  /**
+   * @brief 判断该回调是否按 raw payload 视图接收消息 / Tell whether this callback
+   *        receives messages as a raw payload view
+   * @return 是 raw payload 视图回调则返回 true / Returns true for raw payload view callbacks
+   */
+  bool IsRawPayloadView() const { return block_->accepts_raw_payload; }
 
  private:
   /**
@@ -509,7 +571,10 @@ struct Topic::CallbackBlock : public Topic::SuberBlock
  */
 inline void Topic::RegisterCallback(Callback& cb)
 {
-  ASSERT(block_->data_.payload_type_id == cb.PayloadTypeID());
+  if (!cb.IsRawPayloadView())
+  {
+    ASSERT(block_->data_.payload_type_id == cb.PayloadTypeID());
+  }
 
   auto node = new (std::align_val_t(LibXR::CONCURRENCY_ALIGNMENT))
       LockFreeList::Node<CallbackBlock>(cb);

--- a/src/middleware/message/topic.hpp
+++ b/src/middleware/message/topic.hpp
@@ -130,6 +130,23 @@ class Topic
   };
 
   /**
+   * @struct RawMessageView
+   * @brief 带时间戳和只读原始 payload 视图的消息 / Message carrying a timestamp and
+   *        a read-only raw payload view
+   *
+   * @note 该视图只在当前回调调用期间有效；它不拥有 payload 字节，也不绕过 topic 的
+   *       发布时类型契约。
+   *       This view is valid only for the current callback invocation; it does not
+   *       own the payload bytes and does not bypass the topic's publish-time type
+   *       contract.
+   */
+  struct RawMessageView
+  {
+    MicrosecondTimestamp timestamp;  ///< 消息时间戳。Message timestamp.
+    ConstRawData payload;            ///< 本次发布 payload 的只读字节视图。Read-only byte view of this publish payload.
+  };
+
+  /**
    * @struct Message
    * @brief 带时间戳和 payload 副本的消息对象 / Message object carrying a timestamp and
    *        a payload copy
@@ -507,6 +524,47 @@ class Topic
                      MicrosecondTimestamp timestamp);
 
   /**
+   * @brief 将一段 raw payload 按当前 topic 元数据打包成 packet / Pack a raw payload
+   *        byte view into one packet using the current topic metadata and current timestamp
+   * @param data 待打包 payload 字节 / Payload bytes to pack
+   * @param packet 输出 packet 缓冲区 / Output packet buffer
+   * @return 操作结果错误码 / Error code
+   */
+  ErrorCode PackRaw(ConstRawData data, RawData packet)
+  {
+    return PackRaw(data, packet, NowTimestamp());
+  }
+
+  /**
+   * @brief 将一段 raw payload 按当前 topic 元数据和指定时间戳打包成 packet / Pack a raw
+   *        payload byte view into one packet using the current topic metadata and timestamp
+   * @param data 待打包 payload 字节 / Payload bytes to pack
+   * @param packet 输出 packet 缓冲区 / Output packet buffer
+   * @param timestamp 指定时间戳 / Explicit timestamp
+   * @return 操作结果错误码 / Error code
+   */
+  ErrorCode PackRaw(ConstRawData data, RawData packet, MicrosecondTimestamp timestamp)
+  {
+    if (block_ == nullptr || data.addr_ == nullptr || packet.addr_ == nullptr)
+    {
+      return ErrorCode::PTR_NULL;
+    }
+
+    if (data.size_ != block_->data_.payload_size)
+    {
+      return ErrorCode::SIZE_ERR;
+    }
+
+    if (packet.size_ < PACK_BASE_SIZE + data.size_)
+    {
+      return ErrorCode::NO_BUFF;
+    }
+
+    PackBytes(block_->data_.crc32, packet, timestamp, data);
+    return ErrorCode::OK;
+  }
+
+  /**
    * @brief 等待指定名称的 topic 出现 / Wait until a topic with the given name exists
    * @param name topic 名称 / Topic name
    * @param timeout 等待超时，默认永久等待 / Timeout in ticks, default wait forever
@@ -684,7 +742,8 @@ class Topic
    * @param in_isr 当前是否位于 ISR / Whether the current path is in ISR context
    */
   static void DispatchSubscriber(SuberBlock& block, MicrosecondTimestamp timestamp,
-                                 void* payload_addr, bool from_callback, bool in_isr);
+                                 void* payload_addr, size_t payload_size,
+                                 bool from_callback, bool in_isr);
 
   /**
    * @brief 将一条消息分发给一个 topic 上的全部订阅者 / Dispatch one message to all

--- a/test/base/middleware/message/test_packet_parse.cpp
+++ b/test/base/middleware/message/test_packet_parse.cpp
@@ -86,6 +86,29 @@ void TestPacketHeaderAndServerParse()
   ASSERT(exact_size_server.ParseData(LibXR::ConstRawData(packed_data)) == 1);
   ASSERT(rx_value == value2);
   ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp2));
+
+  const double raw_value = 72.72;
+  const LibXR::MicrosecondTimestamp raw_timestamp(6006);
+  uint8_t raw_packet[PACKET_SIZE] = {};
+  ASSERT(topic.PackRaw(LibXR::ConstRawData(raw_value),
+                       LibXR::RawData(raw_packet, sizeof(raw_packet)), raw_timestamp) ==
+         LibXR::ErrorCode::OK);
+  rx_value = -1.0;
+  ASSERT(topic_server.ParseData(LibXR::ConstRawData(raw_packet, sizeof(raw_packet))) ==
+         1);
+  ASSERT(rx_value == raw_value);
+  ASSERT(TimestampUs(cb_timestamp) == TimestampUs(raw_timestamp));
+
+  uint8_t small_packet[PACKET_SIZE - 1] = {};
+  uint32_t wrong_size_payload = 0;
+  ASSERT(topic.PackRaw(LibXR::ConstRawData(wrong_size_payload),
+                       LibXR::RawData(raw_packet, sizeof(raw_packet)), raw_timestamp) ==
+         LibXR::ErrorCode::SIZE_ERR);
+  ASSERT(topic.PackRaw(LibXR::ConstRawData(raw_value),
+                       LibXR::RawData(small_packet, sizeof(small_packet)),
+                       raw_timestamp) == LibXR::ErrorCode::NO_BUFF);
+  ASSERT(topic.PackRaw(LibXR::ConstRawData(raw_value), LibXR::RawData(),
+                       raw_timestamp) == LibXR::ErrorCode::PTR_NULL);
 }
 
 }  // namespace

--- a/test/base/middleware/message/test_topic_dispatch.cpp
+++ b/test/base/middleware/message/test_topic_dispatch.cpp
@@ -4,11 +4,14 @@
  * @details 测试项目：
  *          1. async、队列和 callback 订阅者 fan-out。
  *          2. callback-context 发布保持时间戳和 ISR 语义。
- *          3. 非平凡 payload 的 typed 传输。
+ *          3. raw payload 视图回调不参与业务 payload TypeID 匹配。
+ *          4. 非平凡 payload 的 typed 传输。
  *          Test items:
  *          1. Fan-out to async, queued, and callback subscribers.
  *          2. Callback-context publish preserves timestamp and ISR semantics.
- *          3. Typed delivery of non-trivial payloads.
+ *          3. Raw payload view callbacks do not participate in business payload
+ *             TypeID matching.
+ *          4. Typed delivery of non-trivial payloads.
  */
 #include "topic_test_common.hpp"
 
@@ -41,6 +44,14 @@ void TestTopicSubscriberDispatch()
   static LibXR::MicrosecondTimestamp cb_timestamp;
   static LibXR::MicrosecondTimestamp view_cb_timestamp;
   static double view_cb_value = 0.0;
+  static LibXR::MicrosecondTimestamp raw_view_timestamp;
+  static LibXR::MicrosecondTimestamp raw_arg_timestamp;
+  static double raw_view_value = 0.0;
+  static double raw_arg_value = 0.0;
+  static double raw_mutable_arg_value = 0.0;
+  static size_t raw_view_size = 0;
+  static size_t raw_arg_size = 0;
+  static size_t raw_mutable_arg_size = 0;
 
   auto msg_cb = LibXR::Topic::Callback::Create(
       [](bool in_isr, void*, LibXR::MicrosecondTimestamp timestamp, double& data)
@@ -61,6 +72,38 @@ void TestTopicSubscriberDispatch()
       },
       reinterpret_cast<void*>(0));
   topic.RegisterCallback(view_cb);
+
+  auto raw_view_cb = LibXR::Topic::Callback::Create(
+      [](bool, void*, const LibXR::Topic::RawMessageView& message)
+      {
+        raw_view_timestamp = message.timestamp;
+        raw_view_size = message.payload.size_;
+        ASSERT(message.payload.addr_ != nullptr);
+        raw_view_value = *static_cast<const double*>(message.payload.addr_);
+      },
+      reinterpret_cast<void*>(0));
+  topic.RegisterCallback(raw_view_cb);
+
+  auto raw_arg_cb = LibXR::Topic::Callback::Create(
+      [](bool, void*, LibXR::MicrosecondTimestamp timestamp, const LibXR::ConstRawData& data)
+      {
+        raw_arg_timestamp = timestamp;
+        raw_arg_size = data.size_;
+        ASSERT(data.addr_ != nullptr);
+        raw_arg_value = *static_cast<const double*>(data.addr_);
+      },
+      reinterpret_cast<void*>(0));
+  topic.RegisterCallback(raw_arg_cb);
+
+  auto raw_mutable_arg_cb = LibXR::Topic::Callback::Create(
+      [](bool, void*, LibXR::ConstRawData& data)
+      {
+        raw_mutable_arg_size = data.size_;
+        ASSERT(data.addr_ != nullptr);
+        raw_mutable_arg_value = *static_cast<const double*>(data.addr_);
+      },
+      reinterpret_cast<void*>(0));
+  topic.RegisterCallback(raw_mutable_arg_cb);
 
   ASSERT(!async_suber.Available());
 
@@ -85,6 +128,14 @@ void TestTopicSubscriberDispatch()
   ASSERT(TimestampUs(cb_timestamp) == TimestampUs(timestamp0));
   ASSERT(view_cb_value == msg[0]);
   ASSERT(TimestampUs(view_cb_timestamp) == TimestampUs(timestamp0));
+  ASSERT(raw_view_value == msg[0]);
+  ASSERT(raw_view_size == sizeof(double));
+  ASSERT(TimestampUs(raw_view_timestamp) == TimestampUs(timestamp0));
+  ASSERT(raw_arg_value == msg[0]);
+  ASSERT(raw_arg_size == sizeof(double));
+  ASSERT(TimestampUs(raw_arg_timestamp) == TimestampUs(timestamp0));
+  ASSERT(raw_mutable_arg_value == msg[0]);
+  ASSERT(raw_mutable_arg_size == sizeof(double));
   ASSERT(!cb_in_isr);
 
   auto byte_stable_topic =
@@ -127,6 +178,14 @@ void TestTopicSubscriberDispatch()
   ASSERT(cb_in_isr);
   ASSERT(view_cb_value == msg[0]);
   ASSERT(TimestampUs(view_cb_timestamp) == TimestampUs(timestamp1));
+  ASSERT(raw_view_value == msg[0]);
+  ASSERT(raw_view_size == sizeof(double));
+  ASSERT(TimestampUs(raw_view_timestamp) == TimestampUs(timestamp1));
+  ASSERT(raw_arg_value == msg[0]);
+  ASSERT(raw_arg_size == sizeof(double));
+  ASSERT(TimestampUs(raw_arg_timestamp) == TimestampUs(timestamp1));
+  ASSERT(raw_mutable_arg_value == msg[0]);
+  ASSERT(raw_mutable_arg_size == sizeof(double));
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- add explicit raw topic callback forms for `ConstRawData` and `Topic::RawMessageView`
- keep typed callbacks on exact payload `TypeID`, while raw byte-view callbacks skip business payload type matching explicitly
- add `Topic::PackRaw(...)` for runtime topic forwarding without exposing private packet internals
- return explicit `ErrorCode` values from `PackRaw` for null pointers, payload-size mismatch, and undersized packet buffers
- cover raw callback fan-out, raw packet parsing, and `PackRaw` failure paths in message tests

## Validation
- Ubuntu24 `/tmp/libxr_raw_topic_api_test2_20260630T010253Z`: `cmake -DLIBXR_TEST_BUILD=ON`, build passed, `build/test/test` passed
- Ubuntu24 `/tmp/libxr_raw_topic_sharedtopic_smoke2_20260630T010357Z`: patched libxr + patched SharedTopicClient constructor/publish smoke passed
- Ubuntu24 `/tmp/libxr_raw_topic_module_smoke2_20260630T010424Z/smoke_raw_topic_20260630T010430Z`: dependency-closure smoke stayed at `48 PASS / 8 FAIL`; `xrobot-org/SharedTopicClient` passed with the dependent branch `xrobot-org/SharedTopicClient@codex/sharedtopicclient-raw-topic-20260630`

Dependent module branch: https://github.com/xrobot-org/SharedTopicClient/tree/codex/sharedtopicclient-raw-topic-20260630
