### PR TITLE
fix(swd): add trailing idle clocks after write data phase

### DIFF
--- a/src/driver/debug/swd_general_gpio.hpp
+++ b/src/driver/debug/swd_general_gpio.hpp
@@ -568,6 +568,16 @@ class SwdGeneralGPIO final : public Swd
       const bool PARITY_BIT = (Parity32(DATA) & 0x1u) != 0u;
       WriteBit(PARITY_BIT);
 
+      // Trailing idle clocks after a write data phase: keep SWDIO driven LOW and
+      // clock the target so it completes/settles the (possibly posted) write before
+      // the next request start bit. Without this, a transfer immediately following an
+      // AP write in the same DAP_Transfer batch samples ACK at the wrong phase (JUNK).
+      swdio_.Write(false);
+      for (uint32_t k = 0; k < WRITE_TRAILING_IDLE_CLOCKS; ++k)
+      {
+        GenOneClk();
+      }
+
       swdio_.Write(true);
       swclk_.Write(false);
     }
@@ -645,6 +655,13 @@ class SwdGeneralGPIO final : public Swd
       const bool PARITY_BIT = (Parity32(DATA) & 0x1u) != 0u;
       WriteBitWithoutDelay(PARITY_BIT);
 
+      // Trailing idle clocks after a write data phase (see delay-path note).
+      swdio_.Write(false);
+      for (uint32_t k = 0; k < WRITE_TRAILING_IDLE_CLOCKS; ++k)
+      {
+        GenOneClkWithoutDelay();
+      }
+
       swdio_.Write(true);
       swclk_.Write(false);
     }
@@ -659,6 +676,8 @@ class SwdGeneralGPIO final : public Swd
       64u;  ///< 线复位时钟周期数。Line reset clock cycles.
   static constexpr uint32_t BYTE_BITS = 8u;  ///< 每字节比特数。Bits per byte.
   static constexpr uint32_t ACK_BITS = 3u;   ///< ACK 比特数。ACK bits.
+  static constexpr uint32_t WRITE_TRAILING_IDLE_CLOCKS =
+      3u;  ///< Idle clocks (SWDIO low) after a write data phase to settle posted writes.
 
   static constexpr uint8_t JTAG_TO_SWD_SEQ0 =
       0x9Eu;  ///< JTAG->SWD 序列字节 0。JTAG-to-SWD sequence byte 0.


### PR DESCRIPTION
## Problem

`SwdGeneralGPIO` ended the SWD **write** data phase immediately after clocking the parity bit (SWDIO high, SWCLK low) with no trailing clocks. Because an AP write is *posted*, the target could still be completing the write when the next transaction's start bit was clocked. A transfer issued immediately after an AP write **within the same batched `DAP_Transfer`** therefore sampled its ACK at the wrong phase and read an invalid value — OpenOCD reports this as `SWD ack not OK @ N JUNK`.

## Symptom

`cortex_m` examine fails with **`Cannot detect cache`** on an STM32F302CB (Cortex-M4) target:

```
SWD DPIDR 0x2ba01477
[stm32f3x.cpu] Cortex-M4 r0p1 processor detected
SWD ack not OK @ 1 JUNK
Cannot detect cache
[stm32f3x.cpu] Examination failed
```

Single-transfer reads (CPUID, MVFR0, DHCSR) all succeed; the failure is the **2nd transfer** of the batched cache/DWT/FPB reads that follow an AP write. Driving one transaction per USB packet (e.g. manual `dap apreg`) masks the bug because inter-packet latency gives the posted write time to settle. Deterministic (10/10), speed-independent (100 kHz == 1000 kHz).

## Fix

After the write parity bit, drive SWDIO **low** and clock `WRITE_TRAILING_IDLE_CLOCKS` idle cycles, in both `TransferWithDelay` and `TransferWithoutDelay`, so the target settles the (possibly posted) write before the next start bit.

## Choosing the constant (hardware threshold sweep)

Rebuild + flash + examine for each value on the STM32F302CB:

| trailing clocks | examine |
|---|---|
| 0 (original) | Cannot detect cache (fail) |
| 1 | Cannot detect cache (fail) |
| 2 | Examination succeed |
| 3 (this PR) | Examination succeed |
| 8 | Examination succeed |

Minimum working value is 2; set to **3** (minimum + margin).

## Throughput impact: negligible

32 KiB block SRAM transfer at 1 MHz SWCLK:

| operation | time |
|---|---|
| block write (posted AP writes, +3 clocks each) | 771 ms |
| block read (unchanged path) | 755 ms |

Write and read are within ~2% — throughput is dominated by USB round-trips, not SWD clock time, so the extra write-phase clocks are lost in the noise.

## Verification (hardware)

STM32F103 CMSIS-DAP probe to STM32F302CB, via OpenOCD 0.12.0+dev:

- `Examination succeed` (was `Cannot detect cache` / `Examination failed`)
- Full ROM-table / DWT / FPB walk completes; `reset halt` works; DHCSR = `0x00030003`
- High-level memory write+read verify byte-exact (`A1B2C3D4 / DEADC0DE / 0BADF00D / FEEDFACE`)
- Manual MEM-AP access unaffected (no regression)

The bug is target-dependent in practice (the same firmware examined an STM32H7/Cortex-M7 without tripping it) and predates recent DAP refactors, so it is not a regression from those changes.
