### PR TITLE
 fix(mspm0): add GPIO/SPI IRQ support and timing fixes

### DIFF
--- a/driver/mspm0/CMakeLists.txt
+++ b/driver/mspm0/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(_xr_mspm0_driver_sources
+    ${CMAKE_CURRENT_LIST_DIR}/mspm0_group1_shared.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mspm0_gpio.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mspm0_pwm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mspm0_timebase.cpp

--- a/driver/mspm0/mspm0_gpio.cpp
+++ b/driver/mspm0/mspm0_gpio.cpp
@@ -1,5 +1,7 @@
 #include "mspm0_gpio.hpp"
 
+#include "mspm0_group1_shared.hpp"
+
 using namespace LibXR;
 
 MSPM0GPIO* MSPM0GPIO::instance_map_[MAX_PORTS][32] = {{nullptr}};
@@ -33,6 +35,17 @@ static constexpr uint32_t MSPM0_GPIO_GetPolarityMask(uint8_t pin,  // NOLINT
   uint32_t shift = (pin % 16) * 2;
   return config_bits << shift;
 }
+#ifdef GPIOA_BASE
+static void gpioa_irq_thunk() { LibXR::MSPM0GPIO::OnInterrupt(GPIOA); }
+#endif
+
+#ifdef GPIOB_BASE
+static void gpiob_irq_thunk() { LibXR::MSPM0GPIO::OnInterrupt(GPIOB); }
+#endif
+
+#ifdef GPIOC_BASE
+static void gpioc_irq_thunk() { LibXR::MSPM0GPIO::OnInterrupt(GPIOC); }
+#endif
 
 MSPM0GPIO::MSPM0GPIO(GPIO_Regs* port, uint32_t pin_mask, uint32_t pincm)
     : port_(port), pin_mask_(pin_mask), pincm_(pincm)
@@ -49,22 +62,24 @@ MSPM0GPIO::MSPM0GPIO(GPIO_Regs* port, uint32_t pin_mask, uint32_t pincm)
   {
     case 0:
 #ifdef GPIOA_BASE
-      NVIC_EnableIRQ(GPIOA_INT_IRQn);
+      LibXR::MSPM0Group1Shared::RegisterGPIOA(&gpioa_irq_thunk);
 #endif
       break;
 
     case 1:
 #ifdef GPIOB_BASE
-      NVIC_EnableIRQ(GPIOB_INT_IRQn);
+      LibXR::MSPM0Group1Shared::RegisterGPIOB(&gpiob_irq_thunk);
 #endif
       break;
 
     case 2:
 #ifdef GPIOC_BASE
-      NVIC_EnableIRQ(GPIOC_INT_IRQn);
+      LibXR::MSPM0Group1Shared::RegisterGPIOC(&gpioc_irq_thunk);
 #endif
       break;
   }
+  default:
+    return;
 }
 
 bool MSPM0GPIO::Read() { return DL_GPIO_readPins(port_, pin_mask_) == pin_mask_; }
@@ -237,6 +252,11 @@ ErrorCode MSPM0GPIO::SetConfig(Configuration config)
 
 void MSPM0GPIO::OnInterruptDispatch(GPIO_Regs* port, int port_idx)
 {
+  if (port_idx < 0 || port_idx >= LibXR::MAX_PORTS)
+  {
+    return;
+  }
+
   uint32_t pending_pins = DL_GPIO_getEnabledInterruptStatus(port, 0xFFFFFFFF);
 
   if (pending_pins != 0)

--- a/driver/mspm0/mspm0_gpio.cpp
+++ b/driver/mspm0/mspm0_gpio.cpp
@@ -77,9 +77,10 @@ MSPM0GPIO::MSPM0GPIO(GPIO_Regs* port, uint32_t pin_mask, uint32_t pincm)
       LibXR::MSPM0Group1Shared::RegisterGPIOC(&gpioc_irq_thunk);
 #endif
       break;
-  }
   default:
-    return;
+    return;     
+  }
+ 
 }
 
 bool MSPM0GPIO::Read() { return DL_GPIO_readPins(port_, pin_mask_) == pin_mask_; }

--- a/driver/mspm0/mspm0_gpio.cpp
+++ b/driver/mspm0/mspm0_gpio.cpp
@@ -77,10 +77,9 @@ MSPM0GPIO::MSPM0GPIO(GPIO_Regs* port, uint32_t pin_mask, uint32_t pincm)
       LibXR::MSPM0Group1Shared::RegisterGPIOC(&gpioc_irq_thunk);
 #endif
       break;
-  default:
-    return;     
+    default:
+      return;
   }
- 
 }
 
 bool MSPM0GPIO::Read() { return DL_GPIO_readPins(port_, pin_mask_) == pin_mask_; }

--- a/driver/mspm0/mspm0_group1_shared.cpp
+++ b/driver/mspm0/mspm0_group1_shared.cpp
@@ -1,0 +1,92 @@
+#include "mspm0_group1_shared.hpp"
+
+namespace LibXR::MSPM0Group1Shared
+{
+void EnableGroup1IRQ()
+{
+#if defined(GPIOA_BASE)
+  NVIC_EnableIRQ(GPIOA_INT_IRQn);
+#elif defined(GPIOB_BASE)
+  NVIC_EnableIRQ(GPIOB_INT_IRQn);
+#elif defined(GPIOC_BASE)
+  NVIC_EnableIRQ(GPIOC_INT_IRQn);
+#elif defined(COMP0_BASE)
+  NVIC_EnableIRQ(COMP0_INT_IRQn);
+#elif defined(COMP1_BASE)
+  NVIC_EnableIRQ(COMP1_INT_IRQn);
+#elif defined(COMP2_BASE)
+  NVIC_EnableIRQ(COMP2_INT_IRQn);
+#elif defined(TRNG_BASE)
+  NVIC_EnableIRQ(TRNG_INT_IRQn);
+#endif
+}
+}  // namespace LibXR::MSPM0Group1Shared
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+extern "C" void GROUP1_IRQHandler(void)
+{
+  uint32_t iidx = DL_Interrupt_getPendingGroup(DL_INTERRUPT_GROUP_1);
+  using namespace LibXR::MSPM0Group1Shared;
+
+  switch (iidx)
+  {
+#if defined(GPIOA_BASE)
+    case DL_INTERRUPT_GROUP1_IIDX_GPIOA:
+      if (auto fn = gpioa_irq_cb)
+      {
+        fn();
+      }
+      break;
+#endif
+#if defined(GPIOB_BASE)
+    case DL_INTERRUPT_GROUP1_IIDX_GPIOB:
+      if (auto fn = gpiob_irq_cb)
+      {
+        fn();
+      }
+      break;
+#endif
+#if defined(COMP0_BASE)
+    case DL_INTERRUPT_GROUP1_IIDX_COMP0:
+      if (auto fn = comp0_irq_cb)
+      {
+        fn();
+      }
+      break;
+#endif
+#if defined(COMP1_BASE)
+    case DL_INTERRUPT_GROUP1_IIDX_COMP1:
+      if (auto fn = comp1_irq_cb)
+      {
+        fn();
+      }
+      break;
+#endif
+#if defined(COMP2_BASE)
+    case DL_INTERRUPT_GROUP1_IIDX_COMP2:
+      if (auto fn = comp2_irq_cb)
+      {
+        fn();
+      }
+      break;
+#endif
+#if defined(TRNG_BASE)
+    case DL_INTERRUPT_GROUP1_IIDX_TRNG:
+      if (auto fn = trng_irq_cb)
+      {
+        fn();
+      }
+      break;
+#endif
+#if defined(GPIOC_BASE)
+    case DL_INTERRUPT_GROUP1_IIDX_GPIOC:
+      if (auto fn = gpioc_irq_cb)
+      {
+        fn();
+      }
+      break;
+#endif
+    default:
+      break;
+  }
+}

--- a/driver/mspm0/mspm0_group1_shared.hpp
+++ b/driver/mspm0/mspm0_group1_shared.hpp
@@ -1,0 +1,184 @@
+#pragma once
+
+#include <ti/driverlib/m0p/dl_interrupt.h>
+
+namespace LibXR::MSPM0Group1Shared
+{
+using IrqFn = void (*)();
+
+#if defined(GPIOA_BASE)
+inline constexpr bool K_HAS_GPIOA = true;
+#else
+inline constexpr bool K_HAS_GPIOA = false;
+#endif
+
+#if defined(GPIOB_BASE)
+inline constexpr bool K_HAS_GPIOB = true;
+#else
+inline constexpr bool K_HAS_GPIOB = false;
+#endif
+
+#if defined(GPIOC_BASE)
+inline constexpr bool K_HAS_GPIOC = true;
+#else
+inline constexpr bool K_HAS_GPIOC = false;
+#endif
+
+#if defined(COMP0_BASE)
+inline constexpr bool K_HAS_COMP0 = true;
+#else
+inline constexpr bool K_HAS_COMP0 = false;
+#endif
+
+#if defined(COMP1_BASE)
+inline constexpr bool K_HAS_COMP1 = true;
+#else
+inline constexpr bool K_HAS_COMP1 = false;
+#endif
+
+#if defined(COMP2_BASE)
+inline constexpr bool K_HAS_COMP2 = true;
+#else
+inline constexpr bool K_HAS_COMP2 = false;
+#endif
+
+#if defined(TRNG_BASE)
+inline constexpr bool K_HAS_TRNG = true;
+#else
+inline constexpr bool K_HAS_TRNG = false;
+#endif
+
+inline constexpr bool K_GROUP1_SHARED =
+    K_HAS_GPIOA || K_HAS_GPIOB || K_HAS_GPIOC || K_HAS_COMP0 || K_HAS_COMP1 ||
+    K_HAS_COMP2 || K_HAS_TRNG;
+
+inline IrqFn gpioa_irq_cb{nullptr};
+inline IrqFn gpiob_irq_cb{nullptr};
+inline IrqFn gpioc_irq_cb{nullptr};
+inline IrqFn comp0_irq_cb{nullptr};
+inline IrqFn comp1_irq_cb{nullptr};
+inline IrqFn comp2_irq_cb{nullptr};
+inline IrqFn trng_irq_cb{nullptr};
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+void EnableGroup1IRQ();
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+inline void RegisterGPIOA(IrqFn fn)
+{
+  if constexpr (K_HAS_GPIOA)
+  {
+    gpioa_irq_cb = fn;
+    if (fn != nullptr)
+    {
+      EnableGroup1IRQ();
+    }
+  }
+  else
+  {
+    (void)fn;
+  }
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+inline void RegisterGPIOB(IrqFn fn)
+{
+  if constexpr (K_HAS_GPIOB)
+  {
+    gpiob_irq_cb = fn;
+    if (fn != nullptr)
+    {
+      EnableGroup1IRQ();
+    }
+  }
+  else
+  {
+    (void)fn;
+  }
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+inline void RegisterGPIOC(IrqFn fn)
+{
+  if constexpr (K_HAS_GPIOC)
+  {
+    gpioc_irq_cb = fn;
+    if (fn != nullptr)
+    {
+      EnableGroup1IRQ();
+    }
+  }
+  else
+  {
+    (void)fn;
+  }
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+inline void RegisterCOMP0(IrqFn fn)
+{
+  if constexpr (K_HAS_COMP0)
+  {
+    comp0_irq_cb = fn;
+    if (fn != nullptr)
+    {
+      EnableGroup1IRQ();
+    }
+  }
+  else
+  {
+    (void)fn;
+  }
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+inline void RegisterCOMP1(IrqFn fn)
+{
+  if constexpr (K_HAS_COMP1)
+  {
+    comp1_irq_cb = fn;
+    if (fn != nullptr)
+    {
+      EnableGroup1IRQ();
+    }
+  }
+  else
+  {
+    (void)fn;
+  }
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+inline void RegisterCOMP2(IrqFn fn)
+{
+  if constexpr (K_HAS_COMP2)
+  {
+    comp2_irq_cb = fn;
+    if (fn != nullptr)
+    {
+      EnableGroup1IRQ();
+    }
+  }
+  else
+  {
+    (void)fn;
+  }
+}
+
+// NOLINTNEXTLINE(readability-identifier-naming)
+inline void RegisterTRNG(IrqFn fn)
+{
+  if constexpr (K_HAS_TRNG)
+  {
+    trng_irq_cb = fn;
+    if (fn != nullptr)
+    {
+      EnableGroup1IRQ();
+    }
+  }
+  else
+  {
+    (void)fn;
+  }
+}
+}  // namespace LibXR::MSPM0Group1Shared

--- a/driver/mspm0/mspm0_group1_shared.hpp
+++ b/driver/mspm0/mspm0_group1_shared.hpp
@@ -48,9 +48,6 @@ inline constexpr bool K_HAS_TRNG = true;
 inline constexpr bool K_HAS_TRNG = false;
 #endif
 
-inline constexpr bool K_GROUP1_SHARED =
-    K_HAS_GPIOA || K_HAS_GPIOB || K_HAS_GPIOC || K_HAS_COMP0 || K_HAS_COMP1 ||
-    K_HAS_COMP2 || K_HAS_TRNG;
 
 inline IrqFn gpioa_irq_cb{nullptr};
 inline IrqFn gpiob_irq_cb{nullptr};

--- a/driver/mspm0/mspm0_pwm.cpp
+++ b/driver/mspm0/mspm0_pwm.cpp
@@ -85,10 +85,11 @@ ErrorCode MSPM0PWM::SetConfig(Configuration config)
   }
 
   uint32_t best_load = (SOURCE_CLOCK / (best_div * best_prescaler * config.frequency));
-  if (best_load > 0)
+  if (best_load == 0)
   {
-    best_load -= 1;
+    return ErrorCode::NOT_SUPPORT;  // Frequency too high to represent
   }
+  best_load -= 1;
 
   DL_Timer_ClockConfig clock_config;
   DL_Timer_getClockConfig(timer_, &clock_config);

--- a/driver/mspm0/mspm0_pwm.hpp
+++ b/driver/mspm0/mspm0_pwm.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "mspm0_conf.hpp"
 #include "pwm.hpp"
-#include "ti_msp_dl_config.h"
+#include "ti_msp_dl_config.h"  // IWYU pragma: keep; required for GPTIMER_Regs and DL_TIMER_CC_INDEX
 
 namespace LibXR
 {

--- a/driver/mspm0/mspm0_spi.cpp
+++ b/driver/mspm0/mspm0_spi.cpp
@@ -722,3 +722,10 @@ extern "C" void SPI1_IRQHandler(void)  // NOLINT
   LibXR::MSPM0SPI::OnInterrupt(1);
 }
 #endif
+
+#if defined(SPI2_BASE)
+extern "C" void SPI2_IRQHandler(void)  // NOLINT
+{
+  LibXR::MSPM0SPI::OnInterrupt(2);
+}
+#endif

--- a/driver/mspm0/mspm0_spi.hpp
+++ b/driver/mspm0/mspm0_spi.hpp
@@ -57,6 +57,10 @@ class MSPM0SPI : public SPI
       case SPI1_INT_IRQn:
         return 1;
 #endif
+#if defined(SPI2_BASE)
+      case SPI2_INT_IRQn:
+        return 2;
+#endif
       default:
         return INVALID_INSTANCE_INDEX;
     }
@@ -70,7 +74,13 @@ class MSPM0SPI : public SPI
     TX_ONLY
   };
 
+#if defined(SPI2_BASE)
+  static constexpr uint8_t MAX_SPI_INSTANCES = 3;
+#elif defined(SPI1_BASE)
   static constexpr uint8_t MAX_SPI_INSTANCES = 2;
+#else
+  static constexpr uint8_t MAX_SPI_INSTANCES = 1;
+#endif
   static constexpr uint8_t INVALID_INSTANCE_INDEX = 0xFF;
   static constexpr uint32_t RX_ONLY_REPEAT_TX_MAX_FRAMES = 256U;
 

--- a/driver/mspm0/mspm0_timebase.cpp
+++ b/driver/mspm0/mspm0_timebase.cpp
@@ -12,9 +12,9 @@ MicrosecondTimestamp Timebase::GetMicroseconds()
 {
   do
   {
-    uint32_t tick_old = sys_tick_ms;
+    uint32_t tick_old = MSPM0Timebase::sys_tick_ms;
     uint32_t val_old = DL_SYSTICK_getValue();
-    uint32_t tick_new = sys_tick_ms;
+    uint32_t tick_new = MSPM0Timebase::sys_tick_ms;
     uint32_t val_new = DL_SYSTICK_getValue();
 
     auto tick_diff = tick_new - tick_old;
@@ -43,8 +43,8 @@ MicrosecondTimestamp Timebase::GetMicroseconds()
 }
 
 MillisecondTimestamp Timebase::GetMilliseconds() { return MSPM0Timebase::sys_tick_ms; }
-void MSPM0Timebase::OnSysTickInterrupt() { sys_tick_ms++; }
-void MSPM0Timebase::Sync(uint32_t ticks) { sys_tick_ms = ticks; }
+void MSPM0Timebase::OnSysTickInterrupt() { MSPM0Timebase::sys_tick_ms++; }
+void MSPM0Timebase::Sync(uint32_t ticks) { MSPM0Timebase::sys_tick_ms = ticks; }
 
 extern "C" void SysTick_Handler(void)  // NOLINT
 {


### PR DESCRIPTION
# fix(mspm0): add GPIO/SPI IRQ support and timing fixes

## 概要

修复 MSPM0 驱动中的时基编译回归，并补齐 MSPM0 GPIO / SPI 中断相关支持。

本 PR 主要解决当前 `master` 上 `driver/mspm0/mspm0_timebase.cpp` 在静态时基重构后出现的编译问题：`Timebase::GetMicroseconds()` 直接引用了未限定作用域的 `sys_tick_ms`，但该计数器实际声明为 `MSPM0Timebase::sys_tick_ms`。

同时，本 PR 增加 MSPM0 `GROUP1_IRQHandler` 的共享分发逻辑，使 GPIOA/GPIOB/GPIOC 等同属 Group1 的中断源可以安全共存，并补充 SPI2 IRQ 支持与 PWM 频率边界检查。

## 背景

在 PR #190 审核期间检查当前主干时，发现 MSPM0 时基实现存在编译回归。

检查时的主干提交：

```text
master: b424e5801406750e720a30d96b2aedc6499883c8
```

相关文件：

```text
driver/mspm0/mspm0_timebase.cpp
driver/mspm0/mspm0_timebase.hpp
```

MSPM0 编译探测失败信息：

```text
driver/mspm0/mspm0_timebase.cpp: In static member function 'static LibXR::MicrosecondTimestamp LibXR::Timebase::GetMicroseconds()':
driver/mspm0/mspm0_timebase.cpp:15:25: error: 'sys_tick_ms' was not declared in this scope
   15 |     uint32_t tick_old = sys_tick_ms;
      |                         ^~~~~~~~~~~
```

同一源文件中的 `GetMilliseconds()` 已经正确使用限定作用域：

```cpp
MillisecondTimestamp Timebase::GetMilliseconds() { return MSPM0Timebase::sys_tick_ms; }
```

因此 `GetMicroseconds()` 也应显式使用 `MSPM0Timebase::sys_tick_ms`，避免依赖不存在的当前作用域符号。

该问题与 PR #190 的实际改动无关。PR #190 仅调整了 SysTick 分母并增加了 `GPIOA_BASE` 保护。

## 修改内容

### 1. 修复 MSPM0 时基编译回归

修复 `driver/mspm0/mspm0_timebase.cpp` 中对 `sys_tick_ms` 的未限定访问：

- `Timebase::GetMicroseconds()` 改为访问 `MSPM0Timebase::sys_tick_ms`
- `MSPM0Timebase::OnSysTickInterrupt()` 显式更新 `MSPM0Timebase::sys_tick_ms`
- `MSPM0Timebase::Sync()` 显式写入 `MSPM0Timebase::sys_tick_ms`

这样可以与 `mspm0_timebase.hpp` 中的静态成员声明保持一致。

### 2. 新增 MSPM0 Group1 共享中断分发

新增：

```text
driver/mspm0/mspm0_group1_shared.hpp
driver/mspm0/mspm0_group1_shared.cpp
```

用于集中实现 `GROUP1_IRQHandler()`，并根据 `DL_Interrupt_getPendingGroup(DL_INTERRUPT_GROUP_1)` 返回的 IIDX 分发到对应外设回调。

当前支持的 Group1 中断源包括：

- GPIOA
- GPIOB
- GPIOC
- COMP0
- COMP1
- COMP2
- TRNG

这样可以避免多个驱动分别定义或直接占用同一个 Group1 IRQ 入口导致冲突。

### 3. GPIO 改用共享 Group1 IRQ 注册机制

`driver/mspm0/mspm0_gpio.cpp` 中，GPIO 不再直接启用单独的 `GPIOx_INT_IRQn`，而是注册到共享 Group1 IRQ 分发器：

- GPIOA 注册 `gpioa_irq_thunk`
- GPIOB 注册 `gpiob_irq_thunk`
- GPIOC 注册 `gpioc_irq_thunk`

中断发生后由共享 `GROUP1_IRQHandler()` 分发到 `MSPM0GPIO::OnInterrupt()`。

同时在 GPIO 中断分发入口增加 `port_idx` 范围保护，避免非法端口索引访问回调数组。

### 4. 补充 SPI2 中断支持

补充 MSPM0 SPI2 的实例映射与 IRQ handler：

- `SPI2_INT_IRQn` 映射到实例索引 `2`
- 当 `SPI2_BASE` 存在时，`MAX_SPI_INSTANCES` 扩展为 `3`
- 新增 `SPI2_IRQHandler()`

这使带有 SPI2 外设的 MSPM0 芯片能够正常进入 `MSPM0SPI::OnInterrupt(2)`。

### 5. 修复 PWM 频率过高时的边界情况

`driver/mspm0/mspm0_pwm.cpp` 中，当计算出的 `best_load == 0` 时，说明目标频率过高，当前定时器配置无法表示。

此前代码会在 `best_load > 0` 时减一，但没有显式拒绝 `best_load == 0` 的情况。本 PR 改为：

- `best_load == 0` 时返回 `ErrorCode::NOT_SUPPORT`
- 其余合法情况再执行 `best_load -= 1`

避免无效计数周期进入后续配置。

## 影响范围

本 PR 影响 MSPM0 平台驱动：

```text
driver/mspm0/CMakeLists.txt
driver/mspm0/mspm0_gpio.cpp
driver/mspm0/mspm0_group1_shared.cpp
driver/mspm0/mspm0_group1_shared.hpp
driver/mspm0/mspm0_pwm.cpp
driver/mspm0/mspm0_spi.cpp
driver/mspm0/mspm0_spi.hpp
driver/mspm0/mspm0_timebase.cpp
```

主要影响范围：

- MSPM0 SysTick / Timebase
- MSPM0 GPIO 中断
- MSPM0 Group1 IRQ 分发
- MSPM0 SPI 中断实例
- MSPM0 PWM 频率配置边界

## 兼容性说明

- 仅在对应外设宏存在时启用相关代码，例如 `GPIOA_BASE`、`GPIOB_BASE`、`GPIOC_BASE`、`SPI2_BASE` 等。
- 对没有 GPIOC、SPI2、COMP 或 TRNG 的芯片，相关分支会被预处理条件排除。
- `GROUP1_IRQHandler()` 使用统一分发方式，避免多个 Group1 外设各自定义 IRQ handler 造成链接或运行时冲突。

## 预期结果

- MSPM0 驱动路径可以通过编译。
- `Timebase::GetMicroseconds()` 使用正确作用域的时基计数器。
- GPIOA/GPIOB/GPIOC 可通过共享 Group1 IRQ 分发正常处理中断。
- 带 SPI2 的 MSPM0 设备可正确处理 SPI2 中断。
- PWM 对不可表示的过高频率返回 `NOT_SUPPORT`，避免生成无效定时器配置。

## 测试说明

已针对本 PR 中涉及的问题进行代码级检查：

- 确认 `GetMicroseconds()` 中的 `sys_tick_ms` 均已限定为 `MSPM0Timebase::sys_tick_ms`
- 确认 `GetMilliseconds()`、`OnSysTickInterrupt()`、`Sync()` 使用同一静态计数器
- 确认 `GROUP1_IRQHandler()` 按 Group1 IIDX 分发 GPIO / COMP / TRNG 回调
- 确认 GPIO 中断注册入口改为共享 Group1 IRQ 注册
- 确认 SPI2 在 `SPI2_BASE` 存在时才启用
- 确认 PWM `best_load == 0` 时返回 `ErrorCode::NOT_SUPPORT`

如维护者需要，可以继续补充针对 MSPM0 模板工程的交叉编译验证记录。

## 相关信息

该修复来源于 PR #190 审核期间发现的主干编译回归。

审查记录：

```text
/root/codex/runs/libxr_pr190_review_20260628/99_summary.txt
```

相关问题：

```text
xrobot-org/MSPM0G3507_LibXR_Template#3
```

## Summary by Sourcery

修复 MSPM0 时间基准编译回归问题，并添加共享的 Group1 中断处理以及 SPI/PWM 边界情况支持。

Bug 修复：
- 更正 MSPM0 时间基准对 SysTick 毫秒计数器的访问方式，以解决编译回归问题。
- 为 GPIO 中断分发增加对无效端口索引的防护，防止越界访问回调。
- 当 PWM 配置请求的频率过高、无法表示时，返回 NOT_SUPPORT，而不是应用无效的定时器装载值。

增强内容：
- 引入共享的 MSPM0 Group1 中断分发器，通过单一处理程序并配合回调注册，统一路由 GPIO、比较器和 TRNG 中断。
- 更新 MSPM0 GPIO，使其注册到共享的 Group1 IRQ 机制，而不是直接启用逐端口 IRQ。
- 扩展 MSPM0 SPI 支持，以处理 SPI2 中断，并根据可用外设调整最大实例数量。
- 在驱动构建配置中包含 MSPM0 Group1 共享中断实现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix MSPM0 timebase compilation regression and add shared Group1 IRQ handling and SPI/PWM edge-case support.

Bug Fixes:
- Correct MSPM0 timebase access to the SysTick millisecond counter to resolve a compilation regression.
- Guard GPIO interrupt dispatch against invalid port indices to prevent out-of-bounds callback access.
- Return NOT_SUPPORT when PWM configuration requests an unrepresentably high frequency instead of applying an invalid timer load value.

Enhancements:
- Introduce a shared MSPM0 Group1 interrupt dispatcher to route GPIO, comparator, and TRNG interrupts through a single handler with callback registration.
- Update MSPM0 GPIO to register with the shared Group1 IRQ mechanism instead of enabling per-port IRQs directly.
- Extend MSPM0 SPI support to handle SPI2 interrupts and adjust the maximum instance count based on available peripherals.
- Include the MSPM0 Group1 shared interrupt implementation in the driver build configuration.

</details>