### PR TITLE
ci(docs): build docs in prebuilt image, drop per-run doxygen install

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -25,50 +25,38 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  # Generate docs inside the prebuilt image (doxygen + graphviz already
+  # installed), then hand the html to the deploy job as a Pages artifact.
+  build:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jiu-xiao/libxr-docs:latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Install documentation dependencies
-        run: sudo apt-get update && sudo apt-get install -y graphviz wget
-
-      - name: Install Doxygen
-        run: |
-          DOXYGEN_VERSION=1.12.0
-          DOXYGEN_TARBALL="doxygen-${DOXYGEN_VERSION}.linux.bin.tar.gz"
-          DOXYGEN_URL="https://github.com/doxygen/doxygen/releases/download/Release_1_12_0/${DOXYGEN_TARBALL}"
-
-          wget \
-            --tries=5 \
-            --waitretry=10 \
-            --retry-connrefused \
-            --retry-on-http-error=403,429,500,502,503,504 \
-            --timeout=30 \
-            --continue \
-            "$DOXYGEN_URL"
-          echo "3c42c3f3fb206732b503862d9c9c11978920a8214f223a3950bbf2520be5f647  ${DOXYGEN_TARBALL}" | sha256sum -c -
-          tar xzf "$DOXYGEN_TARBALL"
-          sudo ln -sf "$(pwd)"/doxygen-${DOXYGEN_VERSION}/bin/* /usr/bin
 
       - name: Check Doxygen Version
         run: doxygen --version
 
       - name: Generate Documentation
-        run: doxygen Doxyfile      
-      
-      - name: Setup Pages
-        uses: actions/configure-pages@v5
+        run: doxygen Doxyfile
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
           path: 'doc/html'
+
+  # Deploy runs on the host runner: the Pages deploy action needs the runner
+  # environment, not the docs container.
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
       - name: Deploy to GitHub Pages
         id: deployment
         timeout-minutes: 5


### PR DESCRIPTION
## What (step 2 of 2)

Now that `ghcr.io/jiu-xiao/libxr-docs:latest` is published (#226, #227), switch the docs workflow to use it and drop the per-run Doxygen download.

- **build** job runs in the docs container (doxygen + graphviz preinstalled), runs `doxygen Doxyfile`, uploads the Pages artifact. The wget/checksum/untar step is gone.
- **deploy** job runs on the host runner (the Pages deploy action needs the runner environment, not the container) and consumes the artifact via `needs: build`.

The image is public, so no GHCR login is needed to pull it.

## Verification

This workflow only runs on push to master, so it can't be exercised on the PR. After merge, the next master push (this merge itself) will run it — I'll confirm the run is green and that docs still deploy.

Net: -31/+19 lines; removes the external dependency on the Doxygen GitHub release being reachable at deploy time.

## Summary by Sourcery

在预构建的容器镜像中运行 Doxygen 文档生成，并在 GitHub Pages 工作流中将构建和部署拆分为两个独立的 Job。

Build:
- 更新文档的 GitHub Actions 工作流，改为使用公共镜像 `ghcr.io/jiu-xiao/libxr-docs:latest`（其中预装了 Doxygen 和 Graphviz），而不是在每次运行时安装它们。
- 将之前单一的部署 Job 拆分为两个 Job：一个构建 Job，用于生成并上传文档工件（artifact）；一个部署 Job，用于消费该工件并发布到 GitHub Pages。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Run Doxygen docs generation in a prebuilt container image and separate build and deploy into distinct jobs in the GitHub Pages workflow.

Build:
- Update docs GitHub Actions workflow to use the public ghcr.io/jiu-xiao/libxr-docs:latest container with preinstalled Doxygen and Graphviz instead of installing them on each run.
- Split the previous single deploy job into a build job that generates and uploads the docs artifact and a deploy job that consumes it to publish GitHub Pages.

</details>