### PR TITLE
ci(docs): lowercase GHCR owner in docs image tag

### DIFF
--- a/.github/workflows/docs-image.yml
+++ b/.github/workflows/docs-image.yml
@@ -31,9 +31,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # GHCR repository names must be lowercase; the owner login may not be.
+      - name: Compute image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}/libxr-docs" >> "$GITHUB_ENV"
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: docker/docs
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/libxr-docs:latest
+          tags: ${{ env.IMAGE }}:latest


### PR DESCRIPTION
The docs image build failed:

```
ERROR: failed to build: invalid tag "ghcr.io/Jiu-xiao/libxr-docs:latest": repository name must be lowercase
```

`github.repository_owner` is `Jiu-xiao` (mixed case), but GHCR repository names must be lowercase. Compute a lowercased image name with bash parameter expansion (`${GITHUB_REPOSITORY_OWNER,,}`) before build-push.

Fixes the first run of the Build Docs Image workflow added in #226.

## Summary by Sourcery

CI:
- 更新文档镜像工作流，在运行 Docker 构建和推送操作之前，通过环境变量计算小写的 GHCR 镜像名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update the docs image workflow to compute a lowercase GHCR image name via environment variable before running the Docker build-push action.

</details>