### PR TITLE
[codex] feat(hpm): add SPI master driver

### DIFF
--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -1,0 +1,1426 @@
+#include "hpm_spi.hpp"
+
+#if LIBXR_HPM_SPI_SUPPORTED
+
+#include <algorithm>
+#include <cstdint>
+
+#if __has_include("board.h")
+#include "board.h"
+#endif
+
+#if LIBXR_HPM_SPI_HAS_DMA_MGR && __has_include("hpm_l1c_drv.h")
+#include "hpm_l1c_drv.h"
+#define LIBXR_HPM_SPI_HAS_L1C 1
+#else
+#define LIBXR_HPM_SPI_HAS_L1C 0
+#endif
+
+extern "C"
+{
+  ATTR_WEAK void board_init_spi_pins(SPI_Type* ptr);
+  ATTR_WEAK uint32_t board_init_spi_clock(SPI_Type* ptr);
+}
+
+using namespace LibXR;
+
+namespace
+{
+#if defined(SPI_SOC_TRANSFER_COUNT_MAX)
+constexpr uint32_t kHpmSpiTransferCountMax = SPI_SOC_TRANSFER_COUNT_MAX;
+#else
+constexpr uint32_t kHpmSpiTransferCountMax = UINT32_MAX;
+#endif
+constexpr uint16_t kSpiRegisterAddressMask = 0x007FU;
+
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+static_assert(sizeof(uintptr_t) <= sizeof(uint32_t),
+              "HPM SPI DMA helper assumes a 32-bit address space.");
+
+#if LIBXR_HPM_SPI_HAS_L1C
+bool ResolveDCacheRange(const void* addr, uint32_t size, uint32_t& start,
+                        uint32_t& aligned_size)
+{
+  if (addr == nullptr || size == 0U)
+  {
+    start = 0U;
+    aligned_size = 0U;
+    return false;
+  }
+
+  const uint64_t line_size = HPM_L1C_CACHELINE_SIZE;
+  const uint64_t address = static_cast<uint64_t>(reinterpret_cast<uintptr_t>(addr));
+  const uint64_t end = address + static_cast<uint64_t>(size);
+  constexpr uint64_t kAddressSpaceSize = static_cast<uint64_t>(UINT32_MAX) + 1ULL;
+  if (line_size == 0U || end > kAddressSpaceSize)
+  {
+    start = 0U;
+    aligned_size = 0U;
+    return false;
+  }
+
+  const uint64_t aligned_start = address - (address % line_size);
+  const uint64_t aligned_end = ((end + line_size - 1U) / line_size) * line_size;
+  const uint64_t range_size = aligned_end - aligned_start;
+  if (aligned_end > kAddressSpaceSize || range_size > UINT32_MAX)
+  {
+    start = 0U;
+    aligned_size = 0U;
+    return false;
+  }
+
+  start = static_cast<uint32_t>(aligned_start);
+  aligned_size = static_cast<uint32_t>(range_size);
+  return aligned_size > 0U;
+}
+#endif
+
+void FlushDCacheIfNeeded(const void* addr, uint32_t size)
+{
+#if LIBXR_HPM_SPI_HAS_L1C
+  if (addr != nullptr && size > 0U && l1c_dc_is_enabled())
+  {
+    uint32_t start = 0U;
+    uint32_t aligned_size = 0U;
+    if (ResolveDCacheRange(addr, size, start, aligned_size))
+    {
+      l1c_dc_flush(start, aligned_size);
+    }
+  }
+#else
+  UNUSED(addr);
+  UNUSED(size);
+#endif
+}
+
+void InvalidateDCacheIfNeeded(const void* addr, uint32_t size)
+{
+#if LIBXR_HPM_SPI_HAS_L1C
+  if (addr != nullptr && size > 0U && l1c_dc_is_enabled())
+  {
+    uint32_t start = 0U;
+    uint32_t aligned_size = 0U;
+    if (ResolveDCacheRange(addr, size, start, aligned_size))
+    {
+      l1c_dc_invalidate(start, aligned_size);
+    }
+  }
+#else
+  UNUSED(addr);
+  UNUSED(size);
+#endif
+}
+#endif
+}  // namespace
+
+HPMSPI::HPMSPI(SPI_Type* spi, clock_name_t clock, RawData rx_buffer, RawData tx_buffer,
+               bool auto_board_init, SPI::Configuration config, ChipSelect cs)
+    : SPI(rx_buffer, tx_buffer),
+      spi_(spi),
+      clock_(clock),
+      rx_buffer_capacity_(rx_buffer.size_),
+      tx_buffer_capacity_(tx_buffer.size_),
+      auto_board_init_(auto_board_init),
+      cs_(cs)
+{
+  ASSERT(spi_ != nullptr);
+  ASSERT(rx_buffer.addr_ != nullptr);
+  ASSERT(tx_buffer.addr_ != nullptr);
+  ASSERT(rx_buffer.size_ > 0);
+  ASSERT(tx_buffer.size_ > 0);
+#if defined(HPM_IP_FEATURE_SPI_CS_SELECT) && (HPM_IP_FEATURE_SPI_CS_SELECT == 1)
+  ASSERT(ConvertChipSelect(cs_) != 0U);
+#endif
+
+  if (auto_board_init_)
+  {
+    if (board_init_spi_pins != nullptr)
+    {
+      board_init_spi_pins(spi_);
+    }
+    if (board_init_spi_clock != nullptr)
+    {
+      source_clock_hz_ = board_init_spi_clock(spi_);
+    }
+  }
+
+  if (source_clock_hz_ == 0)
+  {
+    clock_add_to_group(clock_, 0);
+    source_clock_hz_ = clock_get_frequency(clock_);
+  }
+
+  ASSERT(source_clock_hz_ != 0);
+  const ErrorCode ans = SetConfig(config);
+  ASSERT(ans == ErrorCode::OK);
+}
+
+ErrorCode HPMSPI::ConvertStatus(LibXRHpmSpiStatusType status)
+{
+  switch (status)
+  {
+    case status_success:
+      return ErrorCode::OK;
+    case status_timeout:
+      return ErrorCode::TIMEOUT;
+    case status_invalid_argument:
+      return ErrorCode::ARG_ERR;
+    case status_spi_master_busy:
+      return ErrorCode::BUSY;
+    default:
+      return ErrorCode::FAILED;
+  }
+}
+
+uint8_t HPMSPI::ConvertChipSelect(ChipSelect cs)
+{
+  switch (cs)
+  {
+#if defined(HPM_IP_FEATURE_SPI_CS_SELECT) && (HPM_IP_FEATURE_SPI_CS_SELECT == 1)
+    case ChipSelect::CS0:
+      return spi_cs_0;
+    case ChipSelect::CS1:
+      return spi_cs_1;
+    case ChipSelect::CS2:
+      return spi_cs_2;
+    case ChipSelect::CS3:
+      return spi_cs_3;
+#else
+    case ChipSelect::CS0:
+    case ChipSelect::CS1:
+    case ChipSelect::CS2:
+    case ChipSelect::CS3:
+      return 0U;
+#endif
+    default:
+      return 0U;
+  }
+}
+
+bool HPMSPI::ShouldRecover(LibXRHpmSpiStatusType status)
+{
+  switch (status)
+  {
+    case status_timeout:
+      return true;
+    default:
+      return false;
+  }
+}
+
+spi_sclk_idle_state_t HPMSPI::ConvertPolarity(ClockPolarity polarity)
+{
+  return polarity == ClockPolarity::HIGH ? spi_sclk_high_idle : spi_sclk_low_idle;
+}
+
+spi_sclk_sampling_clk_edges_t HPMSPI::ConvertPhase(ClockPhase phase)
+{
+  return phase == ClockPhase::EDGE_2 ? spi_sclk_sampling_even_clk_edges
+                                     : spi_sclk_sampling_odd_clk_edges;
+}
+
+ErrorCode HPMSPI::ValidateConfiguration(const Configuration& config) const
+{
+  const uint32_t div = SPI::PrescalerToDiv(config.prescaler);
+  if (div == 0U)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  if (div > SPI::PrescalerToDiv(Prescaler::DIV_256))
+  {
+    return ErrorCode::NOT_SUPPORT;
+  }
+
+  // HPM master timing divider requires:
+  // - div == 1: encoded as max speed path
+  // - div in [2, 510] and even
+  if (div != 1U && ((div & 0x1U) != 0U || div > 510U))
+  {
+    return ErrorCode::NOT_SUPPORT;
+  }
+
+  if (config.double_buffer &&
+      ((rx_buffer_capacity_ < 2U) || (tx_buffer_capacity_ < 2U) ||
+       ((rx_buffer_capacity_ / 2U) == 0U) || ((tx_buffer_capacity_ / 2U) == 0U)))
+  {
+    return ErrorCode::SIZE_ERR;
+  }
+
+  return ErrorCode::OK;
+}
+
+ErrorCode HPMSPI::EnsureClockReady()
+{
+  if (source_clock_hz_ != 0U)
+  {
+    return ErrorCode::OK;
+  }
+
+  source_clock_hz_ = clock_get_frequency(clock_);
+  return (source_clock_hz_ != 0U) ? ErrorCode::OK : ErrorCode::INIT_ERR;
+}
+
+void HPMSPI::ApplyFormat(const Configuration& config)
+{
+  spi_format_config_t format{};
+  spi_master_get_default_format_config(&format);
+  format.common_config.data_len_in_bits = 8;
+  format.common_config.data_merge = false;
+  format.common_config.mosi_bidir = false;
+  format.common_config.lsb = false;
+  format.common_config.mode = spi_master_mode;
+  format.common_config.cpol = ConvertPolarity(config.clock_polarity);
+  format.common_config.cpha = ConvertPhase(config.clock_phase);
+  spi_format_init(spi_, &format);
+}
+
+spi_control_config_t HPMSPI::MakeControlConfig(spi_trans_mode_t mode) const
+{
+  spi_control_config_t control{};
+  spi_master_get_default_control_config(&control);
+  control.common_config.trans_mode = mode;
+  control.common_config.data_phase_fmt = spi_single_io_mode;
+#if defined(HPM_IP_FEATURE_SPI_CS_SELECT) && (HPM_IP_FEATURE_SPI_CS_SELECT == 1)
+  control.common_config.cs_index = ConvertChipSelect(cs_);
+#endif
+  return control;
+}
+
+void HPMSPI::ApplyChipSelect() const
+{
+#if defined(HPM_IP_FEATURE_SPI_CS_SELECT) && (HPM_IP_FEATURE_SPI_CS_SELECT == 1)
+  if (spi_ != nullptr)
+  {
+    spi_master_enable_cs_select(spi_,
+                                static_cast<spi_cs_index_t>(ConvertChipSelect(cs_)));
+  }
+#endif
+}
+
+void HPMSPI::RecoverController()
+{
+  if (spi_ == nullptr)
+  {
+    return;
+  }
+
+  spi_reset(spi_);
+  if (spi_poll_reset_complete(spi_, spi_reset_spi, 5000U) != status_success)
+  {
+    configured_ = false;
+    return;
+  }
+
+  if (configured_)
+  {
+    const Configuration config = GetConfig();
+    const ErrorCode ready_ans = EnsureClockReady();
+    if (ready_ans != ErrorCode::OK)
+    {
+      configured_ = false;
+      return;
+    }
+
+    if (ApplyTiming(config.prescaler) != ErrorCode::OK)
+    {
+      configured_ = false;
+      return;
+    }
+
+    ApplyFormat(config);
+  }
+}
+
+ErrorCode HPMSPI::ApplyTiming(Prescaler prescaler)
+{
+  const uint32_t div = SPI::PrescalerToDiv(prescaler);
+  if (div == 0U)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  if (div != 1U && ((div & 0x1U) != 0U || div > 510U))
+  {
+    return ErrorCode::NOT_SUPPORT;
+  }
+
+  const ErrorCode clock_ans = EnsureClockReady();
+  if (clock_ans != ErrorCode::OK)
+  {
+    return clock_ans;
+  }
+
+  if (div > SPI::PrescalerToDiv(Prescaler::DIV_256))
+  {
+    return ErrorCode::NOT_SUPPORT;
+  }
+
+  spi_timing_config_t timing{};
+  spi_master_get_default_timing_config(&timing);
+  timing.master_config.clk_src_freq_in_hz = source_clock_hz_;
+  timing.master_config.sclk_freq_in_hz =
+      (div == 1U) ? source_clock_hz_ : (source_clock_hz_ / div);
+  if (timing.master_config.sclk_freq_in_hz == 0U)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  return ConvertStatus(spi_master_timing_init(spi_, &timing));
+}
+
+ErrorCode HPMSPI::SetConfig(SPI::Configuration config)
+{
+  if (spi_ == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  if (DmaTransferActive())
+  {
+    return ErrorCode::BUSY;
+  }
+#endif
+
+  const ErrorCode valid_ans = ValidateConfiguration(config);
+  if (valid_ans != ErrorCode::OK)
+  {
+    return valid_ans;
+  }
+
+  ErrorCode ans = EnsureClockReady();
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+
+  ans = ApplyTiming(config.prescaler);
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+
+  ApplyFormat(config);
+
+  GetConfig() = config;
+  configured_ = true;
+  return ErrorCode::OK;
+}
+
+ErrorCode HPMSPI::SetChipSelect(ChipSelect cs)
+{
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  if (DmaTransferActive())
+  {
+    return ErrorCode::BUSY;
+  }
+#endif
+#if defined(HPM_IP_FEATURE_SPI_CS_SELECT) && (HPM_IP_FEATURE_SPI_CS_SELECT == 1)
+  if (ConvertChipSelect(cs) == 0U)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  cs_ = cs;
+  return ErrorCode::OK;
+#else
+  UNUSED(cs);
+  return ErrorCode::NOT_SUPPORT;
+#endif
+}
+
+uint32_t HPMSPI::GetMaxBusSpeed() const { return source_clock_hz_; }
+
+SPI::Prescaler HPMSPI::GetMaxPrescaler() const { return Prescaler::DIV_256; }
+
+ErrorCode HPMSPI::SetDmaEnabled(bool enabled)
+{
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  if (DmaTransferActive())
+  {
+    return ErrorCode::BUSY;
+  }
+
+  if (!enabled)
+  {
+    dma_enabled_ = false;
+    return ErrorCode::OK;
+  }
+
+  const ErrorCode ans = EnsureDmaReady();
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+
+  dma_enabled_ = true;
+  return ErrorCode::OK;
+#else
+  dma_enabled_ = false;
+  return enabled ? ErrorCode::NOT_SUPPORT : ErrorCode::OK;
+#endif
+}
+
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+ErrorCode HPMSPI::ConvertDmaStatus(hpm_stat_t status)
+{
+  switch (status)
+  {
+    case status_success:
+      return ErrorCode::OK;
+    case status_timeout:
+      return ErrorCode::TIMEOUT;
+    case status_invalid_argument:
+      return ErrorCode::ARG_ERR;
+    case status_dma_mgr_no_resource:
+      return ErrorCode::FULL;
+    default:
+      return ErrorCode::FAILED;
+  }
+}
+
+ErrorCode HPMSPI::EnsureDmaReady()
+{
+  if (dma_ready_)
+  {
+    return ErrorCode::OK;
+  }
+  if (spi_ == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+
+  dma_mgr_init();
+  hpm_stat_t status =
+      hpm_spi_rx_dma_mgr_install_custom_callback(spi_, &HPMSPI::OnRxDmaTcCallback, this);
+  if (status != status_success)
+  {
+    return (status == status_invalid_argument) ? ErrorCode::NOT_SUPPORT
+                                               : ConvertDmaStatus(status);
+  }
+
+  status =
+      hpm_spi_tx_dma_mgr_install_custom_callback(spi_, &HPMSPI::OnTxDmaTcCallback, this);
+  if (status != status_success)
+  {
+    dma_resource_t* rx_resource = hpm_spi_get_rx_dma_resource(spi_);
+    if (rx_resource != nullptr && rx_resource->base != nullptr)
+    {
+      (void)dma_mgr_release_resource(rx_resource);
+    }
+    return (status == status_invalid_argument) ? ErrorCode::NOT_SUPPORT
+                                               : ConvertDmaStatus(status);
+  }
+
+  dma_ready_ = true;
+  return ErrorCode::OK;
+}
+
+void HPMSPI::ClearDmaContext()
+{
+  dma_ctx_.kind = DmaTransferKind::NONE;
+  dma_ctx_.op = OperationRW();
+  dma_ctx_.rx = nullptr;
+  dma_ctx_.tx = nullptr;
+  dma_ctx_.user_read = {nullptr, 0};
+  dma_ctx_.size = 0U;
+  dma_ctx_.copy_rx_to_user = false;
+  dma_ctx_.switch_buffer_on_success = false;
+  dma_ctx_.rx_done.store(0U, std::memory_order_release);
+  dma_ctx_.tx_done.store(0U, std::memory_order_release);
+}
+
+void HPMSPI::StopDmaTransfer()
+{
+  if (spi_ == nullptr)
+  {
+    return;
+  }
+
+  spi_disable_rx_dma(spi_);
+  spi_disable_tx_dma(spi_);
+
+  dma_resource_t* rx_resource = hpm_spi_get_rx_dma_resource(spi_);
+  if (rx_resource != nullptr && rx_resource->base != nullptr)
+  {
+    (void)dma_mgr_disable_channel(rx_resource);
+  }
+  dma_resource_t* tx_resource = hpm_spi_get_tx_dma_resource(spi_);
+  if (tx_resource != nullptr && tx_resource->base != nullptr)
+  {
+    (void)dma_mgr_disable_channel(tx_resource);
+  }
+}
+
+void HPMSPI::AbortDmaStart()
+{
+  StopDmaTransfer();
+  ClearDmaContext();
+  dma_completion_claim_.store(0U, std::memory_order_release);
+  dma_busy_.store(0U, std::memory_order_release);
+}
+
+bool HPMSPI::TryClaimDmaCompletion()
+{
+  uint32_t expected = 0U;
+  return dma_completion_claim_.compare_exchange_strong(
+      expected, 1U, std::memory_order_acq_rel, std::memory_order_acquire);
+}
+
+ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
+                                   DmaTransferKind kind, RawData user_read,
+                                   bool copy_rx_to_user, bool switch_buffer_on_success,
+                                   OperationRW& op, bool in_isr)
+{
+  if (size == 0U)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::OK);
+  }
+  if (DmaTransferActive())
+  {
+    return FinishOperation(op, in_isr, ErrorCode::BUSY);
+  }
+  if (kind == DmaTransferKind::READ_ONLY && rx == nullptr)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if (kind == DmaTransferKind::WRITE_ONLY && tx == nullptr)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if (kind == DmaTransferKind::WRITE_READ && (rx == nullptr || tx == nullptr))
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+
+  ErrorCode ans = EnsureDmaReady();
+  if (ans != ErrorCode::OK)
+  {
+    return FinishOperation(op, in_isr, ans);
+  }
+
+  dma_busy_.store(1U, std::memory_order_release);
+  ClearDmaContext();
+  dma_ctx_.kind = kind;
+  dma_ctx_.op = op;
+  dma_ctx_.rx = rx;
+  dma_ctx_.tx = tx;
+  dma_ctx_.user_read = user_read;
+  dma_ctx_.size = size;
+  dma_ctx_.copy_rx_to_user = copy_rx_to_user;
+  dma_ctx_.switch_buffer_on_success = switch_buffer_on_success;
+  dma_completion_claim_.store(0U, std::memory_order_release);
+
+  if (op.type == OperationRW::OperationType::BLOCK)
+  {
+    dma_block_wait_.Start(*op.data.sem_info.sem);
+  }
+  op.MarkAsRunning();
+
+  if (tx != nullptr)
+  {
+    FlushDCacheIfNeeded(tx, size);
+  }
+  if (rx != nullptr)
+  {
+    FlushDCacheIfNeeded(rx, size);
+  }
+
+  ApplyChipSelect();
+
+  hpm_stat_t status = status_invalid_argument;
+  switch (kind)
+  {
+    case DmaTransferKind::READ_ONLY:
+      status = hpm_spi_receive_nonblocking(spi_, rx, size);
+      break;
+    case DmaTransferKind::WRITE_ONLY:
+      status = hpm_spi_transmit_nonblocking(spi_, tx, size);
+      break;
+    case DmaTransferKind::WRITE_READ:
+      status = hpm_spi_transmit_receive_nonblocking(spi_, tx, rx, size);
+      break;
+    case DmaTransferKind::NONE:
+    default:
+      status = status_invalid_argument;
+      break;
+  }
+
+  ans = ConvertStatus(status);
+  if (ans != ErrorCode::OK)
+  {
+    if (op.type == OperationRW::OperationType::BLOCK)
+    {
+      dma_block_wait_.Cancel();
+    }
+    AbortDmaStart();
+    return FinishOperation(op, in_isr, ans);
+  }
+
+  if (op.type == OperationRW::OperationType::BLOCK)
+  {
+    return WaitForDmaBlockResult(op.data.sem_info.timeout);
+  }
+  return ErrorCode::OK;
+}
+
+ErrorCode HPMSPI::WaitForDmaBlockResult(uint32_t timeout)
+{
+  const ErrorCode ans = dma_block_wait_.Wait(timeout);
+  if (ans == ErrorCode::TIMEOUT && DmaTransferActive())
+  {
+    CompleteDmaTransfer(false, ErrorCode::TIMEOUT);
+  }
+  return ans;
+}
+
+void HPMSPI::MaybeCompleteDmaTransfer(bool in_isr)
+{
+  if (!DmaTransferActive())
+  {
+    return;
+  }
+
+  bool ready = false;
+  switch (dma_ctx_.kind)
+  {
+    case DmaTransferKind::READ_ONLY:
+      ready = dma_ctx_.rx_done.load(std::memory_order_acquire) != 0U;
+      break;
+    case DmaTransferKind::WRITE_ONLY:
+      ready = dma_ctx_.tx_done.load(std::memory_order_acquire) != 0U;
+      break;
+    case DmaTransferKind::WRITE_READ:
+      ready = (dma_ctx_.rx_done.load(std::memory_order_acquire) != 0U) &&
+              (dma_ctx_.tx_done.load(std::memory_order_acquire) != 0U);
+      break;
+    case DmaTransferKind::NONE:
+    default:
+      break;
+  }
+
+  if (ready)
+  {
+    CompleteDmaTransfer(in_isr, ErrorCode::OK);
+  }
+}
+
+void HPMSPI::CompleteDmaTransfer(bool in_isr, ErrorCode ans)
+{
+  if (!TryClaimDmaCompletion())
+  {
+    return;
+  }
+
+  DmaTransferKind kind = dma_ctx_.kind;
+  OperationRW op = dma_ctx_.op;
+  uint8_t* rx = dma_ctx_.rx;
+  const uint32_t size = dma_ctx_.size;
+  const RawData user_read = dma_ctx_.user_read;
+  const bool copy_rx_to_user = dma_ctx_.copy_rx_to_user;
+  const bool switch_buffer_on_success = dma_ctx_.switch_buffer_on_success;
+  bool dma_stopped = false;
+
+  if (ans != ErrorCode::OK)
+  {
+    StopDmaTransfer();
+    dma_stopped = true;
+  }
+
+  if (ans == ErrorCode::OK && !in_isr)
+  {
+    const hpm_stat_t idle_status = spi_wait_for_idle_status(spi_);
+    ans = ConvertStatus(idle_status);
+  }
+
+  if (!dma_stopped)
+  {
+    StopDmaTransfer();
+  }
+
+  if (rx != nullptr &&
+      (kind == DmaTransferKind::READ_ONLY || kind == DmaTransferKind::WRITE_READ))
+  {
+    InvalidateDCacheIfNeeded(rx, size);
+  }
+
+  if (ans == ErrorCode::OK && copy_rx_to_user && user_read.addr_ != nullptr &&
+      user_read.size_ > 0U)
+  {
+    Memory::FastCopy(user_read.addr_, rx, user_read.size_);
+  }
+  if (ans == ErrorCode::OK && switch_buffer_on_success)
+  {
+    SwitchBuffer();
+  }
+
+  if (ans != ErrorCode::OK && !in_isr)
+  {
+    RecoverController();
+  }
+
+  ClearDmaContext();
+  dma_busy_.store(0U, std::memory_order_release);
+
+  if (op.type == OperationRW::OperationType::BLOCK)
+  {
+    (void)dma_block_wait_.TryPost(in_isr, ans);
+  }
+  else
+  {
+    op.UpdateStatus(in_isr, ans);
+  }
+}
+
+void HPMSPI::OnRxDmaTcCallback(DMA_Type* base, uint32_t channel, void* cb_data_ptr)
+{
+  UNUSED(base);
+  UNUSED(channel);
+  auto* self = static_cast<HPMSPI*>(cb_data_ptr);
+  if (self == nullptr || !self->DmaTransferActive())
+  {
+    return;
+  }
+
+  self->dma_ctx_.rx_done.store(1U, std::memory_order_release);
+  self->MaybeCompleteDmaTransfer(true);
+}
+
+void HPMSPI::OnTxDmaTcCallback(DMA_Type* base, uint32_t channel, void* cb_data_ptr)
+{
+  UNUSED(base);
+  UNUSED(channel);
+  auto* self = static_cast<HPMSPI*>(cb_data_ptr);
+  if (self == nullptr || !self->DmaTransferActive())
+  {
+    return;
+  }
+
+  self->dma_ctx_.tx_done.store(1U, std::memory_order_release);
+  self->MaybeCompleteDmaTransfer(true);
+}
+#endif
+
+ErrorCode HPMSPI::DoTransfer(uint8_t* rx, const uint8_t* tx, uint32_t size)
+{
+  if (size == 0)
+  {
+    return ErrorCode::OK;
+  }
+  if (rx == nullptr || tx == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+  if (size > kHpmSpiTransferCountMax)
+  {
+    return ErrorCode::SIZE_ERR;
+  }
+
+  spi_control_config_t control = MakeControlConfig(spi_trans_write_read_together);
+  const hpm_stat_t status = spi_transfer(spi_, &control, nullptr, nullptr,
+                                         const_cast<uint8_t*>(tx), size, rx, size);
+  if (ShouldRecover(status))
+  {
+    RecoverController();
+  }
+  return ConvertStatus(status);
+}
+
+ErrorCode HPMSPI::DoWriteOnly(const uint8_t* tx, uint32_t size)
+{
+  if (size == 0)
+  {
+    return ErrorCode::OK;
+  }
+  if (tx == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+  if (size > kHpmSpiTransferCountMax)
+  {
+    return ErrorCode::SIZE_ERR;
+  }
+
+  spi_control_config_t control = MakeControlConfig(spi_trans_write_only);
+  const hpm_stat_t status = spi_transfer(spi_, &control, nullptr, nullptr,
+                                         const_cast<uint8_t*>(tx), size, nullptr, 1);
+  if (ShouldRecover(status))
+  {
+    RecoverController();
+  }
+  return ConvertStatus(status);
+}
+
+ErrorCode HPMSPI::DoReadOnly(uint8_t* rx, uint32_t size)
+{
+  if (size == 0)
+  {
+    return ErrorCode::OK;
+  }
+  if (rx == nullptr)
+  {
+    return ErrorCode::PTR_NULL;
+  }
+  if (size > kHpmSpiTransferCountMax)
+  {
+    return ErrorCode::SIZE_ERR;
+  }
+
+  spi_control_config_t control = MakeControlConfig(spi_trans_read_only);
+  const hpm_stat_t status =
+      spi_transfer(spi_, &control, nullptr, nullptr, nullptr, 1, rx, size);
+  if (ShouldRecover(status))
+  {
+    RecoverController();
+  }
+  return ConvertStatus(status);
+}
+
+ErrorCode HPMSPI::DoCommandRead(uint8_t command, uint8_t* rx, uint32_t size)
+{
+  return DoCommandWriteRead(command, nullptr, 0U, rx, size);
+}
+
+ErrorCode HPMSPI::DoCommandWriteRead(uint8_t command, const uint8_t* tx, uint32_t tx_size,
+                                     uint8_t* rx, uint32_t rx_size)
+{
+  if ((tx_size > 0U && tx == nullptr) || (rx_size > 0U && rx == nullptr))
+  {
+    return ErrorCode::PTR_NULL;
+  }
+  if (tx_size > kHpmSpiTransferCountMax || rx_size > kHpmSpiTransferCountMax)
+  {
+    return ErrorCode::SIZE_ERR;
+  }
+
+  spi_trans_mode_t mode = spi_trans_no_data;
+  if (tx_size > 0U && rx_size > 0U)
+  {
+    mode = spi_trans_write_read;
+  }
+  else if (tx_size > 0U)
+  {
+    mode = spi_trans_write_only;
+  }
+  else if (rx_size > 0U)
+  {
+    mode = spi_trans_read_only;
+  }
+
+  spi_control_config_t control = MakeControlConfig(mode);
+  control.master_config.cmd_enable = true;
+  const uint32_t wcount = (tx_size > 0U) ? tx_size : 1U;
+  const uint32_t rcount = (rx_size > 0U) ? rx_size : 1U;
+  const hpm_stat_t status = spi_transfer(spi_, &control, &command, nullptr,
+                                         const_cast<uint8_t*>(tx), wcount, rx, rcount);
+  if (ShouldRecover(status))
+  {
+    RecoverController();
+  }
+  return ConvertStatus(status);
+}
+
+ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
+                               OperationRW& op, bool in_isr)
+{
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  if (DmaTransferActive())
+  {
+    return FinishOperation(op, in_isr, ErrorCode::BUSY);
+  }
+#endif
+
+  const size_t need = std::max(read_data.size_, write_data.size_);
+  if (need == 0)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::OK);
+  }
+  if (read_data.size_ > 0 && read_data.addr_ == nullptr)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if (write_data.size_ > 0 && write_data.addr_ == nullptr)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if (need > kHpmSpiTransferCountMax)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+  }
+
+  RawData rx = GetRxBuffer();
+  RawData tx = GetTxBuffer();
+  if ((read_data.size_ > 0 && rx.addr_ == nullptr) || tx.addr_ == nullptr)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if ((read_data.size_ > 0 && rx.size_ < need) || tx.size_ < need)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+  }
+
+  auto* rx_bytes = static_cast<uint8_t*>(rx.addr_);
+  auto* tx_bytes = static_cast<uint8_t*>(tx.addr_);
+  Memory::FastSet(tx_bytes, 0, need);
+  if (write_data.size_ > 0)
+  {
+    Memory::FastCopy(tx_bytes, write_data.addr_, write_data.size_);
+  }
+
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  if (dma_enabled_)
+  {
+    DmaTransferKind kind = DmaTransferKind::WRITE_ONLY;
+    if (read_data.size_ > 0 && write_data.size_ > 0)
+    {
+      kind = DmaTransferKind::WRITE_READ;
+    }
+    else if (read_data.size_ > 0)
+    {
+      kind = DmaTransferKind::READ_ONLY;
+    }
+
+    return StartDmaTransfer((read_data.size_ > 0) ? rx_bytes : nullptr,
+                            (write_data.size_ > 0) ? tx_bytes : nullptr,
+                            static_cast<uint32_t>(need), kind, read_data,
+                            read_data.size_ > 0, true, op, in_isr);
+  }
+#endif
+
+  ErrorCode ans;
+  if (read_data.size_ > 0 && write_data.size_ > 0)
+  {
+    ans = DoTransfer(rx_bytes, tx_bytes, static_cast<uint32_t>(need));
+  }
+  else if (read_data.size_ > 0)
+  {
+    ans = DoReadOnly(rx_bytes, static_cast<uint32_t>(need));
+  }
+  else
+  {
+    ans = DoWriteOnly(tx_bytes, static_cast<uint32_t>(need));
+  }
+
+  if (ans == ErrorCode::OK && read_data.size_ > 0)
+  {
+    Memory::FastCopy(read_data.addr_, rx_bytes, read_data.size_);
+  }
+
+  if (ans == ErrorCode::OK)
+  {
+    SwitchBuffer();
+  }
+  return FinishOperation(op, in_isr, ans);
+}
+
+ErrorCode HPMSPI::CommandRead(uint8_t command, RawData read_data, OperationRW& op,
+                              bool in_isr)
+{
+  if (read_data.size_ == 0)
+  {
+    UNUSED(command);
+    return FinishOperation(op, in_isr, ErrorCode::OK);
+  }
+
+  return CommandWriteRead(command, ConstRawData(nullptr, 0), read_data, op, in_isr);
+}
+
+ErrorCode HPMSPI::CommandWriteRead(uint8_t command, ConstRawData write_data,
+                                   RawData read_data, OperationRW& op, bool in_isr)
+{
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  if (DmaTransferActive())
+  {
+    return FinishOperation(op, in_isr, ErrorCode::BUSY);
+  }
+#endif
+
+  if (write_data.size_ > 0 && write_data.addr_ == nullptr)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if (read_data.size_ > 0 && read_data.addr_ == nullptr)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if (write_data.size_ > kHpmSpiTransferCountMax ||
+      read_data.size_ > kHpmSpiTransferCountMax)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+  }
+
+  uint8_t* rx_bytes = nullptr;
+  const uint8_t* tx_bytes = nullptr;
+
+  if (write_data.size_ > 0)
+  {
+    RawData tx = GetTxBuffer();
+    if (tx.addr_ == nullptr)
+    {
+      return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    }
+    if (tx.size_ < write_data.size_)
+    {
+      return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    }
+
+    auto* tx_buffer = static_cast<uint8_t*>(tx.addr_);
+    Memory::FastCopy(tx_buffer, write_data.addr_, write_data.size_);
+    tx_bytes = tx_buffer;
+  }
+
+  if (read_data.size_ == 0)
+  {
+    ErrorCode ans = DoCommandWriteRead(
+        command, tx_bytes, static_cast<uint32_t>(write_data.size_), nullptr, 0U);
+    if (ans == ErrorCode::OK)
+    {
+      SwitchBuffer();
+    }
+    return FinishOperation(op, in_isr, ans);
+  }
+
+  RawData rx = GetRxBuffer();
+  if (rx.addr_ == nullptr)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if (rx.size_ < read_data.size_)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+  }
+
+  rx_bytes = static_cast<uint8_t*>(rx.addr_);
+  ErrorCode ans =
+      DoCommandWriteRead(command, tx_bytes, static_cast<uint32_t>(write_data.size_),
+                         rx_bytes, static_cast<uint32_t>(read_data.size_));
+  if (ans == ErrorCode::OK)
+  {
+    Memory::FastCopy(read_data.addr_, rx_bytes, read_data.size_);
+    SwitchBuffer();
+  }
+  return FinishOperation(op, in_isr, ans);
+}
+
+ErrorCode HPMSPI::Transfer(size_t size, OperationRW& op, bool in_isr)
+{
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  if (DmaTransferActive())
+  {
+    return FinishOperation(op, in_isr, ErrorCode::BUSY);
+  }
+#endif
+
+  if (size == 0)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::OK);
+  }
+  if (size > kHpmSpiTransferCountMax)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+  }
+
+  RawData rx = GetRxBuffer();
+  RawData tx = GetTxBuffer();
+  if (rx.addr_ == nullptr || tx.addr_ == nullptr)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if (rx.size_ < size || tx.size_ < size)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+  }
+
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  if (dma_enabled_)
+  {
+    return StartDmaTransfer(static_cast<uint8_t*>(rx.addr_),
+                            static_cast<uint8_t*>(tx.addr_), static_cast<uint32_t>(size),
+                            DmaTransferKind::WRITE_READ, RawData(nullptr, 0), false, true,
+                            op, in_isr);
+  }
+#endif
+
+  ErrorCode ans =
+      DoTransfer(static_cast<uint8_t*>(rx.addr_), static_cast<const uint8_t*>(tx.addr_),
+                 static_cast<uint32_t>(size));
+  if (ans == ErrorCode::OK)
+  {
+    SwitchBuffer();
+  }
+  return FinishOperation(op, in_isr, ans);
+}
+
+ErrorCode HPMSPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bool in_isr)
+{
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  if (DmaTransferActive())
+  {
+    return FinishOperation(op, in_isr, ErrorCode::BUSY);
+  }
+#endif
+
+  if (read_data.size_ == 0)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::OK);
+  }
+  if (read_data.addr_ == nullptr)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if ((reg & static_cast<uint16_t>(~kSpiRegisterAddressMask)) != 0U)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::OUT_OF_RANGE);
+  }
+
+  const size_t total = read_data.size_ + 1;
+  if (total > kHpmSpiTransferCountMax)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+  }
+
+  RawData rx = GetRxBuffer();
+  RawData tx = GetTxBuffer();
+  if (rx.addr_ == nullptr || tx.addr_ == nullptr)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if (rx.size_ < total || tx.size_ < total)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+  }
+
+  auto* rx_bytes = static_cast<uint8_t*>(rx.addr_);
+  auto* tx_bytes = static_cast<uint8_t*>(tx.addr_);
+  tx_bytes[0] = static_cast<uint8_t>(reg | 0x80u);
+  Memory::FastSet(tx_bytes + 1, 0, read_data.size_);
+
+  ErrorCode ans = DoTransfer(rx_bytes, tx_bytes, static_cast<uint32_t>(total));
+  if (ans == ErrorCode::OK)
+  {
+    Memory::FastCopy(read_data.addr_, rx_bytes + 1, read_data.size_);
+  }
+
+  if (ans == ErrorCode::OK)
+  {
+    SwitchBuffer();
+  }
+  return FinishOperation(op, in_isr, ans);
+}
+
+ErrorCode HPMSPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW& op,
+                           bool in_isr)
+{
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  if (DmaTransferActive())
+  {
+    return FinishOperation(op, in_isr, ErrorCode::BUSY);
+  }
+#endif
+
+  const size_t total = write_data.size_ + 1;
+  if ((reg & static_cast<uint16_t>(~kSpiRegisterAddressMask)) != 0U)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::OUT_OF_RANGE);
+  }
+  if (write_data.size_ > 0 && write_data.addr_ == nullptr)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if (total > kHpmSpiTransferCountMax)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+  }
+
+  RawData tx = GetTxBuffer();
+  if (tx.addr_ == nullptr)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if (tx.size_ < total)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+  }
+
+  auto* tx_bytes = static_cast<uint8_t*>(tx.addr_);
+  tx_bytes[0] = static_cast<uint8_t>(reg & 0x7Fu);
+  if (write_data.size_ == 0 && tx.size_ > 1)
+  {
+    tx_bytes[1] = 0;
+  }
+  if (write_data.size_ > 0)
+  {
+    Memory::FastCopy(tx_bytes + 1, write_data.addr_, write_data.size_);
+  }
+
+  ErrorCode ans = DoWriteOnly(tx_bytes, static_cast<uint32_t>(total));
+  if (ans == ErrorCode::OK)
+  {
+    SwitchBuffer();
+  }
+  return FinishOperation(op, in_isr, ans);
+}
+
+#else
+
+using namespace LibXR;
+
+HPMSPI::HPMSPI(LibXRHpmSpiType* spi, clock_name_t clock, RawData rx_buffer,
+               RawData tx_buffer, bool auto_board_init, SPI::Configuration config,
+               ChipSelect cs)
+    : SPI(rx_buffer, tx_buffer),
+      spi_(spi),
+      clock_(clock),
+      rx_buffer_capacity_(rx_buffer.size_),
+      tx_buffer_capacity_(tx_buffer.size_),
+      auto_board_init_(auto_board_init),
+      cs_(cs)
+{
+  (void)spi_;
+  (void)clock_;
+  (void)auto_board_init_;
+  (void)cs_;
+  GetConfig() = config;
+}
+
+ErrorCode HPMSPI::ConvertStatus(LibXRHpmSpiStatusType status)
+{
+  UNUSED(status);
+  return ErrorCode::NOT_SUPPORT;
+}
+
+bool HPMSPI::ShouldRecover(LibXRHpmSpiStatusType status)
+{
+  UNUSED(status);
+  return false;
+}
+
+ErrorCode HPMSPI::ValidateConfiguration(const Configuration& config) const
+{
+  UNUSED(config);
+  return ErrorCode::NOT_SUPPORT;
+}
+
+ErrorCode HPMSPI::EnsureClockReady() { return ErrorCode::NOT_SUPPORT; }
+
+void HPMSPI::ApplyFormat(const Configuration& config) { UNUSED(config); }
+
+void HPMSPI::RecoverController() {}
+
+ErrorCode HPMSPI::ApplyTiming(Prescaler prescaler)
+{
+  UNUSED(prescaler);
+  return ErrorCode::NOT_SUPPORT;
+}
+
+ErrorCode HPMSPI::SetConfig(SPI::Configuration config)
+{
+  GetConfig() = config;
+  configured_ = false;
+  return ErrorCode::NOT_SUPPORT;
+}
+
+ErrorCode HPMSPI::SetChipSelect(ChipSelect cs)
+{
+  UNUSED(cs);
+  return ErrorCode::NOT_SUPPORT;
+}
+
+ErrorCode HPMSPI::SetDmaEnabled(bool enabled)
+{
+  dma_enabled_ = false;
+  return enabled ? ErrorCode::NOT_SUPPORT : ErrorCode::OK;
+}
+
+uint32_t HPMSPI::GetMaxBusSpeed() const { return 0U; }
+
+SPI::Prescaler HPMSPI::GetMaxPrescaler() const { return Prescaler::UNKNOWN; }
+
+ErrorCode HPMSPI::DoTransfer(uint8_t* rx, const uint8_t* tx, uint32_t size)
+{
+  UNUSED(rx);
+  UNUSED(tx);
+  UNUSED(size);
+  return ErrorCode::NOT_SUPPORT;
+}
+
+ErrorCode HPMSPI::DoWriteOnly(const uint8_t* tx, uint32_t size)
+{
+  UNUSED(tx);
+  UNUSED(size);
+  return ErrorCode::NOT_SUPPORT;
+}
+
+ErrorCode HPMSPI::DoReadOnly(uint8_t* rx, uint32_t size)
+{
+  UNUSED(rx);
+  UNUSED(size);
+  return ErrorCode::NOT_SUPPORT;
+}
+
+ErrorCode HPMSPI::DoCommandRead(uint8_t command, uint8_t* rx, uint32_t size)
+{
+  UNUSED(command);
+  UNUSED(rx);
+  UNUSED(size);
+  return ErrorCode::NOT_SUPPORT;
+}
+
+ErrorCode HPMSPI::DoCommandWriteRead(uint8_t command, const uint8_t* tx, uint32_t tx_size,
+                                     uint8_t* rx, uint32_t rx_size)
+{
+  UNUSED(command);
+  UNUSED(tx);
+  UNUSED(tx_size);
+  UNUSED(rx);
+  UNUSED(rx_size);
+  return ErrorCode::NOT_SUPPORT;
+}
+
+ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
+                               OperationRW& op, bool in_isr)
+{
+  UNUSED(read_data);
+  UNUSED(write_data);
+  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
+}
+
+ErrorCode HPMSPI::CommandRead(uint8_t command, RawData read_data, OperationRW& op,
+                              bool in_isr)
+{
+  UNUSED(command);
+  UNUSED(read_data);
+  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
+}
+
+ErrorCode HPMSPI::CommandWriteRead(uint8_t command, ConstRawData write_data,
+                                   RawData read_data, OperationRW& op, bool in_isr)
+{
+  UNUSED(command);
+  UNUSED(write_data);
+  UNUSED(read_data);
+  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
+}
+
+ErrorCode HPMSPI::Transfer(size_t size, OperationRW& op, bool in_isr)
+{
+  UNUSED(size);
+  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
+}
+
+ErrorCode HPMSPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bool in_isr)
+{
+  UNUSED(reg);
+  UNUSED(read_data);
+  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
+}
+
+ErrorCode HPMSPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW& op,
+                           bool in_isr)
+{
+  UNUSED(reg);
+  UNUSED(write_data);
+  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
+}
+
+#endif

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -59,6 +59,9 @@ bool RegisterPayloadSizeTooLarge(size_t size)
 
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
 constexpr bool kHpmSpiDmaAddressSpaceSupported = sizeof(uintptr_t) <= sizeof(uint32_t);
+constexpr uint32_t kDmaBlockPending = 0U;
+constexpr uint32_t kDmaBlockSuccess = 1U;
+constexpr uint32_t kDmaBlockFailure = 2U;
 
 struct DmaRxBufferSelection
 {
@@ -338,6 +341,14 @@ spi_sclk_sampling_clk_edges_t HPMSPI::ConvertPhase(ClockPhase phase)
 
 ErrorCode HPMSPI::ValidateConfiguration(const Configuration& config) const
 {
+  if ((config.clock_polarity != ClockPolarity::LOW &&
+       config.clock_polarity != ClockPolarity::HIGH) ||
+      (config.clock_phase != ClockPhase::EDGE_1 &&
+       config.clock_phase != ClockPhase::EDGE_2))
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
   const ErrorCode prescaler_ans = ValidatePrescaler(config.prescaler);
   if (prescaler_ans != ErrorCode::OK)
   {
@@ -621,6 +632,36 @@ ErrorCode HPMSPI::EnsureDmaReady()
   }
 
   dma_mgr_init();
+  auto release_resource = [](dma_resource_t* resource)
+  {
+    if (resource != nullptr && resource->base != nullptr)
+    {
+      (void)dma_mgr_release_resource(resource);
+    }
+  };
+  auto install_failure_callbacks = [this](dma_resource_t* resource) -> hpm_stat_t
+  {
+    if (resource == nullptr || resource->base == nullptr)
+    {
+      return status_invalid_argument;
+    }
+
+    hpm_stat_t callback_status =
+        dma_mgr_install_chn_error_callback(resource, &HPMSPI::OnDmaFailureCallback, this);
+    if (callback_status != status_success)
+    {
+      return callback_status;
+    }
+    callback_status =
+        dma_mgr_install_chn_abort_callback(resource, &HPMSPI::OnDmaFailureCallback, this);
+    if (callback_status != status_success)
+    {
+      return callback_status;
+    }
+    return dma_mgr_enable_chn_irq(
+        resource, DMA_MGR_INTERRUPT_MASK_ERROR | DMA_MGR_INTERRUPT_MASK_ABORT);
+  };
+
   hpm_stat_t status =
       hpm_spi_rx_dma_mgr_install_custom_callback(spi_, &HPMSPI::OnRxDmaTcCallback, this);
   if (status != status_success)
@@ -629,17 +670,30 @@ ErrorCode HPMSPI::EnsureDmaReady()
                                                : ConvertDmaStatus(status);
   }
 
+  dma_resource_t* rx_resource = hpm_spi_get_rx_dma_resource(spi_);
+  status = install_failure_callbacks(rx_resource);
+  if (status != status_success)
+  {
+    release_resource(rx_resource);
+    return ConvertDmaStatus(status);
+  }
+
   status =
       hpm_spi_tx_dma_mgr_install_custom_callback(spi_, &HPMSPI::OnTxDmaTcCallback, this);
   if (status != status_success)
   {
-    dma_resource_t* rx_resource = hpm_spi_get_rx_dma_resource(spi_);
-    if (rx_resource != nullptr && rx_resource->base != nullptr)
-    {
-      (void)dma_mgr_release_resource(rx_resource);
-    }
+    release_resource(rx_resource);
     return (status == status_invalid_argument) ? ErrorCode::NOT_SUPPORT
                                                : ConvertDmaStatus(status);
+  }
+
+  dma_resource_t* tx_resource = hpm_spi_get_tx_dma_resource(spi_);
+  status = install_failure_callbacks(tx_resource);
+  if (status != status_success)
+  {
+    release_resource(tx_resource);
+    release_resource(rx_resource);
+    return ConvertDmaStatus(status);
   }
 
   dma_ready_ = true;
@@ -682,6 +736,28 @@ void HPMSPI::StopDmaTransfer()
   if (tx_resource != nullptr && tx_resource->base != nullptr)
   {
     (void)dma_mgr_disable_channel(tx_resource);
+  }
+
+  ClearDmaTransferStatus();
+}
+
+void HPMSPI::ClearDmaTransferStatus()
+{
+  if (spi_ == nullptr)
+  {
+    return;
+  }
+
+  dma_resource_t* rx_resource = hpm_spi_get_rx_dma_resource(spi_);
+  if (rx_resource != nullptr && rx_resource->base != nullptr)
+  {
+    dma_clear_transfer_status(rx_resource->base, rx_resource->channel);
+  }
+
+  dma_resource_t* tx_resource = hpm_spi_get_tx_dma_resource(spi_);
+  if (tx_resource != nullptr && tx_resource->base != nullptr)
+  {
+    dma_clear_transfer_status(tx_resource->base, tx_resource->channel);
   }
 }
 
@@ -763,6 +839,10 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   {
     return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
   }
+  if (in_isr)
+  {
+    return FinishOperation(op, true, ErrorCode::NOT_SUPPORT);
+  }
   if (!kHpmSpiDmaAddressSpaceSupported)
   {
     return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
@@ -826,6 +906,7 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
     return FinishOperation(op, in_isr, ans);
   }
 
+  ClearDmaTransferStatus();
   dma_busy_.store(1U, std::memory_order_release);
   ClearDmaContext();
   dma_ctx_.kind = kind;
@@ -898,13 +979,13 @@ ErrorCode HPMSPI::WaitForDmaBlockResult(uint32_t timeout)
 {
   const ErrorCode ans = dma_block_wait_.Wait(timeout);
   if (ans == ErrorCode::OK && DmaTransferActive() &&
-      dma_ctx_.block_dma_ready.load(std::memory_order_acquire) != 0U)
+      dma_ctx_.block_dma_ready.load(std::memory_order_acquire) == kDmaBlockSuccess)
   {
     return CompleteDmaTransfer(false, ErrorCode::OK, false);
   }
-  if (ans == ErrorCode::TIMEOUT && DmaTransferActive())
+  if (ans != ErrorCode::OK && DmaTransferActive())
   {
-    (void)CompleteDmaTransfer(false, ErrorCode::TIMEOUT);
+    (void)CompleteDmaTransfer(false, ans, false);
   }
   return ans;
 }
@@ -938,8 +1019,13 @@ void HPMSPI::MaybeCompleteDmaTransfer(bool in_isr)
   {
     if (dma_ctx_.op != nullptr && dma_ctx_.op->type == OperationRW::OperationType::BLOCK)
     {
-      dma_ctx_.block_dma_ready.store(1U, std::memory_order_release);
-      (void)dma_block_wait_.TryPost(in_isr, ErrorCode::OK);
+      uint32_t expected = kDmaBlockPending;
+      if (dma_ctx_.block_dma_ready.compare_exchange_strong(expected, kDmaBlockSuccess,
+                                                           std::memory_order_acq_rel,
+                                                           std::memory_order_acquire))
+      {
+        (void)dma_block_wait_.TryPost(in_isr, ErrorCode::OK);
+      }
       return;
     }
 
@@ -1055,6 +1141,25 @@ void HPMSPI::OnTxDmaTcCallback(DMA_Type* base, uint32_t channel, void* cb_data_p
 
   self->dma_ctx_.tx_done.store(1U, std::memory_order_release);
   self->MaybeCompleteDmaTransfer(true);
+}
+
+void HPMSPI::OnDmaFailureCallback(DMA_Type* base, uint32_t channel, void* cb_data_ptr)
+{
+  UNUSED(base);
+  UNUSED(channel);
+  auto* self = static_cast<HPMSPI*>(cb_data_ptr);
+  if (self == nullptr || !self->DmaTransferActive())
+  {
+    return;
+  }
+
+  uint32_t expected = kDmaBlockPending;
+  if (self->dma_ctx_.block_dma_ready.compare_exchange_strong(expected, kDmaBlockFailure,
+                                                             std::memory_order_acq_rel,
+                                                             std::memory_order_acquire))
+  {
+    (void)self->dma_block_wait_.TryPost(true, ErrorCode::FAILED);
+  }
 }
 #endif
 
@@ -1220,24 +1325,40 @@ ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
     return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
   }
 
-  RawData rx = GetRxBuffer();
-  RawData tx = GetTxBuffer();
-  if ((read_data.size_ > 0 && rx.addr_ == nullptr) || tx.addr_ == nullptr)
+  RawData rx = {nullptr, 0};
+  if (read_data.size_ > 0)
   {
-    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    rx = GetRxBuffer();
+    if (rx.addr_ == nullptr)
+    {
+      return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    }
+    if (rx.size_ < need)
+    {
+      return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    }
   }
-  if ((read_data.size_ > 0 && rx.size_ < need) || tx.size_ < need)
+
+  RawData tx = {nullptr, 0};
+  uint8_t* tx_bytes = nullptr;
+  if (write_data.size_ > 0)
   {
-    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    tx = GetTxBuffer();
+    if (tx.addr_ == nullptr)
+    {
+      return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    }
+    if (tx.size_ < need)
+    {
+      return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    }
+
+    tx_bytes = static_cast<uint8_t*>(tx.addr_);
+    Memory::FastSet(tx_bytes, 0, need);
+    Memory::FastCopy(tx_bytes, write_data.addr_, write_data.size_);
   }
 
   auto* rx_bytes = static_cast<uint8_t*>(rx.addr_);
-  auto* tx_bytes = static_cast<uint8_t*>(tx.addr_);
-  Memory::FastSet(tx_bytes, 0, need);
-  if (write_data.size_ > 0)
-  {
-    Memory::FastCopy(tx_bytes, write_data.addr_, write_data.size_);
-  }
 
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
   if (dma_enabled_)
@@ -1614,7 +1735,7 @@ ErrorCode HPMSPI::ApplyTiming(Prescaler prescaler)
 
 ErrorCode HPMSPI::SetConfig(SPI::Configuration config)
 {
-  GetConfig() = config;
+  UNUSED(config);
   configured_ = false;
   return ErrorCode::NOT_SUPPORT;
 }

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -808,7 +808,7 @@ ErrorCode HPMSPI::RunBlockingStreamTransfer(uint8_t* rx, const uint8_t* tx, uint
   if (ans == ErrorCode::OK && copy_rx_to_user && user_read.addr_ != nullptr &&
       user_read.size_ > 0U)
   {
-    Memory::FastCopy(user_read.addr_, rx, user_read.size_);
+    Memory::FastMove(user_read.addr_, rx, user_read.size_);
   }
   if (ans == ErrorCode::OK && switch_buffer_on_success)
   {
@@ -1085,7 +1085,7 @@ ErrorCode HPMSPI::CompleteDmaTransfer(bool in_isr, ErrorCode ans, bool notify_bl
   if (ans == ErrorCode::OK && copy_rx_to_user && user_read.addr_ != nullptr &&
       user_read.size_ > 0U)
   {
-    Memory::FastCopy(user_read.addr_, readable_rx, user_read.size_);
+    Memory::FastMove(user_read.addr_, readable_rx, user_read.size_);
   }
   if (ans == ErrorCode::OK && switch_buffer_on_success)
   {
@@ -1399,7 +1399,7 @@ ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
 
   if (ans == ErrorCode::OK && read_data.size_ > 0)
   {
-    Memory::FastCopy(read_data.addr_, rx_bytes, read_data.size_);
+    Memory::FastMove(read_data.addr_, rx_bytes, read_data.size_);
   }
 
   if (ans == ErrorCode::OK)
@@ -1470,7 +1470,7 @@ ErrorCode HPMSPI::CommandWriteRead(uint8_t command, ConstRawData write_data,
     }
 
     auto* tx_buffer = static_cast<uint8_t*>(tx.addr_);
-    Memory::FastCopy(tx_buffer, write_data.addr_, write_data.size_);
+    Memory::FastMove(tx_buffer, write_data.addr_, write_data.size_);
     tx_bytes = tx_buffer;
   }
 
@@ -1501,7 +1501,7 @@ ErrorCode HPMSPI::CommandWriteRead(uint8_t command, ConstRawData write_data,
                          rx_bytes, static_cast<uint32_t>(read_data.size_));
   if (ans == ErrorCode::OK)
   {
-    Memory::FastCopy(read_data.addr_, rx_bytes, read_data.size_);
+    Memory::FastMove(read_data.addr_, rx_bytes, read_data.size_);
     SwitchBuffer();
   }
   return FinishOperation(op, in_isr, ans);
@@ -1613,7 +1613,7 @@ ErrorCode HPMSPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bool
   ErrorCode ans = DoTransfer(rx_bytes, tx_bytes, static_cast<uint32_t>(total));
   if (ans == ErrorCode::OK)
   {
-    Memory::FastCopy(read_data.addr_, rx_bytes + 1, read_data.size_);
+    Memory::FastMove(read_data.addr_, rx_bytes + 1, read_data.size_);
   }
 
   if (ans == ErrorCode::OK)
@@ -1664,11 +1664,11 @@ ErrorCode HPMSPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW& o
   }
 
   auto* tx_bytes = static_cast<uint8_t*>(tx.addr_);
-  tx_bytes[0] = static_cast<uint8_t>(reg & 0x7Fu);
   if (write_data.size_ > 0)
   {
-    Memory::FastCopy(tx_bytes + 1, write_data.addr_, write_data.size_);
+    Memory::FastMove(tx_bytes + 1, write_data.addr_, write_data.size_);
   }
+  tx_bytes[0] = static_cast<uint8_t>(reg & 0x7Fu);
 
   ErrorCode ans = DoWriteOnly(tx_bytes, static_cast<uint32_t>(total));
   if (ans == ErrorCode::OK)

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -609,6 +609,17 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   {
     return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
   }
+  if (copy_rx_to_user)
+  {
+    if (user_read.size_ > size)
+    {
+      return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    }
+    if (user_read.size_ > 0U && user_read.addr_ == nullptr)
+    {
+      return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    }
+  }
 #if LIBXR_HPM_SPI_DMA_BLOCK_WAIT_REQUIRES_TIMEBASE
   if (op.type == OperationRW::OperationType::BLOCK && !Timebase::IsReady())
   {

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -907,7 +907,6 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   }
 
   ClearDmaTransferStatus();
-  dma_busy_.store(1U, std::memory_order_release);
   ClearDmaContext();
   dma_ctx_.kind = kind;
   dma_ctx_.op = &op;
@@ -920,6 +919,7 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   dma_ctx_.copy_rx_to_staging = copy_rx_to_staging;
   dma_ctx_.switch_buffer_on_success = switch_buffer_on_success;
   dma_completion_claim_.store(0U, std::memory_order_release);
+  dma_busy_.store(1U, std::memory_order_release);
 
   if (op.type == OperationRW::OperationType::BLOCK)
   {
@@ -1354,8 +1354,11 @@ ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
     }
 
     tx_bytes = static_cast<uint8_t*>(tx.addr_);
-    Memory::FastSet(tx_bytes, 0, need);
-    Memory::FastCopy(tx_bytes, write_data.addr_, write_data.size_);
+    Memory::FastMove(tx_bytes, write_data.addr_, write_data.size_);
+    if (need > write_data.size_)
+    {
+      Memory::FastSet(tx_bytes + write_data.size_, 0, need - write_data.size_);
+    }
   }
 
   auto* rx_bytes = static_cast<uint8_t*>(rx.addr_);

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -655,10 +655,6 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   {
     FlushDCacheIfNeeded(tx, size);
   }
-  if (rx != nullptr)
-  {
-    FlushDCacheIfNeeded(rx, size);
-  }
 
   ApplyChipSelect();
 

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -235,8 +235,7 @@ ErrorCode HPMSPI::ValidateConfiguration(const Configuration& config) const
   }
 
   if (config.double_buffer &&
-      ((rx_buffer_capacity_ < 2U) || (tx_buffer_capacity_ < 2U) ||
-       ((rx_buffer_capacity_ / 2U) == 0U) || ((tx_buffer_capacity_ / 2U) == 0U)))
+      ((rx_buffer_capacity_ < 2U) || (tx_buffer_capacity_ < 2U)))
   {
     return ErrorCode::SIZE_ERR;
   }

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -234,8 +234,7 @@ ErrorCode HPMSPI::ValidateConfiguration(const Configuration& config) const
     return prescaler_ans;
   }
 
-  if (config.double_buffer &&
-      ((rx_buffer_capacity_ < 2U) || (tx_buffer_capacity_ < 2U)))
+  if (config.double_buffer && ((rx_buffer_capacity_ < 2U) || (tx_buffer_capacity_ < 2U)))
   {
     return ErrorCode::SIZE_ERR;
   }
@@ -950,8 +949,8 @@ ErrorCode HPMSPI::DoCommandWriteRead(uint8_t command, const uint8_t* tx, uint32_
   uint8_t* tx_buffer = (tx_size > 0U) ? const_cast<uint8_t*>(tx) : &dummy_tx;
   uint8_t* rx_buffer = (rx_size > 0U) ? rx : &dummy_rx;
   ApplyChipSelect();
-  const hpm_stat_t status = spi_transfer(spi_, &control, &command, nullptr,
-                                         tx_buffer, wcount, rx_buffer, rcount);
+  const hpm_stat_t status = spi_transfer(spi_, &control, &command, nullptr, tx_buffer,
+                                         wcount, rx_buffer, rcount);
   if (ShouldRecover(status))
   {
     RecoverController();

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -846,6 +846,7 @@ ErrorCode HPMSPI::DoTransfer(uint8_t* rx, const uint8_t* tx, uint32_t size)
   }
 
   spi_control_config_t control = MakeControlConfig(spi_trans_write_read_together);
+  ApplyChipSelect();
   const hpm_stat_t status = spi_transfer(spi_, &control, nullptr, nullptr,
                                          const_cast<uint8_t*>(tx), size, rx, size);
   if (ShouldRecover(status))
@@ -871,8 +872,10 @@ ErrorCode HPMSPI::DoWriteOnly(const uint8_t* tx, uint32_t size)
   }
 
   spi_control_config_t control = MakeControlConfig(spi_trans_write_only);
+  uint8_t dummy_rx = 0U;
+  ApplyChipSelect();
   const hpm_stat_t status = spi_transfer(spi_, &control, nullptr, nullptr,
-                                         const_cast<uint8_t*>(tx), size, nullptr, 1);
+                                         const_cast<uint8_t*>(tx), size, &dummy_rx, 1U);
   if (ShouldRecover(status))
   {
     RecoverController();
@@ -896,8 +899,10 @@ ErrorCode HPMSPI::DoReadOnly(uint8_t* rx, uint32_t size)
   }
 
   spi_control_config_t control = MakeControlConfig(spi_trans_read_only);
+  uint8_t dummy_tx = 0U;
+  ApplyChipSelect();
   const hpm_stat_t status =
-      spi_transfer(spi_, &control, nullptr, nullptr, nullptr, 1, rx, size);
+      spi_transfer(spi_, &control, nullptr, nullptr, &dummy_tx, 1U, rx, size);
   if (ShouldRecover(status))
   {
     RecoverController();
@@ -940,8 +945,13 @@ ErrorCode HPMSPI::DoCommandWriteRead(uint8_t command, const uint8_t* tx, uint32_
   control.master_config.cmd_enable = true;
   const uint32_t wcount = (tx_size > 0U) ? tx_size : 1U;
   const uint32_t rcount = (rx_size > 0U) ? rx_size : 1U;
+  uint8_t dummy_tx = 0U;
+  uint8_t dummy_rx = 0U;
+  uint8_t* tx_buffer = (tx_size > 0U) ? const_cast<uint8_t*>(tx) : &dummy_tx;
+  uint8_t* rx_buffer = (rx_size > 0U) ? rx : &dummy_rx;
+  ApplyChipSelect();
   const hpm_stat_t status = spi_transfer(spi_, &control, &command, nullptr,
-                                         const_cast<uint8_t*>(tx), wcount, rx, rcount);
+                                         tx_buffer, wcount, rx_buffer, rcount);
   if (ShouldRecover(status))
   {
     RecoverController();

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -535,7 +535,7 @@ ErrorCode HPMSPI::EnsureDmaReady()
 void HPMSPI::ClearDmaContext()
 {
   dma_ctx_.kind = DmaTransferKind::NONE;
-  dma_ctx_.op = OperationRW();
+  dma_ctx_.op = nullptr;
   dma_ctx_.rx = nullptr;
   dma_ctx_.tx = nullptr;
   dma_ctx_.user_read = {nullptr, 0};
@@ -635,7 +635,7 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   dma_busy_.store(1U, std::memory_order_release);
   ClearDmaContext();
   dma_ctx_.kind = kind;
-  dma_ctx_.op = op;
+  dma_ctx_.op = &op;
   dma_ctx_.rx = rx;
   dma_ctx_.tx = tx;
   dma_ctx_.user_read = user_read;
@@ -742,7 +742,7 @@ void HPMSPI::CompleteDmaTransfer(bool in_isr, ErrorCode ans)
   }
 
   DmaTransferKind kind = dma_ctx_.kind;
-  OperationRW op = dma_ctx_.op;
+  OperationRW* op = dma_ctx_.op;
   uint8_t* rx = dma_ctx_.rx;
   const uint32_t size = dma_ctx_.size;
   const RawData user_read = dma_ctx_.user_read;
@@ -791,13 +791,13 @@ void HPMSPI::CompleteDmaTransfer(bool in_isr, ErrorCode ans)
   ClearDmaContext();
   dma_busy_.store(0U, std::memory_order_release);
 
-  if (op.type == OperationRW::OperationType::BLOCK)
+  if (op != nullptr && op->type == OperationRW::OperationType::BLOCK)
   {
     (void)dma_block_wait_.TryPost(in_isr, ans);
   }
-  else
+  else if (op != nullptr)
   {
-    op.UpdateStatus(in_isr, ans);
+    op->UpdateStatus(in_isr, ans);
   }
 }
 

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -40,6 +40,18 @@ constexpr uint32_t kHpmSpiTransferCountMax = UINT32_MAX;
 #endif
 constexpr uint16_t kSpiRegisterAddressMask = 0x007FU;
 
+bool TransferSizeTooLarge(size_t size)
+{
+  return size > static_cast<size_t>(UINT32_MAX) ||
+         size > static_cast<size_t>(kHpmSpiTransferCountMax);
+}
+
+bool RegisterPayloadSizeTooLarge(size_t size)
+{
+  return size >= static_cast<size_t>(UINT32_MAX) ||
+         size >= static_cast<size_t>(kHpmSpiTransferCountMax);
+}
+
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
 static_assert(sizeof(uintptr_t) <= sizeof(uint32_t),
               "HPM SPI DMA helper assumes a 32-bit address space.");
@@ -782,7 +794,7 @@ void HPMSPI::CompleteDmaTransfer(bool in_isr, ErrorCode ans)
     SwitchBuffer();
   }
 
-  if (ans != ErrorCode::OK && !in_isr)
+  if (ans != ErrorCode::OK)
   {
     RecoverController();
   }
@@ -982,7 +994,7 @@ ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
   {
     return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
   }
-  if (need > kHpmSpiTransferCountMax)
+  if (TransferSizeTooLarge(need))
   {
     return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
   }
@@ -1083,8 +1095,7 @@ ErrorCode HPMSPI::CommandWriteRead(uint8_t command, ConstRawData write_data,
   {
     return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
   }
-  if (write_data.size_ > kHpmSpiTransferCountMax ||
-      read_data.size_ > kHpmSpiTransferCountMax)
+  if (TransferSizeTooLarge(write_data.size_) || TransferSizeTooLarge(read_data.size_))
   {
     return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
   }
@@ -1156,7 +1167,7 @@ ErrorCode HPMSPI::Transfer(size_t size, OperationRW& op, bool in_isr)
   {
     return FinishOperation(op, in_isr, ErrorCode::OK);
   }
-  if (size > kHpmSpiTransferCountMax)
+  if (TransferSizeTooLarge(size))
   {
     return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
   }
@@ -1215,7 +1226,7 @@ ErrorCode HPMSPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bool
     return FinishOperation(op, in_isr, ErrorCode::OUT_OF_RANGE);
   }
 
-  if (read_data.size_ > (static_cast<size_t>(kHpmSpiTransferCountMax) - 1U))
+  if (RegisterPayloadSizeTooLarge(read_data.size_))
   {
     return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
   }
@@ -1269,7 +1280,7 @@ ErrorCode HPMSPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW& o
   {
     return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
   }
-  if (write_data.size_ > (static_cast<size_t>(kHpmSpiTransferCountMax) - 1U))
+  if (RegisterPayloadSizeTooLarge(write_data.size_))
   {
     return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
   }
@@ -1287,10 +1298,6 @@ ErrorCode HPMSPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW& o
 
   auto* tx_bytes = static_cast<uint8_t*>(tx.addr_);
   tx_bytes[0] = static_cast<uint8_t>(reg & 0x7Fu);
-  if (write_data.size_ == 0 && tx.size_ > 1)
-  {
-    tx_bytes[1] = 0;
-  }
   if (write_data.size_ > 0)
   {
     Memory::FastCopy(tx_bytes + 1, write_data.addr_, write_data.size_);

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -41,12 +41,16 @@ constexpr uint32_t kHpmSpiTransferCountMax = UINT32_MAX;
 #endif
 constexpr uint16_t kSpiRegisterAddressMask = 0x007FU;
 
+// Generic transfers pass the complete hardware transfer count, so the maximum
+// representable HPM count remains valid.
 bool TransferSizeTooLarge(size_t size)
 {
   return size > static_cast<size_t>(UINT32_MAX) ||
          size > static_cast<size_t>(kHpmSpiTransferCountMax);
 }
 
+// Register helpers add one command byte after this payload. Rejecting equality
+// keeps command + payload within both uint32_t and the HPM transfer-count limit.
 bool RegisterPayloadSizeTooLarge(size_t size)
 {
   return size >= static_cast<size_t>(UINT32_MAX) ||

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -57,11 +57,39 @@ bool RegisterPayloadSizeTooLarge(size_t size)
          size >= static_cast<size_t>(kHpmSpiTransferCountMax);
 }
 
+bool BufferRangesOverlap(const void* first, size_t first_size, const void* second,
+                         size_t second_size)
+{
+  if (first == nullptr || second == nullptr || first_size == 0U || second_size == 0U)
+  {
+    return false;
+  }
+
+  const uintptr_t first_addr = reinterpret_cast<uintptr_t>(first);
+  const uintptr_t second_addr = reinterpret_cast<uintptr_t>(second);
+  if (first_addr <= second_addr)
+  {
+    return static_cast<size_t>(second_addr - first_addr) < first_size;
+  }
+  return static_cast<size_t>(first_addr - second_addr) < second_size;
+}
+
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
 constexpr bool kHpmSpiDmaAddressSpaceSupported = sizeof(uintptr_t) <= sizeof(uint32_t);
 constexpr uint32_t kDmaBlockPending = 0U;
 constexpr uint32_t kDmaBlockSuccess = 1U;
 constexpr uint32_t kDmaBlockFailure = 2U;
+#if defined(HPMSOC_HAS_HPMSDK_DMAV2) && defined(DMAV2_CHCTRL_TRANSIZE_TRANSIZE_MASK) && \
+    defined(DMAV2_CHCTRL_TRANSIZE_TRANSIZE_SHIFT)
+constexpr uint32_t kHpmSpiDmaTransferCountMax = static_cast<uint32_t>(
+    DMAV2_CHCTRL_TRANSIZE_TRANSIZE_MASK >> DMAV2_CHCTRL_TRANSIZE_TRANSIZE_SHIFT);
+#elif defined(DMA_CHCTRL_TRANSIZE_TRANSIZE_MASK) && \
+    defined(DMA_CHCTRL_TRANSIZE_TRANSIZE_SHIFT)
+constexpr uint32_t kHpmSpiDmaTransferCountMax = static_cast<uint32_t>(
+    DMA_CHCTRL_TRANSIZE_TRANSIZE_MASK >> DMA_CHCTRL_TRANSIZE_TRANSIZE_SHIFT);
+#else
+constexpr uint32_t kHpmSpiDmaTransferCountMax = UINT32_MAX;
+#endif
 
 struct DmaRxBufferSelection
 {
@@ -443,7 +471,18 @@ void HPMSPI::RecoverController()
   }
 
   spi_reset(spi_);
-  if (spi_poll_reset_complete(spi_, spi_reset_spi, 5000U) != status_success)
+#if defined(SDK_VERSION_NUMBER) && (SDK_VERSION_NUMBER >= 0x010B00U)
+  const bool reset_complete =
+      spi_poll_reset_complete(spi_, spi_reset_spi, 5000U) == status_success;
+#else
+  uint32_t retry = 5000U;
+  while ((spi_->CTRL & SPI_CTRL_SPIRST_MASK) != 0U && retry > 0U)
+  {
+    --retry;
+  }
+  const bool reset_complete = (spi_->CTRL & SPI_CTRL_SPIRST_MASK) == 0U;
+#endif
+  if (!reset_complete)
   {
     configured_ = false;
     return;
@@ -500,63 +539,57 @@ ErrorCode HPMSPI::ApplyTiming(Prescaler prescaler)
 
 ErrorCode HPMSPI::SetConfig(SPI::Configuration config)
 {
+  if (!TryAcquireTransaction())
+  {
+    return ErrorCode::BUSY;
+  }
   if (spi_ == nullptr)
   {
-    return ErrorCode::PTR_NULL;
+    return EndTransaction(ErrorCode::PTR_NULL);
   }
-#if LIBXR_HPM_SPI_HAS_DMA_MGR
-  ErrorCode guard_ans = GuardNoDmaActive();
-  if (guard_ans != ErrorCode::OK)
-  {
-    return guard_ans;
-  }
-#endif
 
   const ErrorCode valid_ans = ValidateConfiguration(config);
   if (valid_ans != ErrorCode::OK)
   {
-    return valid_ans;
+    return EndTransaction(valid_ans);
   }
 
   ErrorCode ans = EnsureClockReady();
   if (ans != ErrorCode::OK)
   {
-    return ans;
+    return EndTransaction(ans);
   }
 
   ans = ApplyTiming(config.prescaler);
   if (ans != ErrorCode::OK)
   {
-    return ans;
+    return EndTransaction(ans);
   }
 
   ApplyFormat(config);
 
   GetConfig() = config;
   configured_ = true;
-  return ErrorCode::OK;
+  return EndTransaction(ErrorCode::OK);
 }
 
 ErrorCode HPMSPI::SetChipSelect(ChipSelect cs)
 {
-#if LIBXR_HPM_SPI_HAS_DMA_MGR
-  ErrorCode guard_ans = GuardNoDmaActive();
-  if (guard_ans != ErrorCode::OK)
+  if (!TryAcquireTransaction())
   {
-    return guard_ans;
+    return ErrorCode::BUSY;
   }
-#endif
 #if defined(HPM_IP_FEATURE_SPI_CS_SELECT) && (HPM_IP_FEATURE_SPI_CS_SELECT == 1)
   if (ConvertChipSelect(cs) == 0U)
   {
-    return ErrorCode::ARG_ERR;
+    return EndTransaction(ErrorCode::ARG_ERR);
   }
 
   cs_ = cs;
-  return ErrorCode::OK;
+  return EndTransaction(ErrorCode::OK);
 #else
   UNUSED(cs);
-  return ErrorCode::NOT_SUPPORT;
+  return EndTransaction(ErrorCode::NOT_SUPPORT);
 #endif
 }
 
@@ -566,39 +599,32 @@ SPI::Prescaler HPMSPI::GetMaxPrescaler() const { return Prescaler::DIV_256; }
 
 ErrorCode HPMSPI::SetDmaEnabled(bool enabled)
 {
-#if LIBXR_HPM_SPI_HAS_DMA_MGR
-  ErrorCode guard_ans = GuardNoDmaActive();
-  if (guard_ans != ErrorCode::OK)
+  if (!TryAcquireTransaction())
   {
-    return guard_ans;
+    return ErrorCode::BUSY;
   }
-
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
   if (!enabled)
   {
     dma_enabled_ = false;
-    return ErrorCode::OK;
+    return EndTransaction(ErrorCode::OK);
   }
 
   const ErrorCode ans = EnsureDmaReady();
   if (ans != ErrorCode::OK)
   {
-    return ans;
+    return EndTransaction(ans);
   }
 
   dma_enabled_ = true;
-  return ErrorCode::OK;
+  return EndTransaction(ErrorCode::OK);
 #else
   dma_enabled_ = false;
-  return enabled ? ErrorCode::NOT_SUPPORT : ErrorCode::OK;
+  return EndTransaction(enabled ? ErrorCode::NOT_SUPPORT : ErrorCode::OK);
 #endif
 }
 
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
-ErrorCode HPMSPI::GuardNoDmaActive() const
-{
-  return DmaTransferActive() ? ErrorCode::BUSY : ErrorCode::OK;
-}
-
 ErrorCode HPMSPI::ConvertDmaStatus(hpm_stat_t status)
 {
   switch (status)
@@ -618,6 +644,12 @@ ErrorCode HPMSPI::ConvertDmaStatus(hpm_stat_t status)
 
 ErrorCode HPMSPI::EnsureDmaReady()
 {
+#if defined(HPM_CORE1)
+  if (read_csr(CSR_MHARTID) != HPM_CORE0)
+  {
+    return ErrorCode::NOT_SUPPORT;
+  }
+#endif
   if (!kHpmSpiDmaAddressSpaceSupported)
   {
     return ErrorCode::NOT_SUPPORT;
@@ -859,6 +891,10 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   {
     return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
   }
+  if (kind == DmaTransferKind::WRITE_READ && BufferRangesOverlap(rx, size, tx, size))
+  {
+    return FinishOperation(op, in_isr, ErrorCode::ARG_ERR);
+  }
   if ((kind == DmaTransferKind::READ_ONLY || kind == DmaTransferKind::WRITE_READ) &&
       rx_capacity < size)
   {
@@ -877,6 +913,12 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
     }
   }
 
+  if (size > kHpmSpiDmaTransferCountMax)
+  {
+    return RunBlockingStreamTransfer(rx, tx, size, kind, user_read, copy_rx_to_user,
+                                     switch_buffer_on_success, op, in_isr);
+  }
+
   uint8_t* dma_rx = rx;
   bool copy_rx_to_staging = false;
   if (kind == DmaTransferKind::READ_ONLY || kind == DmaTransferKind::WRITE_READ)
@@ -892,6 +934,11 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
       return RunBlockingStreamTransfer(rx, tx, size, kind, user_read, copy_rx_to_user,
                                        switch_buffer_on_success, op, in_isr);
     }
+  }
+  if (kind == DmaTransferKind::WRITE_READ && BufferRangesOverlap(dma_rx, size, tx, size))
+  {
+    return RunBlockingStreamTransfer(rx, tx, size, kind, user_read, copy_rx_to_user,
+                                     switch_buffer_on_success, op, in_isr);
   }
 #if LIBXR_HPM_SPI_DMA_BLOCK_WAIT_REQUIRES_TIMEBASE
   if (op.type == OperationRW::OperationType::BLOCK && !Timebase::IsReady())
@@ -965,6 +1012,10 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
       dma_block_wait_.Cancel();
     }
     AbortDmaStart();
+    if (ShouldRecover(status))
+    {
+      RecoverController();
+    }
     return FinishOperation(op, in_isr, ans);
   }
 
@@ -978,10 +1029,12 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
 ErrorCode HPMSPI::WaitForDmaBlockResult(uint32_t timeout)
 {
   const ErrorCode ans = dma_block_wait_.Wait(timeout);
-  if (ans == ErrorCode::OK && DmaTransferActive() &&
-      dma_ctx_.block_dma_ready.load(std::memory_order_acquire) == kDmaBlockSuccess)
+  if (ans == ErrorCode::OK && DmaTransferActive())
   {
-    return CompleteDmaTransfer(false, ErrorCode::OK, false);
+    const uint32_t dma_result = dma_ctx_.block_dma_ready.load(std::memory_order_acquire);
+    const ErrorCode final_ans =
+        (dma_result == kDmaBlockSuccess) ? ErrorCode::OK : ErrorCode::FAILED;
+    return CompleteDmaTransfer(false, final_ans, false);
   }
   if (ans != ErrorCode::OK && DmaTransferActive())
   {
@@ -1153,10 +1206,11 @@ void HPMSPI::OnDmaFailureCallback(DMA_Type* base, uint32_t channel, void* cb_dat
     return;
   }
 
-  uint32_t expected = kDmaBlockPending;
-  if (self->dma_ctx_.block_dma_ready.compare_exchange_strong(expected, kDmaBlockFailure,
-                                                             std::memory_order_acq_rel,
-                                                             std::memory_order_acquire))
+  // DMA manager dispatches TC before ERROR/ABORT when flags share one IRQ, so
+  // failure must be allowed to replace an already published success result.
+  const uint32_t previous = self->dma_ctx_.block_dma_ready.exchange(
+      kDmaBlockFailure, std::memory_order_acq_rel);
+  if (previous == kDmaBlockPending)
   {
     (void)self->dma_block_wait_.TryPost(true, ErrorCode::FAILED);
   }
@@ -1176,6 +1230,10 @@ ErrorCode HPMSPI::DoTransfer(uint8_t* rx, const uint8_t* tx, uint32_t size)
   if (size > kHpmSpiTransferCountMax)
   {
     return ErrorCode::SIZE_ERR;
+  }
+  if (BufferRangesOverlap(rx, size, tx, size))
+  {
+    return ErrorCode::ARG_ERR;
   }
 
   spi_control_config_t control = MakeControlConfig(spi_trans_write_read_together);
@@ -1295,34 +1353,37 @@ ErrorCode HPMSPI::DoCommandWriteRead(uint8_t command, const uint8_t* tx, uint32_
 ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
                                OperationRW& op, bool in_isr)
 {
-#if LIBXR_HPM_SPI_HAS_DMA_MGR
-  ErrorCode guard_ans = GuardNoDmaActive();
-  if (guard_ans != ErrorCode::OK)
+  if (!TryAcquireTransaction())
   {
-    return FinishOperation(op, in_isr, guard_ans);
+    return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
-#endif
 
   const size_t need = std::max(read_data.size_, write_data.size_);
   if (need == 0)
   {
-    return FinishOperation(op, in_isr, ErrorCode::OK);
+    return EndTransaction(op, in_isr, ErrorCode::OK);
   }
   if (!configured_)
   {
-    return FinishOperation(op, in_isr, ErrorCode::INIT_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::INIT_ERR);
   }
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  if (dma_enabled_ && (op.type != OperationRW::OperationType::BLOCK || in_isr))
+  {
+    return EndTransaction(op, in_isr, ErrorCode::NOT_SUPPORT);
+  }
+#endif
   if (read_data.size_ > 0 && read_data.addr_ == nullptr)
   {
-    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    return EndTransaction(op, in_isr, ErrorCode::PTR_NULL);
   }
   if (write_data.size_ > 0 && write_data.addr_ == nullptr)
   {
-    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    return EndTransaction(op, in_isr, ErrorCode::PTR_NULL);
   }
   if (TransferSizeTooLarge(need))
   {
-    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::SIZE_ERR);
   }
 
   RawData rx = {nullptr, 0};
@@ -1331,11 +1392,11 @@ ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
     rx = GetRxBuffer();
     if (rx.addr_ == nullptr)
     {
-      return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+      return EndTransaction(op, in_isr, ErrorCode::PTR_NULL);
     }
     if (rx.size_ < need)
     {
-      return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+      return EndTransaction(op, in_isr, ErrorCode::SIZE_ERR);
     }
   }
 
@@ -1346,11 +1407,11 @@ ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
     tx = GetTxBuffer();
     if (tx.addr_ == nullptr)
     {
-      return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+      return EndTransaction(op, in_isr, ErrorCode::PTR_NULL);
     }
     if (tx.size_ < need)
     {
-      return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+      return EndTransaction(op, in_isr, ErrorCode::SIZE_ERR);
     }
 
     tx_bytes = static_cast<uint8_t*>(tx.addr_);
@@ -1376,10 +1437,11 @@ ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
       kind = DmaTransferKind::READ_ONLY;
     }
 
-    return StartDmaTransfer((read_data.size_ > 0) ? rx_bytes : nullptr,
-                            (write_data.size_ > 0) ? tx_bytes : nullptr,
-                            static_cast<uint32_t>(need), rx.size_, kind, read_data,
-                            read_data.size_ > 0, true, op, in_isr);
+    const ErrorCode ans = StartDmaTransfer(
+        (read_data.size_ > 0) ? rx_bytes : nullptr,
+        (write_data.size_ > 0) ? tx_bytes : nullptr, static_cast<uint32_t>(need),
+        rx.size_, kind, read_data, read_data.size_ > 0, true, op, in_isr);
+    return EndTransaction(ans);
   }
 #endif
 
@@ -1406,7 +1468,7 @@ ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
   {
     SwitchBuffer();
   }
-  return FinishOperation(op, in_isr, ans);
+  return EndTransaction(op, in_isr, ans);
 }
 
 ErrorCode HPMSPI::CommandRead(uint8_t command, RawData read_data, OperationRW& op,
@@ -1417,10 +1479,6 @@ ErrorCode HPMSPI::CommandRead(uint8_t command, RawData read_data, OperationRW& o
     UNUSED(command);
     return FinishOperation(op, in_isr, ErrorCode::OK);
   }
-  if (!configured_)
-  {
-    return FinishOperation(op, in_isr, ErrorCode::INIT_ERR);
-  }
 
   return CommandWriteRead(command, ConstRawData(nullptr, 0), read_data, op, in_isr);
 }
@@ -1428,30 +1486,27 @@ ErrorCode HPMSPI::CommandRead(uint8_t command, RawData read_data, OperationRW& o
 ErrorCode HPMSPI::CommandWriteRead(uint8_t command, ConstRawData write_data,
                                    RawData read_data, OperationRW& op, bool in_isr)
 {
-#if LIBXR_HPM_SPI_HAS_DMA_MGR
-  ErrorCode guard_ans = GuardNoDmaActive();
-  if (guard_ans != ErrorCode::OK)
+  if (!TryAcquireTransaction())
   {
-    return FinishOperation(op, in_isr, guard_ans);
+    return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
-#endif
 
   if (!configured_)
   {
-    return FinishOperation(op, in_isr, ErrorCode::INIT_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::INIT_ERR);
   }
 
   if (write_data.size_ > 0 && write_data.addr_ == nullptr)
   {
-    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    return EndTransaction(op, in_isr, ErrorCode::PTR_NULL);
   }
   if (read_data.size_ > 0 && read_data.addr_ == nullptr)
   {
-    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    return EndTransaction(op, in_isr, ErrorCode::PTR_NULL);
   }
   if (TransferSizeTooLarge(write_data.size_) || TransferSizeTooLarge(read_data.size_))
   {
-    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::SIZE_ERR);
   }
 
   uint8_t* rx_bytes = nullptr;
@@ -1462,11 +1517,11 @@ ErrorCode HPMSPI::CommandWriteRead(uint8_t command, ConstRawData write_data,
     RawData tx = GetTxBuffer();
     if (tx.addr_ == nullptr)
     {
-      return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+      return EndTransaction(op, in_isr, ErrorCode::PTR_NULL);
     }
     if (tx.size_ < write_data.size_)
     {
-      return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+      return EndTransaction(op, in_isr, ErrorCode::SIZE_ERR);
     }
 
     auto* tx_buffer = static_cast<uint8_t*>(tx.addr_);
@@ -1482,17 +1537,17 @@ ErrorCode HPMSPI::CommandWriteRead(uint8_t command, ConstRawData write_data,
     {
       SwitchBuffer();
     }
-    return FinishOperation(op, in_isr, ans);
+    return EndTransaction(op, in_isr, ans);
   }
 
   RawData rx = GetRxBuffer();
   if (rx.addr_ == nullptr)
   {
-    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    return EndTransaction(op, in_isr, ErrorCode::PTR_NULL);
   }
   if (rx.size_ < read_data.size_)
   {
-    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::SIZE_ERR);
   }
 
   rx_bytes = static_cast<uint8_t*>(rx.addr_);
@@ -1504,50 +1559,54 @@ ErrorCode HPMSPI::CommandWriteRead(uint8_t command, ConstRawData write_data,
     Memory::FastMove(read_data.addr_, rx_bytes, read_data.size_);
     SwitchBuffer();
   }
-  return FinishOperation(op, in_isr, ans);
+  return EndTransaction(op, in_isr, ans);
 }
 
 ErrorCode HPMSPI::Transfer(size_t size, OperationRW& op, bool in_isr)
 {
-#if LIBXR_HPM_SPI_HAS_DMA_MGR
-  ErrorCode guard_ans = GuardNoDmaActive();
-  if (guard_ans != ErrorCode::OK)
+  if (!TryAcquireTransaction())
   {
-    return FinishOperation(op, in_isr, guard_ans);
+    return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
-#endif
 
   if (size == 0)
   {
-    return FinishOperation(op, in_isr, ErrorCode::OK);
+    return EndTransaction(op, in_isr, ErrorCode::OK);
   }
   if (!configured_)
   {
-    return FinishOperation(op, in_isr, ErrorCode::INIT_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::INIT_ERR);
   }
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  if (dma_enabled_ && (op.type != OperationRW::OperationType::BLOCK || in_isr))
+  {
+    return EndTransaction(op, in_isr, ErrorCode::NOT_SUPPORT);
+  }
+#endif
   if (TransferSizeTooLarge(size))
   {
-    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::SIZE_ERR);
   }
 
   RawData rx = GetRxBuffer();
   RawData tx = GetTxBuffer();
   if (rx.addr_ == nullptr || tx.addr_ == nullptr)
   {
-    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    return EndTransaction(op, in_isr, ErrorCode::PTR_NULL);
   }
   if (rx.size_ < size || tx.size_ < size)
   {
-    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::SIZE_ERR);
   }
 
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
   if (dma_enabled_)
   {
-    return StartDmaTransfer(static_cast<uint8_t*>(rx.addr_),
-                            static_cast<uint8_t*>(tx.addr_), static_cast<uint32_t>(size),
-                            rx.size_, DmaTransferKind::WRITE_READ, RawData(nullptr, 0),
-                            false, true, op, in_isr);
+    const ErrorCode ans = StartDmaTransfer(
+        static_cast<uint8_t*>(rx.addr_), static_cast<uint8_t*>(tx.addr_),
+        static_cast<uint32_t>(size), rx.size_, DmaTransferKind::WRITE_READ,
+        RawData(nullptr, 0), false, true, op, in_isr);
+    return EndTransaction(ans);
   }
 #endif
 
@@ -1558,39 +1617,36 @@ ErrorCode HPMSPI::Transfer(size_t size, OperationRW& op, bool in_isr)
   {
     SwitchBuffer();
   }
-  return FinishOperation(op, in_isr, ans);
+  return EndTransaction(op, in_isr, ans);
 }
 
 ErrorCode HPMSPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bool in_isr)
 {
-#if LIBXR_HPM_SPI_HAS_DMA_MGR
-  ErrorCode guard_ans = GuardNoDmaActive();
-  if (guard_ans != ErrorCode::OK)
+  if (!TryAcquireTransaction())
   {
-    return FinishOperation(op, in_isr, guard_ans);
+    return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
-#endif
 
   if (read_data.size_ == 0)
   {
-    return FinishOperation(op, in_isr, ErrorCode::OK);
+    return EndTransaction(op, in_isr, ErrorCode::OK);
   }
   if (!configured_)
   {
-    return FinishOperation(op, in_isr, ErrorCode::INIT_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::INIT_ERR);
   }
   if (read_data.addr_ == nullptr)
   {
-    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    return EndTransaction(op, in_isr, ErrorCode::PTR_NULL);
   }
   if ((reg & static_cast<uint16_t>(~kSpiRegisterAddressMask)) != 0U)
   {
-    return FinishOperation(op, in_isr, ErrorCode::OUT_OF_RANGE);
+    return EndTransaction(op, in_isr, ErrorCode::OUT_OF_RANGE);
   }
 
   if (RegisterPayloadSizeTooLarge(read_data.size_))
   {
-    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::SIZE_ERR);
   }
 
   const size_t total = read_data.size_ + 1U;
@@ -1598,11 +1654,11 @@ ErrorCode HPMSPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bool
   RawData tx = GetTxBuffer();
   if (rx.addr_ == nullptr || tx.addr_ == nullptr)
   {
-    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    return EndTransaction(op, in_isr, ErrorCode::PTR_NULL);
   }
   if (rx.size_ < total || tx.size_ < total)
   {
-    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::SIZE_ERR);
   }
 
   auto* rx_bytes = static_cast<uint8_t*>(rx.addr_);
@@ -1620,47 +1676,44 @@ ErrorCode HPMSPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bool
   {
     SwitchBuffer();
   }
-  return FinishOperation(op, in_isr, ans);
+  return EndTransaction(op, in_isr, ans);
 }
 
 ErrorCode HPMSPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW& op,
                            bool in_isr)
 {
-#if LIBXR_HPM_SPI_HAS_DMA_MGR
-  ErrorCode guard_ans = GuardNoDmaActive();
-  if (guard_ans != ErrorCode::OK)
+  if (!TryAcquireTransaction())
   {
-    return FinishOperation(op, in_isr, guard_ans);
+    return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
-#endif
 
   if (!configured_)
   {
-    return FinishOperation(op, in_isr, ErrorCode::INIT_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::INIT_ERR);
   }
 
   if ((reg & static_cast<uint16_t>(~kSpiRegisterAddressMask)) != 0U)
   {
-    return FinishOperation(op, in_isr, ErrorCode::OUT_OF_RANGE);
+    return EndTransaction(op, in_isr, ErrorCode::OUT_OF_RANGE);
   }
   if (write_data.size_ > 0 && write_data.addr_ == nullptr)
   {
-    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    return EndTransaction(op, in_isr, ErrorCode::PTR_NULL);
   }
   if (RegisterPayloadSizeTooLarge(write_data.size_))
   {
-    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::SIZE_ERR);
   }
 
   const size_t total = write_data.size_ + 1U;
   RawData tx = GetTxBuffer();
   if (tx.addr_ == nullptr)
   {
-    return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    return EndTransaction(op, in_isr, ErrorCode::PTR_NULL);
   }
   if (tx.size_ < total)
   {
-    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::SIZE_ERR);
   }
 
   auto* tx_bytes = static_cast<uint8_t*>(tx.addr_);
@@ -1675,7 +1728,7 @@ ErrorCode HPMSPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW& o
   {
     SwitchBuffer();
   }
-  return FinishOperation(op, in_isr, ans);
+  return EndTransaction(op, in_isr, ans);
 }
 
 #else

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -228,7 +228,25 @@ spi_sclk_sampling_clk_edges_t HPMSPI::ConvertPhase(ClockPhase phase)
 
 ErrorCode HPMSPI::ValidateConfiguration(const Configuration& config) const
 {
-  const uint32_t div = SPI::PrescalerToDiv(config.prescaler);
+  const ErrorCode prescaler_ans = ValidatePrescaler(config.prescaler);
+  if (prescaler_ans != ErrorCode::OK)
+  {
+    return prescaler_ans;
+  }
+
+  if (config.double_buffer &&
+      ((rx_buffer_capacity_ < 2U) || (tx_buffer_capacity_ < 2U) ||
+       ((rx_buffer_capacity_ / 2U) == 0U) || ((tx_buffer_capacity_ / 2U) == 0U)))
+  {
+    return ErrorCode::SIZE_ERR;
+  }
+
+  return ErrorCode::OK;
+}
+
+ErrorCode HPMSPI::ValidatePrescaler(Prescaler prescaler)
+{
+  const uint32_t div = SPI::PrescalerToDiv(prescaler);
   if (div == 0U)
   {
     return ErrorCode::ARG_ERR;
@@ -245,13 +263,6 @@ ErrorCode HPMSPI::ValidateConfiguration(const Configuration& config) const
   if (div != 1U && ((div & 0x1U) != 0U || div > 510U))
   {
     return ErrorCode::NOT_SUPPORT;
-  }
-
-  if (config.double_buffer &&
-      ((rx_buffer_capacity_ < 2U) || (tx_buffer_capacity_ < 2U) ||
-       ((rx_buffer_capacity_ / 2U) == 0U) || ((tx_buffer_capacity_ / 2U) == 0U)))
-  {
-    return ErrorCode::SIZE_ERR;
   }
 
   return ErrorCode::OK;
@@ -341,15 +352,10 @@ void HPMSPI::RecoverController()
 
 ErrorCode HPMSPI::ApplyTiming(Prescaler prescaler)
 {
-  const uint32_t div = SPI::PrescalerToDiv(prescaler);
-  if (div == 0U)
+  const ErrorCode prescaler_ans = ValidatePrescaler(prescaler);
+  if (prescaler_ans != ErrorCode::OK)
   {
-    return ErrorCode::ARG_ERR;
-  }
-
-  if (div != 1U && ((div & 0x1U) != 0U || div > 510U))
-  {
-    return ErrorCode::NOT_SUPPORT;
+    return prescaler_ans;
   }
 
   const ErrorCode clock_ans = EnsureClockReady();
@@ -358,11 +364,7 @@ ErrorCode HPMSPI::ApplyTiming(Prescaler prescaler)
     return clock_ans;
   }
 
-  if (div > SPI::PrescalerToDiv(Prescaler::DIV_256))
-  {
-    return ErrorCode::NOT_SUPPORT;
-  }
-
+  const uint32_t div = SPI::PrescalerToDiv(prescaler);
   spi_timing_config_t timing{};
   spi_master_get_default_timing_config(&timing);
   timing.master_config.clk_src_freq_in_hz = source_clock_hz_;
@@ -383,9 +385,10 @@ ErrorCode HPMSPI::SetConfig(SPI::Configuration config)
     return ErrorCode::PTR_NULL;
   }
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
-  if (DmaTransferActive())
+  ErrorCode guard_ans = GuardNoDmaActive();
+  if (guard_ans != ErrorCode::OK)
   {
-    return ErrorCode::BUSY;
+    return guard_ans;
   }
 #endif
 
@@ -417,9 +420,10 @@ ErrorCode HPMSPI::SetConfig(SPI::Configuration config)
 ErrorCode HPMSPI::SetChipSelect(ChipSelect cs)
 {
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
-  if (DmaTransferActive())
+  ErrorCode guard_ans = GuardNoDmaActive();
+  if (guard_ans != ErrorCode::OK)
   {
-    return ErrorCode::BUSY;
+    return guard_ans;
   }
 #endif
 #if defined(HPM_IP_FEATURE_SPI_CS_SELECT) && (HPM_IP_FEATURE_SPI_CS_SELECT == 1)
@@ -443,9 +447,10 @@ SPI::Prescaler HPMSPI::GetMaxPrescaler() const { return Prescaler::DIV_256; }
 ErrorCode HPMSPI::SetDmaEnabled(bool enabled)
 {
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
-  if (DmaTransferActive())
+  ErrorCode guard_ans = GuardNoDmaActive();
+  if (guard_ans != ErrorCode::OK)
   {
-    return ErrorCode::BUSY;
+    return guard_ans;
   }
 
   if (!enabled)
@@ -469,6 +474,11 @@ ErrorCode HPMSPI::SetDmaEnabled(bool enabled)
 }
 
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
+ErrorCode HPMSPI::GuardNoDmaActive() const
+{
+  return DmaTransferActive() ? ErrorCode::BUSY : ErrorCode::OK;
+}
+
 ErrorCode HPMSPI::ConvertDmaStatus(hpm_stat_t status)
 {
   switch (status)
@@ -937,9 +947,10 @@ ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
                                OperationRW& op, bool in_isr)
 {
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
-  if (DmaTransferActive())
+  ErrorCode guard_ans = GuardNoDmaActive();
+  if (guard_ans != ErrorCode::OK)
   {
-    return FinishOperation(op, in_isr, ErrorCode::BUSY);
+    return FinishOperation(op, in_isr, guard_ans);
   }
 #endif
 
@@ -1042,9 +1053,10 @@ ErrorCode HPMSPI::CommandWriteRead(uint8_t command, ConstRawData write_data,
                                    RawData read_data, OperationRW& op, bool in_isr)
 {
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
-  if (DmaTransferActive())
+  ErrorCode guard_ans = GuardNoDmaActive();
+  if (guard_ans != ErrorCode::OK)
   {
-    return FinishOperation(op, in_isr, ErrorCode::BUSY);
+    return FinishOperation(op, in_isr, guard_ans);
   }
 #endif
 
@@ -1118,9 +1130,10 @@ ErrorCode HPMSPI::CommandWriteRead(uint8_t command, ConstRawData write_data,
 ErrorCode HPMSPI::Transfer(size_t size, OperationRW& op, bool in_isr)
 {
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
-  if (DmaTransferActive())
+  ErrorCode guard_ans = GuardNoDmaActive();
+  if (guard_ans != ErrorCode::OK)
   {
-    return FinishOperation(op, in_isr, ErrorCode::BUSY);
+    return FinishOperation(op, in_isr, guard_ans);
   }
 #endif
 
@@ -1167,9 +1180,10 @@ ErrorCode HPMSPI::Transfer(size_t size, OperationRW& op, bool in_isr)
 ErrorCode HPMSPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bool in_isr)
 {
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
-  if (DmaTransferActive())
+  ErrorCode guard_ans = GuardNoDmaActive();
+  if (guard_ans != ErrorCode::OK)
   {
-    return FinishOperation(op, in_isr, ErrorCode::BUSY);
+    return FinishOperation(op, in_isr, guard_ans);
   }
 #endif
 
@@ -1225,9 +1239,10 @@ ErrorCode HPMSPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW& o
                            bool in_isr)
 {
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
-  if (DmaTransferActive())
+  ErrorCode guard_ans = GuardNoDmaActive();
+  if (guard_ans != ErrorCode::OK)
   {
-    return FinishOperation(op, in_isr, ErrorCode::BUSY);
+    return FinishOperation(op, in_isr, guard_ans);
   }
 #endif
 
@@ -1311,6 +1326,12 @@ bool HPMSPI::ShouldRecover(LibXRHpmSpiStatusType status)
 ErrorCode HPMSPI::ValidateConfiguration(const Configuration& config) const
 {
   UNUSED(config);
+  return ErrorCode::NOT_SUPPORT;
+}
+
+ErrorCode HPMSPI::ValidatePrescaler(Prescaler prescaler)
+{
+  UNUSED(prescaler);
   return ErrorCode::NOT_SUPPORT;
 }
 

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -748,6 +748,10 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   {
     return FinishOperation(op, in_isr, ErrorCode::OK);
   }
+  if (size > kHpmSpiTransferCountMax)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+  }
   if (DmaTransferActive())
   {
     return FinishOperation(op, in_isr, ErrorCode::BUSY);

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -1206,12 +1206,12 @@ ErrorCode HPMSPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bool
     return FinishOperation(op, in_isr, ErrorCode::OUT_OF_RANGE);
   }
 
-  const size_t total = read_data.size_ + 1;
-  if (total > kHpmSpiTransferCountMax)
+  if (read_data.size_ > (static_cast<size_t>(kHpmSpiTransferCountMax) - 1U))
   {
     return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
   }
 
+  const size_t total = read_data.size_ + 1U;
   RawData rx = GetRxBuffer();
   RawData tx = GetTxBuffer();
   if (rx.addr_ == nullptr || tx.addr_ == nullptr)
@@ -1252,7 +1252,6 @@ ErrorCode HPMSPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW& o
   }
 #endif
 
-  const size_t total = write_data.size_ + 1;
   if ((reg & static_cast<uint16_t>(~kSpiRegisterAddressMask)) != 0U)
   {
     return FinishOperation(op, in_isr, ErrorCode::OUT_OF_RANGE);
@@ -1261,11 +1260,12 @@ ErrorCode HPMSPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW& o
   {
     return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
   }
-  if (total > kHpmSpiTransferCountMax)
+  if (write_data.size_ > (static_cast<size_t>(kHpmSpiTransferCountMax) - 1U))
   {
     return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
   }
 
+  const size_t total = write_data.size_ + 1U;
   RawData tx = GetTxBuffer();
   if (tx.addr_ == nullptr)
   {

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <limits>
 
 #if __has_include("board.h")
 #include "board.h"
@@ -55,6 +56,12 @@ bool RegisterPayloadSizeTooLarge(size_t size)
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
 constexpr bool kHpmSpiDmaAddressSpaceSupported = sizeof(uintptr_t) <= sizeof(uint32_t);
 
+struct DmaRxBufferSelection
+{
+  uint8_t* dma_rx = nullptr;
+  bool copy_to_staging = false;
+};
+
 #if LIBXR_HPM_SPI_HAS_L1C
 bool ResolveDCacheRange(const void* addr, uint32_t size, uint32_t& start,
                         uint32_t& aligned_size)
@@ -91,6 +98,17 @@ bool ResolveDCacheRange(const void* addr, uint32_t size, uint32_t& start,
   aligned_size = static_cast<uint32_t>(range_size);
   return aligned_size > 0U;
 }
+
+size_t RoundUpDCacheLine(size_t size)
+{
+  constexpr size_t line_size = HPM_L1C_CACHELINE_SIZE;
+  if (line_size == 0U || size > std::numeric_limits<size_t>::max() - (line_size - 1U))
+  {
+    return 0U;
+  }
+
+  return ((size + line_size - 1U) / line_size) * line_size;
+}
 #endif
 
 bool DCacheRangeIsLineExclusive(const void* addr, size_t capacity)
@@ -112,6 +130,62 @@ bool DCacheRangeIsLineExclusive(const void* addr, size_t capacity)
   UNUSED(addr);
   UNUSED(capacity);
   return true;
+#endif
+}
+
+bool SelectDmaRxBuffer(uint8_t* rx, size_t capacity, uint32_t size,
+                       DmaRxBufferSelection& selection)
+{
+  selection = {};
+  if (rx == nullptr || size == 0U || capacity < size)
+  {
+    return false;
+  }
+  if (DCacheRangeIsLineExclusive(rx, capacity))
+  {
+    selection.dma_rx = rx;
+    return true;
+  }
+
+#if LIBXR_HPM_SPI_HAS_L1C
+  if (!l1c_dc_is_enabled())
+  {
+    selection.dma_rx = rx;
+    return true;
+  }
+
+  const uintptr_t start = reinterpret_cast<uintptr_t>(rx);
+  const uintptr_t aligned =
+      (start + HPM_L1C_CACHELINE_SIZE - 1U) &
+      ~(static_cast<uintptr_t>(HPM_L1C_CACHELINE_SIZE) - 1U);
+  if (aligned < start)
+  {
+    return false;
+  }
+
+  const size_t offset = static_cast<size_t>(aligned - start);
+  if (offset > capacity)
+  {
+    return false;
+  }
+
+  const size_t aligned_size = RoundUpDCacheLine(size);
+  if (aligned_size == 0U)
+  {
+    return false;
+  }
+
+  const size_t aligned_capacity = capacity - offset;
+  if (aligned_capacity < aligned_size)
+  {
+    return false;
+  }
+
+  selection.dma_rx = reinterpret_cast<uint8_t*>(aligned);
+  selection.copy_to_staging = selection.dma_rx != rx;
+  return true;
+#else
+  return false;
 #endif
 }
 
@@ -573,10 +647,12 @@ void HPMSPI::ClearDmaContext()
   dma_ctx_.kind = DmaTransferKind::NONE;
   dma_ctx_.op = nullptr;
   dma_ctx_.rx = nullptr;
+  dma_ctx_.staging_rx = nullptr;
   dma_ctx_.tx = nullptr;
   dma_ctx_.user_read = {nullptr, 0};
   dma_ctx_.size = 0U;
   dma_ctx_.copy_rx_to_user = false;
+  dma_ctx_.copy_rx_to_staging = false;
   dma_ctx_.switch_buffer_on_success = false;
   dma_ctx_.block_dma_ready.store(0U, std::memory_order_release);
   dma_ctx_.rx_done.store(0U, std::memory_order_release);
@@ -625,6 +701,42 @@ bool HPMSPI::DmaRxBufferCacheSafe(const void* addr, size_t capacity)
   return DCacheRangeIsLineExclusive(addr, capacity);
 }
 
+ErrorCode HPMSPI::RunBlockingStreamTransfer(uint8_t* rx, const uint8_t* tx,
+                                            uint32_t size, DmaTransferKind kind,
+                                            RawData user_read, bool copy_rx_to_user,
+                                            bool switch_buffer_on_success,
+                                            OperationRW& op, bool in_isr)
+{
+  ErrorCode ans = ErrorCode::FAILED;
+  switch (kind)
+  {
+    case DmaTransferKind::READ_ONLY:
+      ans = DoReadOnly(rx, size);
+      break;
+    case DmaTransferKind::WRITE_ONLY:
+      ans = DoWriteOnly(tx, size);
+      break;
+    case DmaTransferKind::WRITE_READ:
+      ans = DoTransfer(rx, tx, size);
+      break;
+    case DmaTransferKind::NONE:
+    default:
+      ans = ErrorCode::ARG_ERR;
+      break;
+  }
+
+  if (ans == ErrorCode::OK && copy_rx_to_user && user_read.addr_ != nullptr &&
+      user_read.size_ > 0U)
+  {
+    Memory::FastCopy(user_read.addr_, rx, user_read.size_);
+  }
+  if (ans == ErrorCode::OK && switch_buffer_on_success)
+  {
+    SwitchBuffer();
+  }
+  return FinishOperation(op, in_isr, ans);
+}
+
 ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
                                    size_t rx_capacity, DmaTransferKind kind,
                                    RawData user_read, bool copy_rx_to_user,
@@ -664,11 +776,7 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   {
     return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
   }
-  if ((kind == DmaTransferKind::READ_ONLY || kind == DmaTransferKind::WRITE_READ) &&
-      !DmaRxBufferCacheSafe(rx, rx_capacity))
-  {
-    return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
-  }
+
   if (copy_rx_to_user)
   {
     if (user_read.size_ > size)
@@ -678,6 +786,23 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
     if (user_read.size_ > 0U && user_read.addr_ == nullptr)
     {
       return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+    }
+  }
+
+  uint8_t* dma_rx = rx;
+  bool copy_rx_to_staging = false;
+  if (kind == DmaTransferKind::READ_ONLY || kind == DmaTransferKind::WRITE_READ)
+  {
+    DmaRxBufferSelection rx_selection;
+    if (SelectDmaRxBuffer(rx, rx_capacity, size, rx_selection))
+    {
+      dma_rx = rx_selection.dma_rx;
+      copy_rx_to_staging = rx_selection.copy_to_staging;
+    }
+    else
+    {
+      return RunBlockingStreamTransfer(rx, tx, size, kind, user_read, copy_rx_to_user,
+                                       switch_buffer_on_success, op, in_isr);
     }
   }
 #if LIBXR_HPM_SPI_DMA_BLOCK_WAIT_REQUIRES_TIMEBASE
@@ -697,11 +822,13 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   ClearDmaContext();
   dma_ctx_.kind = kind;
   dma_ctx_.op = &op;
-  dma_ctx_.rx = rx;
+  dma_ctx_.rx = dma_rx;
+  dma_ctx_.staging_rx = rx;
   dma_ctx_.tx = tx;
   dma_ctx_.user_read = user_read;
   dma_ctx_.size = size;
   dma_ctx_.copy_rx_to_user = copy_rx_to_user;
+  dma_ctx_.copy_rx_to_staging = copy_rx_to_staging;
   dma_ctx_.switch_buffer_on_success = switch_buffer_on_success;
   dma_completion_claim_.store(0U, std::memory_order_release);
 
@@ -715,10 +842,10 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   {
     FlushDCacheIfNeeded(tx, size);
   }
-  if (rx != nullptr &&
+  if (dma_rx != nullptr &&
       (kind == DmaTransferKind::READ_ONLY || kind == DmaTransferKind::WRITE_READ))
   {
-    InvalidateDCacheIfNeeded(rx, size);
+    InvalidateDCacheIfNeeded(dma_rx, size);
   }
 
   ApplyChipSelect();
@@ -727,13 +854,13 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   switch (kind)
   {
     case DmaTransferKind::READ_ONLY:
-      status = hpm_spi_receive_nonblocking(spi_, rx, size);
+      status = hpm_spi_receive_nonblocking(spi_, dma_rx, size);
       break;
     case DmaTransferKind::WRITE_ONLY:
       status = hpm_spi_transmit_nonblocking(spi_, tx, size);
       break;
     case DmaTransferKind::WRITE_READ:
-      status = hpm_spi_transmit_receive_nonblocking(spi_, tx, rx, size);
+      status = hpm_spi_transmit_receive_nonblocking(spi_, tx, dma_rx, size);
       break;
     case DmaTransferKind::NONE:
     default:
@@ -822,9 +949,11 @@ ErrorCode HPMSPI::CompleteDmaTransfer(bool in_isr, ErrorCode ans, bool notify_bl
   DmaTransferKind kind = dma_ctx_.kind;
   OperationRW* op = dma_ctx_.op;
   uint8_t* rx = dma_ctx_.rx;
+  uint8_t* staging_rx = dma_ctx_.staging_rx;
   const uint32_t size = dma_ctx_.size;
   const RawData user_read = dma_ctx_.user_read;
   const bool copy_rx_to_user = dma_ctx_.copy_rx_to_user;
+  const bool copy_rx_to_staging = dma_ctx_.copy_rx_to_staging;
   const bool switch_buffer_on_success = dma_ctx_.switch_buffer_on_success;
   bool dma_stopped = false;
 
@@ -851,10 +980,18 @@ ErrorCode HPMSPI::CompleteDmaTransfer(bool in_isr, ErrorCode ans, bool notify_bl
     InvalidateDCacheIfNeeded(rx, size);
   }
 
+  uint8_t* readable_rx = rx;
+  if (ans == ErrorCode::OK && copy_rx_to_staging && staging_rx != nullptr &&
+      rx != nullptr)
+  {
+    Memory::FastMove(staging_rx, rx, size);
+    readable_rx = staging_rx;
+  }
+
   if (ans == ErrorCode::OK && copy_rx_to_user && user_read.addr_ != nullptr &&
       user_read.size_ > 0U)
   {
-    Memory::FastCopy(user_read.addr_, rx, user_read.size_);
+    Memory::FastCopy(user_read.addr_, readable_rx, user_read.size_);
   }
   if (ans == ErrorCode::OK && switch_buffer_on_success)
   {

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -53,14 +53,13 @@ bool RegisterPayloadSizeTooLarge(size_t size)
 }
 
 #if LIBXR_HPM_SPI_HAS_DMA_MGR
-static_assert(sizeof(uintptr_t) <= sizeof(uint32_t),
-              "HPM SPI DMA helper assumes a 32-bit address space.");
+constexpr bool kHpmSpiDmaAddressSpaceSupported = sizeof(uintptr_t) <= sizeof(uint32_t);
 
 #if LIBXR_HPM_SPI_HAS_L1C
 bool ResolveDCacheRange(const void* addr, uint32_t size, uint32_t& start,
                         uint32_t& aligned_size)
 {
-  if (addr == nullptr || size == 0U)
+  if (!kHpmSpiDmaAddressSpaceSupported || addr == nullptr || size == 0U)
   {
     start = 0U;
     aligned_size = 0U;
@@ -93,6 +92,28 @@ bool ResolveDCacheRange(const void* addr, uint32_t size, uint32_t& start,
   return aligned_size > 0U;
 }
 #endif
+
+bool DCacheRangeIsLineExclusive(const void* addr, size_t capacity)
+{
+#if LIBXR_HPM_SPI_HAS_L1C
+  if (addr == nullptr || capacity == 0U)
+  {
+    return false;
+  }
+  if (!l1c_dc_is_enabled())
+  {
+    return true;
+  }
+
+  const uintptr_t address = reinterpret_cast<uintptr_t>(addr);
+  return (address % HPM_L1C_CACHELINE_SIZE) == 0U &&
+         (capacity % HPM_L1C_CACHELINE_SIZE) == 0U;
+#else
+  UNUSED(addr);
+  UNUSED(capacity);
+  return true;
+#endif
+}
 
 void FlushDCacheIfNeeded(const void* addr, uint32_t size)
 {
@@ -508,6 +529,10 @@ ErrorCode HPMSPI::ConvertDmaStatus(hpm_stat_t status)
 
 ErrorCode HPMSPI::EnsureDmaReady()
 {
+  if (!kHpmSpiDmaAddressSpaceSupported)
+  {
+    return ErrorCode::NOT_SUPPORT;
+  }
   if (dma_ready_)
   {
     return ErrorCode::OK;
@@ -553,6 +578,7 @@ void HPMSPI::ClearDmaContext()
   dma_ctx_.size = 0U;
   dma_ctx_.copy_rx_to_user = false;
   dma_ctx_.switch_buffer_on_success = false;
+  dma_ctx_.block_dma_ready.store(0U, std::memory_order_release);
   dma_ctx_.rx_done.store(0U, std::memory_order_release);
   dma_ctx_.tx_done.store(0U, std::memory_order_release);
 }
@@ -594,10 +620,16 @@ bool HPMSPI::TryClaimDmaCompletion()
       expected, 1U, std::memory_order_acq_rel, std::memory_order_acquire);
 }
 
+bool HPMSPI::DmaRxBufferCacheSafe(const void* addr, size_t capacity)
+{
+  return DCacheRangeIsLineExclusive(addr, capacity);
+}
+
 ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
-                                   DmaTransferKind kind, RawData user_read,
-                                   bool copy_rx_to_user, bool switch_buffer_on_success,
-                                   OperationRW& op, bool in_isr)
+                                   size_t rx_capacity, DmaTransferKind kind,
+                                   RawData user_read, bool copy_rx_to_user,
+                                   bool switch_buffer_on_success, OperationRW& op,
+                                   bool in_isr)
 {
   if (size == 0U)
   {
@@ -606,6 +638,14 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   if (DmaTransferActive())
   {
     return FinishOperation(op, in_isr, ErrorCode::BUSY);
+  }
+  if (op.type != OperationRW::OperationType::BLOCK)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
+  }
+  if (!kHpmSpiDmaAddressSpaceSupported)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
   }
   if (kind == DmaTransferKind::READ_ONLY && rx == nullptr)
   {
@@ -618,6 +658,16 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   if (kind == DmaTransferKind::WRITE_READ && (rx == nullptr || tx == nullptr))
   {
     return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
+  }
+  if ((kind == DmaTransferKind::READ_ONLY || kind == DmaTransferKind::WRITE_READ) &&
+      rx_capacity < size)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+  }
+  if ((kind == DmaTransferKind::READ_ONLY || kind == DmaTransferKind::WRITE_READ) &&
+      !DmaRxBufferCacheSafe(rx, rx_capacity))
+  {
+    return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
   }
   if (copy_rx_to_user)
   {
@@ -665,6 +715,11 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   {
     FlushDCacheIfNeeded(tx, size);
   }
+  if (rx != nullptr &&
+      (kind == DmaTransferKind::READ_ONLY || kind == DmaTransferKind::WRITE_READ))
+  {
+    InvalidateDCacheIfNeeded(rx, size);
+  }
 
   ApplyChipSelect();
 
@@ -707,9 +762,14 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
 ErrorCode HPMSPI::WaitForDmaBlockResult(uint32_t timeout)
 {
   const ErrorCode ans = dma_block_wait_.Wait(timeout);
+  if (ans == ErrorCode::OK && DmaTransferActive() &&
+      dma_ctx_.block_dma_ready.load(std::memory_order_acquire) != 0U)
+  {
+    return CompleteDmaTransfer(false, ErrorCode::OK, false);
+  }
   if (ans == ErrorCode::TIMEOUT && DmaTransferActive())
   {
-    CompleteDmaTransfer(false, ErrorCode::TIMEOUT);
+    (void)CompleteDmaTransfer(false, ErrorCode::TIMEOUT);
   }
   return ans;
 }
@@ -741,15 +801,22 @@ void HPMSPI::MaybeCompleteDmaTransfer(bool in_isr)
 
   if (ready)
   {
-    CompleteDmaTransfer(in_isr, ErrorCode::OK);
+    if (dma_ctx_.op != nullptr && dma_ctx_.op->type == OperationRW::OperationType::BLOCK)
+    {
+      dma_ctx_.block_dma_ready.store(1U, std::memory_order_release);
+      (void)dma_block_wait_.TryPost(in_isr, ErrorCode::OK);
+      return;
+    }
+
+    (void)CompleteDmaTransfer(in_isr, ErrorCode::OK);
   }
 }
 
-void HPMSPI::CompleteDmaTransfer(bool in_isr, ErrorCode ans)
+ErrorCode HPMSPI::CompleteDmaTransfer(bool in_isr, ErrorCode ans, bool notify_block)
 {
   if (!TryClaimDmaCompletion())
   {
-    return;
+    return ErrorCode::BUSY;
   }
 
   DmaTransferKind kind = dma_ctx_.kind;
@@ -767,7 +834,7 @@ void HPMSPI::CompleteDmaTransfer(bool in_isr, ErrorCode ans)
     dma_stopped = true;
   }
 
-  if (ans == ErrorCode::OK && !in_isr)
+  if (ans == ErrorCode::OK)
   {
     const hpm_stat_t idle_status = spi_wait_for_idle_status(spi_);
     ans = ConvertStatus(idle_status);
@@ -804,12 +871,17 @@ void HPMSPI::CompleteDmaTransfer(bool in_isr, ErrorCode ans)
 
   if (op != nullptr && op->type == OperationRW::OperationType::BLOCK)
   {
-    (void)dma_block_wait_.TryPost(in_isr, ans);
+    if (notify_block)
+    {
+      (void)dma_block_wait_.TryPost(in_isr, ans);
+    }
   }
   else if (op != nullptr)
   {
     op->UpdateStatus(in_isr, ans);
   }
+
+  return ans;
 }
 
 void HPMSPI::OnRxDmaTcCallback(DMA_Type* base, uint32_t channel, void* cb_data_ptr)
@@ -1033,7 +1105,7 @@ ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
 
     return StartDmaTransfer((read_data.size_ > 0) ? rx_bytes : nullptr,
                             (write_data.size_ > 0) ? tx_bytes : nullptr,
-                            static_cast<uint32_t>(need), kind, read_data,
+                            static_cast<uint32_t>(need), rx.size_, kind, read_data,
                             read_data.size_ > 0, true, op, in_isr);
   }
 #endif
@@ -1188,8 +1260,8 @@ ErrorCode HPMSPI::Transfer(size_t size, OperationRW& op, bool in_isr)
   {
     return StartDmaTransfer(static_cast<uint8_t*>(rx.addr_),
                             static_cast<uint8_t*>(tx.addr_), static_cast<uint32_t>(size),
-                            DmaTransferKind::WRITE_READ, RawData(nullptr, 0), false, true,
-                            op, in_isr);
+                            rx.size_, DmaTransferKind::WRITE_READ, RawData(nullptr, 0),
+                            false, true, op, in_isr);
   }
 #endif
 

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -159,9 +159,8 @@ bool SelectDmaRxBuffer(uint8_t* rx, size_t capacity, uint32_t size,
   }
 
   const uintptr_t start = reinterpret_cast<uintptr_t>(rx);
-  const uintptr_t aligned =
-      (start + HPM_L1C_CACHELINE_SIZE - 1U) &
-      ~(static_cast<uintptr_t>(HPM_L1C_CACHELINE_SIZE) - 1U);
+  const uintptr_t aligned = (start + HPM_L1C_CACHELINE_SIZE - 1U) &
+                            ~(static_cast<uintptr_t>(HPM_L1C_CACHELINE_SIZE) - 1U);
   if (aligned < start)
   {
     return false;
@@ -706,9 +705,9 @@ bool HPMSPI::DmaRxBufferCacheSafe(const void* addr, size_t capacity)
   return DCacheRangeIsLineExclusive(addr, capacity);
 }
 
-ErrorCode HPMSPI::RunBlockingStreamTransfer(uint8_t* rx, const uint8_t* tx,
-                                            uint32_t size, DmaTransferKind kind,
-                                            RawData user_read, bool copy_rx_to_user,
+ErrorCode HPMSPI::RunBlockingStreamTransfer(uint8_t* rx, const uint8_t* tx, uint32_t size,
+                                            DmaTransferKind kind, RawData user_read,
+                                            bool copy_rx_to_user,
                                             bool switch_buffer_on_success,
                                             OperationRW& op, bool in_isr)
 {

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -9,6 +9,13 @@
 #include "board.h"
 #endif
 
+#if defined(LIBXR_SYSTEM_none) || defined(LIBXR_SYSTEM_webasm)
+#include "timebase.hpp"
+#define LIBXR_HPM_SPI_DMA_BLOCK_WAIT_REQUIRES_TIMEBASE 1
+#else
+#define LIBXR_HPM_SPI_DMA_BLOCK_WAIT_REQUIRES_TIMEBASE 0
+#endif
+
 #if LIBXR_HPM_SPI_HAS_DMA_MGR && __has_include("hpm_l1c_drv.h")
 #include "hpm_l1c_drv.h"
 #define LIBXR_HPM_SPI_HAS_L1C 1
@@ -592,6 +599,12 @@ ErrorCode HPMSPI::StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
   {
     return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
   }
+#if LIBXR_HPM_SPI_DMA_BLOCK_WAIT_REQUIRES_TIMEBASE
+  if (op.type == OperationRW::OperationType::BLOCK && !Timebase::IsReady())
+  {
+    return FinishOperation(op, in_isr, ErrorCode::INIT_ERR);
+  }
+#endif
 
   ErrorCode ans = EnsureDmaReady();
   if (ans != ErrorCode::OK)

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -452,6 +452,7 @@ void HPMSPI::RecoverController()
     }
 
     ApplyFormat(config);
+    ApplyChipSelect();
   }
 }
 

--- a/driver/hpm/hpm_spi.cpp
+++ b/driver/hpm/hpm_spi.cpp
@@ -1058,6 +1058,10 @@ ErrorCode HPMSPI::ReadAndWrite(RawData read_data, ConstRawData write_data,
   {
     return FinishOperation(op, in_isr, ErrorCode::OK);
   }
+  if (!configured_)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::INIT_ERR);
+  }
   if (read_data.size_ > 0 && read_data.addr_ == nullptr)
   {
     return FinishOperation(op, in_isr, ErrorCode::PTR_NULL);
@@ -1144,6 +1148,10 @@ ErrorCode HPMSPI::CommandRead(uint8_t command, RawData read_data, OperationRW& o
     UNUSED(command);
     return FinishOperation(op, in_isr, ErrorCode::OK);
   }
+  if (!configured_)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::INIT_ERR);
+  }
 
   return CommandWriteRead(command, ConstRawData(nullptr, 0), read_data, op, in_isr);
 }
@@ -1158,6 +1166,11 @@ ErrorCode HPMSPI::CommandWriteRead(uint8_t command, ConstRawData write_data,
     return FinishOperation(op, in_isr, guard_ans);
   }
 #endif
+
+  if (!configured_)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::INIT_ERR);
+  }
 
   if (write_data.size_ > 0 && write_data.addr_ == nullptr)
   {
@@ -1239,6 +1252,10 @@ ErrorCode HPMSPI::Transfer(size_t size, OperationRW& op, bool in_isr)
   {
     return FinishOperation(op, in_isr, ErrorCode::OK);
   }
+  if (!configured_)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::INIT_ERR);
+  }
   if (TransferSizeTooLarge(size))
   {
     return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
@@ -1288,6 +1305,10 @@ ErrorCode HPMSPI::MemRead(uint16_t reg, RawData read_data, OperationRW& op, bool
   if (read_data.size_ == 0)
   {
     return FinishOperation(op, in_isr, ErrorCode::OK);
+  }
+  if (!configured_)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::INIT_ERR);
   }
   if (read_data.addr_ == nullptr)
   {
@@ -1343,6 +1364,11 @@ ErrorCode HPMSPI::MemWrite(uint16_t reg, ConstRawData write_data, OperationRW& o
     return FinishOperation(op, in_isr, guard_ans);
   }
 #endif
+
+  if (!configured_)
+  {
+    return FinishOperation(op, in_isr, ErrorCode::INIT_ERR);
+  }
 
   if ((reg & static_cast<uint16_t>(~kSpiRegisterAddressMask)) != 0U)
   {

--- a/driver/hpm/hpm_spi.hpp
+++ b/driver/hpm/hpm_spi.hpp
@@ -1,0 +1,716 @@
+#pragma once
+
+/**
+ * @file hpm_spi.hpp
+ * @brief HPM SPI 主机驱动适配头文件 / Adapter header for the HPM SPI master driver.
+ *
+ * @details
+ * 本文件在 HPM SDK `hpm_spi_drv` 之上实现 LibXR `SPI` 抽象，默认采用阻塞式
+ * master 传输，并可在工程启用 `USE_DMA_MGR=1` 时为普通 data-phase 流式传输打开
+ * HPM SDK SPI component DMA manager 路径。驱动把 CPOL/CPHA、分频、8-bit 命令式
+ * 寄存器访问、SPI flash command phase helper 和 SDK 状态码映射到 LibXR API。
+ * 多系列兼容依赖 `HPMSOC_HAS_HPMSDK_SPI`、`__has_include("hpm_spi_drv.h")`、
+ * 构造参数传入的实例/clock，以及 `SPI_SOC_TRANSFER_COUNT_MAX` 等 SDK header
+ * 限制宏；真实片选、波形和错误恢复仍需 board 级验证。
+ *
+ * This file implements the LibXR `SPI` abstraction on top of the HPM SDK
+ * `hpm_spi_drv` APIs. The default backend uses blocking master transfers, and
+ * projects built with `USE_DMA_MGR=1` may explicitly enable the HPM SDK SPI
+ * component DMA-manager path for regular data-phase stream transfers. The driver
+ * maps CPOL/CPHA, prescaler selection, 8-bit command-style register access,
+ * SPI-flash command-phase helpers, and SDK status codes into the LibXR API.
+ * Multi-series compatibility relies on `HPMSOC_HAS_HPMSDK_SPI`,
+ * `__has_include("hpm_spi_drv.h")`, constructor-provided instance/clock values,
+ * and SDK header limit macros such as `SPI_SOC_TRANSFER_COUNT_MAX`; real
+ * chip-select behavior, waveforms, and error recovery still require board-level
+ * validation.
+ */
+
+#include <atomic>
+
+#include "hpm_clock_drv.h"
+#include "hpm_soc.h"
+#include "spi.hpp"
+
+#if defined(HPMSOC_HAS_HPMSDK_SPI) && __has_include("hpm_spi_drv.h")
+#include "hpm_spi_drv.h"
+#define LIBXR_HPM_SPI_SUPPORTED 1
+using LibXRHpmSpiType = SPI_Type;
+using LibXRHpmSpiStatusType = hpm_stat_t;
+#else
+#define LIBXR_HPM_SPI_SUPPORTED 0
+using LibXRHpmSpiType = void;
+using LibXRHpmSpiStatusType = int;
+#endif
+
+#if LIBXR_HPM_SPI_SUPPORTED && defined(USE_DMA_MGR) && (USE_DMA_MGR) && \
+    __has_include("hpm_spi.h") && __has_include("hpm_dma_mgr.h")
+#include "hpm_spi.h"
+#define LIBXR_HPM_SPI_HAS_DMA_MGR 1
+#else
+#define LIBXR_HPM_SPI_HAS_DMA_MGR 0
+#endif
+
+namespace LibXR
+{
+
+/**
+ * @class HPMSPI
+ * @brief HPM SDK SPI 主机驱动，适配 LibXR SPI 接口 /
+ * HPM SDK based SPI master driver for the LibXR SPI interface.
+ *
+ * 该类持有一个 HPM SPI 外设实例，提供普通流式传输和简单寄存器式 SPI 访问。
+ * This class owns one HPM SPI peripheral instance and provides stream transfers
+ * and simple register-style SPI access.
+ *
+ * 默认实现调用 HPM SDK 阻塞式传输 API；显式调用 SetDmaEnabled(true) 后，
+ * ReadAndWrite() 和 Transfer() 会使用 HPM SDK SPI component 的 DMA manager
+ * nonblocking data-phase API，直到 DMA 回调完成前同一实例的其它事务会返回 BUSY。
+ * CommandRead()、CommandWriteRead()、MemRead() 和 MemWrite() 保持阻塞路径。
+ * The default implementation calls HPM SDK blocking transfer APIs. After
+ * SetDmaEnabled(true), ReadAndWrite() and Transfer() use the HPM SDK SPI component
+ * DMA-manager nonblocking data-phase APIs, and other transactions on the same
+ * instance return BUSY until the DMA callback completes. CommandRead(),
+ * CommandWriteRead(), MemRead(), and MemWrite() stay on the blocking path.
+ *
+ * 支持 LibXR 操作模式参数；默认同步完成，DMA 启用后仅流式传输可后台完成 /
+ * LibXR operation mode parameters are accepted; transfers complete synchronously
+ * by default, and only stream transfers may complete in the background when DMA is
+ * enabled:
+ * - BLOCK：直接返回最终 ErrorCode，不触发回调或状态更新 /
+ *   BLOCK: returns the final ErrorCode directly without callback/status update.
+ * - POLLING：同步路径返回前更新为 DONE/ERROR；DMA 路径先标记
+ * RUNNING，再在完成回调中更新。 POLLING: synchronous paths update DONE/ERROR before
+ * return; DMA paths mark RUNNING first and update in the completion callback.
+ * - CALLBACK：同步路径返回前执行回调；DMA 路径在完成回调中执行，并透传 in_isr 标志。
+ *   CALLBACK: synchronous paths invoke the callback before return; DMA paths invoke
+ *   it from the completion callback and forward the in_isr flag.
+ * - NONE：同步路径只返回最终 ErrorCode；DMA 路径只负责后台清理，不产生额外通知。
+ *   NONE: synchronous paths only return the final ErrorCode; DMA paths only clean up
+ *   the background transaction without extra notification.
+ *
+ * 多系列适配依赖构造参数传入的 `SPI_Type*`/`clock_name_t`、HPM SDK
+ * `SPI_SOC_TRANSFER_COUNT_MAX` 传输上限，以及工程/board header 暴露的实例、IRQ、DMA
+ * 宏；驱动本身不按 HPM 系列名分叉。
+ * Multi-series adaptation relies on the constructor-provided `SPI_Type*` /
+ * `clock_name_t`, the HPM SDK `SPI_SOC_TRANSFER_COUNT_MAX` transfer limit, and
+ * instance, IRQ, and DMA macros exposed by project or board headers. The driver
+ * itself does not branch by HPM series name.
+ *
+ * 编译期支持由 `HPMSOC_HAS_HPMSDK_SPI` 和 `__has_include("hpm_spi_drv.h")`
+ * 同时 gate；缺少能力宏或裁剪 SDK 头时仍保留 LibXR API 形状，但配置和传输接口返回
+ * `NOT_SUPPORT`，避免无 SPI SoC 或裁剪 SDK 的 glob 构建直接失败。
+ * Compile-time support is gated by both `HPMSOC_HAS_HPMSDK_SPI` and
+ * `__has_include("hpm_spi_drv.h")`. When the capability macro or trimmed SDK header
+ * is missing, the LibXR API shape remains available but configuration and transfer
+ * APIs return `NOT_SUPPORT`, avoiding direct glob-build failures on SoCs or trimmed
+ * SDKs without SPI.
+ *
+ * `SetChipSelect()`, `SetDmaEnabled()`, `IsDmaEnabled()`, `IsDmaSupported()`,
+ * `CommandRead()`, and `CommandWriteRead()` are HPM-specific convenience
+ * extensions. They are intentionally not part of the generic `SPI` virtual
+ * interface in `src/driver/spi.hpp`.
+ */
+class HPMSPI final : public SPI
+{
+ public:
+  /**
+   * @enum ChipSelect
+   * @brief 选择 HPM SPI 硬件片选线 / Select the HPM SPI hardware chip-select line.
+   *
+   * 该枚举只影响 HPM SPI 控制器的硬件 CS 输出。当工程使用 GPIO 手动片选时，
+   * 调用方仍应在一次完整事务外部拉低/拉高 GPIO CS。
+   * This enum affects only the HPM SPI controller hardware CS output. When a project
+   * uses a GPIO-managed chip select, the caller must still assert/deassert the GPIO
+   * around one complete logical transaction.
+   */
+  enum class ChipSelect : uint8_t
+  {
+    CS0 = 0,  ///< 硬件片选 0 / Hardware chip-select 0.
+    CS1,      ///< 硬件片选 1 / Hardware chip-select 1.
+    CS2,      ///< 硬件片选 2 / Hardware chip-select 2.
+    CS3       ///< 硬件片选 3 / Hardware chip-select 3.
+  };
+
+  /**
+   * @brief 构造 HPM SPI 主机对象 / Construct an HPM SPI master object.
+   * @param spi HPM SPI 外设基地址，不能为空 /
+   * HPM SPI peripheral base address. Must not be nullptr.
+   * @param clock HPM 时钟树名称；当板级 helper 未提供时用于开启并查询外设源时钟 /
+   * HPM clock name used to enable and query the peripheral source clock when the
+   * optional board helper does not provide one.
+   * @param rx_buffer 内部 RX 暂存缓冲区，供 ReadAndWrite()、Transfer()、MemRead()
+   * 使用；驱动生命周期内必须保持非空且有效 /
+   * Internal RX staging buffer used by ReadAndWrite(), Transfer(), and MemRead().
+   * It must remain non-null and valid for the driver lifetime.
+   * @param tx_buffer 内部 TX 暂存缓冲区，供所有传输接口使用；驱动生命周期内必须
+   * 保持非空且有效 / Internal TX staging buffer used by all transfer methods.
+   * It must remain non-null and valid for the driver lifetime.
+   * @param auto_board_init 若为 true 且存在 board.h，则自动调用板级 SPI 时钟和引脚
+   * 初始化 helper / If true and board.h is available, call board SPI clock and pin
+   * helper functions automatically.
+   * @param config 初始 SPI 配置；该驱动按 8-bit、MSB-first、single-I/O、master
+   * 模式配置硬件；HPM 后端当前支持 DIV_1 和不超过 DIV_256 的偶数分频 /
+   * Initial SPI configuration. This driver configures hardware as 8-bit,
+   * MSB-first, single-I/O master. The current HPM backend supports DIV_1 and
+   * even prescalers up to DIV_256.
+   * @param cs 硬件片选线；仅在 HPM SDK/SoC 暴露 `cs_index` 时写入控制寄存器 /
+   * Hardware chip-select line. It is written to the transfer control register only
+   * when the HPM SDK/SoC exposes `cs_index`.
+   *
+   * @note 构造函数会断言外设指针为空、暂存缓冲区为空、源时钟无法解析或初始配置无效 /
+   * The constructor asserts on null peripheral pointer, null/empty staging buffers,
+   * unresolved source clock, or invalid initial configuration.
+   */
+  HPMSPI(LibXRHpmSpiType* spi, clock_name_t clock, RawData rx_buffer, RawData tx_buffer,
+         bool auto_board_init = true,
+         SPI::Configuration config = {SPI::ClockPolarity::LOW, SPI::ClockPhase::EDGE_1,
+                                      SPI::Prescaler::DIV_4, false},
+         ChipSelect cs = ChipSelect::CS0);
+
+  /**
+   * @brief 传输 SPI 字节，并可同时采集接收数据 /
+   * Transfer SPI bytes while optionally collecting received bytes.
+   *
+   * 当读写缓冲区都非空时，实际传输长度取两者较大值，较短的写载荷由内部 TX
+   * 暂存缓冲区补 0。只有 read_data 非空时执行只读传输；只有 write_data 非空时
+   * 执行只写传输。
+   * When both buffers are non-empty, the transfer length is the larger size and the
+   * shorter write payload is padded with zero bytes in the internal TX staging buffer.
+   * If only read_data is non-empty, a read-only transfer is used; if only write_data
+   * is non-empty, a write-only transfer is used.
+   *
+   * @note 该流式接口不会自动丢弃命令阶段收到的前缀字节；W25Q128 `0x9F` 这类
+   * opcode-read 命令应使用 CommandRead() 或 CommandWriteRead()。
+   * This stream API does not discard bytes received during a command phase. Use
+   * CommandRead() or CommandWriteRead() for opcode-read commands such as W25Q128
+   * `0x9F`.
+   *
+   * @param read_data 目标缓冲区；size_ 为 0 表示不拷贝接收数据，非零长度时 addr_
+   * 必须非空 / Destination buffer. A zero-size buffer disables receive copy; for
+   * non-zero size, addr_ must be non-null.
+   * @param write_data 源缓冲区；size_ 为 0 表示不发送用户载荷，非零长度时 addr_
+   * 必须非空 / Source buffer. A zero-size buffer disables user transmit payload; for
+   * non-zero size, addr_ must be non-null.
+   * @param op LibXR 读写操作描述符，见类注释中的操作模式说明 /
+   * LibXR read/write operation descriptor. See class-level operation mode notes.
+   * @param in_isr 仅用于 CALLBACK/POLLING 完成分发的中断上下文标志 /
+   * ISR-context flag forwarded only to CALLBACK/POLLING completion handling.
+   * @return 成功返回 OK，包括读写长度都为 0 的情况；空用户缓冲区返回 PTR_NULL；
+   * 传输长度超过 SPI_SOC_TRANSFER_COUNT_MAX 或内部暂存缓冲区容量返回 SIZE_ERR；
+   * 其余返回 HPM SDK 状态转换后的 TIMEOUT、BUSY 或 FAILED /
+   * Returns OK on success, including when both sizes are zero; PTR_NULL for null
+   * non-empty user buffer; SIZE_ERR when the effective length exceeds
+   * SPI_SOC_TRANSFER_COUNT_MAX or staging buffer capacity; otherwise converted HPM
+   * SDK status such as TIMEOUT, BUSY, or FAILED.
+   */
+  ErrorCode ReadAndWrite(RawData read_data, ConstRawData write_data, OperationRW& op,
+                         bool in_isr = false) override;
+
+  /**
+   * @brief 应用 SPI 格式和时序配置 / Apply SPI format and timing configuration.
+   * @param config 目标时钟极性、相位、分频和双缓冲标志 /
+   * Desired clock polarity, phase, prescaler, and double-buffer flag.
+   * @return 成功返回 OK；外设指针为空返回 PTR_NULL；源时钟无法解析返回 INIT_ERR；
+   * 分频无效或计算出的 SCLK 为 0 返回 ARG_ERR；超过 DIV_256 返回 NOT_SUPPORT；
+   * 其余返回 HPM SDK 时序配置状态 /
+   * Returns OK on success, PTR_NULL for null peripheral pointer, INIT_ERR when source
+   * clock cannot be resolved, ARG_ERR for invalid prescaler or zero SCLK, NOT_SUPPORT
+   * beyond DIV_256, or converted HPM SDK timing status otherwise.
+   */
+  ErrorCode SetConfig(SPI::Configuration config) override;
+
+  /**
+   * @brief 设置后续传输使用的硬件片选线 /
+   * Set the hardware chip-select line used by subsequent transfers.
+   *
+   * @param cs 目标硬件 CS0..CS3 / Target hardware CS0..CS3.
+   * @return 成功返回 OK；当前 SDK/SoC 未暴露硬件 CS 选择时返回 NOT_SUPPORT /
+   * Returns OK on success, or NOT_SUPPORT when the current SDK/SoC does not expose
+   * hardware CS selection.
+   *
+   * @note 该函数只更新驱动内部选择，实际 CS 字段在下一次构造 HPM transfer control
+   * 时写入；不要在传输期间调用。
+   * This function only updates the driver's stored selection. The HPM transfer
+   * control register is programmed on the next transfer; do not call it while a
+   * transfer is active.
+   *
+   * @note 如果当前 SoC/SDK 不暴露 `cs_index`，构造函数传入的 CS
+   * 只会被保存，硬件传输不会使用它； SetChipSelect() 将返回 NOT_SUPPORT。/ If the current
+   * SoC/SDK does not expose `cs_index`, the constructor-provided CS is only stored and is
+   * not applied to hardware transfers; SetChipSelect() returns NOT_SUPPORT.
+   */
+  ErrorCode SetChipSelect(ChipSelect cs);
+
+  /**
+   * @brief 获取当前硬件片选线 / Get the current hardware chip-select line.
+   * @return 当前配置的硬件 CS / Current configured hardware CS.
+   */
+  ChipSelect GetChipSelect() const { return cs_; }
+
+  /**
+   * @brief 启用或关闭 HPM SPI DMA manager 路径 /
+   * Enable or disable the HPM SPI DMA-manager path.
+   *
+   * DMA 路径仅在工程启用 `USE_DMA_MGR=1` 且 HPM SDK 提供 `hpm_spi.h`
+   * 组件 API 时可用。它只覆盖普通 data-phase 流式传输，即 ReadAndWrite() 和
+   * Transfer()；CommandRead() / CommandWriteRead() 仍使用 HPM SDK command phase
+   * 阻塞传输，以保持 SPI flash opcode-read 时序。
+   *
+   * The DMA path is available only when the project builds with `USE_DMA_MGR=1`
+   * and the HPM SDK `hpm_spi.h` component APIs are present. It covers regular
+   * data-phase stream transfers through ReadAndWrite() and Transfer() only.
+   * CommandRead() / CommandWriteRead() keep using the blocking HPM SDK command
+   * phase so SPI-flash opcode-read timing remains unchanged.
+   *
+   * @param enabled true 启用 DMA，false 回到同步阻塞路径 /
+   * true to enable DMA, false to use the synchronous blocking path.
+   * @return OK 表示状态已更新；BUSY 表示有后台 DMA 事务未完成；NOT_SUPPORT 表示
+   * 当前构建未提供 SPI DMA manager 支持 /
+   * OK when updated, BUSY while an async DMA transaction is active, or
+   * NOT_SUPPORT when this build does not provide SPI DMA-manager support.
+   */
+  ErrorCode SetDmaEnabled(bool enabled);
+
+  /**
+   * @brief 查询当前是否启用 DMA 流式传输 / Query whether DMA stream transfers are
+   * enabled.
+   * @return true 表示 ReadAndWrite()/Transfer() 会优先使用 DMA /
+   * true when ReadAndWrite()/Transfer() prefer DMA.
+   */
+  bool IsDmaEnabled() const { return dma_enabled_; }
+
+  /**
+   * @brief 查询当前构建是否支持 HPM SPI DMA manager /
+   * Query build-time HPM SPI DMA-manager support.
+   * @return true 表示可调用 SetDmaEnabled(true) /
+   * true when SetDmaEnabled(true) can succeed.
+   */
+  static constexpr bool IsDmaSupported() { return LIBXR_HPM_SPI_HAS_DMA_MGR != 0; }
+
+  /**
+   * @brief 发送 8-bit 命令后读取数据 / Read data after sending an 8-bit command.
+   *
+   * 该接口使用 HPM SDK 的 command phase：先在同一次硬件事务中发送 `command`，
+   * 再进入 read-only data phase 读取 `read_data.size_` 字节。它适合 SPI flash
+   * JEDEC ID、状态寄存器、电子 ID 等 opcode-read 命令，避免调用方手工拼接
+   * dummy 字节并丢弃前缀接收字节。
+   * This method uses the HPM SDK command phase: it sends `command` and then reads
+   * `read_data.size_` bytes in the read-only data phase of the same hardware
+   * transaction. It is intended for opcode-read commands such as SPI flash JEDEC ID,
+   * status-register, and electronic-ID reads, avoiding manual dummy bytes and prefix
+   * RX discard in the caller.
+   *
+   * 当工程使用 GPIO 手动片选时，调用方仍需在调用该函数外层包住一次完整 CS 低电平窗口。
+   * When GPIO chip select is used, the caller must still wrap this call in one full
+   * active CS window.
+   *
+   * @param command 8-bit 命令字节 / 8-bit command byte.
+   * @param read_data 接收缓冲区；size_ 为 0 时不访问总线并返回 OK /
+   * Destination buffer. A zero-size buffer completes with OK without bus access.
+   * @param op LibXR 读写操作描述符 / LibXR read/write operation descriptor.
+   * @param in_isr CALLBACK/POLLING 完成分发的中断上下文标志 /
+   * ISR-context flag forwarded to CALLBACK/POLLING completion handling.
+   * @return 成功返回 OK；空目标缓冲区返回 PTR_NULL；长度超过硬件限制或暂存缓冲区容量返回
+   * SIZE_ERR；其余返回 HPM SDK 状态转换后的错误码 /
+   * Returns OK on success, PTR_NULL for a null non-empty destination, SIZE_ERR when
+   * the read length exceeds hardware limits or staging capacity, or converted HPM SDK
+   * status otherwise.
+   */
+  ErrorCode CommandRead(uint8_t command, RawData read_data, OperationRW& op,
+                        bool in_isr = false);
+
+  /**
+   * @brief 发送 8-bit 命令后顺序写入并读取数据 /
+   * Write and then read data after sending an 8-bit command.
+   *
+   * 该接口把 `command` 放入 HPM SDK command phase，随后在 data phase 中按
+   * `write_data`、`read_data` 的存在情况选择 write-only、read-only、write-then-read
+   * 或 no-data 事务。它可覆盖 SPI flash 的 command-only、command+read、
+   * command+address-as-write-data+read 等常见命令模式；如需 dummy 字节，请把它们
+   * 放入 `write_data`，本 API 不配置硬件 dummy cycle。
+   * This method places `command` in the HPM SDK command phase, then selects
+   * write-only, read-only, write-then-read, or no-data transaction mode from the
+   * presence of `write_data` and `read_data`. It covers common SPI flash command
+   * shapes such as command-only, command+read, and command+address-as-write-data+read.
+   * If dummy bytes are required, include them in `write_data`; this API does not
+   * configure hardware dummy cycles.
+   *
+   * 当工程使用 GPIO 手动片选时，调用方仍需在调用该函数外层包住一次完整 CS 低电平窗口。
+   * When GPIO chip select is used, the caller must still wrap this call in one full
+   * active CS window.
+   *
+   * @param command 8-bit 命令字节 / 8-bit command byte.
+   * @param write_data 命令后的写入数据；size_ 为 0 时跳过写数据阶段 /
+   * Data written after the command. A zero-size buffer skips the write data phase.
+   * @param read_data 写入数据后的读取缓冲区；size_ 为 0 时跳过读数据阶段 /
+   * Destination buffer read after the write data phase. A zero-size buffer skips the
+   * read data phase.
+   * @param op LibXR 读写操作描述符 / LibXR read/write operation descriptor.
+   * @param in_isr CALLBACK/POLLING 完成分发的中断上下文标志 /
+   * ISR-context flag forwarded to CALLBACK/POLLING completion handling.
+   * @return 成功返回 OK；非零长度空缓冲区返回
+   * PTR_NULL；任一阶段长度超过硬件限制或暂存缓冲区容量返回 SIZE_ERR；其余返回 HPM SDK
+   * 状态转换后的错误码 / Returns OK on success, PTR_NULL for a null non-empty buffer,
+   * SIZE_ERR when either phase exceeds hardware limits or staging capacity, or converted
+   * HPM SDK status otherwise.
+   *
+   * @note command-only 和 write-then-read 路径依赖 HPM SPI command phase 以及对应
+   * transfer mode；较旧 SDK 若不支持这些模式，底层会返回 SDK 错误并映射为 LibXR
+   * ErrorCode。/ The command-only and write-then-read paths rely on the HPM SPI command
+   * phase and matching transfer modes. Older SDKs that do not implement those modes will
+   * return an SDK error that is converted to a LibXR ErrorCode.
+   */
+  ErrorCode CommandWriteRead(uint8_t command, ConstRawData write_data, RawData read_data,
+                             OperationRW& op, bool in_isr = false);
+
+  /**
+   * @brief 使用 8-bit 命令字节读取 SPI 寄存器 /
+   * Read bytes from an SPI register using an 8-bit command byte.
+   *
+   * 发送的命令字节为 static_cast<uint8_t>(reg | 0x80)：bit7 表示读操作，
+   * bit0..6 为寄存器地址，reg 高于 bit7 的位视为越界。
+   * The transmitted command byte is static_cast<uint8_t>(reg | 0x80): bit 7 marks
+   * a read operation and bits 0..6 carry the register address. Bits above bit 7 are
+   * treated as out of range.
+   *
+   * @param reg 寄存器地址；置读位前的有效范围为 0x00..0x7F /
+   * Register address. Effective range before applying the read bit is 0x00..0x7F.
+   * @param read_data 目标载荷缓冲区；size_ 为 0 时不访问总线并返回 OK；非零长度时
+   * addr_ 必须非空 / Destination payload buffer. A zero-size buffer completes with OK
+   * without bus access; for non-zero size, addr_ must be non-null.
+   * @param op LibXR 读写操作描述符，见类注释中的操作模式说明 /
+   * LibXR read/write operation descriptor. See class-level operation mode notes.
+   * @param in_isr 仅用于 CALLBACK/POLLING 完成分发的中断上下文标志 /
+   * ISR-context flag forwarded only to CALLBACK/POLLING completion handling.
+   * @return 成功返回 OK；空目标缓冲区返回 PTR_NULL；寄存器地址超过 0x7F 返回
+   * OUT_OF_RANGE；命令字节加载荷超过硬件限制或暂存缓冲区容量返回 SIZE_ERR；其余返回
+   * HPM SDK 状态转换后的错误码 / Returns OK on success, PTR_NULL for null non-empty
+   * destination, OUT_OF_RANGE for register addresses above 0x7F, SIZE_ERR when command
+   * byte plus payload exceeds hardware limit or staging capacity, or converted HPM SDK
+   * status otherwise.
+   * @note 该接口保留给“bit7 表示读写”的寄存器型 SPI 设备；它不是通用 SPI flash
+   * opcode-read API。读取 W25Q128 `0x9F` 这类命令应优先使用 CommandRead()。
+   * This method is kept for register-style SPI devices where bit 7 marks read/write.
+   * It is not a generic SPI flash opcode-read API; prefer CommandRead() for W25Q128
+   * commands such as `0x9F`.
+   */
+  ErrorCode MemRead(uint16_t reg, RawData read_data, OperationRW& op,
+                    bool in_isr = false) override;
+
+  /**
+   * @brief 使用 8-bit 命令字节写入 SPI 寄存器 /
+   * Write bytes to an SPI register using an 8-bit command byte.
+   *
+   * 发送的命令字节为 static_cast<uint8_t>(reg & 0x7F)：bit7 被清零表示写操作，
+   * bit0..6 为寄存器地址，reg 高于 bit7 的位视为越界。零长度载荷合法，只发送命令字节。
+   * The transmitted command byte is static_cast<uint8_t>(reg & 0x7F): bit 7 is
+   * cleared for write operation and bits 0..6 carry the register address. Bits above
+   * bit 7 are treated as out of range. A zero-size payload is valid and sends only the
+   * command byte.
+   *
+   * @param reg 寄存器地址；有效范围为 0x00..0x7F /
+   * Register address. Effective range is 0x00..0x7F.
+   * @param write_data 源载荷缓冲区；非零长度时 addr_ 必须非空 /
+   * Source payload buffer. For non-zero size, addr_ must be non-null.
+   * @param op LibXR 读写操作描述符，见类注释中的操作模式说明 /
+   * LibXR read/write operation descriptor. See class-level operation mode notes.
+   * @param in_isr 仅用于 CALLBACK/POLLING 完成分发的中断上下文标志 /
+   * ISR-context flag forwarded only to CALLBACK/POLLING completion handling.
+   * @return 成功返回 OK；空载荷指针返回 PTR_NULL；寄存器地址超过 0x7F 返回 OUT_OF_RANGE；
+   * 命令字节加载荷超过硬件限制或 TX 暂存缓冲区容量返回 SIZE_ERR；其余返回 HPM SDK
+   * 状态转换后的错误码 / Returns OK on success, PTR_NULL for null non-empty payload,
+   * OUT_OF_RANGE for register addresses above 0x7F, SIZE_ERR when command byte plus
+   * payload exceeds hardware limit or TX staging capacity, or converted HPM SDK status
+   * otherwise.
+   */
+  ErrorCode MemWrite(uint16_t reg, ConstRawData write_data, OperationRW& op,
+                     bool in_isr = false) override;
+
+  /**
+   * @brief 获取 SPI 源时钟频率，即理论最高总线速度 /
+   * Get SPI source clock frequency, the theoretical fastest bus speed.
+   * @return 源时钟频率，单位 Hz；成功解析时钟前为 0 /
+   * Source clock frequency in Hz, or 0 before successful clock discovery.
+   */
+  uint32_t GetMaxBusSpeed() const override;
+
+  /**
+   * @brief 获取该 HPM SPI 后端支持的最慢分频 /
+   * Get the slowest prescaler supported by this HPM SPI backend.
+   * @return Prescaler::DIV_256 / Prescaler::DIV_256.
+   */
+  Prescaler GetMaxPrescaler() const override;
+
+  /**
+   * @brief 从当前活动 TX 暂存缓冲区传输到 RX 暂存缓冲区 /
+   * Transfer from the active TX staging buffer into the RX staging buffer.
+   *
+   * 这是给已通过 GetTxBuffer() 准备数据的调用者使用的零拷贝路径。当前活动 RX/TX
+   * 暂存缓冲区都必须至少有 size 字节。传输结束后调用 SwitchBuffer()，使双缓冲用户
+   * 切换到另一组缓冲区；当前实现仅在传输成功后执行 SwitchBuffer()。
+   * This is the zero-copy path for callers that prepared data through GetTxBuffer().
+   * The active RX/TX staging buffers must both contain at least size bytes. After the
+   * transfer, SwitchBuffer() is called so double-buffer users advance to the other
+   * buffer pair; the current implementation switches only after successful transfer.
+   *
+   * @param size 传输字节数；0 合法并直接返回 OK；非零时不能超过
+   * SPI_SOC_TRANSFER_COUNT_MAX / Number of bytes to transfer. Zero is valid and
+   * completes with OK; non-zero size must not exceed SPI_SOC_TRANSFER_COUNT_MAX.
+   * @param op LibXR 读写操作描述符，见类注释中的操作模式说明 /
+   * LibXR read/write operation descriptor. See class-level operation mode notes.
+   * @param in_isr 仅用于 CALLBACK/POLLING 完成分发的中断上下文标志 /
+   * ISR-context flag forwarded only to CALLBACK/POLLING completion handling.
+   * @return 成功返回 OK；长度超过硬件限制或活动暂存缓冲区容量返回 SIZE_ERR；活动
+   * 暂存指针为空返回 PTR_NULL；其余返回 HPM SDK 状态转换后的错误码 /
+   * Returns OK on success, SIZE_ERR when size exceeds hardware limit or active staging
+   * capacity, PTR_NULL for null active staging pointer, or converted HPM SDK status
+   * otherwise.
+   */
+  ErrorCode Transfer(size_t size, OperationRW& op, bool in_isr = false) override;
+
+ private:
+  /**
+   * @brief 将 HPM SDK SPI 状态码转换为 LibXR 错误码 /
+   * Convert HPM SDK SPI status to LibXR ErrorCode.
+   */
+  static ErrorCode ConvertStatus(LibXRHpmSpiStatusType status);
+
+#if LIBXR_HPM_SPI_SUPPORTED
+  /**
+   * @brief 将片选枚举转换为 HPM SDK CS 掩码 / Convert chip-select enum to HPM SDK CS
+   * mask.
+   */
+  static uint8_t ConvertChipSelect(ChipSelect cs);
+#endif
+
+  /**
+   * @brief 转换 LibXR SPI 时钟极性到 HPM SDK 枚举 /
+   * Convert LibXR SPI clock polarity to HPM SDK enum.
+   */
+#if LIBXR_HPM_SPI_SUPPORTED
+  static spi_sclk_idle_state_t ConvertPolarity(ClockPolarity polarity);
+
+  /**
+   * @brief 转换 LibXR SPI 时钟相位到 HPM SDK 枚举 /
+   * Convert LibXR SPI clock phase to HPM SDK enum.
+   */
+  static spi_sclk_sampling_clk_edges_t ConvertPhase(ClockPhase phase);
+#endif
+
+  /**
+   * @brief 完成 LibXR 操作状态更新或回调 /
+   * Complete LibXR operation status update or callback dispatch.
+   */
+  template <typename Op>
+  static ErrorCode FinishOperation(Op& op, bool in_isr, ErrorCode ans)
+  {
+    if (op.type != Op::OperationType::BLOCK)
+    {
+      op.UpdateStatus(in_isr, ans);
+    }
+    return ans;
+  }
+
+  /**
+   * @brief 根据 LibXR 分频参数配置 HPM SPI 时序 /
+   * Configure HPM SPI timing from LibXR prescaler.
+   */
+  ErrorCode ApplyTiming(Prescaler prescaler);
+
+  /**
+   * @brief 校验 HPM SPI 配置参数 / Validate HPM SPI configuration.
+   */
+  ErrorCode ValidateConfiguration(const Configuration& config) const;
+
+  /**
+   * @brief 确保源时钟频率已可用 / Ensure the source clock frequency is available.
+   */
+  ErrorCode EnsureClockReady();
+
+  /**
+   * @brief 按当前 LibXR 配置写入 HPM SPI 格式寄存器 /
+   * Apply HPM SPI format registers from the current LibXR configuration.
+   */
+  void ApplyFormat(const Configuration& config);
+
+  /**
+   * @brief 构造一次普通主机传输的控制参数 /
+   * Build control configuration for a regular master transfer.
+   */
+#if LIBXR_HPM_SPI_SUPPORTED
+  spi_control_config_t MakeControlConfig(spi_trans_mode_t mode) const;
+
+  /**
+   * @brief 将已保存的硬件片选写入控制器 / Apply the stored hardware CS.
+   */
+  void ApplyChipSelect() const;
+#endif
+
+  /**
+   * @brief 判断失败后是否需要复位控制器 / Decide whether a failed transfer should
+   * recover the controller.
+   */
+  static bool ShouldRecover(LibXRHpmSpiStatusType status);
+
+  /**
+   * @brief 复位 HPM SPI 控制器并恢复上次成功配置 /
+   * Reset the HPM SPI controller and restore the last successful configuration.
+   */
+  void RecoverController();
+
+  /**
+   * @brief 执行全双工写读同时传输 / Execute full-duplex write-read transfer.
+   */
+  ErrorCode DoTransfer(uint8_t* rx, const uint8_t* tx, uint32_t size);
+
+  /**
+   * @brief 执行只写传输 / Execute write-only transfer.
+   */
+  ErrorCode DoWriteOnly(const uint8_t* tx, uint32_t size);
+
+  /**
+   * @brief 执行只读传输 / Execute read-only transfer.
+   */
+  ErrorCode DoReadOnly(uint8_t* rx, uint32_t size);
+
+  /**
+   * @brief 执行 command phase + read data phase 传输 /
+   * Execute a command-phase plus read data-phase transfer.
+   */
+  ErrorCode DoCommandRead(uint8_t command, uint8_t* rx, uint32_t size);
+
+  /**
+   * @brief 执行 command phase + write/read data phase 传输 /
+   * Execute a command-phase plus optional write/read data-phase transfer.
+   */
+  ErrorCode DoCommandWriteRead(uint8_t command, const uint8_t* tx, uint32_t tx_size,
+                               uint8_t* rx, uint32_t rx_size);
+
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  /**
+   * @brief HPM SPI DMA 后台事务类型 / HPM SPI DMA background transfer kind.
+   */
+  enum class DmaTransferKind : uint8_t
+  {
+    NONE,
+    READ_ONLY,
+    WRITE_ONLY,
+    WRITE_READ
+  };
+
+  /**
+   * @brief HPM SPI DMA 事务上下文 / HPM SPI DMA transfer context.
+   */
+  struct DmaTransferContext
+  {
+    DmaTransferKind kind = DmaTransferKind::NONE;
+    OperationRW op = {};
+    uint8_t* rx = nullptr;
+    uint8_t* tx = nullptr;
+    RawData user_read = {nullptr, 0};
+    uint32_t size = 0;
+    bool copy_rx_to_user = false;
+    bool switch_buffer_on_success = false;
+    std::atomic<uint32_t> rx_done{0U};
+    std::atomic<uint32_t> tx_done{0U};
+  };
+
+  /**
+   * @brief 将 DMA manager 状态码转换为 LibXR 错误码 /
+   * Convert DMA-manager status to LibXR ErrorCode.
+   */
+  static ErrorCode ConvertDmaStatus(hpm_stat_t status);
+
+  /**
+   * @brief 准备并安装 SPI DMA manager 回调 / Prepare and install SPI DMA-manager
+   * callbacks.
+   */
+  ErrorCode EnsureDmaReady();
+
+  /**
+   * @brief 查询当前是否有 DMA 后台事务 / Query whether a DMA transaction is active.
+   */
+  bool DmaTransferActive() const
+  {
+    return dma_busy_.load(std::memory_order_acquire) != 0U;
+  }
+
+  /**
+   * @brief 启动一次 data-phase DMA 传输 / Start one data-phase DMA transfer.
+   */
+  ErrorCode StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
+                             DmaTransferKind kind, RawData user_read,
+                             bool copy_rx_to_user, bool switch_buffer_on_success,
+                             OperationRW& op, bool in_isr);
+
+  /**
+   * @brief 停止当前 DMA 请求和通道 / Stop current DMA requests and channels.
+   */
+  void StopDmaTransfer();
+
+  /**
+   * @brief 清空 DMA 事务上下文 / Clear DMA transfer context.
+   */
+  void ClearDmaContext();
+
+  /**
+   * @brief 在 DMA 启动失败后回滚状态 / Roll back state after DMA start failure.
+   */
+  void AbortDmaStart();
+
+  /**
+   * @brief 等待 BLOCK 模式 DMA 结果 / Wait for a BLOCK-mode DMA result.
+   */
+  ErrorCode WaitForDmaBlockResult(uint32_t timeout);
+
+  /**
+   * @brief DMA 回调后检查事务是否完成 / Check whether DMA callbacks complete the
+   * transfer.
+   */
+  void MaybeCompleteDmaTransfer(bool in_isr);
+
+  /**
+   * @brief 完成并分发 DMA 事务结果 / Complete and dispatch a DMA transaction result.
+   */
+  void CompleteDmaTransfer(bool in_isr, ErrorCode ans);
+
+  /**
+   * @brief 抢占 DMA 完成所有权 / Claim single DMA completion ownership.
+   */
+  bool TryClaimDmaCompletion();
+
+  /**
+   * @brief RX DMA terminal-count callback / RX DMA 终端计数回调。
+   */
+  static void OnRxDmaTcCallback(DMA_Type* base, uint32_t channel, void* cb_data_ptr);
+
+  /**
+   * @brief TX DMA terminal-count callback / TX DMA 终端计数回调。
+   */
+  static void OnTxDmaTcCallback(DMA_Type* base, uint32_t channel, void* cb_data_ptr);
+#endif
+
+  LibXRHpmSpiType* spi_;           ///< SPI 外设实例 / SPI peripheral instance.
+  clock_name_t clock_;             ///< SPI 源时钟名称 / SPI source clock name.
+  uint32_t source_clock_hz_ = 0;   ///< 缓存的源时钟频率 / Cached source clock frequency.
+  size_t rx_buffer_capacity_ = 0;  ///< 原始 RX 缓冲区容量 / Raw RX buffer capacity.
+  size_t tx_buffer_capacity_ = 0;  ///< 原始 TX 缓冲区容量 / Raw TX buffer capacity.
+  bool configured_ = false;        ///< 是否已有成功配置 / Whether a config was applied.
+  bool dma_enabled_ =
+      false;  ///< 是否启用 DMA 流式传输 / Whether DMA stream path is enabled.
+#if LIBXR_HPM_SPI_HAS_DMA_MGR
+  bool dma_ready_ =
+      false;  ///< DMA manager 回调是否已安装 / Whether DMA callbacks are installed.
+  std::atomic<uint32_t> dma_busy_{
+      0U};  ///< DMA 后台事务活动标志 / DMA background transfer active flag.
+  std::atomic<uint32_t> dma_completion_claim_{
+      0U};                           ///< DMA 完成抢占标志 / DMA completion claim flag.
+  DmaTransferContext dma_ctx_{};     ///< DMA 事务上下文 / DMA transfer context.
+  AsyncBlockWait dma_block_wait_{};  ///< BLOCK 模式 DMA 等待器 / BLOCK-mode DMA waiter.
+#endif
+  bool auto_board_init_;  ///< 是否自动调用板级初始化 / Whether board init is automatic.
+  ChipSelect cs_ = ChipSelect::CS0;  ///< 当前硬件片选 / Current hardware chip-select.
+};
+
+}  // namespace LibXR

--- a/driver/hpm/hpm_spi.hpp
+++ b/driver/hpm/hpm_spi.hpp
@@ -535,6 +535,12 @@ class HPMSPI final : public SPI
   }
 
   /**
+   * @brief 校验 LibXR SPI 分频参数是否可映射到 HPM SPI timing /
+   * Validate whether a LibXR SPI prescaler can map to HPM SPI timing.
+   */
+  static ErrorCode ValidatePrescaler(Prescaler prescaler);
+
+  /**
    * @brief 根据 LibXR 分频参数配置 HPM SPI 时序 /
    * Configure HPM SPI timing from LibXR prescaler.
    */
@@ -657,6 +663,11 @@ class HPMSPI final : public SPI
   {
     return dma_busy_.load(std::memory_order_acquire) != 0U;
   }
+
+  /**
+   * @brief 若已有 DMA 后台事务则返回 BUSY / Return BUSY if a DMA transfer is active.
+   */
+  ErrorCode GuardNoDmaActive() const;
 
   /**
    * @brief 启动一次 data-phase DMA 传输 / Start one data-phase DMA transfer.

--- a/driver/hpm/hpm_spi.hpp
+++ b/driver/hpm/hpm_spi.hpp
@@ -633,7 +633,7 @@ class HPMSPI final : public SPI
   struct DmaTransferContext
   {
     DmaTransferKind kind = DmaTransferKind::NONE;
-    OperationRW op = {};
+    OperationRW* op = nullptr;
     uint8_t* rx = nullptr;
     uint8_t* tx = nullptr;
     RawData user_read = {nullptr, 0};

--- a/driver/hpm/hpm_spi.hpp
+++ b/driver/hpm/hpm_spi.hpp
@@ -303,7 +303,10 @@ class HPMSPI final : public SPI
    * @brief 查询当前构建是否支持 HPM SPI DMA manager /
    * Query build-time HPM SPI DMA-manager support.
    * @return true 表示可调用 SetDmaEnabled(true) /
-   * true when SetDmaEnabled(true) can succeed.
+   * true when DMA-manager support is compiled into this build.
+   * @note This is a build-time indicator only. SetDmaEnabled(true) remains the
+   * authoritative runtime check because resource allocation and callback setup
+   * can still fail.
    */
   static constexpr bool IsDmaSupported() { return LIBXR_HPM_SPI_HAS_DMA_MGR != 0; }
 

--- a/driver/hpm/hpm_spi.hpp
+++ b/driver/hpm/hpm_spi.hpp
@@ -75,19 +75,18 @@ namespace LibXR
  *
  * 支持 LibXR 操作模式参数；默认同步完成，DMA 启用后仅流式传输可后台完成 /
  * LibXR operation mode parameters are accepted; transfers complete synchronously
- * by default, and only stream transfers may complete in the background when DMA is
- * enabled:
+ * by default, and only BLOCK stream transfers use DMA when DMA is enabled:
  * - BLOCK：直接返回最终 ErrorCode，不触发回调或状态更新 /
  *   BLOCK: returns the final ErrorCode directly without callback/status update.
  * - POLLING：同步路径返回前更新为 DONE/ERROR；DMA 路径先标记
  * RUNNING，再在完成回调中更新。 POLLING: synchronous paths update DONE/ERROR before
- * return; DMA paths mark RUNNING first and update in the completion callback.
+ * return; DMA-enabled POLLING transfers return NOT_SUPPORT.
  * - CALLBACK：同步路径返回前执行回调；DMA 路径在完成回调中执行，并透传 in_isr 标志。
- *   CALLBACK: synchronous paths invoke the callback before return; DMA paths invoke
- *   it from the completion callback and forward the in_isr flag.
+ *   CALLBACK: synchronous paths invoke the callback before return; DMA-enabled
+ *   CALLBACK transfers return NOT_SUPPORT.
  * - NONE：同步路径只返回最终 ErrorCode；DMA 路径只负责后台清理，不产生额外通知。
- *   NONE: synchronous paths only return the final ErrorCode; DMA paths only clean up
- *   the background transaction without extra notification.
+ *   NONE: synchronous paths only return the final ErrorCode; DMA-enabled NONE
+ *   transfers return NOT_SUPPORT.
  *
  * 多系列适配依赖构造参数传入的 `SPI_Type*`/`clock_name_t`、HPM SDK
  * `SPI_SOC_TRANSFER_COUNT_MAX` 传输上限，以及工程/board header 暴露的实例、IRQ、DMA
@@ -640,6 +639,7 @@ class HPMSPI final : public SPI
     uint32_t size = 0;
     bool copy_rx_to_user = false;
     bool switch_buffer_on_success = false;
+    std::atomic<uint32_t> block_dma_ready{0U};
     std::atomic<uint32_t> rx_done{0U};
     std::atomic<uint32_t> tx_done{0U};
   };
@@ -673,6 +673,7 @@ class HPMSPI final : public SPI
    * @brief 启动一次 data-phase DMA 传输 / Start one data-phase DMA transfer.
    */
   ErrorCode StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
+                             size_t rx_capacity,
                              DmaTransferKind kind, RawData user_read,
                              bool copy_rx_to_user, bool switch_buffer_on_success,
                              OperationRW& op, bool in_isr);
@@ -698,6 +699,11 @@ class HPMSPI final : public SPI
   ErrorCode WaitForDmaBlockResult(uint32_t timeout);
 
   /**
+   * @brief 查询 DMA 接收缓存契约是否安全 / Check whether the DMA RX cache contract is safe.
+   */
+  static bool DmaRxBufferCacheSafe(const void* addr, size_t capacity);
+
+  /**
    * @brief DMA 回调后检查事务是否完成 / Check whether DMA callbacks complete the
    * transfer.
    */
@@ -706,7 +712,7 @@ class HPMSPI final : public SPI
   /**
    * @brief 完成并分发 DMA 事务结果 / Complete and dispatch a DMA transaction result.
    */
-  void CompleteDmaTransfer(bool in_isr, ErrorCode ans);
+  ErrorCode CompleteDmaTransfer(bool in_isr, ErrorCode ans, bool notify_block = true);
 
   /**
    * @brief 抢占 DMA 完成所有权 / Claim single DMA completion ownership.

--- a/driver/hpm/hpm_spi.hpp
+++ b/driver/hpm/hpm_spi.hpp
@@ -32,6 +32,10 @@
 #include "hpm_soc.h"
 #include "spi.hpp"
 
+#if __has_include("hpm_sdk_version.h")
+#include "hpm_sdk_version.h"
+#endif
+
 #if defined(HPMSOC_HAS_HPMSDK_SPI) && __has_include("hpm_spi_drv.h")
 #include "hpm_spi_drv.h"
 #define LIBXR_HPM_SPI_SUPPORTED 1
@@ -44,6 +48,7 @@ using LibXRHpmSpiStatusType = int;
 #endif
 
 #if LIBXR_HPM_SPI_SUPPORTED && defined(USE_DMA_MGR) && (USE_DMA_MGR) && \
+    defined(SDK_VERSION_NUMBER) && (SDK_VERSION_NUMBER >= 0x010B00U) && \
     __has_include("hpm_spi.h") && __has_include("hpm_dma_mgr.h")
 #include "hpm_spi.h"
 #define LIBXR_HPM_SPI_HAS_DMA_MGR 1
@@ -73,18 +78,18 @@ namespace LibXR
  * instance return BUSY until the DMA callback completes. CommandRead(),
  * CommandWriteRead(), MemRead(), and MemWrite() stay on the blocking path.
  *
- * 支持 LibXR 操作模式参数；默认同步完成，DMA 启用后仅流式传输可后台完成 /
+ * 支持 LibXR 操作模式参数；默认同步完成，DMA 启用后仅 BLOCK 流式传输使用 DMA /
  * LibXR operation mode parameters are accepted; transfers complete synchronously
  * by default, and only BLOCK stream transfers use DMA when DMA is enabled:
  * - BLOCK：直接返回最终 ErrorCode，不触发回调或状态更新 /
  *   BLOCK: returns the final ErrorCode directly without callback/status update.
- * - POLLING：同步路径返回前更新为 DONE/ERROR；DMA 路径先标记
- * RUNNING，再在完成回调中更新。 POLLING: synchronous paths update DONE/ERROR before
- * return; DMA-enabled POLLING transfers return NOT_SUPPORT.
- * - CALLBACK：同步路径返回前执行回调；DMA 路径在完成回调中执行，并透传 in_isr 标志。
+ * - POLLING：同步路径返回前更新为 DONE/ERROR；DMA 启用时返回 NOT_SUPPORT。
+ *   POLLING: synchronous paths update DONE/ERROR before return; DMA-enabled
+ *   POLLING transfers return NOT_SUPPORT.
+ * - CALLBACK：同步路径返回前执行回调；DMA 启用时返回 NOT_SUPPORT。
  *   CALLBACK: synchronous paths invoke the callback before return; DMA-enabled
  *   CALLBACK transfers return NOT_SUPPORT.
- * - NONE：同步路径只返回最终 ErrorCode；DMA 路径只负责后台清理，不产生额外通知。
+ * - NONE：同步路径只返回最终 ErrorCode；DMA 启用时返回 NOT_SUPPORT。
  *   NONE: synchronous paths only return the final ErrorCode; DMA-enabled NONE
  *   transfers return NOT_SUPPORT.
  *
@@ -139,12 +144,15 @@ class HPMSPI final : public SPI
    * HPM clock name used to enable and query the peripheral source clock when the
    * optional board helper does not provide one.
    * @param rx_buffer 内部 RX 暂存缓冲区，供 ReadAndWrite()、Transfer()、MemRead()
-   * 使用；驱动生命周期内必须保持非空且有效 /
-   * Internal RX staging buffer used by ReadAndWrite(), Transfer(), and MemRead().
-   * It must remain non-null and valid for the driver lifetime.
+   * 使用；驱动生命周期内必须保持非空且有效，并满足 `alignof(size_t)` 对齐及
+   * `2 * alignof(size_t)` 整倍数容量要求 / Internal RX staging buffer used by
+   * ReadAndWrite(), Transfer(), and MemRead(). It must remain non-null and valid for
+   * the driver lifetime, be aligned to `alignof(size_t)`, and have a size divisible
+   * by `2 * alignof(size_t)`.
    * @param tx_buffer 内部 TX 暂存缓冲区，供所有传输接口使用；驱动生命周期内必须
-   * 保持非空且有效 / Internal TX staging buffer used by all transfer methods.
-   * It must remain non-null and valid for the driver lifetime.
+   * 保持非空且有效，并满足相同的对齐和容量要求 / Internal TX staging buffer used
+   * by all transfer methods. It must satisfy the same lifetime, alignment, and size
+   * requirements.
    * @param auto_board_init 若为 true 且存在 board.h，则自动调用板级 SPI 时钟和引脚
    * 初始化 helper / If true and board.h is available, call board SPI clock and pin
    * helper functions automatically.
@@ -157,9 +165,13 @@ class HPMSPI final : public SPI
    * Hardware chip-select line. It is written to the transfer control register only
    * when the HPM SDK/SoC exposes `cs_index`.
    *
-   * @note 构造函数会断言外设指针为空、暂存缓冲区为空、源时钟无法解析或初始配置无效 /
-   * The constructor asserts on null peripheral pointer, null/empty staging buffers,
-   * unresolved source clock, or invalid initial configuration.
+   * @note RX/TX 暂存区在全双工传输使用的范围内不得重叠；检测到重叠时传输返回
+   * ARG_ERR。RX and TX staging ranges used by a full-duplex transfer must not overlap;
+   * an overlapping transfer returns ARG_ERR.
+   * @note 构造函数会断言外设指针为空、暂存缓冲区为空或不满足基类对齐/容量要求、
+   * 源时钟无法解析或初始配置无效 / The constructor asserts on null peripheral pointer,
+   * null/empty staging buffers, staging buffers that violate the base-class
+   * alignment/size contract, unresolved source clock, or invalid initial configuration.
    */
   HPMSPI(LibXRHpmSpiType* spi, clock_name_t clock, RawData rx_buffer, RawData tx_buffer,
          bool auto_board_init = true,
@@ -254,16 +266,16 @@ class HPMSPI final : public SPI
    * @brief 启用或关闭 HPM SPI DMA manager 路径 /
    * Enable or disable the HPM SPI DMA-manager path.
    *
-   * DMA 路径仅在工程启用 `USE_DMA_MGR=1` 且 HPM SDK 提供 `hpm_spi.h`
-   * 组件 API 时可用。它只覆盖普通 data-phase 流式传输，即 ReadAndWrite() 和
-   * Transfer()；CommandRead() / CommandWriteRead() 仍使用 HPM SDK command phase
-   * 阻塞传输，以保持 SPI flash opcode-read 时序。
+   * DMA 路径仅在工程启用 `USE_DMA_MGR=1` 且 HPM SDK 版本不低于 1.11.0、提供
+   * `hpm_spi.h` 自定义 DMA 回调 API 时可用。它只覆盖普通 data-phase 流式传输，即
+   * ReadAndWrite() 和 Transfer()；CommandRead() / CommandWriteRead() 仍使用 HPM SDK
+   * command phase 阻塞传输，以保持 SPI flash opcode-read 时序。
    *
-   * The DMA path is available only when the project builds with `USE_DMA_MGR=1`
-   * and the HPM SDK `hpm_spi.h` component APIs are present. It covers regular
-   * data-phase stream transfers through ReadAndWrite() and Transfer() only.
-   * CommandRead() / CommandWriteRead() keep using the blocking HPM SDK command
-   * phase so SPI-flash opcode-read timing remains unchanged.
+   * The DMA path is available only when the project builds with `USE_DMA_MGR=1`,
+   * HPM SDK 1.11.0 or newer is used, and the `hpm_spi.h` custom DMA callback APIs
+   * are present. It covers regular data-phase stream transfers through ReadAndWrite()
+   * and Transfer() only. CommandRead() / CommandWriteRead() keep using the blocking
+   * HPM SDK command phase so SPI-flash opcode-read timing remains unchanged.
    * 在 system/none、webasm 等轮询等待系统中，BLOCK DMA 操作依赖 LibXR
    * Timebase 进行超时等待；未初始化 Timebase 时，ReadAndWrite() / Transfer()
    * 会在启动 DMA 前返回 INIT_ERR。RTOS/POSIX 系统使用各自的 semaphore 等待机制。
@@ -281,6 +293,12 @@ class HPMSPI final : public SPI
    * tries an aligned subrange and moves received bytes back after completion. If
    * no such range fits, BLOCK transfers fall back to the synchronous path, avoiding
    * unrelated dirty-data loss when invalidating shared cache lines.
+   * @note 当前 HPM SDK SPI component 固定按 core0 转换 DMA 地址，因此双核 SoC 的
+   * core1 上 SetDmaEnabled(true) 返回 NOT_SUPPORT。若传输长度超过 DMA 控制器计数范围，
+   * BLOCK 操作回退到同步路径 / The current HPM SDK SPI component converts DMA
+   * addresses as core0, so SetDmaEnabled(true) returns NOT_SUPPORT on core1 of a
+   * dual-core SoC. BLOCK transfers larger than the DMA controller count field fall
+   * back to the synchronous path.
    *
    * @param enabled true 启用 DMA，false 回到同步阻塞路径 /
    * true to enable DMA, false to use the synchronous blocking path.
@@ -550,6 +568,34 @@ class HPMSPI final : public SPI
   }
 
   /**
+   * @brief 原子获取实例事务所有权 / Atomically acquire instance transaction ownership.
+   */
+  bool TryAcquireTransaction()
+  {
+    uint32_t expected = 0U;
+    return transaction_busy_.compare_exchange_strong(
+        expected, 1U, std::memory_order_acq_rel, std::memory_order_acquire);
+  }
+
+  /**
+   * @brief 释放事务所有权并返回结果 / Release transaction ownership and return a result.
+   */
+  ErrorCode EndTransaction(ErrorCode ans)
+  {
+    transaction_busy_.store(0U, std::memory_order_release);
+    return ans;
+  }
+
+  /**
+   * @brief 释放事务所有权后分发操作结果 / Release ownership before dispatching a result.
+   */
+  ErrorCode EndTransaction(OperationRW& op, bool in_isr, ErrorCode ans)
+  {
+    transaction_busy_.store(0U, std::memory_order_release);
+    return FinishOperation(op, in_isr, ans);
+  }
+
+  /**
    * @brief 校验 LibXR SPI 分频参数是否可映射到 HPM SPI timing /
    * Validate whether a LibXR SPI prescaler can map to HPM SPI timing.
    */
@@ -683,16 +729,10 @@ class HPMSPI final : public SPI
   }
 
   /**
-   * @brief 若已有 DMA 后台事务则返回 BUSY / Return BUSY if a DMA transfer is active.
-   */
-  ErrorCode GuardNoDmaActive() const;
-
-  /**
    * @brief 启动一次 data-phase DMA 传输 / Start one data-phase DMA transfer.
    */
   ErrorCode StartDmaTransfer(uint8_t* rx, uint8_t* tx, uint32_t size,
-                             size_t rx_capacity,
-                             DmaTransferKind kind, RawData user_read,
+                             size_t rx_capacity, DmaTransferKind kind, RawData user_read,
                              bool copy_rx_to_user, bool switch_buffer_on_success,
                              OperationRW& op, bool in_isr);
 
@@ -773,7 +813,9 @@ class HPMSPI final : public SPI
   uint32_t source_clock_hz_ = 0;   ///< 缓存的源时钟频率 / Cached source clock frequency.
   size_t rx_buffer_capacity_ = 0;  ///< 原始 RX 缓冲区容量 / Raw RX buffer capacity.
   size_t tx_buffer_capacity_ = 0;  ///< 原始 TX 缓冲区容量 / Raw TX buffer capacity.
-  bool configured_ = false;        ///< 是否已有成功配置 / Whether a config was applied.
+  std::atomic<uint32_t> transaction_busy_{
+      0U};  ///< 实例事务占用标志 / Instance transaction ownership flag.
+  bool configured_ = false;  ///< 是否已有成功配置 / Whether a config was applied.
   bool dma_enabled_ =
       false;  ///< 是否启用 DMA 流式传输 / Whether DMA stream path is enabled.
 #if LIBXR_HPM_SPI_HAS_DMA_MGR

--- a/driver/hpm/hpm_spi.hpp
+++ b/driver/hpm/hpm_spi.hpp
@@ -272,14 +272,15 @@ class HPMSPI final : public SPI
    * Transfer() return INIT_ERR before starting DMA. RTOS/POSIX systems use their
    * native semaphore wait paths.
    *
-   * @note 启用 D-cache 的平台上，BLOCK DMA RX 要求内部 RX staging buffer 起始地址按
-   * `HPM_L1C_CACHELINE_SIZE` 对齐，且容量为 cache line 的整数倍；否则 ReadAndWrite() /
-   * Transfer() 会在启动 DMA 前返回 NOT_SUPPORT，避免无效化共享 cache line 时丢失其他
-   * dirty data。On D-cache-enabled platforms, BLOCK DMA RX requires the internal RX
-   * staging buffer start address to be aligned to `HPM_L1C_CACHELINE_SIZE`, and its
-   * capacity to be a multiple of the cache-line size. Otherwise ReadAndWrite() /
-   * Transfer() returns NOT_SUPPORT before starting DMA, avoiding unrelated dirty
-   * data loss when invalidating shared cache lines.
+   * @note 启用 D-cache 的平台上，DMA RX 会优先使用内部 RX staging buffer 中的
+   * cache-line 独占区域；若原始 staging buffer 不满足直接 DMA 条件，驱动会尝试在 buffer
+   * 内选择对齐子区并在完成后搬回原始 staging 起点。若空间不足，BLOCK 传输回退到同步路径，
+   * 避免无效化共享 cache line 时丢失其他 dirty data。On D-cache-enabled platforms,
+   * DMA RX first uses a cache-line-exclusive range inside the internal RX staging
+   * buffer. If the original staging buffer is not directly DMA-safe, the driver
+   * tries an aligned subrange and moves received bytes back after completion. If
+   * no such range fits, BLOCK transfers fall back to the synchronous path, avoiding
+   * unrelated dirty-data loss when invalidating shared cache lines.
    *
    * @param enabled true 启用 DMA，false 回到同步阻塞路径 /
    * true to enable DMA, false to use the synchronous blocking path.
@@ -646,10 +647,12 @@ class HPMSPI final : public SPI
     DmaTransferKind kind = DmaTransferKind::NONE;
     OperationRW* op = nullptr;
     uint8_t* rx = nullptr;
+    uint8_t* staging_rx = nullptr;
     uint8_t* tx = nullptr;
     RawData user_read = {nullptr, 0};
     uint32_t size = 0;
     bool copy_rx_to_user = false;
+    bool copy_rx_to_staging = false;
     bool switch_buffer_on_success = false;
     std::atomic<uint32_t> block_dma_ready{0U};
     std::atomic<uint32_t> rx_done{0U};
@@ -714,6 +717,15 @@ class HPMSPI final : public SPI
    * @brief 查询 DMA 接收缓存契约是否安全 / Check whether the DMA RX cache contract is safe.
    */
   static bool DmaRxBufferCacheSafe(const void* addr, size_t capacity);
+
+  /**
+   * @brief 使用同步路径执行一次流式传输 / Run one stream transfer through the blocking path.
+   */
+  ErrorCode RunBlockingStreamTransfer(uint8_t* rx, const uint8_t* tx, uint32_t size,
+                                      DmaTransferKind kind, RawData user_read,
+                                      bool copy_rx_to_user,
+                                      bool switch_buffer_on_success,
+                                      OperationRW& op, bool in_isr);
 
   /**
    * @brief DMA 回调后检查事务是否完成 / Check whether DMA callbacks complete the

--- a/driver/hpm/hpm_spi.hpp
+++ b/driver/hpm/hpm_spi.hpp
@@ -699,6 +699,11 @@ class HPMSPI final : public SPI
   void StopDmaTransfer();
 
   /**
+   * @brief 清除 RX/TX DMA 通道的残留状态 / Clear stale RX/TX DMA channel status.
+   */
+  void ClearDmaTransferStatus();
+
+  /**
    * @brief 清空 DMA 事务上下文 / Clear DMA transfer context.
    */
   void ClearDmaContext();
@@ -752,6 +757,12 @@ class HPMSPI final : public SPI
    * @brief TX DMA terminal-count callback / TX DMA 终端计数回调。
    */
   static void OnTxDmaTcCallback(DMA_Type* base, uint32_t channel, void* cb_data_ptr);
+
+  /**
+   * @brief DMA error/abort callback / DMA 错误或中止回调。
+   */
+  static void OnDmaFailureCallback(DMA_Type* base, uint32_t channel,
+                                   void* cb_data_ptr);
 #endif
 
   LibXRHpmSpiType* spi_;           ///< SPI 外设实例 / SPI peripheral instance.

--- a/driver/hpm/hpm_spi.hpp
+++ b/driver/hpm/hpm_spi.hpp
@@ -167,6 +167,9 @@ class HPMSPI final : public SPI
                                       SPI::Prescaler::DIV_4, false},
          ChipSelect cs = ChipSelect::CS0);
 
+  HPMSPI(const HPMSPI&) = delete;
+  HPMSPI& operator=(const HPMSPI&) = delete;
+
   /**
    * @brief 传输 SPI 字节，并可同时采集接收数据 /
    * Transfer SPI bytes while optionally collecting received bytes.
@@ -268,6 +271,15 @@ class HPMSPI final : public SPI
    * require a LibXR Timebase for timeout-aware waits; otherwise ReadAndWrite() /
    * Transfer() return INIT_ERR before starting DMA. RTOS/POSIX systems use their
    * native semaphore wait paths.
+   *
+   * @note 启用 D-cache 的平台上，BLOCK DMA RX 要求内部 RX staging buffer 起始地址按
+   * `HPM_L1C_CACHELINE_SIZE` 对齐，且容量为 cache line 的整数倍；否则 ReadAndWrite() /
+   * Transfer() 会在启动 DMA 前返回 NOT_SUPPORT，避免无效化共享 cache line 时丢失其他
+   * dirty data。On D-cache-enabled platforms, BLOCK DMA RX requires the internal RX
+   * staging buffer start address to be aligned to `HPM_L1C_CACHELINE_SIZE`, and its
+   * capacity to be a multiple of the cache-line size. Otherwise ReadAndWrite() /
+   * Transfer() returns NOT_SUPPORT before starting DMA, avoiding unrelated dirty
+   * data loss when invalidating shared cache lines.
    *
    * @param enabled true 启用 DMA，false 回到同步阻塞路径 /
    * true to enable DMA, false to use the synchronous blocking path.

--- a/driver/hpm/hpm_spi.hpp
+++ b/driver/hpm/hpm_spi.hpp
@@ -262,6 +262,13 @@ class HPMSPI final : public SPI
    * data-phase stream transfers through ReadAndWrite() and Transfer() only.
    * CommandRead() / CommandWriteRead() keep using the blocking HPM SDK command
    * phase so SPI-flash opcode-read timing remains unchanged.
+   * 在 system/none、webasm 等轮询等待系统中，BLOCK DMA 操作依赖 LibXR
+   * Timebase 进行超时等待；未初始化 Timebase 时，ReadAndWrite() / Transfer()
+   * 会在启动 DMA 前返回 INIT_ERR。RTOS/POSIX 系统使用各自的 semaphore 等待机制。
+   * On polling-wait systems such as system/none and webasm, BLOCK DMA operations
+   * require a LibXR Timebase for timeout-aware waits; otherwise ReadAndWrite() /
+   * Transfer() return INIT_ERR before starting DMA. RTOS/POSIX systems use their
+   * native semaphore wait paths.
    *
    * @param enabled true 启用 DMA，false 回到同步阻塞路径 /
    * true to enable DMA, false to use the synchronous blocking path.
@@ -287,6 +294,21 @@ class HPMSPI final : public SPI
    * true when SetDmaEnabled(true) can succeed.
    */
   static constexpr bool IsDmaSupported() { return LIBXR_HPM_SPI_HAS_DMA_MGR != 0; }
+
+  /**
+   * @brief 查询控制器是否已有可用配置 / Query whether the controller has a
+   * valid applied configuration.
+   *
+   * 当底层 HPM 控制器复位/恢复失败时，该状态会被清除，后续传输将返回 INIT_ERR，
+   * 调用方可用它区分普通传输错误和控制器已不可用状态。
+   * The flag is cleared when low-level HPM controller reset/recovery fails. Later
+   * transfers return INIT_ERR, and callers can use this query to distinguish a
+   * normal transfer error from a controller that is no longer configured.
+   *
+   * @return true 表示 SetConfig() 已成功应用且恢复流程未清除该状态 /
+   * true when SetConfig() succeeded and recovery has not cleared the state.
+   */
+  bool IsConfigured() const { return configured_; }
 
   /**
    * @brief 发送 8-bit 命令后读取数据 / Read data after sending an 8-bit command.


### PR DESCRIPTION
## Summary
- Add HPM SPI master driver for the current LibXR SPI abstraction.
- Support blocking transfer, memory read/write helpers, DMA transfer path, manual chip-select selection, and controller recovery state reporting.
- Keep this PR driver-only: no BSP firmware, test binaries, logic analyzer captures, or generated artifacts are included.

Related to xrobot-org/XRobot-Dev-Roadmap#18.

## Validation
- Clean built the HPM5361EVKLite BSP with `LIBXR_DIR=D:/Codes/libxr_hpm_spi_pr`, `USE_DMA_MGR=1`, and `LIBXR_PRINT_ENABLE_FLOAT=0`.
- Flashed and verified through OpenOCD on HPM5361EVKLite.
- Hardware: LSM6DSV16X on SPI1, mode 0, CS=PA26, SCLK=PA27, MISO=PA28, MOSI=PA29.
- Serial full-test loop after the latest Sourcery cleanup reached `bitbang_pass=19 memread_pass=19 stream_block_pass=19 dma_pass=19 spi_fail=0`.
- DSLogic capture decoded WHO_AM_I frames `MOSI=[8F 00] MISO=[00 70]` and burst sample frames after the helper refactor.

## Review Notes
- Addressed Sourcery feedback by exposing `IsConfigured()`, guarding BLOCK DMA when `Timebase` is unavailable, centralizing prescaler validation, and unifying public DMA-busy guards.
- A larger DMA helper extraction was intentionally left out of this driver-only PR to avoid broad refactoring after hardware validation.

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

新特性：
- 提供 HPMSPI 类，将 LibXR SPI 抽象适配到 HPM SDK 的 SPI 主外设。
- 支持阻塞式 SPI 传输、命令阶段辅助函数、寄存器风格的内存读写 API，以及针对基于 HPM 的板卡的手动片选（chip-select）选择。
- 暴露可选的 DMA 管理器集成，用于流式传输（ReadAndWrite 和 Transfer），并可通过构建时开关和运行时启用/禁用进行控制。
- 添加驱动层配置校验、分频器限制，以及在 HPM SDK 与 LibXR 错误码之间进行状态/错误映射。
- 上报控制器配置状态，并在某些传输失败后执行恢复操作，以保持 SPI 主控制器可用。

增强：
- 引入驱动侧抽象，用于与板级相关的 SPI 时钟/引脚初始化，而不绑定到特定的 BSP 固件。
- 在 HPM SPI 或 DMA 不可用时提供优雅的 NOT_SUPPORT 存根（stubs），从而确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个基于 HPM SDK 的 SPI 主机驱动，实现与 LibXR SPI 抽象层的集成，并提供可选的 DMA 支持；当 HPM SPI 不可用时能够优雅回退。

New Features:
- 添加一个 HPMSPI 驱动，在 HPM SDK 的 SPI 主控制器外设之上实现 LibXR SPI 接口。
- 支持阻塞式 SPI 传输、8 位命令辅助函数、寄存器风格的内存读写 API，以及面向基于 HPM 的开发板的可配置硬件片选引脚。
- 暴露可选的 DMA 管理器集成，用于流式传输（包括缓存处理和在故障时的控制器恢复），同时为命令与内存操作保留阻塞式路径。

Enhancements:
- 在驱动侧提供一个抽象层，用于板级 SPI 时钟和引脚初始化，而无需依赖特定的 BSP 固件。
- 在缺少 HPM SDK SPI 或 DMA 管理器支持的配置中添加 NOT_SUPPORT 桩代码，确保非 SPI 构建仍能通过编译。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an HPM SDK–based SPI master driver that integrates with the LibXR SPI abstraction, with optional DMA support and graceful fallbacks when HPM SPI is unavailable.

New Features:
- Add an HPMSPI driver that implements the LibXR SPI interface on top of the HPM SDK SPI master peripheral.
- Support blocking SPI transfers, 8-bit command helpers, register-style memory read/write APIs, and configurable hardware chip-select lines for HPM-based boards.
- Expose optional DMA-manager integration for stream transfers, including cache handling and controller recovery on failures, while preserving blocking paths for command and memory operations.

Enhancements:
- Provide a driver-side abstraction for board-specific SPI clock and pin initialization without depending on a particular BSP firmware.
- Add NOT_SUPPORT stubs for configurations where HPM SDK SPI or DMA manager support is absent, keeping non-SPI builds compilable.

</details>

</details>

</details>

</details>

</details>

</details>

</details>

</details>