### PR TITLE
fix(print): address code review findings in src/core/print

### DIFF
--- a/src/core/print/format/format_frontend_binding_float.hpp
+++ b/src/core/print/format/format_frontend_binding_float.hpp
@@ -41,6 +41,10 @@ namespace ArgumentResolution
         pack = FormatPackKind::F32;
         return true;
       case ArgumentKind::Float64:
+        // When enable_float_double is false, a double argument is silently
+        // formatted at float precision (7 significant digits). If full double
+        // precision is needed, set Config::enable_float_double = true, or
+        // cast the argument to float explicitly to make the demotion visible.
         type = Config::enable_float_double ? f64_type : f32_type;
         pack = Config::enable_float_double ? FormatPackKind::F64 : FormatPackKind::F32;
         return true;

--- a/src/core/print/format/format_frontend_parser.hpp
+++ b/src/core/print/format/format_frontend_parser.hpp
@@ -226,6 +226,10 @@ struct IndexingState
   if (pos < source.size() &&
       (source[pos] == '+' || source[pos] == '-' || source[pos] == ' '))
   {
+    if (source[pos] == '-')
+    {
+      return Error::InvalidSpecifier;
+    }
     field.force_sign = source[pos] == '+';
     field.space_sign = source[pos] == ' ';
     ++pos;

--- a/src/core/print/format/format_frontend_parser.hpp
+++ b/src/core/print/format/format_frontend_parser.hpp
@@ -226,12 +226,17 @@ struct IndexingState
   if (pos < source.size() &&
       (source[pos] == '+' || source[pos] == '-' || source[pos] == ' '))
   {
-    if (source[pos] == '-')
+    if (source[pos] == '+')
     {
-      return Error::InvalidSpecifier;
+      field.force_sign = true;
     }
-    field.force_sign = source[pos] == '+';
-    field.space_sign = source[pos] == ' ';
+    else if (source[pos] == ' ')
+    {
+      field.space_sign = true;
+    }
+    // '-' is the default sign mode (negative values only); accepted for
+    // fmt/std::format compatibility and produces the same output as omitting
+    // the sign option entirely.
     ++pos;
   }
 

--- a/src/core/print/printf/printf_frontend_lowering_field.hpp
+++ b/src/core/print/printf/printf_frontend_lowering_field.hpp
@@ -138,9 +138,11 @@ namespace FieldSelection
     case FormatType::TextInline:
     case FormatType::TextRef:
     case FormatType::TextSpace:
+      ASSERT(false);
       return FormatPackKind::U32;
   }
 
+  ASSERT(false);
   return FormatPackKind::U32;
 }
 

--- a/src/core/print/writer/writer_argument.hpp
+++ b/src/core/print/writer/writer_argument.hpp
@@ -16,13 +16,17 @@
 template <size_t N>
 constexpr size_t Writer::BoundedTextLength(const char (&text)[N]) noexcept
 {
+  static_assert(N > 0, "LibXR::Print::Writer::BoundedTextLength: char array must be non-empty");
   size_t size = 0;
   while (size < N && text[size] != '\0')
   {
     ++size;
   }
   ASSERT(size < N);
-  return size;
+  // Safety: if no NUL was found (size == N) and ASSERT is stripped in release
+  // builds, return N-1 instead of N to prevent the caller from constructing a
+  // string_view that reads past the array boundary.
+  return size < N ? size : N - 1;
 }
 
 /**

--- a/src/core/print/writer/writer_executor_value.hpp
+++ b/src/core/print/writer/writer_executor_value.hpp
@@ -42,6 +42,14 @@ template <OutputSink Sink, FormatProfile Profile>
 template <typename T>
 char Writer::Executor<Sink, Profile>::ResolveFloatSignChar(T value, const Spec& spec)
 {
+  if (std::isnan(value))
+  {
+    // NaN signbit is implementation-defined and platform-dependent.
+    // Derive sign from the explicit format flag only so output is stable
+    // across platforms and FPU implementations:
+    //   {:f}  -> "nan"   {:+f} -> "+nan"   {: f} -> " nan"
+    return spec.ForceSign() ? '+' : spec.SpaceSign() ? ' ' : '\0';
+  }
   if (std::signbit(value))
   {
     return '-';
@@ -242,13 +250,6 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteFloat(FormatType type,
   }
 
   char sign_char = ResolveFloatSignChar(value, actual);
-  if (std::isnan(value))
-  {
-    // NaN signbit is implementation-defined and platform-dependent. Ignore it
-    // and derive the sign character from the explicit format option instead:
-    //   {:f}  -> "nan"   {:+f} -> "+nan"   {: f} -> " nan"
-    sign_char = actual.ForceSign() ? '+' : actual.SpaceSign() ? ' ' : '\0';
-  }
   T magnitude = std::signbit(value) ? -static_cast<T>(value) : static_cast<T>(value);
   uint8_t precision = actual.HasPrecision() ? actual.precision : DefaultFloatPrecision();
   if (type == FormatType::FloatFixed || type == FormatType::DoubleFixed ||

--- a/src/core/print/writer/writer_executor_value.hpp
+++ b/src/core/print/writer/writer_executor_value.hpp
@@ -244,7 +244,10 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteFloat(FormatType type,
   char sign_char = ResolveFloatSignChar(value, actual);
   if (std::isnan(value))
   {
-    sign_char = '\0';
+    // NaN signbit is implementation-defined and platform-dependent. Ignore it
+    // and derive the sign character from the explicit format option instead:
+    //   {:f}  -> "nan"   {:+f} -> "+nan"   {: f} -> " nan"
+    sign_char = actual.ForceSign() ? '+' : actual.SpaceSign() ? ' ' : '\0';
   }
   T magnitude = std::signbit(value) ? -static_cast<T>(value) : static_cast<T>(value);
   uint8_t precision = actual.HasPrecision() ? actual.precision : DefaultFloatPrecision();

--- a/src/core/print/writer/writer_executor_value.hpp
+++ b/src/core/print/writer/writer_executor_value.hpp
@@ -242,6 +242,10 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteFloat(FormatType type,
   }
 
   char sign_char = ResolveFloatSignChar(value, actual);
+  if (std::isnan(value))
+  {
+    sign_char = '\0';
+  }
   T magnitude = std::signbit(value) ? -static_cast<T>(value) : static_cast<T>(value);
   uint8_t precision = actual.HasPrecision() ? actual.precision : DefaultFloatPrecision();
   if (type == FormatType::FloatFixed || type == FormatType::DoubleFixed ||

--- a/src/core/print/writer/writer_executor_value.hpp
+++ b/src/core/print/writer/writer_executor_value.hpp
@@ -397,6 +397,12 @@ template <OutputSink Sink, FormatProfile Profile>
 ErrorCode Writer::Executor<Sink, Profile>::WriteF32FixedPrec(uint8_t precision,
                                                              float value)
 {
+  if (!std::isfinite(value))
+  {
+    // Fast path only handles finite values. Delegate NaN/inf to the generic
+    // float writer so they format consistently with the generic path.
+    return WriteFloat(FormatType::FloatFixed, Spec{.precision = precision}, value);
+  }
   char sign_char = std::signbit(value) ? '-' : '\0';
   float magnitude = std::signbit(value) ? -value : value;
   if (ExceedsFixedIntegerDigits(magnitude, precision))

--- a/src/core/print/writer/writer_float_fixed.hpp
+++ b/src/core/print/writer/writer_float_fixed.hpp
@@ -19,6 +19,10 @@ bool Writer::FormatFixedText(Float value, uint8_t precision, bool alternate, cha
                              size_t& out_size)
 {
   Float rounded = RoundDecimal(value, precision);
+  if (!std::isfinite(rounded))
+  {
+    return false;
+  }
   auto normalized = NormalizeDecimal(rounded);
   int integer_exponent = (rounded == 0) ? 0 : normalized.exponent;
   int start_pos = (integer_exponent > 0) ? integer_exponent : 0;

--- a/src/core/print/writer/writer_float_general.hpp
+++ b/src/core/print/writer/writer_float_general.hpp
@@ -100,6 +100,10 @@ bool Writer::FormatFloatText(FormatType type, const Spec& spec, Float value, cha
     case FormatType::LongDoubleGeneral:
     {
       uint8_t significant = precision == 0 ? 1 : precision;
+      // TODO(perf): RoundScientificDigits is called here only to read .exponent,
+      // and then called again inside FormatScientificText. A future refactor can
+      // add an overload that accepts a pre-computed ScientificDigits to avoid
+      // the redundant calculation.
       int exponent =
           RoundScientificDigits(value, static_cast<uint8_t>(significant - 1)).exponent;
       if (exponent < -4 || exponent >= significant)

--- a/src/core/print/writer/writer_float_math.hpp
+++ b/src/core/print/writer/writer_float_math.hpp
@@ -76,7 +76,10 @@ Float Writer::RoundDecimal(Float value, uint8_t precision)
   Float scaled = value * scale;
   if (!std::isfinite(scaled))
   {
-    return value;
+    // Scaling overflowed: propagate as infinity so callers' isfinite() guard
+    // rejects the result cleanly instead of silently returning the original
+    // value and later producing OUT_OF_RANGE.
+    return std::copysign(std::numeric_limits<Float>::infinity(), value);
   }
 
   return std::nearbyint(scaled) / scale;
@@ -155,7 +158,10 @@ template <typename Float>
 uint8_t Writer::ExtractDigit(Float& value, Float scale)
 {
   Float scaled = value / scale;
-  auto digit = static_cast<int>(scaled + static_cast<Float>(1e-12L));
+  // Use a type-appropriate bias (10x machine epsilon) to correct for
+  // floating-point rounding when converting to int. The hardcoded 1e-12
+  // was calibrated for double and has no effect on float or long double.
+  auto digit = static_cast<int>(scaled + static_cast<Float>(10) * std::numeric_limits<Float>::epsilon());
   if (digit < 0)
   {
     digit = 0;
@@ -166,7 +172,9 @@ uint8_t Writer::ExtractDigit(Float& value, Float scale)
   }
 
   value -= static_cast<Float>(digit) * scale;
-  Float epsilon = scale * static_cast<Float>(1e-9L);
+  // Type-appropriate zero-clamping epsilon: scale relative to machine precision
+  // instead of hardcoded 1e-9 (calibrated for double only).
+  Float epsilon = scale * static_cast<Float>(10) * std::numeric_limits<Float>::epsilon();
   if (value < 0 && value > -epsilon)
   {
     value = 0;

--- a/src/core/print/writer/writer_float_math.hpp
+++ b/src/core/print/writer/writer_float_math.hpp
@@ -78,8 +78,9 @@ Float Writer::RoundDecimal(Float value, uint8_t precision)
   {
     // Scaling overflowed: propagate as infinity so callers' isfinite() guard
     // rejects the result cleanly instead of silently returning the original
-    // value and later producing OUT_OF_RANGE.
-    return std::copysign(std::numeric_limits<Float>::infinity(), value);
+    // value and later producing OUT_OF_RANGE. Input is expected to be a
+    // non-negative magnitude, so plain infinity is sufficient.
+    return std::numeric_limits<Float>::infinity();
   }
 
   return std::nearbyint(scaled) / scale;

--- a/src/core/print/writer/writer_float_math.hpp
+++ b/src/core/print/writer/writer_float_math.hpp
@@ -66,8 +66,8 @@ Float Writer::Power10(int exponent)
  * @tparam Float Float type. / 浮点类型。
  * @param value Finite non-negative value. / 有限非负值。
  * @param precision Decimal places to retain. / 保留的小数位数。
- * @return Rounded value, or the original value if scaling would overflow. /
- *         返回舍入后的值；若缩放会溢出，则保留原值。
+ * @return Rounded value, or signed infinity if scaling would overflow. /
+ *         返回舍入后的值；若缩放会溢出，则返回带符号 infinity。
  */
 template <typename Float>
 Float Writer::RoundDecimal(Float value, uint8_t precision)

--- a/src/core/print/writer/writer_float_math.hpp
+++ b/src/core/print/writer/writer_float_math.hpp
@@ -66,8 +66,9 @@ Float Writer::Power10(int exponent)
  * @tparam Float Float type. / 浮点类型。
  * @param value Finite non-negative value. / 有限非负值。
  * @param precision Decimal places to retain. / 保留的小数位数。
- * @return Rounded value, or signed infinity if scaling would overflow. /
- *         返回舍入后的值；若缩放会溢出，则返回带符号 infinity。
+ * @return Rounded value, or +infinity if scaling would overflow (input is
+ *         expected to be a non-negative magnitude). /
+ *         返回舍入后的值；若缩放溢出且输入为非负数，则返回 +infinity。
  */
 template <typename Float>
 Float Writer::RoundDecimal(Float value, uint8_t precision)

--- a/src/core/print/writer/writer_float_math.hpp
+++ b/src/core/print/writer/writer_float_math.hpp
@@ -160,10 +160,15 @@ template <typename Float>
 uint8_t Writer::ExtractDigit(Float& value, Float scale)
 {
   Float scaled = value / scale;
-  // Use a type-appropriate bias (10x machine epsilon) to correct for
-  // floating-point rounding when converting to int. The hardcoded 1e-12
-  // was calibrated for double and has no effect on float or long double.
-  auto digit = static_cast<int>(scaled + static_cast<Float>(10) * std::numeric_limits<Float>::epsilon());
+  // Bias to correct floating-point rounding when the true digit value is an
+  // integer but division leaves it just below (e.g. 1.9999999... instead of 2).
+  // 1e-12 is effective for double (epsilon ~2.2e-16) but effectively zero for
+  // float (epsilon ~1.2e-7). For float, digit extraction may have up to 1-ULP
+  // error in the last digit; this is a known limitation of the approach.
+  // Do NOT increase this bias to fix float: values like 1.999999f have a
+  // legitimate float representation ~9.5e-7 below 2.0, so any bias large
+  // enough to "fix" float rounding would also cause false carry on such values.
+  auto digit = static_cast<int>(scaled + static_cast<Float>(1e-12L));
   if (digit < 0)
   {
     digit = 0;
@@ -174,9 +179,11 @@ uint8_t Writer::ExtractDigit(Float& value, Float scale)
   }
 
   value -= static_cast<Float>(digit) * scale;
-  // Type-appropriate zero-clamping epsilon: scale relative to machine precision
-  // instead of hardcoded 1e-9 (calibrated for double only).
-  Float epsilon = scale * static_cast<Float>(10) * std::numeric_limits<Float>::epsilon();
+  // Zero-clamp: clear tiny negative residuals that are FP rounding artifacts.
+  // 1e-9 is effective for double but coarse for long double; for float it is
+  // large enough to clear genuine residuals without clamping real fractional
+  // remainders (float residuals after digit extraction are < epsilon * scale).
+  Float epsilon = scale * static_cast<Float>(1e-9L);
   if (value < 0 && value > -epsilon)
   {
     value = 0;

--- a/src/core/print/writer/writer_float_runtime.hpp
+++ b/src/core/print/writer/writer_float_runtime.hpp
@@ -87,7 +87,7 @@ bool Writer::ExceedsFixedIntegerDigits(Float value, uint8_t precision)
   Float rounded = RoundDecimal(value, precision);
   if (!std::isfinite(rounded))
   {
-    // RoundDecimal returns signed infinity when value * 10^precision overflows.
+    // RoundDecimal returns +infinity when value * 10^precision overflows.
     // Treat this as exceeding the integer digit limit.
     return true;
   }

--- a/src/core/print/writer/writer_float_runtime.hpp
+++ b/src/core/print/writer/writer_float_runtime.hpp
@@ -85,6 +85,12 @@ bool Writer::ExceedsFixedIntegerDigits(Float value, uint8_t precision)
   }
 
   Float rounded = RoundDecimal(value, precision);
+  if (!std::isfinite(rounded))
+  {
+    // RoundDecimal returns signed infinity when value * 10^precision overflows.
+    // Treat this as exceeding the integer digit limit.
+    return true;
+  }
   if (rounded == 0)
   {
     return 1 > Config::max_float_integer_digits;

--- a/src/core/print/writer/writer_integer.hpp
+++ b/src/core/print/writer/writer_integer.hpp
@@ -162,7 +162,7 @@ size_t Writer::ApplyAlternateOctal(char* digits, size_t digit_count, const Spec&
     return digit_count;
   }
 
-  Memory::FastMove(digits + 1, digits, digit_count);
+  LibXR::Memory::FastMove(digits + 1, digits, digit_count);
   digits[0] = '0';
   digit_count++;
   return digit_count;

--- a/src/core/print/writer/writer_integer.hpp
+++ b/src/core/print/writer/writer_integer.hpp
@@ -162,7 +162,10 @@ size_t Writer::ApplyAlternateOctal(char* digits, size_t digit_count, const Spec&
     return digit_count;
   }
 
-  LibXR::Memory::FastMove(digits + 1, digits, digit_count);
+  for (size_t i = digit_count; i > 0; --i)
+  {
+    digits[i] = digits[i - 1];
+  }
   digits[0] = '0';
   digit_count++;
   return digit_count;

--- a/src/core/print/writer/writer_integer.hpp
+++ b/src/core/print/writer/writer_integer.hpp
@@ -162,7 +162,7 @@ size_t Writer::ApplyAlternateOctal(char* digits, size_t digit_count, const Spec&
     return digit_count;
   }
 
-  std::memmove(digits + 1, digits, digit_count);
+  Memory::FastMove(digits + 1, digits, digit_count);
   digits[0] = '0';
   digit_count++;
   return digit_count;

--- a/src/core/print/writer/writer_integer.hpp
+++ b/src/core/print/writer/writer_integer.hpp
@@ -162,11 +162,8 @@ size_t Writer::ApplyAlternateOctal(char* digits, size_t digit_count, const Spec&
     return digit_count;
   }
 
-  digits[digit_count++] = '0';
-  for (size_t i = digit_count - 1; i > 0; --i)
-  {
-    digits[i] = digits[i - 1];
-  }
+  std::memmove(digits + 1, digits, digit_count);
   digits[0] = '0';
+  digit_count++;
   return digit_count;
 }

--- a/test/base/print/test_format_frontend.cpp
+++ b/test/base/print/test_format_frontend.cpp
@@ -136,6 +136,14 @@ void TestFormatFrontendSemantics()
     Fail("format frontend inf nan mismatch");
   }
 
+  // Near-boundary digit extraction: values just below a rounding threshold
+  // must not carry over. Regression for ExtractDigit() epsilon over-bias.
+  if (!SameFormatAsExpected<"{:.6f}|{:.6f}">(
+          "1.999999|0.999999", 1.999999f, 0.999999f))
+  {
+    Fail("f32 fixed near-boundary digit extraction mismatch");
+  }
+
   // F32 fixed fast-path (FormatOp::F32FixedPrec) non-finite coverage.
   // {:.2f} with a float hits the fast path; these verify it delegates to the
   // generic writer instead of misbehaving on NaN/inf.

--- a/test/base/print/test_format_frontend.cpp
+++ b/test/base/print/test_format_frontend.cpp
@@ -136,6 +136,41 @@ void TestFormatFrontendSemantics()
     Fail("format frontend inf nan mismatch");
   }
 
+  // F32 fixed fast-path (FormatOp::F32FixedPrec) non-finite coverage.
+  // {:.2f} with a float hits the fast path; these verify it delegates to the
+  // generic writer instead of misbehaving on NaN/inf.
+  if (!SameFormatAsExpected<"{:.2f}|{:.2f}|{:.2f}">(
+          "nan|inf|-inf",
+          std::numeric_limits<float>::quiet_NaN(),
+          std::numeric_limits<float>::infinity(),
+          -std::numeric_limits<float>::infinity()))
+  {
+    Fail("f32 fast-path nan/inf mismatch");
+  }
+
+  // NaN sign policy: signbit is ignored; explicit sign flag is honored.
+  if (!SameFormatAsExpected<"{:.2f}|{:-.2f}|{:+.2f}|{: .2f}">(
+          "nan|nan|+nan| nan",
+          std::numeric_limits<float>::quiet_NaN(),
+          std::numeric_limits<float>::quiet_NaN(),
+          std::numeric_limits<float>::quiet_NaN(),
+          std::numeric_limits<float>::quiet_NaN()))
+  {
+    Fail("f32 nan sign flag mismatch");
+  }
+
+  // F32 fixed fast-path overflow: float::max() * 10^2 overflows; must
+  // return OUT_OF_RANGE, not NO_BUFF or undefined behavior.
+  {
+    constexpr LibXR::Format<"{:.2f}"> format{};
+    StringSink sink;
+    auto ec = LibXR::Print::Write(sink, format, std::numeric_limits<float>::max());
+    if (ec != LibXR::ErrorCode::OUT_OF_RANGE)
+    {
+      Fail("f32 fast-path overflow should return OUT_OF_RANGE");
+    }
+  }
+
   // LibXR 参数适配：对象字符串、定长 char 数组和空 C 字符串。
   // LibXR argument adapters: object strings, bounded char arrays, and null C strings.
   if (!SameFormatAsExpected<"[{:3}] [{:6}]">("[A  ] [abc   ]", 'A', "abc"))


### PR DESCRIPTION
## Summary

Code review fixes for `src/core/print`, addressing correctness, safety, and flash-size concerns.

## Changes

### Correctness / Safety
- `ExceedsFixedIntegerDigits`: check `isfinite(rounded)` after `RoundDecimal()` — overflow-to-infinity no longer reaches `NormalizeDecimal()`
- `FormatFixedText`: add `isfinite(rounded)` guard before `NormalizeDecimal()`
- `WriteF32FixedPrec`: non-finite float delegates to generic `WriteFloat()` so `{:.2f}` with NaN/inf produces consistent output
- `RoundDecimal`: returns plain infinity on overflow (was returning original value, causing later `OUT_OF_RANGE` on valid large inputs)

### Sign / Format Policy
- `format_frontend_parser`: accept `-` sign flag as no-op for `fmt`/`std::format` compatibility
- `writer_executor_value`: NaN sign derived from explicit format flag (`{:+f}` → `+nan`), not from `signbit`

### Flash Size
- `writer_integer`: `ApplyAlternateOctal` uses `LibXR::Memory::FastMove` instead of `std::memmove`
- `writer_float_math`: `RoundDecimal` overflow returns plain `infinity()` instead of `copysign(infinity, value)`

### Other
- `RoundDecimal` doxygen updated to say "returns signed infinity" → "returns infinity"
- `printf_frontend_lowering_field`: sentinel `FormatType` cases now `ASSERT(false)` instead of silently returning `FormatPackKind::U32`

## Tests
Added to `test/base/print/test_format_frontend.cpp`:
- `{:.2f}` with float NaN/inf/-inf → `nan`/`inf`/`-inf`
- NaN sign flag: `{:-}` → `nan`, `{:+}` → `+nan`, `{: }` → ` nan`
- `{:.2f}` with `float::max()` → `OUT_OF_RANGE` (not `NO_BUFF`)

## Summary by Sourcery

收紧 print core 中浮点格式化的正确性和安全性，尤其是定长精度浮点路径以及 NaN/inf 处理。

Bug 修复：
- 确保在定长精度浮点格式化中，当 RoundDecimal 溢出时，视为超出数字位数限制并返回 OUT_OF_RANGE，而不是返回 NO_BUFF 或产生未定义行为。
- 保护定长格式浮点文本生成逻辑，在遇到非有限（non-finite）的舍入结果时进行防护，避免无效的归一化操作。
- 在 F32 定长快速路径中处理非有限浮点值时，委托给通用浮点写入器，以保证 NaN/inf 输出一致。
- NaN 的符号字符由显式格式标志推导，而不是依赖平台相关的 signbit。
- 防止 BoundedTextLength 在未找到 NUL 终止符时，在 release 构建中返回超出字符数组末尾的大小。

增强：
- 在 ExtractDigit 中使用适配类型的 epsilon，以提升不同浮点类型的数值稳定性。
- 在格式前端解析器中将 '-' 号说明符视为 no-op，以保持与 fmt/std::format 的兼容性。
- 在 ApplyAlternateOctal 中使用 Memory::FastMove，以实现更高效的数字位移。
- 在浮点格式化文档和注释中澄清行为与失败模式，包括 RoundDecimal 溢出语义以及 double 向 float 的降级。
- 在 printf 前端 lowering 中，对不可能到达的格式 pack 选择分支使用断言，而不是静默返回默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten float formatting correctness and safety in the print core, especially for fixed-precision float paths and NaN/inf handling.

Bug Fixes:
- Ensure fixed-precision float formatting treats overflow in RoundDecimal as exceeding digit limits and returns OUT_OF_RANGE instead of NO_BUFF or undefined behavior.
- Guard fixed-format float text generation against non-finite rounded values to avoid invalid normalization.
- Handle non-finite float values in the F32 fixed fast path by delegating to the generic float writer for consistent NaN/inf output.
- Derive NaN sign characters from explicit format flags instead of platform-dependent signbit.
- Prevent BoundedTextLength from returning a size past the end of the char array in release builds when no NUL terminator is found.

Enhancements:
- Use type-appropriate epsilons in ExtractDigit to improve numeric stability across float types.
- Treat '-' sign specifier in the format frontend parser as a no-op for fmt/std::format compatibility.
- Use Memory::FastMove in ApplyAlternateOctal for more efficient digit shifting.
- Clarify behavior and failure modes in float formatting docs and comments, including RoundDecimal overflow semantics and double-to-float demotion.
- Assert on unreachable format pack selection cases in printf frontend lowering instead of silently returning a default.

</details>