### PR TITLE
Align HPM I2C with Other Platform

### DIFF
--- a/driver/hpm/hpm_i2c.cpp
+++ b/driver/hpm/hpm_i2c.cpp
@@ -2,6 +2,13 @@
 
 #include <cstdint>
 
+#if defined(LIBXR_SYSTEM_none) || defined(LIBXR_SYSTEM_webasm)
+#include "timebase.hpp"
+#define LIBXR_HPM_I2C_BLOCK_WAIT_REQUIRES_TIMEBASE 1
+#else
+#define LIBXR_HPM_I2C_BLOCK_WAIT_REQUIRES_TIMEBASE 0
+#endif
+
 #if LIBXR_HPM_I2C_SUPPORTED
 
 using namespace LibXR;
@@ -11,6 +18,31 @@ namespace
 
 constexpr uint16_t kSharedMax7BitAddress = 0x7FU;
 constexpr uint16_t kSharedMax10BitAddress = 0x3FFU;
+
+bool HpmI2cTransferSizeTooLarge(size_t size)
+{
+  return size > static_cast<size_t>(UINT32_MAX) ||
+         size > static_cast<size_t>(I2C_SOC_TRANSFER_COUNT_MAX);
+}
+
+#if LIBXR_HPM_I2C_HAS_DMA_MGR
+bool CanUseHpmI2cAsyncDma(bool is_block, bool in_isr)
+{
+  if (!is_block)
+  {
+    return true;
+  }
+  if (in_isr)
+  {
+    return false;
+  }
+#if LIBXR_HPM_I2C_BLOCK_WAIT_REQUIRES_TIMEBASE
+  return Timebase::IsReady();
+#else
+  return true;
+#endif
+}
+#endif
 
 uint16_t ResolveHpmI2cMaxSlaveAddress(HPMI2C::AddressMode mode)
 {
@@ -83,15 +115,13 @@ ErrorCode HPMI2C::SetWaitPolicy(WaitPolicy policy)
     return ErrorCode::ARG_ERR;
   }
 
-#if LIBXR_HPM_I2C_HAS_DMA_MGR
-  if (AsyncTransferActive())
+  if (!TryAcquireTransaction())
   {
     return ErrorCode::BUSY;
   }
-#endif
 
   wait_policy_ = policy;
-  return ErrorCode::OK;
+  return EndTransaction(ErrorCode::OK);
 }
 
 #if __has_include("board.h")
@@ -342,7 +372,9 @@ hpm_stat_t DoManualTransferWithFlagsImpl(I2C_Type* i2c, uint16_t slave_addr, Raw
     return status_invalid_argument;
   }
 
-  i2c_enable_10bit_address_mode(i2c, (flags & I2C_ADDR_10BIT) != 0U);
+  const uint32_t saved_addressing = i2c->SETUP & I2C_SETUP_ADDRESSING_MASK;
+  i2c->SETUP = (i2c->SETUP & ~I2C_SETUP_ADDRESSING_MASK) |
+               I2C_SETUP_ADDRESSING_SET((flags & I2C_ADDR_10BIT) != 0U);
   i2c_clear_status(
       i2c, I2C_STATUS_CMPL_MASK | I2C_STATUS_ADDRHIT_MASK | I2C_STATUS_BYTETRANS_MASK);
   i2c_clear_fifo(i2c);
@@ -426,7 +458,14 @@ hpm_stat_t DoManualTransferWithFlagsImpl(I2C_Type* i2c, uint16_t slave_addr, Raw
       left--;
       if (left == 0U)
       {
-        i2c_respond_Nack(i2c);
+        if ((flags & I2C_NO_STOP) != 0U && (flags & I2C_NO_READ_ACK) == 0U)
+        {
+          i2c_respond_ack(i2c);
+        }
+        else
+        {
+          i2c_respond_Nack(i2c);
+        }
       }
       else if ((flags & I2C_NO_READ_ACK) == 0U)
       {
@@ -479,20 +518,21 @@ hpm_stat_t DoManualTransferWithFlagsImpl(I2C_Type* i2c, uint16_t slave_addr, Raw
 
   if (raw_status == status_success)
   {
-    const bool complete =
-        WaitUntil([i2c]() { return (i2c_get_status(i2c) & I2C_STATUS_CMPL_MASK) != 0U; },
-                  policy.transfer_timeout_us);
-    if (!complete)
+    const bool wait_for_completion =
+        (flags & I2C_RD) == 0U || (flags & I2C_NO_STOP) == 0U;
+    if (wait_for_completion &&
+        !WaitUntil([i2c]() { return (i2c_get_status(i2c) & I2C_STATUS_CMPL_MASK) != 0U; },
+                   policy.transfer_timeout_us))
     {
       raw_status = status_timeout;
     }
-    else
+    else if (i2c_get_data_count(i2c) != 0U)
+    {
+      raw_status = status_i2c_transmit_not_completed;
+    }
+    if ((i2c_get_status(i2c) & I2C_STATUS_CMPL_MASK) != 0U)
     {
       i2c_clear_status(i2c, I2C_STATUS_CMPL_MASK);
-      if (i2c_get_data_count(i2c) != 0U)
-      {
-        raw_status = status_i2c_transmit_not_completed;
-      }
     }
   }
 
@@ -508,6 +548,7 @@ hpm_stat_t DoManualTransferWithFlagsImpl(I2C_Type* i2c, uint16_t slave_addr, Raw
   }
 
   i2c->INTEN = saved_inten;
+  i2c->SETUP = (i2c->SETUP & ~I2C_SETUP_ADDRESSING_MASK) | saved_addressing;
   return raw_status;
 }
 
@@ -598,17 +639,21 @@ ErrorCode HPMI2C::SetAddressMode(AddressMode mode)
   {
     return ErrorCode::PTR_NULL;
   }
-
-  if (address_mode_ == mode && configured_)
+  if (mode != AddressMode::ADDR_7BIT && mode != AddressMode::ADDR_10BIT)
   {
-    return ErrorCode::OK;
+    return ErrorCode::ARG_ERR;
   }
-
-#if LIBXR_HPM_I2C_HAS_DMA_MGR
-  if (AsyncTransferActive())
+  if (!TryAcquireTransaction())
   {
     return ErrorCode::BUSY;
   }
+
+  if (address_mode_ == mode && configured_)
+  {
+    return EndTransaction(ErrorCode::OK);
+  }
+
+#if LIBXR_HPM_I2C_HAS_DMA_MGR
   DisableAsyncI2cIrq();
   StopAsyncDma();
 #endif
@@ -616,18 +661,19 @@ ErrorCode HPMI2C::SetAddressMode(AddressMode mode)
   (void)WaitForBusIdle(i2c_, wait_policy_.bus_idle_timeout_us);
 
   const AddressMode previous_mode = address_mode_;
+  const bool was_configured = configured_;
   address_mode_ = mode;
   const ErrorCode ans = ApplyConfig(current_config_);
   (void)WaitForBusIdle(i2c_, wait_policy_.bus_idle_timeout_us);
   if (ans != ErrorCode::OK)
   {
     address_mode_ = previous_mode;
-    if (configured_)
+    if (was_configured)
     {
       (void)ApplyConfig(current_config_);
     }
   }
-  return ans;
+  return EndTransaction(ans);
 }
 
 ErrorCode HPMI2C::ConvertStatus(hpm_stat_t status)
@@ -699,20 +745,6 @@ ErrorCode HPMI2C::ConvertDmaStatus(hpm_stat_t status)
 }
 #endif
 
-i2c_seq_transfer_opt_t HPMI2C::ConvertSequenceFrame(SequenceFrame frame)
-{
-  switch (frame)
-  {
-    case SequenceFrame::FIRST:
-      return i2c_frist_frame;
-    case SequenceFrame::NEXT:
-      return i2c_next_frame;
-    case SequenceFrame::LAST:
-    default:
-      return i2c_last_frame;
-  }
-}
-
 uint16_t HPMI2C::BuildTransferFlags(uint16_t flags) const
 {
   return (address_mode_ == AddressMode::ADDR_10BIT) ? (flags | kI2CFlagAddr10Bit) : flags;
@@ -779,6 +811,7 @@ ErrorCode HPMI2C::ApplyConfig(const Configuration& config)
   i2c_config.i2c_mode = mode;
   i2c_config.is_10bit_addressing = (address_mode_ == AddressMode::ADDR_10BIT);
 
+  configured_ = false;
   ans = ConvertStatus(i2c_init_master(i2c_, source_clock_hz_, &i2c_config));
   if (ans == ErrorCode::OK)
   {
@@ -797,6 +830,7 @@ bool HPMI2C::ShouldRecover(hpm_stat_t status)
     case status_i2c_bus_busy:
     case status_i2c_no_ack:
     case status_i2c_no_addr_hit:
+    case status_i2c_transmit_not_completed:
       return true;
     default:
       return false;
@@ -810,11 +844,13 @@ void HPMI2C::RecoverController()
     return;
   }
 
+  const bool restore_config = configured_;
   IssueStopAndWait(i2c_, wait_policy_);
   (void)WaitForBusIdle(i2c_, wait_policy_.bus_idle_timeout_us);
   TryRecoverBusLines();
+  configured_ = false;
   i2c_reset(i2c_);
-  if (configured_)
+  if (restore_config)
   {
     (void)ApplyConfig(current_config_);
   }
@@ -863,7 +899,7 @@ ErrorCode HPMI2C::PrepareAsyncTransfer(uint16_t slave_addr, uint16_t flags, uint
 
   if (require_bus_idle)
   {
-    if (!WaitForBusIdle(i2c_, wait_policy_.transfer_timeout_us))
+    if (!WaitForBusIdle(i2c_, wait_policy_.bus_idle_timeout_us))
     {
       return ErrorCode::BUSY;
     }
@@ -1101,6 +1137,7 @@ void HPMI2C::StopAsyncDma()
   if (async_dma_ready_)
   {
     (void)dma_mgr_disable_channel(&async_dma_resource_);
+    dma_clear_transfer_status(async_dma_resource_.base, async_dma_resource_.channel);
   }
   if (i2c_ != nullptr)
   {
@@ -1118,8 +1155,14 @@ void HPMI2C::AsyncCompletionStateMachine::Reset(AsyncTransferContext& ctx)
 {
   ctx.final_status.store(status_success, std::memory_order_release);
   ctx.should_recover.store(false, std::memory_order_release);
+  ctx.submission_done.store(false, std::memory_order_release);
   ctx.dma_done.store(false, std::memory_order_release);
   ctx.cmpl_done.store(false, std::memory_order_release);
+}
+
+void HPMI2C::AsyncCompletionStateMachine::MarkSubmissionDone(AsyncTransferContext& ctx)
+{
+  ctx.submission_done.store(true, std::memory_order_release);
 }
 
 void HPMI2C::AsyncCompletionStateMachine::MarkDmaDone(AsyncTransferContext& ctx)
@@ -1130,22 +1173,36 @@ void HPMI2C::AsyncCompletionStateMachine::MarkDmaDone(AsyncTransferContext& ctx)
 void HPMI2C::AsyncCompletionStateMachine::MarkI2cDone(AsyncTransferContext& ctx,
                                                       hpm_stat_t status, bool recover)
 {
-  ctx.cmpl_done.store(true, std::memory_order_release);
   ctx.final_status.store(status, std::memory_order_release);
   ctx.should_recover.store(recover, std::memory_order_release);
+  ctx.cmpl_done.store(true, std::memory_order_release);
 }
 
 void HPMI2C::AsyncCompletionStateMachine::MarkFailure(AsyncTransferContext& ctx,
                                                       hpm_stat_t status, bool recover)
 {
-  ctx.final_status.store(status, std::memory_order_release);
   ctx.should_recover.store(recover, std::memory_order_release);
+  ctx.final_status.store(status, std::memory_order_release);
+}
+
+void HPMI2C::AsyncCompletionStateMachine::MarkTerminalFailure(AsyncTransferContext& ctx,
+                                                              hpm_stat_t status,
+                                                              bool recover)
+{
+  MarkFailure(ctx, status, recover);
+  ctx.dma_done.store(true, std::memory_order_release);
+  ctx.cmpl_done.store(true, std::memory_order_release);
 }
 
 void HPMI2C::AsyncCompletionStateMachine::SetFinalStatus(AsyncTransferContext& ctx,
                                                          hpm_stat_t status)
 {
   ctx.final_status.store(status, std::memory_order_release);
+}
+
+bool HPMI2C::AsyncCompletionStateMachine::SubmissionDone(const AsyncTransferContext& ctx)
+{
+  return ctx.submission_done.load(std::memory_order_acquire);
 }
 
 bool HPMI2C::AsyncCompletionStateMachine::DmaDone(const AsyncTransferContext& ctx)
@@ -1155,7 +1212,8 @@ bool HPMI2C::AsyncCompletionStateMachine::DmaDone(const AsyncTransferContext& ct
 
 bool HPMI2C::AsyncCompletionStateMachine::Ready(const AsyncTransferContext& ctx)
 {
-  return DmaDone(ctx) && ctx.cmpl_done.load(std::memory_order_acquire);
+  return SubmissionDone(ctx) && DmaDone(ctx) &&
+         ctx.cmpl_done.load(std::memory_order_acquire);
 }
 
 hpm_stat_t HPMI2C::AsyncCompletionStateMachine::FinalStatus(
@@ -1188,8 +1246,8 @@ void HPMI2C::ClearAsyncContext()
 
 void HPMI2C::ResetAsyncState()
 {
-  ClearAsyncContext();
   async_busy_.store(0U, std::memory_order_release);
+  ClearAsyncContext();
   async_completion_claim_.store(0U, std::memory_order_release);
 }
 
@@ -1216,9 +1274,9 @@ void HPMI2C::AbortAsyncStart(bool stop_dma, bool disable_irq, bool recover_contr
   ResetAsyncState();
 }
 
-void HPMI2C::CompleteAsyncTransfer(bool in_isr, ErrorCode ans)
+void HPMI2C::CompleteAsyncTransfer(bool in_isr, ErrorCode ans, bool force_recover)
 {
-  if (!TryClaimAsyncCompletion())
+  if (!AsyncTransferActive() || !TryClaimAsyncCompletion())
   {
     return;
   }
@@ -1226,7 +1284,8 @@ void HPMI2C::CompleteAsyncTransfer(bool in_isr, ErrorCode ans)
   StopAsyncDma();
   ReleaseAsyncBus();
 
-  const bool should_recover = AsyncCompletionStateMachine::ShouldRecover(async_ctx_);
+  const bool should_recover =
+      force_recover || AsyncCompletionStateMachine::ShouldRecover(async_ctx_);
   if (ans != ErrorCode::OK && should_recover)
   {
     RecoverController();
@@ -1235,10 +1294,18 @@ void HPMI2C::CompleteAsyncTransfer(bool in_isr, ErrorCode ans)
   const AsyncTransferKind kind = async_ctx_.kind;
   ReadOperation read_op = async_ctx_.read_op;
   WriteOperation write_op = async_ctx_.write_op;
+  const bool is_write =
+      kind == AsyncTransferKind::WRITE || kind == AsyncTransferKind::MEM_WRITE;
+  const bool is_block = is_write ? write_op.type == WriteOperation::OperationType::BLOCK
+                                 : read_op.type == ReadOperation::OperationType::BLOCK;
   async_ctx_.kind = AsyncTransferKind::NONE;
   ResetAsyncState();
+  if (!is_block)
+  {
+    ReleaseTransaction();
+  }
 
-  if (kind == AsyncTransferKind::WRITE || kind == AsyncTransferKind::MEM_WRITE)
+  if (is_write)
   {
     CompleteAsyncOperation(write_op, in_isr, ans);
   }
@@ -1262,7 +1329,6 @@ ErrorCode HPMI2C::StartWriteAsync(uint16_t slave_addr, ConstRawData write_data,
     return ans;
   }
 
-  async_busy_.store(1U, std::memory_order_release);
   ClearAsyncContext();
   async_ctx_.kind = AsyncTransferKind::WRITE;
   async_ctx_.slave_addr = slave_addr;
@@ -1272,6 +1338,8 @@ ErrorCode HPMI2C::StartWriteAsync(uint16_t slave_addr, ConstRawData write_data,
   async_completion_claim_.store(0U, std::memory_order_release);
 
   StartAsyncBlockWaitIfNeeded(op);
+  op.MarkAsRunning();
+  async_busy_.store(1U, std::memory_order_release);
 
   ans = EnableAsyncI2cIrq();
   if (ans != ErrorCode::OK)
@@ -1303,8 +1371,26 @@ ErrorCode HPMI2C::StartWriteAsync(uint16_t slave_addr, ConstRawData write_data,
     CancelAsyncBlockWaitIfNeeded(op);
     return ans;
   }
+  const bool addr_hit = WaitUntil(
+      [this]()
+      {
+        return !AsyncTransferActive() ||
+               (i2c_get_status(i2c_) & I2C_STATUS_ADDRHIT_MASK) != 0U;
+      },
+      wait_policy_.addr_hit_timeout_us);
+  if (AsyncTransferActive() && !addr_hit)
+  {
+    AsyncCompletionStateMachine::MarkFailure(async_ctx_, status_i2c_no_addr_hit, true);
+    AbortAsyncStart(true, true, true);
+    CancelAsyncBlockWaitIfNeeded(op);
+    return ErrorCode::NO_RESPONSE;
+  }
+  if (AsyncTransferActive())
+  {
+    i2c_clear_status(i2c_, I2C_STATUS_ADDRHIT_MASK);
+  }
+  FinishAsyncSubmission();
 
-  op.MarkAsRunning();
   if (op.type == WriteOperation::OperationType::BLOCK)
   {
     return WaitForAsyncBlockResult(op.data.sem_info.timeout);
@@ -1326,7 +1412,6 @@ ErrorCode HPMI2C::StartReadAsync(uint16_t slave_addr, RawData read_data,
     return ans;
   }
 
-  async_busy_.store(1U, std::memory_order_release);
   ClearAsyncContext();
   async_ctx_.kind = AsyncTransferKind::READ;
   async_ctx_.slave_addr = slave_addr;
@@ -1336,6 +1421,8 @@ ErrorCode HPMI2C::StartReadAsync(uint16_t slave_addr, RawData read_data,
   async_completion_claim_.store(0U, std::memory_order_release);
 
   StartAsyncBlockWaitIfNeeded(op);
+  op.MarkAsRunning();
+  async_busy_.store(1U, std::memory_order_release);
 
   ans = EnableAsyncI2cIrq();
   if (ans != ErrorCode::OK)
@@ -1367,8 +1454,26 @@ ErrorCode HPMI2C::StartReadAsync(uint16_t slave_addr, RawData read_data,
     CancelAsyncBlockWaitIfNeeded(op);
     return ans;
   }
+  const bool addr_hit = WaitUntil(
+      [this]()
+      {
+        return !AsyncTransferActive() ||
+               (i2c_get_status(i2c_) & I2C_STATUS_ADDRHIT_MASK) != 0U;
+      },
+      wait_policy_.addr_hit_timeout_us);
+  if (AsyncTransferActive() && !addr_hit)
+  {
+    AsyncCompletionStateMachine::MarkFailure(async_ctx_, status_i2c_no_addr_hit, true);
+    AbortAsyncStart(true, true, true);
+    CancelAsyncBlockWaitIfNeeded(op);
+    return ErrorCode::NO_RESPONSE;
+  }
+  if (AsyncTransferActive())
+  {
+    i2c_clear_status(i2c_, I2C_STATUS_ADDRHIT_MASK);
+  }
+  FinishAsyncSubmission();
 
-  op.MarkAsRunning();
   if (op.type == ReadOperation::OperationType::BLOCK)
   {
     return WaitForAsyncBlockResult(op.data.sem_info.timeout);
@@ -1402,7 +1507,6 @@ ErrorCode HPMI2C::StartMemReadAsync(uint16_t slave_addr, uint16_t mem_addr,
     return ans;
   }
 
-  async_busy_.store(1U, std::memory_order_release);
   ClearAsyncContext();
   async_ctx_.kind = AsyncTransferKind::MEM_READ;
   async_ctx_.slave_addr = slave_addr;
@@ -1416,11 +1520,17 @@ ErrorCode HPMI2C::StartMemReadAsync(uint16_t slave_addr, uint16_t mem_addr,
   async_completion_claim_.store(0U, std::memory_order_release);
 
   StartAsyncBlockWaitIfNeeded(op);
+  op.MarkAsRunning();
+  async_busy_.store(1U, std::memory_order_release);
 
   ans = PrepareAsyncTransfer(slave_addr, kI2CFlagNoStop, async_ctx_.mem_addr_size_in_byte,
                              true, true);
   if (ans != ErrorCode::OK)
   {
+    if (ans == ErrorCode::BUSY || ans == ErrorCode::NO_RESPONSE)
+    {
+      RecoverController();
+    }
     ResetAsyncState();
     CancelAsyncBlockWaitIfNeeded(op);
     return ans;
@@ -1436,11 +1546,16 @@ ErrorCode HPMI2C::StartMemReadAsync(uint16_t slave_addr, uint16_t mem_addr,
                 wait_policy_.transfer_timeout_us);
   if (!mem_addr_complete)
   {
-    AsyncCompletionStateMachine::MarkFailure(async_ctx_, status_timeout, true);
-    StopAndReleaseAsyncBus();
-    ResetAsyncState();
+    AbortAsyncStart(false, false, true);
     CancelAsyncBlockWaitIfNeeded(op);
     return ErrorCode::TIMEOUT;
+  }
+  const uint32_t mem_addr_status = i2c_get_status(i2c_);
+  if (!I2C_STATUS_ACK_GET(mem_addr_status))
+  {
+    AbortAsyncStart(false, false, true);
+    CancelAsyncBlockWaitIfNeeded(op);
+    return ErrorCode::NO_RESPONSE;
   }
   i2c_clear_status(i2c_, I2C_STATUS_CMPL_MASK);
   i2c_clear_fifo(i2c_);
@@ -1482,18 +1597,25 @@ ErrorCode HPMI2C::StartMemReadAsync(uint16_t slave_addr, uint16_t mem_addr,
 
   i2c_master_issue_data_transmission(i2c_);
   const bool addr_hit = WaitUntil(
-      [this]() { return (i2c_get_status(i2c_) & I2C_STATUS_ADDRHIT_MASK) != 0U; },
+      [this]()
+      {
+        return !AsyncTransferActive() ||
+               (i2c_get_status(i2c_) & I2C_STATUS_ADDRHIT_MASK) != 0U;
+      },
       wait_policy_.addr_hit_timeout_us);
-  if (!addr_hit)
+  if (AsyncTransferActive() && !addr_hit)
   {
     AsyncCompletionStateMachine::MarkFailure(async_ctx_, status_i2c_no_addr_hit, true);
     AbortAsyncStart(true, true, true);
     CancelAsyncBlockWaitIfNeeded(op);
     return ErrorCode::NO_RESPONSE;
   }
-  i2c_clear_status(i2c_, I2C_STATUS_ADDRHIT_MASK);
+  if (AsyncTransferActive())
+  {
+    i2c_clear_status(i2c_, I2C_STATUS_ADDRHIT_MASK);
+  }
+  FinishAsyncSubmission();
 
-  op.MarkAsRunning();
   if (op.type == ReadOperation::OperationType::BLOCK)
   {
     return WaitForAsyncBlockResult(op.data.sem_info.timeout);
@@ -1520,7 +1642,9 @@ ErrorCode HPMI2C::StartMemWriteAsync(uint16_t slave_addr, uint16_t mem_addr,
   {
     return ans;
   }
-  if ((addr_size + write_data.size_) > I2C_SOC_TRANSFER_COUNT_MAX)
+  const size_t transfer_max = static_cast<size_t>(I2C_SOC_TRANSFER_COUNT_MAX);
+  if (HpmI2cTransferSizeTooLarge(write_data.size_) || addr_size > transfer_max ||
+      write_data.size_ > (transfer_max - addr_size))
   {
     return ErrorCode::SIZE_ERR;
   }
@@ -1531,7 +1655,6 @@ ErrorCode HPMI2C::StartMemWriteAsync(uint16_t slave_addr, uint16_t mem_addr,
     return ans;
   }
 
-  async_busy_.store(1U, std::memory_order_release);
   ClearAsyncContext();
   async_ctx_.kind = AsyncTransferKind::MEM_WRITE;
   async_ctx_.slave_addr = slave_addr;
@@ -1545,11 +1668,17 @@ ErrorCode HPMI2C::StartMemWriteAsync(uint16_t slave_addr, uint16_t mem_addr,
   async_completion_claim_.store(0U, std::memory_order_release);
 
   StartAsyncBlockWaitIfNeeded(op);
+  op.MarkAsRunning();
+  async_busy_.store(1U, std::memory_order_release);
 
   ans = PrepareAsyncTransfer(slave_addr, kI2CFlagNoStop, async_ctx_.mem_addr_size_in_byte,
                              true, true);
   if (ans != ErrorCode::OK)
   {
+    if (ans == ErrorCode::BUSY || ans == ErrorCode::NO_RESPONSE)
+    {
+      RecoverController();
+    }
     ResetAsyncState();
     CancelAsyncBlockWaitIfNeeded(op);
     return ans;
@@ -1565,11 +1694,16 @@ ErrorCode HPMI2C::StartMemWriteAsync(uint16_t slave_addr, uint16_t mem_addr,
                 wait_policy_.transfer_timeout_us);
   if (!mem_addr_complete)
   {
-    AsyncCompletionStateMachine::MarkFailure(async_ctx_, status_timeout, true);
-    StopAndReleaseAsyncBus();
-    ResetAsyncState();
+    AbortAsyncStart(false, false, true);
     CancelAsyncBlockWaitIfNeeded(op);
     return ErrorCode::TIMEOUT;
+  }
+  const uint32_t mem_addr_status = i2c_get_status(i2c_);
+  if (!I2C_STATUS_ACK_GET(mem_addr_status))
+  {
+    AbortAsyncStart(false, false, true);
+    CancelAsyncBlockWaitIfNeeded(op);
+    return ErrorCode::NO_RESPONSE;
   }
   i2c_clear_status(i2c_, I2C_STATUS_CMPL_MASK);
   i2c_clear_fifo(i2c_);
@@ -1611,8 +1745,8 @@ ErrorCode HPMI2C::StartMemWriteAsync(uint16_t slave_addr, uint16_t mem_addr,
   }
 
   i2c_master_issue_data_transmission(i2c_);
+  FinishAsyncSubmission();
 
-  op.MarkAsRunning();
   if (op.type == WriteOperation::OperationType::BLOCK)
   {
     return WaitForAsyncBlockResult(op.data.sem_info.timeout);
@@ -1622,6 +1756,12 @@ ErrorCode HPMI2C::StartMemWriteAsync(uint16_t slave_addr, uint16_t mem_addr,
 
 ErrorCode HPMI2C::EnsureAsyncDmaReady()
 {
+#if defined(HPM_CORE1)
+  if (read_csr(CSR_MHARTID) != HPM_CORE0)
+  {
+    return ErrorCode::NOT_SUPPORT;
+  }
+#endif
   if (async_dma_ready_)
   {
     return ErrorCode::OK;
@@ -1717,10 +1857,9 @@ ErrorCode HPMI2C::EnsureAsyncDmaReady()
 ErrorCode HPMI2C::WaitForAsyncBlockResult(uint32_t timeout)
 {
   const ErrorCode ans = block_wait_.Wait(timeout);
-  if (ans == ErrorCode::TIMEOUT && AsyncTransferActive())
+  if (ans == ErrorCode::TIMEOUT)
   {
-    AsyncCompletionStateMachine::MarkFailure(async_ctx_, status_timeout, true);
-    CompleteAsyncTransfer(false, ErrorCode::TIMEOUT);
+    CompleteAsyncTransfer(false, ErrorCode::TIMEOUT, true);
   }
   return ans;
 }
@@ -1797,8 +1936,8 @@ void HPMI2C::HandleAsyncInterrupt(bool in_isr)
   if ((status & I2C_STATUS_ARBLOSE_MASK) != 0U)
   {
     i2c_clear_status(i2c_, I2C_STATUS_ARBLOSE_MASK);
-    AsyncCompletionStateMachine::MarkI2cDone(async_ctx_, status_timeout, true);
-    CompleteAsyncTransfer(in_isr, ErrorCode::TIMEOUT);
+    AsyncCompletionStateMachine::MarkTerminalFailure(async_ctx_, status_timeout, true);
+    MaybeCompleteAsyncTransfer(in_isr);
     return;
   }
 
@@ -1820,6 +1959,17 @@ void HPMI2C::HandleAsyncInterrupt(bool in_isr)
   MaybeCompleteAsyncTransfer(in_isr);
 }
 
+void HPMI2C::FinishAsyncSubmission()
+{
+  if (!AsyncTransferActive())
+  {
+    return;
+  }
+
+  AsyncCompletionStateMachine::MarkSubmissionDone(async_ctx_);
+  MaybeCompleteAsyncTransfer(false);
+}
+
 void HPMI2C::MaybeCompleteAsyncTransfer(bool in_isr)
 {
   if (!AsyncTransferActive() || !AsyncCompletionStateMachine::Ready(async_ctx_))
@@ -1834,12 +1984,14 @@ void HPMI2C::MaybeCompleteAsyncTransfer(bool in_isr)
                              static_cast<uint32_t>(async_ctx_.read_data.size_));
   }
   hpm_stat_t final_status = AsyncCompletionStateMachine::FinalStatus(async_ctx_);
+  bool force_recover = false;
   if (final_status == status_success && i2c_get_data_count(i2c_) != 0U)
   {
     final_status = status_i2c_transmit_not_completed;
+    force_recover = true;
     AsyncCompletionStateMachine::SetFinalStatus(async_ctx_, final_status);
   }
-  CompleteAsyncTransfer(in_isr, ConvertStatus(final_status));
+  CompleteAsyncTransfer(in_isr, ConvertStatus(final_status), force_recover);
 }
 
 bool HPMI2C::TryClaimAsyncCompletion()
@@ -1849,6 +2001,7 @@ bool HPMI2C::TryClaimAsyncCompletion()
       expected, 1U, std::memory_order_acq_rel, std::memory_order_acquire);
 }
 
+// DMA manager consumes the W1C status before dispatching the matching callback.
 void HPMI2C::OnDmaTcCallback(DMA_Type* base, uint32_t channel, void* cb_data_ptr)
 {
   UNUSED(base);
@@ -1872,12 +2025,8 @@ void HPMI2C::OnDmaErrorCallback(DMA_Type* base, uint32_t channel, void* cb_data_
   {
     return;
   }
-  if (AsyncCompletionStateMachine::DmaDone(self->async_ctx_))
-  {
-    return;
-  }
-  AsyncCompletionStateMachine::MarkFailure(self->async_ctx_, status_fail, true);
-  self->CompleteAsyncTransfer(true, ErrorCode::FAILED);
+  AsyncCompletionStateMachine::MarkTerminalFailure(self->async_ctx_, status_fail, true);
+  self->MaybeCompleteAsyncTransfer(true);
 }
 
 void HPMI2C::OnDmaAbortCallback(DMA_Type* base, uint32_t channel, void* cb_data_ptr)
@@ -1889,18 +2038,25 @@ void HPMI2C::OnDmaAbortCallback(DMA_Type* base, uint32_t channel, void* cb_data_
   {
     return;
   }
-  if (AsyncCompletionStateMachine::DmaDone(self->async_ctx_))
-  {
-    return;
-  }
-  AsyncCompletionStateMachine::MarkFailure(self->async_ctx_, status_fail, true);
-  self->CompleteAsyncTransfer(true, ErrorCode::FAILED);
+  AsyncCompletionStateMachine::MarkTerminalFailure(self->async_ctx_, status_fail, true);
+  self->MaybeCompleteAsyncTransfer(true);
 }
 #endif
 
 ErrorCode HPMI2C::ValidateTransferArgs(uint16_t slave_addr, RawData data,
                                        bool allow_zero_size) const
 {
+  return ValidateTransferArgs(slave_addr, data, allow_zero_size, address_mode_);
+}
+
+ErrorCode HPMI2C::ValidateTransferArgs(uint16_t slave_addr, RawData data,
+                                       bool allow_zero_size, AddressMode mode) const
+{
+  const ErrorCode address_ans = ValidateHpmI2cSlaveAddress(mode, slave_addr);
+  if (address_ans != ErrorCode::OK)
+  {
+    return address_ans;
+  }
   if (data.size_ == 0)
   {
     return allow_zero_size ? ErrorCode::OK : ErrorCode::ARG_ERR;
@@ -1909,16 +2065,27 @@ ErrorCode HPMI2C::ValidateTransferArgs(uint16_t slave_addr, RawData data,
   {
     return ErrorCode::PTR_NULL;
   }
-  if (data.size_ > I2C_SOC_TRANSFER_COUNT_MAX)
+  if (HpmI2cTransferSizeTooLarge(data.size_))
   {
     return ErrorCode::SIZE_ERR;
   }
-  return ValidateSlaveAddress(slave_addr);
+  return ErrorCode::OK;
 }
 
 ErrorCode HPMI2C::ValidateTransferArgs(uint16_t slave_addr, ConstRawData data,
                                        bool allow_zero_size) const
 {
+  return ValidateTransferArgs(slave_addr, data, allow_zero_size, address_mode_);
+}
+
+ErrorCode HPMI2C::ValidateTransferArgs(uint16_t slave_addr, ConstRawData data,
+                                       bool allow_zero_size, AddressMode mode) const
+{
+  const ErrorCode address_ans = ValidateHpmI2cSlaveAddress(mode, slave_addr);
+  if (address_ans != ErrorCode::OK)
+  {
+    return address_ans;
+  }
   if (data.size_ == 0)
   {
     return allow_zero_size ? ErrorCode::OK : ErrorCode::ARG_ERR;
@@ -1927,17 +2094,22 @@ ErrorCode HPMI2C::ValidateTransferArgs(uint16_t slave_addr, ConstRawData data,
   {
     return ErrorCode::PTR_NULL;
   }
-  if (data.size_ > I2C_SOC_TRANSFER_COUNT_MAX)
+  if (HpmI2cTransferSizeTooLarge(data.size_))
   {
     return ErrorCode::SIZE_ERR;
   }
-  return ValidateSlaveAddress(slave_addr);
+  return ErrorCode::OK;
 }
 
 ErrorCode HPMI2C::ValidateMemWriteArgs(uint16_t slave_addr, ConstRawData write_data,
                                        MemAddrLength mem_addr_size,
                                        uint32_t& addr_size) const
 {
+  const ErrorCode address_ans = ValidateSlaveAddress(slave_addr);
+  if (address_ans != ErrorCode::OK)
+  {
+    return address_ans;
+  }
   if (write_data.size_ > 0 && write_data.addr_ == nullptr)
   {
     return ErrorCode::PTR_NULL;
@@ -1948,11 +2120,13 @@ ErrorCode HPMI2C::ValidateMemWriteArgs(uint16_t slave_addr, ConstRawData write_d
   {
     return ans;
   }
-  if ((addr_size + write_data.size_) > I2C_SOC_TRANSFER_COUNT_MAX)
+  const size_t transfer_max = static_cast<size_t>(I2C_SOC_TRANSFER_COUNT_MAX);
+  if (HpmI2cTransferSizeTooLarge(write_data.size_) || addr_size > transfer_max ||
+      write_data.size_ > (transfer_max - addr_size))
   {
     return ErrorCode::SIZE_ERR;
   }
-  return ValidateSlaveAddress(slave_addr);
+  return ErrorCode::OK;
 }
 
 ErrorCode HPMI2C::SetConfig(Configuration config)
@@ -1961,31 +2135,35 @@ ErrorCode HPMI2C::SetConfig(Configuration config)
   {
     return ErrorCode::PTR_NULL;
   }
+  if (!TryAcquireTransaction())
+  {
+    return ErrorCode::BUSY;
+  }
 
-  return ApplyConfig(config);
+  return EndTransaction(ApplyConfig(config));
 }
 
 ErrorCode HPMI2C::Read(uint16_t slave_addr, RawData read_data, ReadOperation& op,
                        bool in_isr)
 {
-  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, read_data, true);
-  if (arg_ans != ErrorCode::OK || read_data.size_ == 0)
-  {
-    return FinishOperation(op, in_isr, arg_ans);
-  }
-
-#if LIBXR_HPM_I2C_HAS_DMA_MGR
-  if (AsyncTransferActive())
+  if (!TryAcquireTransaction())
   {
     return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
+  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, read_data, true);
+  if (arg_ans != ErrorCode::OK || read_data.size_ == 0)
+  {
+    return EndTransaction(op, in_isr, arg_ans);
+  }
 
-  if (read_data.size_ > dma_enable_min_size_)
+#if LIBXR_HPM_I2C_HAS_DMA_MGR
+  if (read_data.size_ > dma_enable_min_size_ &&
+      CanUseHpmI2cAsyncDma(op.type == ReadOperation::OperationType::BLOCK, in_isr))
   {
     const ErrorCode ans = StartReadAsync(slave_addr, read_data, op);
-    if (ans != ErrorCode::OK)
+    if (ans != ErrorCode::OK || op.type == ReadOperation::OperationType::BLOCK)
     {
-      return FinishOperation(op, in_isr, ans);
+      return EndTransaction(op, in_isr, ans);
     }
     return ans;
   }
@@ -1994,7 +2172,7 @@ ErrorCode HPMI2C::Read(uint16_t slave_addr, RawData read_data, ReadOperation& op
   ErrorCode ans = EnsureControllerReady();
   if (ans != ErrorCode::OK)
   {
-    return FinishOperation(op, in_isr, ans);
+    return EndTransaction(op, in_isr, ans);
   }
 
   hpm_stat_t status =
@@ -2005,7 +2183,7 @@ ErrorCode HPMI2C::Read(uint16_t slave_addr, RawData read_data, ReadOperation& op
   {
     RecoverController();
   }
-  return FinishOperation(op, in_isr, ans);
+  return EndTransaction(op, in_isr, ans);
 }
 
 ErrorCode HPMI2C::DoSequenceWrite(uint16_t slave_addr, ConstRawData write_data,
@@ -2024,41 +2202,24 @@ ErrorCode HPMI2C::DoSequenceWrite(uint16_t slave_addr, ConstRawData write_data,
     return ans;
   }
 
-  hpm_stat_t status;
-  if (address_mode_ == AddressMode::ADDR_10BIT)
+  uint16_t flags = check_ack ? kI2CFlagWriteCheckAck : 0U;
+  switch (frame)
   {
-    uint16_t flags = kI2CFlagWriteCheckAck;
-    if (!check_ack)
-    {
-      flags = 0U;
-    }
-    switch (frame)
-    {
-      case SequenceFrame::FIRST:
-        flags |= 0U;
-        flags |= kI2CFlagAddr10Bit;
-        flags |= kI2CFlagNoStop;
-        break;
-      case SequenceFrame::NEXT:
-        flags |= kI2CFlagAddr10Bit | I2C_NO_START | I2C_NO_ADDRESS | kI2CFlagNoStop;
-        break;
-      case SequenceFrame::LAST:
-      default:
-        flags |= kI2CFlagAddr10Bit | I2C_NO_START | I2C_NO_ADDRESS;
-        break;
-    }
-    const hpm_stat_t raw_status = DoManualTransferWithFlags(
-        slave_addr, RawData(const_cast<void*>(write_data.addr_), write_data.size_),
-        flags);
-    status = raw_status;
+    case SequenceFrame::FIRST:
+      flags |= kI2CFlagNoStop;
+      break;
+    case SequenceFrame::NEXT:
+      flags |= kI2CFlagNoStart | kI2CFlagNoAddress | kI2CFlagNoStop;
+      break;
+    case SequenceFrame::LAST:
+      flags |= kI2CFlagNoStart | kI2CFlagNoAddress;
+      break;
+    default:
+      return ErrorCode::ARG_ERR;
   }
-  else
-  {
-    status = i2c_master_seq_transmit_check_ack(
-        i2c_, slave_addr,
-        const_cast<uint8_t*>(static_cast<const uint8_t*>(write_data.addr_)),
-        static_cast<uint32_t>(write_data.size_), ConvertSequenceFrame(frame), check_ack);
-  }
+  const hpm_stat_t status = DoManualTransferWithFlags(
+      slave_addr, RawData(const_cast<void*>(write_data.addr_), write_data.size_),
+      BuildTransferFlags(flags));
 
   ans = ConvertStatus(status);
   if (ShouldRecover(status))
@@ -2084,31 +2245,23 @@ ErrorCode HPMI2C::DoSequenceRead(uint16_t slave_addr, RawData read_data,
     return ans;
   }
 
-  hpm_stat_t status;
-  if (address_mode_ == AddressMode::ADDR_10BIT)
+  uint16_t flags = kI2CFlagRead;
+  switch (frame)
   {
-    uint16_t flags = kI2CFlagRead | kI2CFlagAddr10Bit;
-    switch (frame)
-    {
-      case SequenceFrame::FIRST:
-        flags |= kI2CFlagNoStop;
-        break;
-      case SequenceFrame::NEXT:
-        flags |= I2C_NO_START | I2C_NO_ADDRESS | kI2CFlagNoStop;
-        break;
-      case SequenceFrame::LAST:
-      default:
-        flags |= I2C_NO_START | I2C_NO_ADDRESS;
-        break;
-    }
-    status = DoManualTransferWithFlags(slave_addr, read_data, flags);
+    case SequenceFrame::FIRST:
+      flags |= kI2CFlagNoStop;
+      break;
+    case SequenceFrame::NEXT:
+      flags |= kI2CFlagNoStart | kI2CFlagNoAddress | kI2CFlagNoStop;
+      break;
+    case SequenceFrame::LAST:
+      flags |= kI2CFlagNoStart | kI2CFlagNoAddress;
+      break;
+    default:
+      return ErrorCode::ARG_ERR;
   }
-  else
-  {
-    status = i2c_master_seq_receive(
-        i2c_, slave_addr, static_cast<uint8_t*>(read_data.addr_),
-        static_cast<uint32_t>(read_data.size_), ConvertSequenceFrame(frame));
-  }
+  const hpm_stat_t status =
+      DoManualTransferWithFlags(slave_addr, read_data, BuildTransferFlags(flags));
 
   ans = ConvertStatus(status);
   if (ShouldRecover(status))
@@ -2160,70 +2313,68 @@ ErrorCode HPMI2C::SequenceWrite(uint16_t slave_addr, ConstRawData write_data,
                                 SequenceFrame frame, bool check_ack, WriteOperation& op,
                                 bool in_isr)
 {
-  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, write_data, false);
-  if (arg_ans != ErrorCode::OK)
-  {
-    return FinishOperation(op, in_isr, arg_ans);
-  }
-#if LIBXR_HPM_I2C_HAS_DMA_MGR
-  if (AsyncTransferActive())
+  if (!TryAcquireTransaction())
   {
     return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
-#endif
-  return FinishOperation(op, in_isr,
-                         DoSequenceWrite(slave_addr, write_data, frame, check_ack));
+  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, write_data, false);
+  if (arg_ans != ErrorCode::OK)
+  {
+    return EndTransaction(op, in_isr, arg_ans);
+  }
+  return EndTransaction(op, in_isr,
+                        DoSequenceWrite(slave_addr, write_data, frame, check_ack));
 }
 
 ErrorCode HPMI2C::SequenceRead(uint16_t slave_addr, RawData read_data,
                                SequenceFrame frame, ReadOperation& op, bool in_isr)
 {
-  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, read_data, false);
-  if (arg_ans != ErrorCode::OK)
-  {
-    return FinishOperation(op, in_isr, arg_ans);
-  }
-#if LIBXR_HPM_I2C_HAS_DMA_MGR
-  if (AsyncTransferActive())
+  if (!TryAcquireTransaction())
   {
     return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
-#endif
-  return FinishOperation(op, in_isr, DoSequenceRead(slave_addr, read_data, frame));
+  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, read_data, false);
+  if (arg_ans != ErrorCode::OK)
+  {
+    return EndTransaction(op, in_isr, arg_ans);
+  }
+  return EndTransaction(op, in_isr, DoSequenceRead(slave_addr, read_data, frame));
 }
 
 ErrorCode HPMI2C::TransferWithFlags(uint16_t slave_addr, RawData data, uint16_t flags,
                                     ReadOperation& op, bool in_isr)
 {
-  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, data, false);
-  if (arg_ans != ErrorCode::OK)
-  {
-    return FinishOperation(op, in_isr, arg_ans);
-  }
-#if LIBXR_HPM_I2C_HAS_DMA_MGR
-  if (AsyncTransferActive())
+  if (!TryAcquireTransaction())
   {
     return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
-#endif
-  return FinishOperation(op, in_isr, DoTransferWithFlags(slave_addr, data, flags));
+  const AddressMode transfer_mode = (BuildTransferFlags(flags) & kI2CFlagAddr10Bit) != 0U
+                                        ? AddressMode::ADDR_10BIT
+                                        : AddressMode::ADDR_7BIT;
+  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, data, false, transfer_mode);
+  if (arg_ans != ErrorCode::OK)
+  {
+    return EndTransaction(op, in_isr, arg_ans);
+  }
+  return EndTransaction(op, in_isr, DoTransferWithFlags(slave_addr, data, flags));
 }
 
 ErrorCode HPMI2C::TransferWithFlags(uint16_t slave_addr, ConstRawData data,
                                     uint16_t flags, WriteOperation& op, bool in_isr)
 {
-  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, data, false);
-  if (arg_ans != ErrorCode::OK)
-  {
-    return FinishOperation(op, in_isr, arg_ans);
-  }
-#if LIBXR_HPM_I2C_HAS_DMA_MGR
-  if (AsyncTransferActive())
+  if (!TryAcquireTransaction())
   {
     return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
-#endif
-  return FinishOperation(
+  const AddressMode transfer_mode = (BuildTransferFlags(flags) & kI2CFlagAddr10Bit) != 0U
+                                        ? AddressMode::ADDR_10BIT
+                                        : AddressMode::ADDR_7BIT;
+  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, data, false, transfer_mode);
+  if (arg_ans != ErrorCode::OK)
+  {
+    return EndTransaction(op, in_isr, arg_ans);
+  }
+  return EndTransaction(
       op, in_isr,
       DoTransferWithFlags(slave_addr, RawData(const_cast<void*>(data.addr_), data.size_),
                           static_cast<uint16_t>(flags & ~kI2CFlagRead)));
@@ -2232,24 +2383,24 @@ ErrorCode HPMI2C::TransferWithFlags(uint16_t slave_addr, ConstRawData data,
 ErrorCode HPMI2C::Write(uint16_t slave_addr, ConstRawData write_data, WriteOperation& op,
                         bool in_isr)
 {
-  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, write_data, true);
-  if (arg_ans != ErrorCode::OK || write_data.size_ == 0)
-  {
-    return FinishOperation(op, in_isr, arg_ans);
-  }
-
-#if LIBXR_HPM_I2C_HAS_DMA_MGR
-  if (AsyncTransferActive())
+  if (!TryAcquireTransaction())
   {
     return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
+  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, write_data, true);
+  if (arg_ans != ErrorCode::OK || write_data.size_ == 0)
+  {
+    return EndTransaction(op, in_isr, arg_ans);
+  }
 
-  if (write_data.size_ > dma_enable_min_size_)
+#if LIBXR_HPM_I2C_HAS_DMA_MGR
+  if (write_data.size_ > dma_enable_min_size_ &&
+      CanUseHpmI2cAsyncDma(op.type == WriteOperation::OperationType::BLOCK, in_isr))
   {
     const ErrorCode ans = StartWriteAsync(slave_addr, write_data, op);
-    if (ans != ErrorCode::OK)
+    if (ans != ErrorCode::OK || op.type == WriteOperation::OperationType::BLOCK)
     {
-      return FinishOperation(op, in_isr, ans);
+      return EndTransaction(op, in_isr, ans);
     }
     return ans;
   }
@@ -2258,7 +2409,7 @@ ErrorCode HPMI2C::Write(uint16_t slave_addr, ConstRawData write_data, WriteOpera
   ErrorCode ans = EnsureControllerReady();
   if (ans != ErrorCode::OK)
   {
-    return FinishOperation(op, in_isr, ans);
+    return EndTransaction(op, in_isr, ans);
   }
 
   hpm_stat_t status = i2c_master_write(
@@ -2270,51 +2421,54 @@ ErrorCode HPMI2C::Write(uint16_t slave_addr, ConstRawData write_data, WriteOpera
   {
     RecoverController();
   }
-  return FinishOperation(op, in_isr, ans);
+  return EndTransaction(op, in_isr, ans);
 }
 
 ErrorCode HPMI2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_data,
                           ReadOperation& op, MemAddrLength mem_addr_size, bool in_isr)
 {
-  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, read_data, true);
-  if (arg_ans != ErrorCode::OK || read_data.size_ == 0)
-  {
-    return FinishOperation(op, in_isr, arg_ans);
-  }
-
-#if LIBXR_HPM_I2C_HAS_DMA_MGR
-  if (AsyncTransferActive())
+  if (!TryAcquireTransaction())
   {
     return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
-
-  if (read_data.size_ > dma_enable_min_size_)
+  const ErrorCode arg_ans = ValidateTransferArgs(slave_addr, read_data, true);
+  if (arg_ans != ErrorCode::OK)
   {
-    const ErrorCode ans =
-        StartMemReadAsync(slave_addr, mem_addr, read_data, op, mem_addr_size);
-    if (ans != ErrorCode::OK)
-    {
-      return FinishOperation(op, in_isr, ans);
-    }
-    return ans;
+    return EndTransaction(op, in_isr, arg_ans);
   }
-#endif
 
   uint32_t addr_size = 0;
   ErrorCode ans = ResolveMemAddressSize(mem_addr_size, addr_size);
   if (ans != ErrorCode::OK)
   {
-    return FinishOperation(op, in_isr, ans);
+    return EndTransaction(op, in_isr, ans);
   }
   if (addr_size > I2C_SOC_TRANSFER_COUNT_MAX)
   {
-    return FinishOperation(op, in_isr, ErrorCode::SIZE_ERR);
+    return EndTransaction(op, in_isr, ErrorCode::SIZE_ERR);
   }
+  if (read_data.size_ == 0)
+  {
+    return EndTransaction(op, in_isr, ErrorCode::OK);
+  }
+
+#if LIBXR_HPM_I2C_HAS_DMA_MGR
+  if (read_data.size_ > dma_enable_min_size_ &&
+      CanUseHpmI2cAsyncDma(op.type == ReadOperation::OperationType::BLOCK, in_isr))
+  {
+    ans = StartMemReadAsync(slave_addr, mem_addr, read_data, op, mem_addr_size);
+    if (ans != ErrorCode::OK || op.type == ReadOperation::OperationType::BLOCK)
+    {
+      return EndTransaction(op, in_isr, ans);
+    }
+    return ans;
+  }
+#endif
 
   ans = EnsureControllerReady();
   if (ans != ErrorCode::OK)
   {
-    return FinishOperation(op, in_isr, ans);
+    return EndTransaction(op, in_isr, ans);
   }
 
   uint8_t addr[2] = {};
@@ -2326,7 +2480,7 @@ ErrorCode HPMI2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_d
                           true);
     if (ans == ErrorCode::OK)
     {
-      ans = DoSequenceRead(slave_addr, read_data, SequenceFrame::LAST);
+      ans = DoTransferWithFlags(slave_addr, read_data, kI2CFlagRead);
     }
   }
   else
@@ -2340,32 +2494,32 @@ ErrorCode HPMI2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_d
       RecoverController();
     }
   }
-  return FinishOperation(op, in_isr, ans);
+  return EndTransaction(op, in_isr, ans);
 }
 
 ErrorCode HPMI2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
                            ConstRawData write_data, WriteOperation& op,
                            MemAddrLength mem_addr_size, bool in_isr)
 {
+  if (!TryAcquireTransaction())
+  {
+    return FinishOperation(op, in_isr, ErrorCode::BUSY);
+  }
   uint32_t addr_size = 0;
   ErrorCode ans = ValidateMemWriteArgs(slave_addr, write_data, mem_addr_size, addr_size);
   if (ans != ErrorCode::OK)
   {
-    return FinishOperation(op, in_isr, ans);
+    return EndTransaction(op, in_isr, ans);
   }
 
 #if LIBXR_HPM_I2C_HAS_DMA_MGR
-  if (AsyncTransferActive())
-  {
-    return FinishOperation(op, in_isr, ErrorCode::BUSY);
-  }
-
-  if (write_data.size_ > dma_enable_min_size_)
+  if (write_data.size_ > dma_enable_min_size_ &&
+      CanUseHpmI2cAsyncDma(op.type == WriteOperation::OperationType::BLOCK, in_isr))
   {
     ans = StartMemWriteAsync(slave_addr, mem_addr, write_data, op, mem_addr_size);
-    if (ans != ErrorCode::OK)
+    if (ans != ErrorCode::OK || op.type == WriteOperation::OperationType::BLOCK)
     {
-      return FinishOperation(op, in_isr, ans);
+      return EndTransaction(op, in_isr, ans);
     }
     return ans;
   }
@@ -2374,7 +2528,7 @@ ErrorCode HPMI2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
   ans = EnsureControllerReady();
   if (ans != ErrorCode::OK)
   {
-    return FinishOperation(op, in_isr, ans);
+    return EndTransaction(op, in_isr, ans);
   }
 
   uint8_t addr[2] = {};
@@ -2424,7 +2578,7 @@ ErrorCode HPMI2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
       RecoverController();
     }
   }
-  return FinishOperation(op, in_isr, ans);
+  return EndTransaction(op, in_isr, ans);
 }
 
 #endif  // LIBXR_HPM_I2C_SUPPORTED

--- a/driver/hpm/hpm_i2c.cpp
+++ b/driver/hpm/hpm_i2c.cpp
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 
+#if LIBXR_HPM_I2C_SUPPORTED
+
 using namespace LibXR;
 
 namespace
@@ -91,8 +93,6 @@ ErrorCode HPMI2C::SetWaitPolicy(WaitPolicy policy)
   wait_policy_ = policy;
   return ErrorCode::OK;
 }
-
-#if LIBXR_HPM_I2C_SUPPORTED
 
 #if __has_include("board.h")
 extern "C"
@@ -561,8 +561,12 @@ extern "C" void libxr_hpm_i2c_process_interrupt(I2C_Type* ptr) { UNUSED(ptr); }
 #endif
 
 HPMI2C::HPMI2C(I2C_Type* i2c, clock_name_t clock, bool auto_board_init,
-               I2C::Configuration config)
-    : i2c_(i2c), clock_(clock), current_config_(config), auto_board_init_(auto_board_init)
+               I2C::Configuration config, uint32_t dma_enable_min_size)
+    : i2c_(i2c),
+      clock_(clock),
+      current_config_(config),
+      dma_enable_min_size_(dma_enable_min_size),
+      auto_board_init_(auto_board_init)
 {
   ASSERT(i2c_ != nullptr);
 
@@ -1234,7 +1238,7 @@ void HPMI2C::CompleteAsyncTransfer(bool in_isr, ErrorCode ans)
   async_ctx_.kind = AsyncTransferKind::NONE;
   ResetAsyncState();
 
-  if (kind == AsyncTransferKind::WRITE)
+  if (kind == AsyncTransferKind::WRITE || kind == AsyncTransferKind::MEM_WRITE)
   {
     CompleteAsyncOperation(write_op, in_isr, ans);
   }
@@ -1497,6 +1501,125 @@ ErrorCode HPMI2C::StartMemReadAsync(uint16_t slave_addr, uint16_t mem_addr,
   return ErrorCode::OK;
 }
 
+ErrorCode HPMI2C::StartMemWriteAsync(uint16_t slave_addr, uint16_t mem_addr,
+                                     ConstRawData write_data, WriteOperation& op,
+                                     MemAddrLength mem_addr_size)
+{
+  if (AsyncTransferActive())
+  {
+    return ErrorCode::BUSY;
+  }
+  if (write_data.size_ == 0U)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  uint32_t addr_size = 0U;
+  ErrorCode ans = ResolveMemAddressSize(mem_addr_size, addr_size);
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+  if ((addr_size + write_data.size_) > I2C_SOC_TRANSFER_COUNT_MAX)
+  {
+    return ErrorCode::SIZE_ERR;
+  }
+
+  ans = EnsureControllerReady();
+  if (ans != ErrorCode::OK)
+  {
+    return ans;
+  }
+
+  async_busy_.store(1U, std::memory_order_release);
+  ClearAsyncContext();
+  async_ctx_.kind = AsyncTransferKind::MEM_WRITE;
+  async_ctx_.slave_addr = slave_addr;
+  async_ctx_.mem_addr = mem_addr;
+  async_ctx_.mem_addr_size = mem_addr_size;
+  async_ctx_.mem_addr_size_in_byte = addr_size;
+  FillMemAddress(mem_addr, mem_addr_size, async_ctx_.mem_addr_bytes);
+  async_ctx_.write_data = write_data;
+  async_ctx_.write_op = op;
+  async_ctx_.flags = kI2CFlagWriteCheckAck;
+  async_completion_claim_.store(0U, std::memory_order_release);
+
+  StartAsyncBlockWaitIfNeeded(op);
+
+  ans = PrepareAsyncTransfer(slave_addr, kI2CFlagNoStop, async_ctx_.mem_addr_size_in_byte,
+                             true, true);
+  if (ans != ErrorCode::OK)
+  {
+    ResetAsyncState();
+    CancelAsyncBlockWaitIfNeeded(op);
+    return ans;
+  }
+
+  for (uint32_t i = 0U; i < async_ctx_.mem_addr_size_in_byte; ++i)
+  {
+    i2c_write_byte(i2c_, async_ctx_.mem_addr_bytes[i]);
+  }
+
+  const bool mem_addr_complete =
+      WaitUntil([this]() { return (i2c_get_status(i2c_) & I2C_STATUS_CMPL_MASK) != 0U; },
+                wait_policy_.transfer_timeout_us);
+  if (!mem_addr_complete)
+  {
+    AsyncCompletionStateMachine::MarkFailure(async_ctx_, status_timeout, true);
+    StopAndReleaseAsyncBus();
+    ResetAsyncState();
+    CancelAsyncBlockWaitIfNeeded(op);
+    return ErrorCode::TIMEOUT;
+  }
+  i2c_clear_status(i2c_, I2C_STATUS_CMPL_MASK);
+  i2c_clear_fifo(i2c_);
+
+  const uint16_t final_flags =
+      BuildTransferFlags(kI2CFlagNoStart | kI2CFlagNoAddress | kI2CFlagWriteCheckAck);
+  i2c_master_set_slave_address(i2c_, slave_addr);
+  i2c_set_direction(i2c_, I2C_DIR_MASTER_WRITE);
+  i2c_master_disable_start_phase(i2c_);
+  i2c_master_disable_addr_phase(i2c_);
+  i2c_master_enable_stop_phase(i2c_);
+  i2c_master_enable_data_phase(i2c_);
+  i2c_set_data_count(i2c_, static_cast<uint32_t>(write_data.size_));
+  i2c_dma_disable(i2c_);
+  if ((final_flags & kI2CFlagAddr10Bit) != 0U)
+  {
+    i2c_enable_10bit_address_mode(i2c_, true);
+  }
+
+  ans = EnableAsyncI2cIrq();
+  if (ans != ErrorCode::OK)
+  {
+    AsyncCompletionStateMachine::MarkFailure(async_ctx_, status_fail, true);
+    StopAndReleaseAsyncBus();
+    ResetAsyncState();
+    CancelAsyncBlockWaitIfNeeded(op);
+    return ErrorCode::NOT_SUPPORT;
+  }
+
+  ans = StartAsyncWriteDma(write_data.addr_, static_cast<uint32_t>(write_data.size_));
+  if (ans != ErrorCode::OK)
+  {
+    AsyncCompletionStateMachine::MarkFailure(async_ctx_, status_fail, true);
+    DisableAsyncI2cIrq();
+    StopAndReleaseAsyncBus();
+    ResetAsyncState();
+    CancelAsyncBlockWaitIfNeeded(op);
+    return ans;
+  }
+
+  i2c_master_issue_data_transmission(i2c_);
+
+  op.MarkAsRunning();
+  if (op.type == WriteOperation::OperationType::BLOCK)
+  {
+    return WaitForAsyncBlockResult(op.data.sem_info.timeout);
+  }
+  return ErrorCode::OK;
+}
+
 ErrorCode HPMI2C::EnsureAsyncDmaReady()
 {
   if (async_dma_ready_)
@@ -1682,7 +1805,8 @@ void HPMI2C::HandleAsyncInterrupt(bool in_isr)
   if ((status & I2C_STATUS_CMPL_MASK) != 0U)
   {
     i2c_clear_status(i2c_, I2C_STATUS_CMPL_MASK);
-    if (async_ctx_.kind == AsyncTransferKind::WRITE &&
+    if ((async_ctx_.kind == AsyncTransferKind::WRITE ||
+         async_ctx_.kind == AsyncTransferKind::MEM_WRITE) &&
         (async_ctx_.flags & kI2CFlagWriteCheckAck) != 0U && !I2C_STATUS_ACK_GET(status))
     {
       AsyncCompletionStateMachine::MarkI2cDone(async_ctx_, status_i2c_no_ack, true);
@@ -1856,12 +1980,12 @@ ErrorCode HPMI2C::Read(uint16_t slave_addr, RawData read_data, ReadOperation& op
     return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
 
-  if (op.type != ReadOperation::OperationType::BLOCK)
+  if (read_data.size_ > dma_enable_min_size_)
   {
     const ErrorCode ans = StartReadAsync(slave_addr, read_data, op);
     if (ans != ErrorCode::OK)
     {
-      op.UpdateStatus(in_isr, ans);
+      return FinishOperation(op, in_isr, ans);
     }
     return ans;
   }
@@ -2120,12 +2244,12 @@ ErrorCode HPMI2C::Write(uint16_t slave_addr, ConstRawData write_data, WriteOpera
     return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
 
-  if (op.type != WriteOperation::OperationType::BLOCK)
+  if (write_data.size_ > dma_enable_min_size_)
   {
     const ErrorCode ans = StartWriteAsync(slave_addr, write_data, op);
     if (ans != ErrorCode::OK)
     {
-      op.UpdateStatus(in_isr, ans);
+      return FinishOperation(op, in_isr, ans);
     }
     return ans;
   }
@@ -2164,13 +2288,13 @@ ErrorCode HPMI2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_d
     return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
 
-  if (op.type != ReadOperation::OperationType::BLOCK)
+  if (read_data.size_ > dma_enable_min_size_)
   {
     const ErrorCode ans =
         StartMemReadAsync(slave_addr, mem_addr, read_data, op, mem_addr_size);
     if (ans != ErrorCode::OK)
     {
-      op.UpdateStatus(in_isr, ans);
+      return FinishOperation(op, in_isr, ans);
     }
     return ans;
   }
@@ -2235,6 +2359,16 @@ ErrorCode HPMI2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
   {
     return FinishOperation(op, in_isr, ErrorCode::BUSY);
   }
+
+  if (write_data.size_ > dma_enable_min_size_)
+  {
+    ans = StartMemWriteAsync(slave_addr, mem_addr, write_data, op, mem_addr_size);
+    if (ans != ErrorCode::OK)
+    {
+      return FinishOperation(op, in_isr, ans);
+    }
+    return ans;
+  }
 #endif
 
   ans = EnsureControllerReady();
@@ -2293,170 +2427,4 @@ ErrorCode HPMI2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
   return FinishOperation(op, in_isr, ans);
 }
 
-#else
-
-extern "C" void libxr_hpm_i2c_process_interrupt(LibXRHpmI2cType* ptr) { UNUSED(ptr); }
-
-HPMI2C::HPMI2C(LibXRHpmI2cType* i2c, clock_name_t clock, bool auto_board_init,
-               I2C::Configuration config)
-    : i2c_(i2c), clock_(clock), current_config_(config), auto_board_init_(auto_board_init)
-{
-  (void)i2c_;
-  (void)clock_;
-  (void)auto_board_init_;
-}
-
-ErrorCode HPMI2C::SetAddressMode(AddressMode mode)
-{
-  address_mode_ = mode;
-  return ErrorCode::NOT_SUPPORT;
-}
-
-ErrorCode HPMI2C::ConvertStatus(hpm_stat_t status)
-{
-  UNUSED(status);
-  return ErrorCode::NOT_SUPPORT;
-}
-
-uint16_t HPMI2C::BuildTransferFlags(uint16_t flags) const { return flags; }
-
-ErrorCode HPMI2C::DoSequenceWrite(uint16_t slave_addr, ConstRawData write_data,
-                                  SequenceFrame frame, bool check_ack)
-{
-  UNUSED(slave_addr);
-  UNUSED(write_data);
-  UNUSED(frame);
-  UNUSED(check_ack);
-  return ErrorCode::NOT_SUPPORT;
-}
-
-ErrorCode HPMI2C::DoSequenceRead(uint16_t slave_addr, RawData read_data,
-                                 SequenceFrame frame)
-{
-  UNUSED(slave_addr);
-  UNUSED(read_data);
-  UNUSED(frame);
-  return ErrorCode::NOT_SUPPORT;
-}
-
-ErrorCode HPMI2C::DoTransferWithFlags(uint16_t slave_addr, RawData data, uint16_t flags)
-{
-  UNUSED(slave_addr);
-  UNUSED(data);
-  UNUSED(flags);
-  return ErrorCode::NOT_SUPPORT;
-}
-
-hpm_stat_t HPMI2C::DoManualTransferWithFlags(uint16_t slave_addr, RawData data,
-                                             uint16_t flags)
-{
-  UNUSED(slave_addr);
-  UNUSED(data);
-  UNUSED(flags);
-  return status_fail;
-}
-
-ErrorCode HPMI2C::EnsureClockReady() { return ErrorCode::NOT_SUPPORT; }
-
-ErrorCode HPMI2C::EnsureControllerReady() { return ErrorCode::NOT_SUPPORT; }
-
-ErrorCode HPMI2C::ApplyConfig(const Configuration& config)
-{
-  current_config_ = config;
-  configured_ = false;
-  return ErrorCode::NOT_SUPPORT;
-}
-
-bool HPMI2C::ShouldRecover(hpm_stat_t status)
-{
-  UNUSED(status);
-  return false;
-}
-
-void HPMI2C::RecoverController() {}
-
-void HPMI2C::TryRecoverBusLines() {}
-
-ErrorCode HPMI2C::SetConfig(Configuration config)
-{
-  current_config_ = config;
-  configured_ = false;
-  return ErrorCode::NOT_SUPPORT;
-}
-
-ErrorCode HPMI2C::Read(uint16_t slave_addr, RawData read_data, ReadOperation& op,
-                       bool in_isr)
-{
-  UNUSED(slave_addr);
-  UNUSED(read_data);
-  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
-}
-
-ErrorCode HPMI2C::Write(uint16_t slave_addr, ConstRawData write_data, WriteOperation& op,
-                        bool in_isr)
-{
-  UNUSED(slave_addr);
-  UNUSED(write_data);
-  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
-}
-
-ErrorCode HPMI2C::MemRead(uint16_t slave_addr, uint16_t mem_addr, RawData read_data,
-                          ReadOperation& op, MemAddrLength mem_addr_size, bool in_isr)
-{
-  UNUSED(slave_addr);
-  UNUSED(mem_addr);
-  UNUSED(read_data);
-  UNUSED(mem_addr_size);
-  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
-}
-
-ErrorCode HPMI2C::MemWrite(uint16_t slave_addr, uint16_t mem_addr,
-                           ConstRawData write_data, WriteOperation& op,
-                           MemAddrLength mem_addr_size, bool in_isr)
-{
-  UNUSED(slave_addr);
-  UNUSED(mem_addr);
-  UNUSED(write_data);
-  UNUSED(mem_addr_size);
-  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
-}
-
-ErrorCode HPMI2C::SequenceWrite(uint16_t slave_addr, ConstRawData write_data,
-                                SequenceFrame frame, bool check_ack, WriteOperation& op,
-                                bool in_isr)
-{
-  UNUSED(slave_addr);
-  UNUSED(write_data);
-  UNUSED(frame);
-  UNUSED(check_ack);
-  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
-}
-
-ErrorCode HPMI2C::SequenceRead(uint16_t slave_addr, RawData read_data,
-                               SequenceFrame frame, ReadOperation& op, bool in_isr)
-{
-  UNUSED(slave_addr);
-  UNUSED(read_data);
-  UNUSED(frame);
-  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
-}
-
-ErrorCode HPMI2C::TransferWithFlags(uint16_t slave_addr, RawData data, uint16_t flags,
-                                    ReadOperation& op, bool in_isr)
-{
-  UNUSED(slave_addr);
-  UNUSED(data);
-  UNUSED(flags);
-  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
-}
-
-ErrorCode HPMI2C::TransferWithFlags(uint16_t slave_addr, ConstRawData data,
-                                    uint16_t flags, WriteOperation& op, bool in_isr)
-{
-  UNUSED(slave_addr);
-  UNUSED(data);
-  UNUSED(flags);
-  return FinishOperation(op, in_isr, ErrorCode::NOT_SUPPORT);
-}
-
-#endif
+#endif  // LIBXR_HPM_I2C_SUPPORTED

--- a/driver/hpm/hpm_i2c.hpp
+++ b/driver/hpm/hpm_i2c.hpp
@@ -30,10 +30,8 @@
 #if defined(HPMSOC_HAS_HPMSDK_I2C) && __has_include("hpm_i2c_drv.h")
 #include "hpm_i2c_drv.h"
 #define LIBXR_HPM_I2C_SUPPORTED 1
-using LibXRHpmI2cType = I2C_Type;
 #else
 #define LIBXR_HPM_I2C_SUPPORTED 0
-using LibXRHpmI2cType = void;
 #endif
 
 #if LIBXR_HPM_I2C_SUPPORTED && __has_include("hpm_dma_mgr.h")
@@ -43,7 +41,9 @@ using LibXRHpmI2cType = void;
 #define LIBXR_HPM_I2C_HAS_DMA_MGR 0
 #endif
 
-extern "C" void libxr_hpm_i2c_process_interrupt(LibXRHpmI2cType* ptr);
+#if LIBXR_HPM_I2C_SUPPORTED
+
+extern "C" void libxr_hpm_i2c_process_interrupt(I2C_Type* ptr);
 
 namespace LibXR
 {
@@ -67,17 +67,20 @@ namespace LibXR
  * busy, or no response, the driver attempts to rebuild the controller with the most
  * recent successful configuration.
  *
- * BLOCK 模式保持同步阻塞式传输；当工程提供旧分支的 `hpm_dma_mgr.h` helper 时，
- * POLLING / CALLBACK / NONE 可复用 DMA 后台路径覆盖 Write / Read / MemRead。
+ * 当工程提供旧分支的 `hpm_dma_mgr.h` helper 时，超过实例 DMA 阈值的 BLOCK /
+ * POLLING / CALLBACK / NONE 可复用 DMA 后台路径覆盖 Write / Read / MemRead /
+ * MemWrite；小包仍走同步阻塞式传输并按 LibXR Operation 语义即时完成。
  * 当前 upstream HPM5301 模板未携带该 helper 时，这些操作降级为同步完成并即时更新
- * LibXR Operation 状态。MemWrite 始终保持阻塞路径。对 10-bit / 扩展 flags 的
- * blocking 手工 phase 路径，地址阶段会显式等待 `ADDRHIT`，失败时按适配层策略强制
- * cleanup 并按原始 HPM 状态触发恢复链路。
- * BLOCK mode stays on synchronous blocking transfers. When the project provides the
- * legacy-branch `hpm_dma_mgr.h` helper, POLLING / CALLBACK / NONE can reuse the DMA
- * backed path for Write / Read / MemRead. Without that helper, as in the current
- * upstream HPM5301 template, these operations complete synchronously and update the
- * LibXR Operation state before returning. MemWrite always stays on the blocking path.
+ * LibXR Operation 状态。对 10-bit / 扩展 flags 的 blocking 手工 phase 路径，
+ * 地址阶段会显式等待 `ADDRHIT`，失败时按适配层策略强制 cleanup 并按原始 HPM
+ * 状态触发恢复链路。
+ * When the project provides the legacy-branch `hpm_dma_mgr.h` helper, BLOCK /
+ * POLLING / CALLBACK / NONE transfers larger than the instance DMA threshold can
+ * reuse the DMA backed path for Write / Read / MemRead / MemWrite. Smaller packets
+ * stay on synchronous blocking transfers and complete the LibXR Operation
+ * immediately. Without that helper, as in the current upstream HPM5301 template,
+ * these operations complete synchronously and update the LibXR Operation state
+ * before returning.
  * For the blocking manual phase path used by 10-bit / extended-flag transfers, the
  * address phase explicitly waits for `ADDRHIT`; failures force adapter-level cleanup
  * and preserve the original HPM status for recovery handling.
@@ -135,13 +138,12 @@ namespace LibXR
  * the same IRQ later, the ownership scheme should be revised in a separate change.
  *
  * 编译期支持由 `HPMSOC_HAS_HPMSDK_I2C` 和 `__has_include("hpm_i2c_drv.h")`
- * 同时 gate；缺少能力宏或裁剪 SDK 头时仍保留 LibXR API 形状，但所有事务返回
- * `NOT_SUPPORT`，避免 `driver/hpm` glob 构建在无 I2C SoC 上因 SDK 头缺失失败。
+ * 同时 gate；缺少能力宏或裁剪 SDK 头时会直接排除整个 HPMI2C 类定义，避免在无
+ * I2C SoC 上暴露不可用 stub。
  * Compile-time support is gated by both `HPMSOC_HAS_HPMSDK_I2C` and
  * `__has_include("hpm_i2c_drv.h")`. When the capability macro or trimmed SDK header
- * is missing, the LibXR API shape remains available but transfer APIs return
- * `NOT_SUPPORT`, preventing the `driver/hpm` glob build from failing on SoCs without
- * I2C.
+ * is missing, the whole HPMI2C class definition is excluded instead of exposing
+ * unavailable stubs.
  */
 class HPMI2C final : public I2C
 {
@@ -198,7 +200,8 @@ class HPMI2C final : public I2C
     NONE,
     READ,
     WRITE,
-    MEM_READ
+    MEM_READ,
+    MEM_WRITE
   };
 
   /**
@@ -245,13 +248,17 @@ class HPMI2C final : public I2C
    * rates: 100 kHz, 400 kHz, and 1 MHz. Other rates are rejected by SetConfig().
    * The default address mode is 7-bit; call SetAddressMode() after construction to
    * switch to 10-bit when needed.
+   * @param dma_enable_min_size 启用 DMA 后台路径的最小传输阈值；size 大于该值时使用
+   * DMA，否则使用同步路径 / Minimum transfer threshold for the DMA-backed path;
+   * transfers with size greater than this value use DMA, otherwise they use the
+   * synchronous path.
    *
    * @note 构造函数会在外设指针为空、源时钟无法解析或初始配置无效时断言失败 /
    * The constructor asserts when the peripheral pointer is null, the source clock
    * cannot be resolved, or the initial configuration is invalid.
    */
-  HPMI2C(LibXRHpmI2cType* i2c, clock_name_t clock, bool auto_board_init = true,
-         I2C::Configuration config = {100000});
+  HPMI2C(I2C_Type* i2c, clock_name_t clock, bool auto_board_init = true,
+         I2C::Configuration config = {100000}, uint32_t dma_enable_min_size = 3U);
 
   /**
    * @brief 设置 HPM 主机寻址模式并重建控制器 / Set HPM master addressing mode and
@@ -507,7 +514,7 @@ class HPMI2C final : public I2C
 #endif
 
  private:
-  friend void ::libxr_hpm_i2c_process_interrupt(LibXRHpmI2cType* ptr);
+  friend void ::libxr_hpm_i2c_process_interrupt(I2C_Type* ptr);
 
 #if LIBXR_HPM_I2C_HAS_DMA_MGR
   /**
@@ -790,6 +797,14 @@ class HPMI2C final : public I2C
                               ReadOperation& op, MemAddrLength mem_addr_size);
 
   /**
+   * @brief 后台寄存器写事务提交 /
+   * Submit one asynchronous memory/register write transaction.
+   */
+  ErrorCode StartMemWriteAsync(uint16_t slave_addr, uint16_t mem_addr,
+                               ConstRawData write_data, WriteOperation& op,
+                               MemAddrLength mem_addr_size);
+
+  /**
    * @brief DMA manager 资源就绪检查 / Ensure DMA manager resource is ready.
    */
   ErrorCode EnsureAsyncDmaReady();
@@ -916,7 +931,7 @@ class HPMI2C final : public I2C
     return ans;
   }
 
-  LibXRHpmI2cType* i2c_;          ///< I2C 外设实例 / I2C peripheral instance.
+  I2C_Type* i2c_;                 ///< I2C 外设实例 / I2C peripheral instance.
   clock_name_t clock_;            ///< I2C 源时钟名称 / I2C source clock name.
   uint32_t source_clock_hz_ = 0;  ///< 缓存的源时钟频率 / Cached source clock frequency.
   Configuration current_config_{
@@ -926,6 +941,8 @@ class HPMI2C final : public I2C
   AddressMode address_mode_ =
       AddressMode::ADDR_7BIT;  ///< 当前主机寻址模式 / Current master addressing mode.
   bool configured_ = false;    ///< 是否已有成功配置 / Whether a valid config was applied.
+  uint32_t dma_enable_min_size_ =
+      3U;  ///< 启用 DMA 后台路径的最小阈值 / Minimum size threshold for DMA path.
 #if LIBXR_HPM_I2C_HAS_DMA_MGR
   std::atomic<uint32_t> async_busy_{
       0U};  ///< 后台事务活动标志 / Asynchronous transfer active flag.
@@ -944,3 +961,5 @@ class HPMI2C final : public I2C
 };
 
 }  // namespace LibXR
+
+#endif  // LIBXR_HPM_I2C_SUPPORTED

--- a/driver/hpm/hpm_i2c.hpp
+++ b/driver/hpm/hpm_i2c.hpp
@@ -92,10 +92,9 @@ namespace LibXR
  * final result through UpdateStatus() or AsyncBlockWait.
  * 异步完成路径的 `dma_done`、`cmpl_done`、`final_status` 和 `should_recover`
  * 原子状态由内部 AsyncCompletionStateMachine helper 统一更新，IRQ 和 DMA 回调只声明
- * 发生的事件。
- * The asynchronous completion atomics `dma_done`, `cmpl_done`, `final_status`, and
- * `should_recover` are updated through the internal AsyncCompletionStateMachine
- * helper, leaving IRQ and DMA callbacks to report events only.
+ * 发生的事件。硬件启动发布前，完成事件只记录而不清理控制器。
+ * The asynchronous completion atomics are updated through the internal state machine.
+ * Completion events are deferred until hardware submission has finished.
  *
  * 当 DMA 后台事务正在进行时，同步 Read / Write / MemRead / MemWrite、顺序
  * SequenceRead / SequenceWrite 以及扩展 flags 手动 phase 入口会返回 `BUSY`；
@@ -332,8 +331,8 @@ class HPMI2C final : public I2C
   /**
    * @brief 执行一段 HPM 扩展标志主机事务 / Execute one HPM master transfer with
    * extended SDK flags.
-   * @param slave_addr 当前寻址模式下的从设备地址，不包含 R/W 位 / Slave address in
-   * the current addressing mode, without the R/W bit.
+   * @param slave_addr 当前寻址模式或 ADDR_10BIT 标志下的从设备地址，不包含 R/W 位 /
+   * Slave address in the active mode, or 10-bit mode when ADDR_10BIT is set.
    * @param data 数据缓冲区；按 flags 指示读或写 / Data buffer used for read or write
    * according to flags.
    * @param flags HPM 扩展事务标志组合 / Combined HPM extended transfer flags.
@@ -347,8 +346,8 @@ class HPMI2C final : public I2C
   /**
    * @brief 执行一段 HPM 扩展标志主机写事务 / Execute one HPM master write transfer
    * with extended SDK flags.
-   * @param slave_addr 当前寻址模式下的从设备地址，不包含 R/W 位 / Slave address in
-   * the current addressing mode, without the R/W bit.
+   * @param slave_addr 当前寻址模式或 ADDR_10BIT 标志下的从设备地址，不包含 R/W 位 /
+   * Slave address in the active mode, or 10-bit mode when ADDR_10BIT is set.
    * @param data 要写出的数据缓冲区 / Data buffer to be transmitted.
    * @param flags HPM 扩展事务标志组合；READ 位若被传入会被忽略 / Combined HPM
    * extended transfer flags. The READ bit is ignored when provided.
@@ -507,10 +506,14 @@ class HPMI2C final : public I2C
   /**
    * @brief 供 DMA / 中断完成路径调用的完成入口 /
    * Completion entry used by DMA / interrupt driven paths.
-   * @param in_isr 当前是否位于中断上下文 / Whether current context is ISR.
-   * @param ans 事务最终错误码 / Final transfer error code.
+   * @param in_isr
+   * 当前是否位于中断上下文 / Whether current context is ISR.
+   * @param ans
+   * 事务最终错误码 / Final transfer error code.
+   * @param force_recover
+   * 无条件执行控制器恢复 / Force controller recovery.
    */
-  void CompleteAsyncTransfer(bool in_isr, ErrorCode ans);
+  void CompleteAsyncTransfer(bool in_isr, ErrorCode ans, bool force_recover = false);
 #endif
 
  private:
@@ -538,6 +541,8 @@ class HPMI2C final : public I2C
         status_success};  ///< DMA/IRQ 共享最终状态 / Final status shared by DMA/IRQ.
     std::atomic<bool> should_recover{
         false};  ///< DMA/IRQ 共享恢复标志 / Recovery flag shared by DMA/IRQ.
+    std::atomic<bool> submission_done{
+        false};  ///< 硬件启动阶段已结束 / Hardware submission phase has finished.
     std::atomic<bool> dma_done{
         false};  ///< DMA 回调完成标志 / DMA callback completion flag.
     std::atomic<bool> cmpl_done{false};  ///< I2C IRQ 完成标志 / I2C IRQ completion flag.
@@ -546,19 +551,21 @@ class HPMI2C final : public I2C
   /**
    * @brief 异步 DMA/I2C 完成状态 helper / Async DMA/I2C completion state helper.
    *
-   * 该 helper 集中更新 `dma_done`、`cmpl_done`、`final_status` 和 `should_recover`，
-   * 使 DMA 回调、I2C IRQ 和 BLOCK timeout 只表达发生的事件。
-   * This helper centralizes updates to `dma_done`, `cmpl_done`, `final_status`, and
-   * `should_recover`, so DMA callbacks, I2C IRQ handling, and BLOCK timeout paths
-   * only report events.
+   * 该 helper 集中更新异步完成原子状态；`submission_done` 在硬件启动完成前阻止清理。
+   * This helper centralizes asynchronous completion state. `submission_done` blocks
+   * cleanup until hardware submission has finished.
    */
   struct AsyncCompletionStateMachine
   {
     static void Reset(AsyncTransferContext& ctx);
+    static void MarkSubmissionDone(AsyncTransferContext& ctx);
     static void MarkDmaDone(AsyncTransferContext& ctx);
     static void MarkI2cDone(AsyncTransferContext& ctx, hpm_stat_t status, bool recover);
     static void MarkFailure(AsyncTransferContext& ctx, hpm_stat_t status, bool recover);
+    static void MarkTerminalFailure(AsyncTransferContext& ctx, hpm_stat_t status,
+                                    bool recover);
     static void SetFinalStatus(AsyncTransferContext& ctx, hpm_stat_t status);
+    static bool SubmissionDone(const AsyncTransferContext& ctx);
     static bool DmaDone(const AsyncTransferContext& ctx);
     static bool Ready(const AsyncTransferContext& ctx);
     static hpm_stat_t FinalStatus(const AsyncTransferContext& ctx);
@@ -601,16 +608,8 @@ class HPMI2C final : public I2C
 #endif
 
   /**
-   * @brief 转换 HPM 顺序分段枚举到 SDK 枚举 / Convert HPM sequence frame enum to SDK
-   * enum.
-   */
-#if LIBXR_HPM_I2C_SUPPORTED
-  static i2c_seq_transfer_opt_t ConvertSequenceFrame(SequenceFrame frame);
-#endif
-
-  /**
-   * @brief 从当前地址模式补齐 HPM SDK 事务标志 / Merge current address-mode bit into SDK
-   * transfer flags.
+   * @brief 从当前地址模式补齐 HPM SDK 事务标志 / Merge current
+   * address-mode bit into SDK transfer flags.
    */
   uint16_t BuildTransferFlags(uint16_t flags) const;
 
@@ -632,11 +631,17 @@ class HPMI2C final : public I2C
   ErrorCode ValidateTransferArgs(uint16_t slave_addr, RawData data,
                                  bool allow_zero_size) const;
 
+  ErrorCode ValidateTransferArgs(uint16_t slave_addr, RawData data, bool allow_zero_size,
+                                 AddressMode mode) const;
+
   /**
    * @brief 校验普通写事务入口参数 / Validate common write entry arguments.
    */
   ErrorCode ValidateTransferArgs(uint16_t slave_addr, ConstRawData data,
                                  bool allow_zero_size) const;
+
+  ErrorCode ValidateTransferArgs(uint16_t slave_addr, ConstRawData data,
+                                 bool allow_zero_size, AddressMode mode) const;
 
   /**
    * @brief 校验寄存器写事务入口参数并解析寄存器地址长度 /
@@ -845,6 +850,12 @@ class HPMI2C final : public I2C
   void HandleAsyncInterrupt(bool in_isr);
 
   /**
+   * @brief 发布硬件启动完成并处理暂存事件 /
+   * Finalize hardware submission and process deferred events.
+   */
+  void FinishAsyncSubmission();
+
+  /**
    * @brief 当 DMA 与 I2C 两阶段都满足时统一完成事务 /
    * Complete the transfer once both DMA and I2C phases are satisfied.
    */
@@ -931,6 +942,28 @@ class HPMI2C final : public I2C
     return ans;
   }
 
+  bool TryAcquireTransaction()
+  {
+    uint32_t expected = 0U;
+    return transaction_busy_.compare_exchange_strong(
+        expected, 1U, std::memory_order_acq_rel, std::memory_order_acquire);
+  }
+
+  void ReleaseTransaction() { transaction_busy_.store(0U, std::memory_order_release); }
+
+  ErrorCode EndTransaction(ErrorCode ans)
+  {
+    ReleaseTransaction();
+    return ans;
+  }
+
+  template <typename Op>
+  ErrorCode EndTransaction(Op& op, bool in_isr, ErrorCode ans)
+  {
+    ReleaseTransaction();
+    return FinishOperation(op, in_isr, ans);
+  }
+
   I2C_Type* i2c_;                 ///< I2C 外设实例 / I2C peripheral instance.
   clock_name_t clock_;            ///< I2C 源时钟名称 / I2C source clock name.
   uint32_t source_clock_hz_ = 0;  ///< 缓存的源时钟频率 / Cached source clock frequency.
@@ -940,7 +973,9 @@ class HPMI2C final : public I2C
       DefaultWaitPolicy();  ///< 当前忙等超时策略 / Current busy-wait timeout policy.
   AddressMode address_mode_ =
       AddressMode::ADDR_7BIT;  ///< 当前主机寻址模式 / Current master addressing mode.
-  bool configured_ = false;    ///< 是否已有成功配置 / Whether a valid config was applied.
+  std::atomic<uint32_t> transaction_busy_{
+      0U};                   ///< 实例事务占用标志 / Instance transaction ownership flag.
+  bool configured_ = false;  ///< 是否已有成功配置 / Whether a valid config was applied.
   uint32_t dma_enable_min_size_ =
       3U;  ///< 启用 DMA 后台路径的最小阈值 / Minimum size threshold for DMA path.
 #if LIBXR_HPM_I2C_HAS_DMA_MGR


### PR DESCRIPTION
## What
- 对齐 HPM I2C 阻塞传输行为与其他平台后端的通用策略。
- 当传输长度大于 `dma_enable_min_size` 时使用异步 / DMA 后台路径，小包保持同步路径。
- 补齐 HPM I2C `MemWrite` 的异步 / DMA 路径，使 `Read`、`Write`、`MemRead`、`MemWrite` 行为一致。
- 对不支持 I2C 的 HPM 平台改为编译期 macro guard，不再暴露运行时 stub 实现。
- 保持 `LibXR::I2C` 通用 API 不变，不修改 STM32 I2C 实现。

## Why
- HPM I2C 之前的阻塞操作策略没有完全对齐其他平台后端。
- `Read`、`Write`、`MemRead`、`MemWrite` 应该使用一致的传输长度判断策略。
- 不支持 HPM I2C 的目标应在编译期能力边界被裁剪，而不是保留可实例化但只返回 `NOT_SUPPORT` 的 stub。
- 这样可以保持构造 / 配置阶段的初始化语义，同时把普通传输错误继续通过 `ErrorCode` 返回。

## Verify
- 使用 HPM5E31 模板工程构建通过：`cmake --build --preset debug-flash-xip -j 1`。
- 使用 CMSIS-DAP + OpenOCD 将 `build/output/demo.elf` 烧录到 HPM5E31 / `hpm5e00evk`，`program ... verify` 通过。
- 在 I2C0 上连接 INA228，地址 `0x40`。
- 成功读取 INA228 普通寄存器：
  - `DEVICE_ID = 0x2281`
  - `CONFIG = 0x0000`
  - `DIE_TEMP_RAW = 0x0DB8`
- 扫描 `0x40..0x4F`，仅 `0x40` 响应。
- 在 I2C0 上补充验证大于 DMA 阈值的读路径：读取 INA228 `ENERGY` 寄存器 `0x09`，长度 5 字节，大于默认 `dma_enable_min_size = 3`，因此触发 HPM I2C async / DMA-backed `MemRead` 路径。
- DMA-size 读运行结果：`dma_energy_result=0`，`dma_ok_count=7`，`dma_fail_count=0`。
- 最终运行时探测结果：`probe_count=7`，`ok_count=7`，`fail_count=0`，`status_flags=0x3EB`。

## Not Verified
- 未在 HPM5E31 之外的其他 HPM SoC 上进行板级验证。
- 未进行 10-bit 地址模式硬件验证。
- I2C1 / I2C2 / I2C3 尚未逐实例进行板级 DMA 传输验证：当前板上只确认 INA228 接在 I2C0；I2C2 需要额外接线，I2C1 / I2C3 还需要补充板级 pinmux 后才能做完整板级验证。