### PR TITLE
ci(pages): cancel in-progress deploys to fix Doxygen artifact conflict

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -15,11 +15,14 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Allow only one concurrent deployment, and cancel any in-progress run when a
+# newer push arrives. Without this, overlapping runs both upload a
+# "github-pages" artifact against the same Pages deployment, which makes
+# deploy-pages fail with "Multiple artifacts named github-pages" and can leave
+# a later run blocking on the environment lock until it times out.
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   # Single deploy job since we're just deploying
@@ -68,4 +71,5 @@ jobs:
           path: 'doc/html'
       - name: Deploy to GitHub Pages
         id: deployment
+        timeout-minutes: 5
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Problem

The Doxygen Pages workflow (`.github/workflows/doxygen.yml`) fails on master. Two failure modes, same root cause:

- `Error: Multiple artifacts named "github-pages" were unexpectedly found for this workflow run. Artifact count is 2.`
- `Deploy to GitHub Pages` hanging until `Timeout reached, aborting!` (10+ min)

Root cause: `concurrency` was set to `cancel-in-progress: false`. Rapid pushes to master produce overlapping runs; two runs upload a `github-pages` artifact against the same Pages deployment, and a later run blocks on the environment lock.

## Fix

- `cancel-in-progress: true` — a newer push supersedes an unfinished run (safe for Pages: the old deploy would be overwritten anyway)
- `timeout-minutes: 5` on the deploy step — fail fast instead of hanging for 10 minutes if the environment is still contended

Only touches the workflow file; no source changes.

## Summary by Sourcery

调整 Doxygen GitHub Pages 工作流，以防止重叠的部署发生冲突，并在部署卡住时更快失败。

CI：
- 启用在有更新的 push 到来时取消正在运行的 Doxygen Pages 工作流，以避免产生相互冲突的 GitHub Pages 构建产物。
- 为 GitHub Pages 部署步骤设置更短的超时时间，以避免在环境被锁定时长时间挂起。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust the Doxygen GitHub Pages workflow to prevent overlapping deployments from conflicting and to fail faster when deployments hang.

CI:
- Enable cancellation of in-progress Doxygen Pages workflow runs when a newer push arrives to avoid conflicting GitHub Pages artifacts.
- Set a shorter timeout on the GitHub Pages deployment step to avoid long hangs when the environment is locked.

</details>