### PR TITLE
fix(daplink): use standard CMSIS-DAP interface names

### DIFF
--- a/src/driver/usb/device/dap/daplink_v1.hpp
+++ b/src/driver/usb/device/dap/daplink_v1.hpp
@@ -50,6 +50,7 @@ class DapLinkV1Class
 {
  public:
   static constexpr bool JTAG_ENABLED = DapLinkV1BuildConfig::kEnableJtag;
+  static constexpr const char* DEFAULT_INTERFACE_STRING = "CMSIS-DAP";
   struct InfoStrings
   {
     const char* vendor = nullptr;
@@ -239,7 +240,9 @@ template <typename SwdPort>
 DapLinkV1Class<SwdPort>::DapLinkV1Class(SwdPort& swd_link, LibXR::GPIO* nreset_gpio,
                                Endpoint::EPNumber in_ep_num,
                                Endpoint::EPNumber out_ep_num)
-    : HID(true, 1, 1, in_ep_num, out_ep_num), swd_(swd_link), nreset_gpio_(nreset_gpio)
+    : HID(true, 1, 1, in_ep_num, out_ep_num, DEFAULT_INTERFACE_STRING),
+      swd_(swd_link),
+      nreset_gpio_(nreset_gpio)
 {
   if constexpr (JTAG_ENABLED)
   {

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -39,7 +39,7 @@ class DapLinkV2Class : public DeviceClass
 {
  public:
   static constexpr bool JTAG_ENABLED = DapLinkV2BuildConfig::kEnableJtag;
-  static constexpr const char* DEFAULT_INTERFACE_STRING = "XRUSB CMSIS-DAP v2";
+  static constexpr const char* DEFAULT_INTERFACE_STRING = "CMSIS-DAP v2";
 
   /**
    * @brief Info string set


### PR DESCRIPTION
## Summary
- Set DAPLink v1 interface string to `CMSIS-DAP`.
- Set DAPLink v2 default interface string to `CMSIS-DAP v2`.
- Keep XRUSB/XRobot branding in descriptor/DAP_Info fields rather than the CMSIS-DAP interface name.

## Validation
- Ubuntu24: `/home/xiao/runs/libxr_dap_interface_names_retry_20260702T224844Z/99_summary.txt`
- `git diff --check`
- CMake configure/build
- `./build-ci/test/test`
- `tools/format_driver_src.sh --check`
- `tools/format_cmake_files.sh --check`

## Summary by Sourcery

为 DAPLink v1 和 v2 标准化 CMSIS-DAP USB 接口命名。

Bug Fixes:
- 确保 DAPLink v1 以标准的 CMSIS-DAP USB 接口字符串进行枚举。

Enhancements:
- 将 DAPLink v2 的默认 USB 接口字符串更新为通用的 CMSIS-DAP v2 名称，同时在描述符字段中保留厂商品牌信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize CMSIS-DAP USB interface naming for DAPLink v1 and v2.

Bug Fixes:
- Ensure DAPLink v1 enumerates with the standard CMSIS-DAP USB interface string.

Enhancements:
- Update DAPLink v2 default USB interface string to the generic CMSIS-DAP v2 name while keeping vendor branding in descriptor fields.

</details>