### PR TITLE
ci(docs): add prebuilt docs image (doxygen + graphviz)

### DIFF
--- a/.github/workflows/docs-image.yml
+++ b/.github/workflows/docs-image.yml
@@ -1,0 +1,39 @@
+name: Build Docs Image
+
+on:
+  # Rebuild when the image definition changes.
+  push:
+    branches: ["master"]
+    paths:
+      - "docker/docs/Dockerfile"
+      - ".github/workflows/docs-image.yml"
+  # Allow manual rebuilds (e.g. to pick up a new base image).
+  workflow_dispatch:
+
+concurrency:
+  group: "docs-image"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/docs
+          push: true
+          tags: ghcr.io/${{ github.repository_owner }}/libxr-docs:latest

--- a/docker/docs/Dockerfile
+++ b/docker/docs/Dockerfile
@@ -1,0 +1,29 @@
+# Documentation build image for LibXR.
+# Preinstalls the exact Doxygen release and Graphviz used by the
+# "Generate and Deploy Doxygen Docs" workflow, so CI does not download and
+# verify the Doxygen tarball on every run.
+FROM ubuntu:24.04
+
+ARG DOXYGEN_VERSION=1.12.0
+ARG DOXYGEN_SHA256=3c42c3f3fb206732b503862d9c9c11978920a8214f223a3950bbf2520be5f647
+
+# graphviz: dot diagrams; ca-certificates/wget: fetch the release tarball once
+# at image build time.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        graphviz \
+        ca-certificates \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    tarball="doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"; \
+    release="Release_$(echo "${DOXYGEN_VERSION}" | tr '.' '_')"; \
+    wget --tries=5 --waitretry=10 --retry-connrefused \
+         --retry-on-http-error=403,429,500,502,503,504 --timeout=30 \
+         "https://github.com/doxygen/doxygen/releases/download/${release}/${tarball}"; \
+    echo "${DOXYGEN_SHA256}  ${tarball}" | sha256sum -c -; \
+    tar xzf "${tarball}" -C /opt; \
+    ln -sf "/opt/doxygen-${DOXYGEN_VERSION}/bin/"* /usr/local/bin/; \
+    rm -f "${tarball}"; \
+    doxygen --version


### PR DESCRIPTION
## Why

The `Generate and Deploy Doxygen Docs` workflow downloads, checksums, and unpacks the Doxygen tarball on every run. That is slow and depends on the Doxygen GitHub release being reachable (a 403/429/outage breaks docs deploys).

## What (step 1 of 2)

- `docker/docs/Dockerfile`: Ubuntu 24.04 + Graphviz + Doxygen 1.12.0, pinned by the **same sha256** the current workflow already verifies.
- `.github/workflows/docs-image.yml`: builds and pushes the image to `ghcr.io/<owner>/libxr-docs:latest`, triggered only when the image definition changes (or manually).

## Follow-up (step 2, separate PR)

Once this merges and the image is published, a second PR will switch `doxygen.yml` to run in this container and drop the per-run wget/install step. Splitting avoids a chicken-and-egg failure where `doxygen.yml` would reference an image that does not exist yet.

No source or existing-workflow changes in this PR.

## Summary by Sourcery

添加专用的 Docker 镜像和 CI 工作流程，用于构建预装 Doxygen 和 Graphviz 的文档。

Build:
- 引入一个基于 Ubuntu 24.04 的文档构建镜像 Dockerfile，并预装并固定版本的 Doxygen 和 Graphviz。
- 添加一个 GitHub Actions 工作流程，在相关变更或手动触发时构建并发布该文档镜像到 GHCR。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a dedicated Docker image and CI workflow for building documentation with preinstalled Doxygen and Graphviz.

Build:
- Introduce a Dockerfile for a docs build image based on Ubuntu 24.04 with pinned Doxygen and Graphviz preinstalled.
- Add a GitHub Actions workflow to build and publish the docs image to GHCR on relevant changes or manual dispatch.

</details>