### PR TITLE
fix(rw): ReadPort virtual dtor, symmetric FailAndClearAll guard, doc double-arm

### DIFF
--- a/src/core/rw/read_port.cpp
+++ b/src/core/rw/read_port.cpp
@@ -308,9 +308,26 @@ ErrorCode ReadPort::ClearQueuedData(bool in_isr)
 void ReadPort::FailAndClearAll(ErrorCode reason, bool in_isr)
 {
   ASSERT(queue_data_ != nullptr);
-  queue_data_->Reset();
 
   auto state = busy_.load(std::memory_order_acquire);
+
+  // Symmetric to WritePort::FailAndClearAll's guard on
+  // LOCKED/BLOCK_PUBLISHING/RESETTING: CLEARING means ClearQueuedData() still owns
+  // dequeue progress, which violates this API's "backend already unavailable, no
+  // concurrent activity" precondition. Assert in dev builds and back off in release
+  // builds instead of silently stomping the in-flight clear back to IDLE.
+  // 对称于 WritePort::FailAndClearAll 对 LOCKED/BLOCK_PUBLISHING/RESETTING 的守卫：
+  // CLEARING 表示 ClearQueuedData() 仍占有出队进度，违反了本接口“后端已不可用、
+  // 无并发活动”的前置条件。开发期触发断言，发布期直接退回，而不是把正在进行的
+  // 清队列静默踩回 IDLE。
+  if (state == BusyState::CLEARING)
+  {
+    DEV_ASSERT_FROM_CALLBACK(false, in_isr);
+    return;
+  }
+
+  queue_data_->Reset();
+
   if (state == BusyState::PENDING)
   {
     if (info_.op.type == ReadOperation::OperationType::BLOCK)

--- a/src/core/rw/read_port.hpp
+++ b/src/core/rw/read_port.hpp
@@ -68,6 +68,19 @@ class ReadPort
   ReadPort(size_t buffer_size = 128);
 
   /**
+   * @brief 虚析构函数，保证通过基类指针析构派生读端口的安全性。
+   *        Virtual destructor for safe destruction of derived read ports through a base
+   *        pointer.
+   *
+   * @note 仅补齐虚析构以消除“有虚函数却非虚析构”的编译告警；不改变析构行为，
+   *       裸指针成员的所有权语义与此前保持一致。
+   *       Only adds the virtual destructor to silence the non-virtual-dtor warning; the
+   *       destruction behavior is unchanged and raw-pointer member ownership stays as
+   *       before.
+   */
+  virtual ~ReadPort() = default;
+
+  /**
    * @brief 获取队列的剩余可用空间。
    *        Gets the remaining available space in the queue.
    *

--- a/src/core/rw/write_port.cpp
+++ b/src/core/rw/write_port.cpp
@@ -152,6 +152,15 @@ ErrorCode WritePort::CommitWrite(ConstRawData data, WriteOperation& op, bool met
     ASSERT(ans == ErrorCode::OK);
   }
 
+  // Non-BLOCK ops are armed here. BLOCK ops submitted through Stream::SubmitBuffered()
+  // were already armed (MarkAsRunning + BLOCK_PUBLISHING) before the metadata was
+  // published, so the meta_pushed re-arm below is an idempotent no-op kept only to cover
+  // the direct-submit (meta_pushed == false) BLOCK path, which arms via BLOCK_PUBLISHING
+  // above. MarkAsRunning only affects POLLING ops, so re-marking a BLOCK op is harmless.
+  // 非 BLOCK op 在此挂起。经 Stream::SubmitBuffered() 提交的 BLOCK op 在发布元数据前
+  // 已经挂起（MarkAsRunning + BLOCK_PUBLISHING），因此下面 meta_pushed 分支的重复挂起
+  // 是幂等空操作，仅为覆盖直接提交（meta_pushed == false）的 BLOCK 路径而保留。
+  // MarkAsRunning 只对 POLLING op 生效，重复标记 BLOCK op 无副作用。
   if (op.type != WriteOperation::OperationType::BLOCK)
   {
     op.MarkAsRunning();


### PR DESCRIPTION
## 概述
`src/core/rw` 代码审查后的三处小修，均满足「合法契约下行为不变」。

## 改动
- **ReadPort 虚析构** (`read_port.hpp`)：`OnRxDequeue` 已使 `ReadPort` 成为多态类型，补 `virtual ~ReadPort() = default;` 消除 `-Wnon-virtual-dtor`。不改变可拷贝/移动性与析构动作。
- **ReadPort::FailAndClearAll 对称守卫** (`read_port.cpp`)：补一个与 `WritePort` 侧 `LOCKED/BLOCK_PUBLISHING/RESETTING` 对称的 `CLEARING` 守卫，并把 `busy_` 读取提到 `Reset()` 前。合法路径零变化；误用（存在并发 `ClearQueuedData`）时 dev 断言 / release 退回，不再静默把进行中的清队列踩回 `IDLE`。
- **双重 MarkAsRunning 注释** (`write_port.cpp`)：说明 BLOCK stream 路径上的幂等重复挂起（`Stream::SubmitBuffered` 在发布元数据前已挂起）。纯注释。

## 测试
- 本地环境禁用编译，未在本机验证；依赖本 PR 的 CI（check.yml）跑编译与测试。

## 未处理（审查中提出但按维护者意见保留）
- mutex 惰性初始化竞争+泄漏、端口析构队列泄漏、`operator<<` 静默丢数据、`static_cast<int8_t>` 冗余等，均为设计取舍或需更大改动，本 PR 不涉及。

## Summary by Sourcery

确保多态析构的安全性，以及对读/写端口故障处理进行更严格的保护，同时澄清写路径中的阻塞语义。

Bug Fixes（错误修复）:
- 为 `ReadPort::FailAndClearAll` 增加防护，避免在正在执行 CLEARING 操作时被调用，从而防止与并发的 `ClearQueuedData()` 发生竞态。

Enhancements（增强）:
- 通过引入虚析构函数，使 `ReadPort` 可以通过基类指针安全析构，而不改变原有的所有权语义。
- 为 BLOCK 写操作的幂等 `MarkAsRunning` 行为添加文档说明，以在 `CommitWrite()` 中澄清阻塞流的语义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure safe polymorphic destruction and stricter guarding around read/write port failure handling while clarifying write path blocking semantics.

Bug Fixes:
- Guard ReadPort::FailAndClearAll against being called while a CLEARING operation is in progress to avoid racing with concurrent ClearQueuedData().

Enhancements:
- Make ReadPort destructible via base pointers by introducing a virtual destructor without changing ownership semantics.
- Document idempotent MarkAsRunning behavior for BLOCK write operations to clarify blocking stream semantics in CommitWrite().

</details>