### PR TITLE
Add HPM ADC Support

### DIFF
--- a/driver/hpm/hpm_adc.cpp
+++ b/driver/hpm/hpm_adc.cpp
@@ -15,6 +15,7 @@ constexpr uint32_t READ_RETRY_COUNT = 1024U;
 }  // namespace
 
 extern "C" void __attribute__((weak)) board_init_adc16_pins(void) {}
+extern "C" void __attribute__((weak)) board_init_adc12_pins(void) {}
 extern "C" uint32_t __attribute__((weak)) board_init_adc_clock(void* ptr,
                                                                bool clk_src_bus)
 {
@@ -148,7 +149,14 @@ bool HPMADC::Init(uint32_t sample_cycle, adc_v2_resolution_bits_t resolution,
 
   if (auto_board_init)
   {
-    board_init_adc16_pins();
+    if (hpm_adc_v2_get_ip_type(adc_) == adc_v2_ip_adc12)
+    {
+      board_init_adc12_pins();
+    }
+    else
+    {
+      board_init_adc16_pins();
+    }
   }
 
   const uint32_t clock_hz =

--- a/driver/hpm/hpm_adc.cpp
+++ b/driver/hpm/hpm_adc.cpp
@@ -140,8 +140,8 @@ float HPMADC::ResolutionMax(adc_v2_resolution_bits_t resolution)
 bool HPMADC::Init(uint32_t sample_cycle, adc_v2_resolution_bits_t resolution,
                   uint8_t clock_divider, bool auto_board_init)
 {
-  if ((hpm_adc_v2_get_ip_type(adc_) == adc_v2_ip_unknown) ||
-      (NUM_CHANNELS == 0U) || (sample_cycle == 0U))
+  if ((hpm_adc_v2_get_ip_type(adc_) == adc_v2_ip_unknown) || (NUM_CHANNELS == 0U) ||
+      (sample_cycle == 0U))
   {
     return false;
   }
@@ -151,7 +151,8 @@ bool HPMADC::Init(uint32_t sample_cycle, adc_v2_resolution_bits_t resolution,
     board_init_adc16_pins();
   }
 
-  const uint32_t clock_hz = board_init_adc_clock(reinterpret_cast<void*>(adc_.base), true);
+  const uint32_t clock_hz =
+      board_init_adc_clock(reinterpret_cast<void*>(adc_.base), true);
   if (clock_hz == 0U)
   {
     clock_add_to_group(clock_, 0);

--- a/driver/hpm/hpm_adc.cpp
+++ b/driver/hpm/hpm_adc.cpp
@@ -1,0 +1,213 @@
+#include "hpm_adc.hpp"
+
+#if LIBXR_HPM_ADC_SUPPORTED
+
+#include "board.h"
+
+using namespace LibXR;
+
+namespace
+{
+
+constexpr uint32_t LOCK_MAGIC = 0xADCA5A5AU;
+constexpr uint32_t READ_RETRY_COUNT = 1024U;
+
+}  // namespace
+
+extern "C" void __attribute__((weak)) board_init_adc16_pins(void) {}
+extern "C" uint32_t __attribute__((weak)) board_init_adc_clock(void* ptr,
+                                                               bool clk_src_bus)
+{
+  (void)ptr;
+  (void)clk_src_bus;
+  return 0U;
+}
+
+HPMADC::Channel::Channel() : adc_(nullptr), index_(0U), ch_(0U) {}
+
+HPMADC::Channel::Channel(HPMADC* adc, uint8_t index, uint8_t ch)
+    : adc_(adc), index_(index), ch_(ch)
+{
+}
+
+float HPMADC::Channel::Read() { return adc_ ? adc_->ReadChannel(index_) : 0.0f; }
+
+HPMADC::HPMADC(ADC16_Type* adc, clock_name_t clock,
+               std::initializer_list<uint8_t> channels, float vref, uint32_t sample_cycle,
+               adc16_resolution_t resolution, adc16_clock_divider_t clock_divider,
+               bool auto_board_init, uint8_t filter_size)
+    : adc_(adc),
+      clock_(clock),
+      NUM_CHANNELS(static_cast<uint8_t>(channels.size())),
+      filter_size_(filter_size),
+      resolution_(ResolutionMax(resolution)),
+      vref_(vref),
+      valid_(false)
+{
+  ASSERT(adc_ != nullptr);
+  ASSERT(NUM_CHANNELS > 0U);
+  ASSERT(NUM_CHANNELS <= MAX_CHANNELS);
+  ASSERT(vref_ > 0.0f);
+  ASSERT(filter_size_ > 0U);
+  ASSERT(resolution_ > 0.0f);
+
+  auto it = channels.begin();
+  for (uint8_t i = 0; i < NUM_CHANNELS; ++i)
+  {
+    channels_[i] = Channel(this, i, *it++);
+    last_raw_[i] = 0U;
+  }
+
+  valid_ = Init(sample_cycle, resolution, clock_divider, auto_board_init);
+  ASSERT(valid_);
+}
+
+HPMADC::Channel& HPMADC::GetChannel(uint8_t index)
+{
+  ASSERT(index < NUM_CHANNELS);
+  return channels_[index];
+}
+
+float HPMADC::ReadChannel(uint8_t channel)
+{
+  ASSERT(valid_);
+  ASSERT(channel < NUM_CHANNELS);
+  if (!valid_)
+  {
+    return 0.0f;
+  }
+  if (channel >= NUM_CHANNELS)
+  {
+    return -1.0f;
+  }
+
+  uint32_t expected = 0U;
+  if (!locked_.compare_exchange_strong(expected, LOCK_MAGIC, std::memory_order_acquire,
+                                       std::memory_order_relaxed))
+  {
+    ASSERT(false);
+    return 0.0f;
+  }
+
+  uint32_t sum = 0U;
+  uint8_t samples = 0U;
+  for (uint8_t i = 0U; i < filter_size_; ++i)
+  {
+    uint16_t raw = 0U;
+    hpm_stat_t status = status_fail;
+    for (uint32_t retry = 0U; retry < READ_RETRY_COUNT; ++retry)
+    {
+      status = adc16_get_oneshot_result(adc_, channels_[channel].ch_, &raw);
+      if (status == status_success)
+      {
+        break;
+      }
+    }
+
+    if (status == status_success)
+    {
+      last_raw_[channel] = raw;
+      sum += raw;
+      ++samples;
+    }
+  }
+
+  locked_.store(0U, std::memory_order_release);
+
+  if (samples == 0U)
+  {
+    return 0.0f;
+  }
+
+  return ConvertToVoltage(static_cast<float>(sum) / static_cast<float>(samples));
+}
+
+uint16_t HPMADC::GetLastRaw(uint8_t channel) const
+{
+  ASSERT(channel < NUM_CHANNELS);
+  if (channel >= NUM_CHANNELS)
+  {
+    return 0U;
+  }
+  return last_raw_[channel];
+}
+
+float HPMADC::ResolutionMax(adc16_resolution_t resolution)
+{
+  switch (resolution)
+  {
+    case adc16_res_8_bits:
+      return 255.0f;
+    case adc16_res_10_bits:
+      return 1023.0f;
+    case adc16_res_12_bits:
+      return 4095.0f;
+    case adc16_res_16_bits:
+    default:
+      return 65535.0f;
+  }
+}
+
+bool HPMADC::Init(uint32_t sample_cycle, adc16_resolution_t resolution,
+                  adc16_clock_divider_t clock_divider, bool auto_board_init)
+{
+  if ((adc_ == nullptr) || (NUM_CHANNELS == 0U) || (sample_cycle == 0U))
+  {
+    return false;
+  }
+
+  if (auto_board_init)
+  {
+    board_init_adc16_pins();
+  }
+
+  const uint32_t clock_hz = board_init_adc_clock(adc_, true);
+  if (clock_hz == 0U)
+  {
+    clock_add_to_group(clock_, 0);
+  }
+
+  adc16_config_t config;
+  adc16_get_default_config(&config);
+  config.res = resolution;
+  config.conv_mode = adc16_conv_mode_oneshot;
+  config.adc_clk_div = clock_divider;
+  config.wait_dis = true;
+  config.sel_sync_ahb = true;
+  config.adc_ahb_en = false;
+
+  if (adc16_init(adc_, &config) != status_success)
+  {
+    return false;
+  }
+
+  for (uint8_t i = 0; i < NUM_CHANNELS; ++i)
+  {
+    adc16_channel_config_t channel_config;
+    adc16_get_channel_default_config(&channel_config);
+    channel_config.ch = channels_[i].ch_;
+    channel_config.sample_cycle = sample_cycle;
+
+    if (adc16_init_channel(adc_, &channel_config) != status_success)
+    {
+      return false;
+    }
+
+    last_raw_[i] = 0U;
+  }
+
+  adc16_set_nonblocking_read(adc_);
+
+#if defined(ADC_SOC_BUSMODE_ENABLE_CTRL_SUPPORT) && ADC_SOC_BUSMODE_ENABLE_CTRL_SUPPORT
+  adc16_enable_oneshot_mode(adc_);
+#endif
+
+  return true;
+}
+
+float HPMADC::ConvertToVoltage(float adc_value) const
+{
+  return adc_value * vref_ / resolution_;
+}
+
+#endif

--- a/driver/hpm/hpm_adc.cpp
+++ b/driver/hpm/hpm_adc.cpp
@@ -32,9 +32,9 @@ HPMADC::Channel::Channel(HPMADC* adc, uint8_t index, uint8_t ch)
 
 float HPMADC::Channel::Read() { return adc_ ? adc_->ReadChannel(index_) : 0.0f; }
 
-HPMADC::HPMADC(ADC16_Type* adc, clock_name_t clock,
+HPMADC::HPMADC(adc_v2_handle_t adc, clock_name_t clock,
                std::initializer_list<uint8_t> channels, float vref, uint32_t sample_cycle,
-               adc16_resolution_t resolution, adc16_clock_divider_t clock_divider,
+               adc_v2_resolution_bits_t resolution, uint8_t clock_divider,
                bool auto_board_init, uint8_t filter_size)
     : adc_(adc),
       clock_(clock),
@@ -44,7 +44,7 @@ HPMADC::HPMADC(ADC16_Type* adc, clock_name_t clock,
       vref_(vref),
       valid_(false)
 {
-  ASSERT(adc_ != nullptr);
+  ASSERT(hpm_adc_v2_get_ip_type(adc_) != adc_v2_ip_unknown);
   ASSERT(NUM_CHANNELS > 0U);
   ASSERT(NUM_CHANNELS <= MAX_CHANNELS);
   ASSERT(vref_ > 0.0f);
@@ -97,7 +97,7 @@ float HPMADC::ReadChannel(uint8_t channel)
     hpm_stat_t status = status_fail;
     for (uint32_t retry = 0U; retry < READ_RETRY_COUNT; ++retry)
     {
-      status = adc16_get_oneshot_result(adc_, channels_[channel].ch_, &raw);
+      status = hpm_adc_v2_get_oneshot_result(adc_, channels_[channel].ch_, &raw);
       if (status == status_success)
       {
         break;
@@ -132,26 +132,16 @@ uint16_t HPMADC::GetLastRaw(uint8_t channel) const
   return last_raw_[channel];
 }
 
-float HPMADC::ResolutionMax(adc16_resolution_t resolution)
+float HPMADC::ResolutionMax(adc_v2_resolution_bits_t resolution)
 {
-  switch (resolution)
-  {
-    case adc16_res_8_bits:
-      return 255.0f;
-    case adc16_res_10_bits:
-      return 1023.0f;
-    case adc16_res_12_bits:
-      return 4095.0f;
-    case adc16_res_16_bits:
-    default:
-      return 65535.0f;
-  }
+  return static_cast<float>((1UL << static_cast<uint8_t>(resolution)) - 1UL);
 }
 
-bool HPMADC::Init(uint32_t sample_cycle, adc16_resolution_t resolution,
-                  adc16_clock_divider_t clock_divider, bool auto_board_init)
+bool HPMADC::Init(uint32_t sample_cycle, adc_v2_resolution_bits_t resolution,
+                  uint8_t clock_divider, bool auto_board_init)
 {
-  if ((adc_ == nullptr) || (NUM_CHANNELS == 0U) || (sample_cycle == 0U))
+  if ((hpm_adc_v2_get_ip_type(adc_) == adc_v2_ip_unknown) ||
+      (NUM_CHANNELS == 0U) || (sample_cycle == 0U))
   {
     return false;
   }
@@ -161,34 +151,33 @@ bool HPMADC::Init(uint32_t sample_cycle, adc16_resolution_t resolution,
     board_init_adc16_pins();
   }
 
-  const uint32_t clock_hz = board_init_adc_clock(adc_, true);
+  const uint32_t clock_hz = board_init_adc_clock(reinterpret_cast<void*>(adc_.base), true);
   if (clock_hz == 0U)
   {
     clock_add_to_group(clock_, 0);
   }
 
-  adc16_config_t config;
-  adc16_get_default_config(&config);
-  config.res = resolution;
-  config.conv_mode = adc16_conv_mode_oneshot;
-  config.adc_clk_div = clock_divider;
+  adc_v2_config_t config;
+  hpm_adc_v2_get_default_config(adc_, &config);
+  config.resolution_bits = static_cast<uint8_t>(resolution);
+  config.conv_mode = adc_v2_conv_mode_oneshot;
+  config.clock_div = clock_divider;
   config.wait_dis = true;
   config.sel_sync_ahb = true;
-  config.adc_ahb_en = false;
 
-  if (adc16_init(adc_, &config) != status_success)
+  if (hpm_adc_v2_init(adc_, &config) != status_success)
   {
     return false;
   }
 
   for (uint8_t i = 0; i < NUM_CHANNELS; ++i)
   {
-    adc16_channel_config_t channel_config;
-    adc16_get_channel_default_config(&channel_config);
+    adc_v2_channel_config_t channel_config;
+    hpm_adc_v2_get_channel_default_config(adc_, &channel_config);
     channel_config.ch = channels_[i].ch_;
     channel_config.sample_cycle = sample_cycle;
 
-    if (adc16_init_channel(adc_, &channel_config) != status_success)
+    if (hpm_adc_v2_init_channel(adc_, &channel_config) != status_success)
     {
       return false;
     }
@@ -196,11 +185,7 @@ bool HPMADC::Init(uint32_t sample_cycle, adc16_resolution_t resolution,
     last_raw_[i] = 0U;
   }
 
-  adc16_set_nonblocking_read(adc_);
-
-#if defined(ADC_SOC_BUSMODE_ENABLE_CTRL_SUPPORT) && ADC_SOC_BUSMODE_ENABLE_CTRL_SUPPORT
-  adc16_enable_oneshot_mode(adc_);
-#endif
+  hpm_adc_v2_set_nonblocking_read(adc_);
 
   return true;
 }

--- a/driver/hpm/hpm_adc.hpp
+++ b/driver/hpm/hpm_adc.hpp
@@ -45,7 +45,7 @@ class HPMADC
 
   HPMADC(adc_v2_handle_t adc, clock_name_t clock, std::initializer_list<uint8_t> channels,
          float vref, uint32_t sample_cycle = 20U,
-         adc_v2_resolution_bits_t resolution = adc_v2_resolution_16bit,
+         adc_v2_resolution_bits_t resolution = adc_v2_resolution_12bit,
          uint8_t clock_divider = 4U, bool auto_board_init = true,
          uint8_t filter_size = 1U);
 

--- a/driver/hpm/hpm_adc.hpp
+++ b/driver/hpm/hpm_adc.hpp
@@ -46,8 +46,8 @@ class HPMADC
   HPMADC(adc_v2_handle_t adc, clock_name_t clock, std::initializer_list<uint8_t> channels,
          float vref, uint32_t sample_cycle = 20U,
          adc_v2_resolution_bits_t resolution = adc_v2_resolution_16bit,
-         uint8_t clock_divider = 4U,
-         bool auto_board_init = true, uint8_t filter_size = 1U);
+         uint8_t clock_divider = 4U, bool auto_board_init = true,
+         uint8_t filter_size = 1U);
 
   Channel& GetChannel(uint8_t index);
 

--- a/driver/hpm/hpm_adc.hpp
+++ b/driver/hpm/hpm_adc.hpp
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <atomic>
+#include <initializer_list>
+
+#include "adc.hpp"
+#include "hpm_clock_drv.h"
+#include "hpm_soc.h"
+#include "libxr.hpp"
+#include "libxr_def.hpp"
+
+#if defined(HPMSOC_HAS_HPMSDK_ADC16) && __has_include("hpm_adc16_drv.h")
+#define LIBXR_HPM_ADC_SUPPORTED 1
+#include "hpm_adc16_drv.h"
+#else
+#define LIBXR_HPM_ADC_SUPPORTED 0
+#endif
+
+#if LIBXR_HPM_ADC_SUPPORTED
+
+namespace LibXR
+{
+
+class HPMADC
+{
+ public:
+  class Channel : public ADC
+  {
+   public:
+    Channel(HPMADC* adc, uint8_t index, uint8_t ch);
+
+    float Read() override;
+
+    uint8_t ChannelNumber() const { return ch_; }
+
+   private:
+    Channel();
+
+    HPMADC* adc_;
+    uint8_t index_;
+    uint8_t ch_;
+
+    friend class HPMADC;
+  };
+
+  HPMADC(ADC16_Type* adc, clock_name_t clock, std::initializer_list<uint8_t> channels,
+         float vref, uint32_t sample_cycle = 20U,
+         adc16_resolution_t resolution = adc16_res_16_bits,
+         adc16_clock_divider_t clock_divider = adc16_clock_divider_4,
+         bool auto_board_init = true, uint8_t filter_size = 1U);
+
+  Channel& GetChannel(uint8_t index);
+
+  float ReadChannel(uint8_t channel);
+
+  uint16_t GetLastRaw(uint8_t channel) const;
+
+  bool IsValid() const { return valid_; }
+
+ private:
+  static float ResolutionMax(adc16_resolution_t resolution);
+
+  bool Init(uint32_t sample_cycle, adc16_resolution_t resolution,
+            adc16_clock_divider_t clock_divider, bool auto_board_init);
+
+  float ConvertToVoltage(float adc_value) const;
+
+  static constexpr uint8_t MAX_CHANNELS =
+#ifdef ADC_SOC_MAX_CHANNEL_NUM
+      static_cast<uint8_t>(ADC_SOC_MAX_CHANNEL_NUM);
+#else
+      32U;
+#endif
+
+  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<uint32_t> locked_ = 0U;
+  ADC16_Type* adc_;
+  clock_name_t clock_;
+  const uint8_t NUM_CHANNELS;
+  Channel channels_[MAX_CHANNELS];
+  uint16_t last_raw_[MAX_CHANNELS];
+  const uint8_t filter_size_;
+  float resolution_;
+  float vref_;
+  bool valid_;
+};
+
+}  // namespace LibXR
+
+#endif

--- a/driver/hpm/hpm_adc.hpp
+++ b/driver/hpm/hpm_adc.hpp
@@ -4,14 +4,14 @@
 #include <initializer_list>
 
 #include "adc.hpp"
+#include "hpm_adc_v2.h"
 #include "hpm_clock_drv.h"
 #include "hpm_soc.h"
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 
-#if defined(HPMSOC_HAS_HPMSDK_ADC16) && __has_include("hpm_adc16_drv.h")
+#if __has_include("hpm_adc_v2.h")
 #define LIBXR_HPM_ADC_SUPPORTED 1
-#include "hpm_adc16_drv.h"
 #else
 #define LIBXR_HPM_ADC_SUPPORTED 0
 #endif
@@ -43,10 +43,10 @@ class HPMADC
     friend class HPMADC;
   };
 
-  HPMADC(ADC16_Type* adc, clock_name_t clock, std::initializer_list<uint8_t> channels,
+  HPMADC(adc_v2_handle_t adc, clock_name_t clock, std::initializer_list<uint8_t> channels,
          float vref, uint32_t sample_cycle = 20U,
-         adc16_resolution_t resolution = adc16_res_16_bits,
-         adc16_clock_divider_t clock_divider = adc16_clock_divider_4,
+         adc_v2_resolution_bits_t resolution = adc_v2_resolution_16bit,
+         uint8_t clock_divider = 4U,
          bool auto_board_init = true, uint8_t filter_size = 1U);
 
   Channel& GetChannel(uint8_t index);
@@ -58,10 +58,10 @@ class HPMADC
   bool IsValid() const { return valid_; }
 
  private:
-  static float ResolutionMax(adc16_resolution_t resolution);
+  static float ResolutionMax(adc_v2_resolution_bits_t resolution);
 
-  bool Init(uint32_t sample_cycle, adc16_resolution_t resolution,
-            adc16_clock_divider_t clock_divider, bool auto_board_init);
+  bool Init(uint32_t sample_cycle, adc_v2_resolution_bits_t resolution,
+            uint8_t clock_divider, bool auto_board_init);
 
   float ConvertToVoltage(float adc_value) const;
 
@@ -73,7 +73,7 @@ class HPMADC
 #endif
 
   alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<uint32_t> locked_ = 0U;
-  ADC16_Type* adc_;
+  adc_v2_handle_t adc_;
   clock_name_t clock_;
   const uint8_t NUM_CHANNELS;
   Channel channels_[MAX_CHANNELS];


### PR DESCRIPTION
## What
- 新增 HPM ADC16 驱动，支持 one-shot 通道读取
- 通过通用 `ADC` 接口暴露通道对象
- 通道对象和最近一次原始采样值使用固定存储，避免驱动热路径依赖堆分配

## Why
- HPM 平台需要与现有 LibXR ADC 抽象对齐的 ADC 后端
- HPM 裸机运行时中曾观察到动态分配路径导致板端调试不稳定，因此这里收敛为固定存储实现
- 对应 Roadmap：xrobot-org/XRobot-Dev-Roadmap#23

## Verify
- 使用 HPM SDK 工具链构建 `HPM5E31_LibXR_Template`
- 在 HPM5E31 板端运行 ADC16 one-shot 采样
- 观察到 `adc_clock_hz=200000000`、`adc_result=0`、`adc_raw=9626`、`adc_voltage_mv=485`、`adc_read_count=8`
- OpenOCD program / halt / dump 流程完成，`openocd_exit=0`

## Not Verified
- 尚未覆盖 HPM5E31 以外的 HPM ADC16 SoC
- 尚未做多 ADC 实例压力测试

## Summary by Sourcery

添加一个 HPM ADC16 后端，在受支持的 HPM 平台上使用固定存储和单次采样来暴露 LibXR ADC 通道。

New Features:
- 引入一个 HPMADC 驱动，将 HPM ADC16 集成到通用的 LibXR ADC 接口中。
- 暴露按通道划分的 ADC 对象，支持一次性电压读取并访问最近一次的原始采样值。

Enhancements:
- 使用静态分配的通道和采样缓冲区，并配合简单的锁机制，避免堆内存分配，同时在 HPM 裸机目标上确保并发访问的安全性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an HPM ADC16 backend that exposes LibXR ADC channels using fixed storage and one-shot sampling on supported HPM platforms.

New Features:
- Introduce an HPMADC driver that integrates HPM ADC16 with the generic LibXR ADC interface.
- Expose per-channel ADC objects supporting one-shot voltage reads and access to the last raw sample value.

Enhancements:
- Use statically allocated channel and sample buffers with a simple locking mechanism to avoid heap allocation and ensure safe concurrent access on HPM bare-metal targets.

</details>