### PR TITLE
refactor(message): keep callback payload size in erased block

### DIFF
--- a/src/middleware/message/publish.cpp
+++ b/src/middleware/message/publish.cpp
@@ -10,8 +10,7 @@
 using namespace LibXR;
 
 void Topic::DispatchSubscriber(SuberBlock& block, MicrosecondTimestamp timestamp,
-                               void* payload_addr, size_t payload_size,
-                               bool from_callback, bool in_isr)
+                               void* payload_addr, bool from_callback, bool in_isr)
 {
   switch (block.type)
   {
@@ -61,7 +60,7 @@ void Topic::DispatchSubscriber(SuberBlock& block, MicrosecondTimestamp timestamp
     case SuberType::CALLBACK:
     {
       auto cb_block = static_cast<CallbackBlock*>(&block);
-      cb_block->cb.Run(from_callback && in_isr, timestamp, payload_addr, payload_size);
+      cb_block->Run(from_callback && in_isr, timestamp, payload_addr);
       break;
     }
   }
@@ -73,8 +72,7 @@ void Topic::DispatchSubscribers(TopicHandle topic, MicrosecondTimestamp timestam
   topic->data_.subers.Foreach<SuberBlock>(
       [=](SuberBlock& block)
       {
-        DispatchSubscriber(block, timestamp, payload_addr, topic->data_.payload_size,
-                           from_callback, in_isr);
+        DispatchSubscriber(block, timestamp, payload_addr, from_callback, in_isr);
         return ErrorCode::OK;
       });
 }

--- a/src/middleware/message/subscriber/callback.hpp
+++ b/src/middleware/message/subscriber/callback.hpp
@@ -553,13 +553,31 @@ struct Topic::CallbackBlock : public Topic::SuberBlock
   /**
    * @brief 构造一个回调订阅块 / Construct one callback subscriber block
    * @param callback 要挂接的回调句柄 / Callback handle to attach
+   * @param topic_payload_size 当前 topic 的固定 payload 字节数 / Fixed payload
+   *        size of the topic this callback is registered to
    */
-  explicit CallbackBlock(Callback& callback) : cb(callback)
+  CallbackBlock(Callback& callback, size_t topic_payload_size)
+      : cb(callback), payload_size(topic_payload_size)
   {
     type = SuberType::CALLBACK;
   }
 
+  /**
+   * @brief 通过注册时绑定的 topic payload size 执行回调 / Run the callback with the
+   *        topic payload size bound at registration time
+   * @param in_isr 当前是否处于中断上下文 / Whether the current path runs in ISR context
+   * @param timestamp 当前消息时间戳 / Current message timestamp
+   * @param payload_addr 当前消息 payload 对象地址 / Address of the current payload object
+   */
+  void Run(bool in_isr, MicrosecondTimestamp timestamp, void* payload_addr) const
+  {
+    cb.Run(in_isr, timestamp, payload_addr, payload_size);
+  }
+
   Callback cb;  ///< 订阅的回调句柄。Subscribed callback handle.
+
+  /// 注册到的 topic 固定 payload 字节数。Fixed payload size of the subscribed topic.
+  size_t payload_size = 0;
 };
 
 /**
@@ -577,7 +595,7 @@ inline void Topic::RegisterCallback(Callback& cb)
   }
 
   auto node = new (std::align_val_t(LibXR::CONCURRENCY_ALIGNMENT))
-      LockFreeList::Node<CallbackBlock>(cb);
+      LockFreeList::Node<CallbackBlock>(cb, block_->data_.payload_size);
   block_->data_.subers.Add(*node);
 }
 }  // namespace LibXR

--- a/src/middleware/message/topic.hpp
+++ b/src/middleware/message/topic.hpp
@@ -742,8 +742,7 @@ class Topic
    * @param in_isr 当前是否位于 ISR / Whether the current path is in ISR context
    */
   static void DispatchSubscriber(SuberBlock& block, MicrosecondTimestamp timestamp,
-                                 void* payload_addr, size_t payload_size,
-                                 bool from_callback, bool in_isr);
+                                 void* payload_addr, bool from_callback, bool in_isr);
 
   /**
    * @brief 将一条消息分发给一个 topic 上的全部订阅者 / Dispatch one message to all


### PR DESCRIPTION
## Summary
- Follow-up cleanup after PR #218.
- Move raw callback payload-size binding out of the common publish dispatch path and into `Topic::CallbackBlock`.
- Restore `DispatchSubscriber` to dispatch only the subscriber block, timestamp, payload address, and context flags.
- Keep typed callback behavior unchanged; raw callbacks still receive the registered topic payload size through the erased callback block.

## Validation
- `git diff --check`
- Ubuntu24 `/tmp` full test build:
  - `cmake -S . -B build -G Ninja -DLIBXR_TEST_BUILD=ON`
  - `cmake --build build -j$(nproc)`
  - `./build/test/test`
- Remote run: `/tmp/libxr_callback_size_erasure_20260630T015709Z`

## Summary by Sourcery

重构基于回调的订阅者分发逻辑，在回调注册时绑定主题的负载大小，使发布分发路径与负载大小的细节解耦。

增强内容：
- 将主题的固定负载大小存储在每个回调订阅者块中，并在调用原始回调时使用该值。
- 简化 `Topic::DispatchSubscriber`，使其仅传递时间戳、负载地址和上下文标志，并将负载大小的处理委托给回调块的实现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor callback-based subscriber dispatch to bind topic payload size at callback registration time and keep the publish dispatch path agnostic of payload-size details.

Enhancements:
- Store the topic’s fixed payload size inside each callback subscriber block and use it when invoking raw callbacks.
- Simplify Topic::DispatchSubscriber to only pass timestamp, payload address, and context flags by delegating payload-size handling to the callback block implementation.

</details>