### PR TITLE
refactor(print): share backends with precise profile pruning

### DIFF
--- a/src/core/print/format/format_frontend_binding_float.hpp
+++ b/src/core/print/format/format_frontend_binding_float.hpp
@@ -41,12 +41,12 @@ namespace ArgumentResolution
         pack = FormatPackKind::F32;
         return true;
       case ArgumentKind::Float64:
-        // When enable_float_double is false, a double argument is silently
-        // formatted at float precision (7 significant digits). If full double
-        // precision is needed, set Config::enable_float_double = true, or
-        // cast the argument to float explicitly to make the demotion visible.
-        type = Config::enable_float_double ? f64_type : f32_type;
-        pack = Config::enable_float_double ? FormatPackKind::F64 : FormatPackKind::F32;
+        if (!Config::enable_float_double)
+        {
+          return false;
+        }
+        type = f64_type;
+        pack = FormatPackKind::F64;
         return true;
       case ArgumentKind::LongDouble:
         if (!Config::enable_float_long_double)

--- a/src/core/print/format/format_frontend_binding_float.hpp
+++ b/src/core/print/format/format_frontend_binding_float.hpp
@@ -11,6 +11,7 @@ namespace ArgumentResolution
  * @param parsed 已解析的 brace 字段 / Parsed brace field
  * @param kind 当前字段选中的前端参数类别 / Frontend-side argument family selected for this field
  * @return 返回解析后的共享字段；精度或类型不匹配时返回首个错误 / Returns the resolved shared field, or the first precision or type mismatch error
+ * @note double 支持关闭时，double 参数会降为 F32 存储与格式化 / When double support is disabled, double arguments are reduced to F32 storage and formatting
  */
 [[nodiscard]] consteval ResolvedField ResolveFloatField(const ParsedField& parsed,
                                                         ArgumentKind kind)
@@ -41,12 +42,8 @@ namespace ArgumentResolution
         pack = FormatPackKind::F32;
         return true;
       case ArgumentKind::Float64:
-        if (!Config::enable_float_double)
-        {
-          return false;
-        }
-        type = f64_type;
-        pack = FormatPackKind::F64;
+        type = Config::enable_float_double ? f64_type : f32_type;
+        pack = Config::enable_float_double ? FormatPackKind::F64 : FormatPackKind::F32;
         return true;
       case ArgumentKind::LongDouble:
         if (!Config::enable_float_long_double)

--- a/src/core/print/format_argument.hpp
+++ b/src/core/print/format_argument.hpp
@@ -112,8 +112,7 @@ struct TypeTraits
       case FormatArgumentRule::String:
         return is_string_like;
       case FormatArgumentRule::Float:
-        return std::is_same_v<Decayed, float> ||
-               (Config::enable_float_double && std::is_same_v<Decayed, double>);
+        return is_float;
       case FormatArgumentRule::LongDouble:
         return is_long_double;
       default:

--- a/src/core/print/format_argument.hpp
+++ b/src/core/print/format_argument.hpp
@@ -112,7 +112,8 @@ struct TypeTraits
       case FormatArgumentRule::String:
         return is_string_like;
       case FormatArgumentRule::Float:
-        return is_float;
+        return std::is_same_v<Decayed, float> ||
+               (Config::enable_float_double && std::is_same_v<Decayed, double>);
       case FormatArgumentRule::LongDouble:
         return is_long_double;
       default:

--- a/src/core/print/format_compile.hpp
+++ b/src/core/print/format_compile.hpp
@@ -159,6 +159,8 @@ class FormatCompiler
 
   /**
    * @brief 指出某个操作码族需要打开哪一个 writer-profile 位。 / Says which writer-profile bit one opcode family needs.
+   * @param op 待分类的操作码 / Opcode to classify
+   * @return 对应的窄路径 profile 位；无需窄路径时返回 `None` / Required narrow-path profile bit, or `None` when no narrow path is needed
    */
   [[nodiscard]] static consteval FormatProfile ProfileForOp(FormatOp op)
   {
@@ -176,7 +178,7 @@ class FormatCompiler
       case FormatOp::CharacterRaw:
         return FormatProfile::TextArg;
       case FormatOp::GenericField:
-        return FormatProfile::Generic;
+        return FormatProfile::None;
       case FormatOp::TextInline:
       case FormatOp::TextRef:
       case FormatOp::TextSpace:
@@ -383,7 +385,8 @@ class FormatCompiler
           break;
       }
 
-      profile |= ProfileForOp(op);
+      profile |= op == FormatOp::GenericField ? GenericProfileFor(field.type)
+                                              : ProfileForOp(op);
 
       arg_scratch[arg_count++] = FormatArgumentInfo{
           .pack = field.pack,

--- a/src/core/print/format_protocol.hpp
+++ b/src/core/print/format_protocol.hpp
@@ -223,7 +223,7 @@ enum class FormatArgumentRule : uint8_t
   Pointer,           ///< object pointer or nullptr / 对象指针或 nullptr
   Character,         ///< any integral or enum accepted by %c / 可按 %c 接受的整数或枚举
   String,            ///< C string, string_view, or string / C 字符串、string_view 或 string
-  Float,             ///< float or double / float 或 double
+  Float,             ///< float, plus double when double support is enabled / float；启用 double 支持时也接受 double
   LongDouble,        ///< exact long double / 精确匹配 long double
 };
 
@@ -374,18 +374,44 @@ enum class FormatPackKind : uint8_t
 };
 
 /**
- * @brief 编译期选出的粗粒度运行期执行器配置。 / Coarse runtime executor profiles selected at compile time.
+ * @brief 编译期选出的精确运行期执行器配置。 / Precise runtime executor profiles selected at compile time.
  *
  * The low bits describe which narrow fast-path families appear in the bytecode.
- * Generic marks that at least one field still requires the old wide fallback.
- * 低位描述当前字节码里出现了哪些窄快路径族；Generic 表示至少存在一个字段仍需走旧的宽回退路径。
+ * The remaining bits identify the exact semantic types used by generic fields,
+ * so unrelated integer, text, pointer, and float backends remain prunable.
+ * 低位描述当前字节码里出现了哪些窄快路径族；其余位精确标记通用字段使用的语义类型，
+ * 使无关的整数、文本、指针和浮点后端仍可被裁剪。
  */
-enum class FormatProfile : uint8_t
+enum class FormatProfile : uint32_t
 {
   None = 0,            ///< text-only stream / 只有文本记录的流
-  NarrowInt = 1U << 0, ///< signed/unsigned narrow integer fast path family / 有符号/无符号窄整数快路径族
-  TextArg = 1U << 1,   ///< raw text argument fast path / 原始文本参数快路径
-  Generic = 1U << 7,   ///< at least one field uses generic fallback / 至少有一个字段使用通用回退
+  NarrowInt = 1U << 0, ///< narrow integer fast-path family / 窄整数快路径族
+  TextArg = 1U << 1,   ///< raw text argument fast-path family / 原始文本参数快路径族
+  GenericSigned32 = 1U << 2,   ///< generic signed 32-bit decimal / 通用 32 位有符号十进制
+  GenericSigned64 = 1U << 3,   ///< generic signed 64-bit decimal / 通用 64 位有符号十进制
+  GenericUnsigned32 = 1U << 4, ///< generic unsigned 32-bit decimal / 通用 32 位无符号十进制
+  GenericUnsigned64 = 1U << 5, ///< generic unsigned 64-bit decimal / 通用 64 位无符号十进制
+  GenericBinary32 = 1U << 6,   ///< generic 32-bit binary / 通用 32 位二进制
+  GenericBinary64 = 1U << 7,   ///< generic 64-bit binary / 通用 64 位二进制
+  GenericOctal32 = 1U << 8,    ///< generic 32-bit octal / 通用 32 位八进制
+  GenericOctal64 = 1U << 9,    ///< generic 64-bit octal / 通用 64 位八进制
+  GenericHexLower32 = 1U << 10, ///< generic lowercase 32-bit hex / 通用小写 32 位十六进制
+  GenericHexLower64 = 1U << 11, ///< generic lowercase 64-bit hex / 通用小写 64 位十六进制
+  GenericHexUpper32 = 1U << 12, ///< generic uppercase 32-bit hex / 通用大写 32 位十六进制
+  GenericHexUpper64 = 1U << 13, ///< generic uppercase 64-bit hex / 通用大写 64 位十六进制
+  GenericPointer = 1U << 14,   ///< generic pointer field / 通用指针字段
+  GenericCharacter = 1U << 15, ///< generic character field / 通用字符字段
+  GenericString = 1U << 16,    ///< generic string field / 通用字符串字段
+  GenericFloatFixed = 1U << 17, ///< generic float fixed-point / 通用 float 定点格式
+  GenericFloatScientific = 1U << 18, ///< generic float scientific / 通用 float 科学计数法
+  GenericFloatGeneral = 1U << 19, ///< generic float general / 通用 float 通用格式
+  GenericDoubleFixed = 1U << 20, ///< generic double fixed-point / 通用 double 定点格式
+  GenericDoubleScientific = 1U << 21, ///< generic double scientific / 通用 double 科学计数法
+  GenericDoubleGeneral = 1U << 22, ///< generic double general / 通用 double 通用格式
+  GenericLongDoubleFixed = 1U << 23, ///< generic long double fixed-point / 通用 long double 定点格式
+  GenericLongDoubleScientific = 1U << 24, ///< generic long double scientific / 通用 long double 科学计数法
+  GenericLongDoubleGeneral = 1U << 25, ///< generic long double general / 通用 long double 通用格式
+  Generic = 0x03FFFFFCU, ///< compatibility mask for every generic field / 所有通用字段的兼容掩码
 };
 
 /**
@@ -396,8 +422,8 @@ enum class FormatProfile : uint8_t
  */
 [[nodiscard]] constexpr FormatProfile operator|(FormatProfile left, FormatProfile right)
 {
-  return static_cast<FormatProfile>(static_cast<uint8_t>(left) |
-                                    static_cast<uint8_t>(right));
+  return static_cast<FormatProfile>(static_cast<uint32_t>(left) |
+                                    static_cast<uint32_t>(right));
 }
 
 /**
@@ -420,8 +446,33 @@ constexpr FormatProfile& operator|=(FormatProfile& left, FormatProfile right)
  */
 [[nodiscard]] constexpr bool HasProfile(FormatProfile profile, FormatProfile bit)
 {
-  return (static_cast<uint8_t>(profile) & static_cast<uint8_t>(bit)) != 0;
+  return (static_cast<uint32_t>(profile) & static_cast<uint32_t>(bit)) != 0;
 }
+
+/**
+ * @brief 返回一个通用字段语义类型对应的精确 profile 位 / Return the precise profile bit for one generic-field semantic type
+ * @param type 通用字段携带的语义类型 / Semantic type carried by the generic field
+ * @return 对应的精确 profile 位；非通用值类型返回 `None` / The precise profile bit, or `None` for non-value semantic types
+ */
+[[nodiscard]] constexpr FormatProfile GenericProfileFor(FormatType type)
+{
+  auto value = static_cast<uint8_t>(type);
+  auto first = static_cast<uint8_t>(FormatType::Signed32);
+  auto last = static_cast<uint8_t>(FormatType::LongDoubleGeneral);
+  if (value < first || value > last)
+  {
+    return FormatProfile::None;
+  }
+  return static_cast<FormatProfile>(uint32_t{1} << (2U + value - first));
+}
+
+static_assert(GenericProfileFor(FormatType::Signed32) ==
+              FormatProfile::GenericSigned32);
+static_assert(GenericProfileFor(FormatType::LongDoubleGeneral) ==
+              FormatProfile::GenericLongDoubleGeneral);
+static_assert(GenericProfileFor(FormatType::TextSpace) == FormatProfile::None);
+static_assert(static_cast<uint32_t>(FormatProfile::Generic) ==
+              ((uint32_t{1} << 26U) - (uint32_t{1} << 2U)));
 
 /**
  * @brief Writer 消费的编译格式运行期协议。 / Compiled-format runtime contract consumed by Writer.

--- a/src/core/print/format_protocol.hpp
+++ b/src/core/print/format_protocol.hpp
@@ -125,6 +125,7 @@ inline constexpr bool enable_float_fixed =
     enable_float && LIBXR_PRINT_FLOAT_ENABLE_FIXED;
 /**
  * @brief 在浮点功能开启时启用基于 double 的默认浮点格式化 / Enables double-backed default float formatting when floating-point support is enabled.
+ * @note 关闭时仍接受 double 输入，但会按 F32 降精度格式化 / When disabled, double input remains accepted but is formatted at reduced F32 precision
  */
 inline constexpr bool enable_float_double =
     enable_float && LIBXR_PRINT_FLOAT_ENABLE_DOUBLE;
@@ -223,7 +224,7 @@ enum class FormatArgumentRule : uint8_t
   Pointer,           ///< object pointer or nullptr / 对象指针或 nullptr
   Character,         ///< any integral or enum accepted by %c / 可按 %c 接受的整数或枚举
   String,            ///< C string, string_view, or string / C 字符串、string_view 或 string
-  Float,             ///< float, plus double when double support is enabled / float；启用 double 支持时也接受 double
+  Float,             ///< float or double / float 或 double
   LongDouble,        ///< exact long double / 精确匹配 long double
 };
 

--- a/src/core/print/writer.hpp
+++ b/src/core/print/writer.hpp
@@ -588,7 +588,7 @@ class Writer
   class CodeReader;
   class ArgumentReader;
 
-  template <OutputSink Sink, FormatProfile Profile>
+  template <OutputSink Sink>
   class Executor;
 
   /**
@@ -604,7 +604,7 @@ class Writer
   [[nodiscard]] static LIBXR_NOINLINE ErrorCode Execute(Sink& sink, const uint8_t* codes,
                                                         const uint8_t* args)
   {
-    return Executor<Sink, Profile>(sink, codes, args).Run();
+    return Executor<Sink>(sink, codes, args).template Run<Profile>();
   }
 
   /**

--- a/src/core/print/writer/writer_executor.hpp
+++ b/src/core/print/writer/writer_executor.hpp
@@ -129,9 +129,11 @@ class Writer::Executor
 
   /**
    * @brief 将一个 `GenericField` 载荷分发到对应的宽回退路径 / Dispatch one `GenericField` payload to the corresponding wide fallback
+   * @tparam Profile 当前编译格式使用的精确通用字段类型集合 / Exact generic-field type set used by the current compiled format
    * @param type `GenericField` 记录携带的语义字段类型 / Semantic field type carried by the `GenericField` record
    * @return 返回该字段的具体写出结果 / Returns the concrete writer result for that field
    */
+  template <FormatProfile Profile>
   [[nodiscard]] ErrorCode DispatchGenericField(FormatType type);
 
   /**

--- a/src/core/print/writer/writer_executor.hpp
+++ b/src/core/print/writer/writer_executor.hpp
@@ -1,9 +1,10 @@
 #pragma once
 
 /**
- * @brief 按编译格式 profile 特化的、按输出端类型区分的字节码执行器 / Per-sink bytecode executor specialized by the compiled format profile
+ * @brief 按输出端共享重后端、按调用点 profile 裁剪操作码分发的字节码执行器 / Per-sink bytecode executor with shared heavy backends and per-call profile-pruned opcode dispatch
+ * @tparam Sink 输出端类型，需满足 `OutputSink` / Sink type satisfying `OutputSink`
  */
-template <OutputSink Sink, FormatProfile Profile>
+template <OutputSink Sink>
 class Writer::Executor
 {
  public:
@@ -17,8 +18,10 @@ class Writer::Executor
 
   /**
    * @brief 持续执行记录流，直到遇到 `FormatOp::End` / Run until the compiled record stream reaches `FormatOp::End`
+   * @tparam Profile 当前编译格式需要的操作码配置 / Opcode profile required by the current compiled format
    * @return 返回首个 sink 或运行期错误；正常执行到记录流结束时返回 `ErrorCode::OK` / Returns the first sink or runtime error, or `ErrorCode::OK` when the record stream finishes normally
    */
+  template <FormatProfile Profile>
   [[nodiscard]] ErrorCode Run();
 
  private:
@@ -133,9 +136,11 @@ class Writer::Executor
 
   /**
    * @brief 将一个运行期操作码分发到选中的特化路径 / Dispatch one runtime opcode to the selected specialized path
+   * @tparam Profile 当前编译格式需要的操作码配置 / Opcode profile required by the current compiled format
    * @param op 解码后的运行期操作码 / Decoded runtime opcode
    * @return 返回该操作码对应特化路径的运行结果 / Returns the specialized runtime result for that opcode
    */
+  template <FormatProfile Profile>
   [[nodiscard]] ErrorCode DispatchOp(FormatOp op);
 
   Sink& sink_;

--- a/src/core/print/writer/writer_executor_field.hpp
+++ b/src/core/print/writer/writer_executor_field.hpp
@@ -9,8 +9,8 @@
  * @param text Text chunk to write. / 待写出的文本片段。
  * @return Returns the sink write result. / 返回 sink 写出结果。
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::WriteRaw(std::string_view text)
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::WriteRaw(std::string_view text)
 {
   return sink_.Write(text);
 }
@@ -21,8 +21,8 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteRaw(std::string_view text)
  * @param count 重复次数 / Repeat count
  * @return 返回首个 sink 错误；全部填充字节写出后返回 `ErrorCode::OK` / Returns the first sink error, or `ErrorCode::OK` when all fill bytes are written
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::WritePadding(char fill, size_t count)
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::WritePadding(char fill, size_t count)
 {
   char chunk[16];
   std::memset(chunk, fill, sizeof(chunk));
@@ -47,8 +47,8 @@ ErrorCode Writer::Executor<Sink, Profile>::WritePadding(char fill, size_t count)
  * @param spec 解码后的字段规格 / Decoded field spec
  * @return 返回首个 sink 错误；成功时返回 `ErrorCode::OK` / Returns the first sink error, or `ErrorCode::OK` on success
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::WriteTextField(std::string_view text,
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::WriteTextField(std::string_view text,
                                                           const Spec& spec)
 {
   size_t pad = FieldPadding(spec.width, text.size());
@@ -87,8 +87,8 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteTextField(std::string_view text,
  * @param spec 解码后的字段规格 / Decoded field spec
  * @return 返回首个 sink 错误；成功时返回 `ErrorCode::OK` / Returns the first sink error, or `ErrorCode::OK` on success
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::WriteIntegerField(
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::WriteIntegerField(
     char sign_char, std::string_view prefix, std::string_view digits, const Spec& spec)
 {
   auto write_char = [this](char ch) -> ErrorCode {
@@ -166,8 +166,8 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteIntegerField(
  * @param spec 解码后的字段规格 / Decoded field spec
  * @return 返回首个 sink 错误；成功时返回 `ErrorCode::OK` / Returns the first sink error, or `ErrorCode::OK` on success
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::WriteFloatField(char sign_char,
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::WriteFloatField(char sign_char,
                                                            std::string_view text,
                                                            const Spec& spec)
 {

--- a/src/core/print/writer/writer_executor_generic.hpp
+++ b/src/core/print/writer/writer_executor_generic.hpp
@@ -9,9 +9,9 @@
  * @tparam Int 有符号打包存储类型 / Signed packed-storage type
  * @return 返回具体有符号字段写出结果 / Returns the concrete signed-field write result
  */
-template <OutputSink Sink, FormatProfile Profile>
+template <OutputSink Sink>
 template <std::signed_integral Int>
-ErrorCode Writer::Executor<Sink, Profile>::DispatchSignedField()
+ErrorCode Writer::Executor<Sink>::DispatchSignedField()
 {
   return WriteSigned(codes_.ReadSpec(), args_.Read<Int>());
 }
@@ -22,9 +22,9 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchSignedField()
  * @tparam UInt 无符号打包存储类型 / Unsigned packed-storage type
  * @return 返回选定整数语义路径的写出结果 / Returns the selected integer-field write result
  */
-template <OutputSink Sink, FormatProfile Profile>
+template <OutputSink Sink>
 template <FormatType Type, std::unsigned_integral UInt>
-ErrorCode Writer::Executor<Sink, Profile>::DispatchUnsignedField()
+ErrorCode Writer::Executor<Sink>::DispatchUnsignedField()
 {
   return DispatchUnsigned<Type>(codes_.ReadSpec(), args_.Read<UInt>());
 }
@@ -36,9 +36,9 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchUnsignedField()
  * @tparam Float 打包浮点存储类型 / Packed float storage type
  * @return 返回选定浮点语义路径的写出结果 / Returns the selected float-field write result
  */
-template <OutputSink Sink, FormatProfile Profile>
+template <OutputSink Sink>
 template <FormatType Type, typename Float>
-ErrorCode Writer::Executor<Sink, Profile>::DispatchFloatField()
+ErrorCode Writer::Executor<Sink>::DispatchFloatField()
 {
   return WriteFloat(Type, codes_.ReadSpec(), args_.Read<Float>());
 }
@@ -48,8 +48,8 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchFloatField()
  * @brief 读取一个指针载荷并走指针字段写出路径 / Read one pointer payload and write it through the pointer field path
  * @return 返回指针字段写出结果 / Returns the pointer-field write result
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::DispatchPointerField()
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::DispatchPointerField()
 {
   return WritePointer(codes_.ReadSpec(), args_.Read<uintptr_t>());
 }
@@ -58,8 +58,8 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchPointerField()
  * @brief 读取一个字符载荷并走字符字段写出路径 / Read one character payload and write it through the character field path
  * @return 返回字符字段写出结果 / Returns the character-field write result
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::DispatchCharacterField()
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::DispatchCharacterField()
 {
   return WriteCharacter(codes_.ReadSpec(), args_.Read<char>());
 }
@@ -68,8 +68,8 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchCharacterField()
  * @brief 读取一个字符串载荷并走字符串字段写出路径 / Read one string payload and write it through the string field path
  * @return 返回字符串字段写出结果 / Returns the string-field write result
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::DispatchStringField()
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::DispatchStringField()
 {
   return WriteString(codes_.ReadSpec(), args_.Read<std::string_view>());
 }
@@ -79,8 +79,8 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchStringField()
  * @param type 当前 `GenericField` 携带的运行期语义类型 / Runtime semantic type carried by this `GenericField`
  * @return 返回具体宽回退路径的写出结果 / Returns the concrete wide-path write result
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::DispatchGenericField(FormatType type)
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::DispatchGenericField(FormatType type)
 {
   switch (type)
   {

--- a/src/core/print/writer/writer_executor_generic.hpp
+++ b/src/core/print/writer/writer_executor_generic.hpp
@@ -80,159 +80,184 @@ ErrorCode Writer::Executor<Sink>::DispatchStringField()
  * @return 返回具体宽回退路径的写出结果 / Returns the concrete wide-path write result
  */
 template <OutputSink Sink>
+template <FormatProfile Profile>
 ErrorCode Writer::Executor<Sink>::DispatchGenericField(FormatType type)
 {
   switch (type)
   {
     case FormatType::Signed32:
-      if constexpr (!Config::enable_integer)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericSigned32) &&
+                    Config::enable_integer)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchSignedField<int32_t>();
       }
-      return DispatchSignedField<int32_t>();
+      return ErrorCode::STATE_ERR;
     case FormatType::Signed64:
-      if constexpr (!Config::enable_integer || !Config::enable_integer_64bit)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericSigned64) &&
+                    Config::enable_integer && Config::enable_integer_64bit)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchSignedField<int64_t>();
       }
-      return DispatchSignedField<int64_t>();
+      return ErrorCode::STATE_ERR;
     case FormatType::Unsigned32:
-      if constexpr (!Config::enable_integer)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericUnsigned32) &&
+                    Config::enable_integer)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchUnsignedField<FormatType::Unsigned32, uint32_t>();
       }
-      return DispatchUnsignedField<FormatType::Unsigned32, uint32_t>();
+      return ErrorCode::STATE_ERR;
     case FormatType::Unsigned64:
-      if constexpr (!Config::enable_integer || !Config::enable_integer_64bit)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericUnsigned64) &&
+                    Config::enable_integer && Config::enable_integer_64bit)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchUnsignedField<FormatType::Unsigned64, uint64_t>();
       }
-      return DispatchUnsignedField<FormatType::Unsigned64, uint64_t>();
+      return ErrorCode::STATE_ERR;
     case FormatType::Binary32:
-      if constexpr (!Config::enable_integer || !Config::enable_integer_base8_16)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericBinary32) &&
+                    Config::enable_integer && Config::enable_integer_base8_16)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchUnsignedField<FormatType::Binary32, uint32_t>();
       }
-      return DispatchUnsignedField<FormatType::Binary32, uint32_t>();
+      return ErrorCode::STATE_ERR;
     case FormatType::Binary64:
-      if constexpr (!Config::enable_integer || !Config::enable_integer_base8_16 ||
-                    !Config::enable_integer_64bit)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericBinary64) &&
+                    Config::enable_integer && Config::enable_integer_base8_16 &&
+                    Config::enable_integer_64bit)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchUnsignedField<FormatType::Binary64, uint64_t>();
       }
-      return DispatchUnsignedField<FormatType::Binary64, uint64_t>();
+      return ErrorCode::STATE_ERR;
     case FormatType::Octal32:
-      if constexpr (!Config::enable_integer || !Config::enable_integer_base8_16)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericOctal32) &&
+                    Config::enable_integer && Config::enable_integer_base8_16)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchUnsignedField<FormatType::Octal32, uint32_t>();
       }
-      return DispatchUnsignedField<FormatType::Octal32, uint32_t>();
+      return ErrorCode::STATE_ERR;
     case FormatType::Octal64:
-      if constexpr (!Config::enable_integer || !Config::enable_integer_base8_16 ||
-                    !Config::enable_integer_64bit)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericOctal64) &&
+                    Config::enable_integer && Config::enable_integer_base8_16 &&
+                    Config::enable_integer_64bit)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchUnsignedField<FormatType::Octal64, uint64_t>();
       }
-      return DispatchUnsignedField<FormatType::Octal64, uint64_t>();
+      return ErrorCode::STATE_ERR;
     case FormatType::HexLower32:
-      if constexpr (!Config::enable_integer || !Config::enable_integer_base8_16)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericHexLower32) &&
+                    Config::enable_integer && Config::enable_integer_base8_16)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchUnsignedField<FormatType::HexLower32, uint32_t>();
       }
-      return DispatchUnsignedField<FormatType::HexLower32, uint32_t>();
+      return ErrorCode::STATE_ERR;
     case FormatType::HexLower64:
-      if constexpr (!Config::enable_integer || !Config::enable_integer_base8_16 ||
-                    !Config::enable_integer_64bit)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericHexLower64) &&
+                    Config::enable_integer && Config::enable_integer_base8_16 &&
+                    Config::enable_integer_64bit)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchUnsignedField<FormatType::HexLower64, uint64_t>();
       }
-      return DispatchUnsignedField<FormatType::HexLower64, uint64_t>();
+      return ErrorCode::STATE_ERR;
     case FormatType::HexUpper32:
-      if constexpr (!Config::enable_integer || !Config::enable_integer_base8_16)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericHexUpper32) &&
+                    Config::enable_integer && Config::enable_integer_base8_16)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchUnsignedField<FormatType::HexUpper32, uint32_t>();
       }
-      return DispatchUnsignedField<FormatType::HexUpper32, uint32_t>();
+      return ErrorCode::STATE_ERR;
     case FormatType::HexUpper64:
-      if constexpr (!Config::enable_integer || !Config::enable_integer_base8_16 ||
-                    !Config::enable_integer_64bit)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericHexUpper64) &&
+                    Config::enable_integer && Config::enable_integer_base8_16 &&
+                    Config::enable_integer_64bit)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchUnsignedField<FormatType::HexUpper64, uint64_t>();
       }
-      return DispatchUnsignedField<FormatType::HexUpper64, uint64_t>();
+      return ErrorCode::STATE_ERR;
     case FormatType::Pointer:
-      if constexpr (!Config::enable_pointer)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericPointer) &&
+                    Config::enable_pointer)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchPointerField();
       }
-      return DispatchPointerField();
+      return ErrorCode::STATE_ERR;
     case FormatType::Character:
-      if constexpr (!Config::enable_text)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericCharacter) &&
+                    Config::enable_text)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchCharacterField();
       }
-      return DispatchCharacterField();
+      return ErrorCode::STATE_ERR;
     case FormatType::String:
-      if constexpr (!Config::enable_text)
+      if constexpr (HasProfile(Profile, FormatProfile::GenericString) &&
+                    Config::enable_text)
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchStringField();
       }
-      return DispatchStringField();
+      return ErrorCode::STATE_ERR;
 #if LIBXR_PRINT_ENABLE_FLOAT
     case FormatType::FloatFixed:
-      if constexpr (!FloatEnabled(FormatType::FloatFixed))
+      if constexpr (HasProfile(Profile, FormatProfile::GenericFloatFixed) &&
+                    FloatEnabled(FormatType::FloatFixed))
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchFloatField<FormatType::FloatFixed, float>();
       }
-      return DispatchFloatField<FormatType::FloatFixed, float>();
+      return ErrorCode::STATE_ERR;
     case FormatType::DoubleFixed:
-      if constexpr (!FloatEnabled(FormatType::DoubleFixed))
+      if constexpr (HasProfile(Profile, FormatProfile::GenericDoubleFixed) &&
+                    FloatEnabled(FormatType::DoubleFixed))
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchFloatField<FormatType::DoubleFixed, double>();
       }
-      return DispatchFloatField<FormatType::DoubleFixed, double>();
+      return ErrorCode::STATE_ERR;
     case FormatType::FloatScientific:
-      if constexpr (!FloatEnabled(FormatType::FloatScientific))
+      if constexpr (HasProfile(Profile, FormatProfile::GenericFloatScientific) &&
+                    FloatEnabled(FormatType::FloatScientific))
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchFloatField<FormatType::FloatScientific, float>();
       }
-      return DispatchFloatField<FormatType::FloatScientific, float>();
+      return ErrorCode::STATE_ERR;
     case FormatType::DoubleScientific:
-      if constexpr (!FloatEnabled(FormatType::DoubleScientific))
+      if constexpr (HasProfile(Profile, FormatProfile::GenericDoubleScientific) &&
+                    FloatEnabled(FormatType::DoubleScientific))
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchFloatField<FormatType::DoubleScientific, double>();
       }
-      return DispatchFloatField<FormatType::DoubleScientific, double>();
+      return ErrorCode::STATE_ERR;
     case FormatType::FloatGeneral:
-      if constexpr (!FloatEnabled(FormatType::FloatGeneral))
+      if constexpr (HasProfile(Profile, FormatProfile::GenericFloatGeneral) &&
+                    FloatEnabled(FormatType::FloatGeneral))
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchFloatField<FormatType::FloatGeneral, float>();
       }
-      return DispatchFloatField<FormatType::FloatGeneral, float>();
+      return ErrorCode::STATE_ERR;
     case FormatType::DoubleGeneral:
-      if constexpr (!FloatEnabled(FormatType::DoubleGeneral))
+      if constexpr (HasProfile(Profile, FormatProfile::GenericDoubleGeneral) &&
+                    FloatEnabled(FormatType::DoubleGeneral))
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchFloatField<FormatType::DoubleGeneral, double>();
       }
-      return DispatchFloatField<FormatType::DoubleGeneral, double>();
+      return ErrorCode::STATE_ERR;
     case FormatType::LongDoubleFixed:
-      if constexpr (!FloatEnabled(FormatType::LongDoubleFixed))
+      if constexpr (HasProfile(Profile, FormatProfile::GenericLongDoubleFixed) &&
+                    FloatEnabled(FormatType::LongDoubleFixed))
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchFloatField<FormatType::LongDoubleFixed, long double>();
       }
-      return DispatchFloatField<FormatType::LongDoubleFixed, long double>();
+      return ErrorCode::STATE_ERR;
     case FormatType::LongDoubleScientific:
-      if constexpr (!FloatEnabled(FormatType::LongDoubleScientific))
+      if constexpr (HasProfile(Profile, FormatProfile::GenericLongDoubleScientific) &&
+                    FloatEnabled(FormatType::LongDoubleScientific))
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchFloatField<FormatType::LongDoubleScientific, long double>();
       }
-      return DispatchFloatField<FormatType::LongDoubleScientific, long double>();
+      return ErrorCode::STATE_ERR;
     case FormatType::LongDoubleGeneral:
-      if constexpr (!FloatEnabled(FormatType::LongDoubleGeneral))
+      if constexpr (HasProfile(Profile, FormatProfile::GenericLongDoubleGeneral) &&
+                    FloatEnabled(FormatType::LongDoubleGeneral))
       {
-        return ErrorCode::STATE_ERR;
+        return DispatchFloatField<FormatType::LongDoubleGeneral, long double>();
       }
-      return DispatchFloatField<FormatType::LongDoubleGeneral, long double>();
+      return ErrorCode::STATE_ERR;
 #endif
     case FormatType::TextInline:
     case FormatType::TextRef:

--- a/src/core/print/writer/writer_executor_opcode.hpp
+++ b/src/core/print/writer/writer_executor_opcode.hpp
@@ -133,7 +133,7 @@ ErrorCode Writer::Executor<Sink>::DispatchOp(FormatOp op)
       {
         return ErrorCode::STATE_ERR;
       }
-      return DispatchGenericField(codes_.ReadFormatType());
+      return DispatchGenericField<Profile>(codes_.ReadFormatType());
     case FormatOp::End:
     default:
       return ErrorCode::STATE_ERR;

--- a/src/core/print/writer/writer_executor_opcode.hpp
+++ b/src/core/print/writer/writer_executor_opcode.hpp
@@ -10,9 +10,9 @@
  * @param codes 指向编译字节流的指针 / Pointer to the compiled byte stream
  * @param args 指向已打包参数字节块的指针；无参数时可为空 / Pointer to the packed argument blob, or null when no arguments exist
  */
-template <OutputSink Sink, FormatProfile Profile>
-Writer::Executor<Sink, Profile>::Executor(Sink& sink, const uint8_t* codes,
-                                          const uint8_t* args)
+template <OutputSink Sink>
+Writer::Executor<Sink>::Executor(Sink& sink, const uint8_t* codes,
+                                 const uint8_t* args)
     : sink_(sink),
       codes_(codes),
       args_(args)
@@ -21,12 +21,14 @@ Writer::Executor<Sink, Profile>::Executor(Sink& sink, const uint8_t* codes,
 
 /**
  * @brief 运行操作码循环，直到遇到 End 或首个 sink/运行期错误 / Runs the opcode loop until End or the first sink/runtime error.
+ * @tparam Profile 当前编译格式需要的操作码配置 / Opcode profile required by the current compiled format
  * @return Returns `ErrorCode::OK` on normal completion, or the first sink /
  *         runtime error. / 正常结束返回 `ErrorCode::OK`；否则返回首个
  *         sink/运行期错误。
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::Run()
+template <OutputSink Sink>
+template <FormatProfile Profile>
+ErrorCode Writer::Executor<Sink>::Run()
 {
   while (true)
   {
@@ -36,7 +38,7 @@ ErrorCode Writer::Executor<Sink, Profile>::Run()
       return ErrorCode::OK;
     }
 
-    auto ec = DispatchOp(op);
+    auto ec = DispatchOp<Profile>(op);
     if (ec != ErrorCode::OK)
     {
       return ec;
@@ -46,12 +48,14 @@ ErrorCode Writer::Executor<Sink, Profile>::Run()
 
 /**
  * @brief 将一个顶层操作码分发到其特化运行期路径 / Dispatches one top-level opcode to its specialized runtime path.
+ * @tparam Profile 当前编译格式需要的操作码配置 / Opcode profile required by the current compiled format
  * @param op Decoded runtime opcode. / 解码后的运行期操作码。
  * @return Returns the specialized runtime result for that opcode. /
  *         返回该操作码对应特化路径的运行结果。
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::DispatchOp(FormatOp op)
+template <OutputSink Sink>
+template <FormatProfile Profile>
+ErrorCode Writer::Executor<Sink>::DispatchOp(FormatOp op)
 {
   switch (op)
   {

--- a/src/core/print/writer/writer_executor_value.hpp
+++ b/src/core/print/writer/writer_executor_value.hpp
@@ -11,9 +11,9 @@
  * @param spec 解码后的字段规格 / Decoded field spec
  * @return 返回 `'-'`、`'+'`、`' '` 或 `'\0'` / Returns `'-'`, `'+'`, `' '`, or `'\0'`
  */
-template <OutputSink Sink, FormatProfile Profile>
+template <OutputSink Sink>
 template <std::signed_integral Int>
-char Writer::Executor<Sink, Profile>::ResolveSignChar(Int value, const Spec& spec)
+char Writer::Executor<Sink>::ResolveSignChar(Int value, const Spec& spec)
 {
   if (value < 0)
   {
@@ -38,9 +38,9 @@ char Writer::Executor<Sink, Profile>::ResolveSignChar(Int value, const Spec& spe
  * @param spec 解码后的字段规格 / Decoded field spec
  * @return 返回 `'-'`、`'+'`、`' '` 或 `'\0'` / Returns `'-'`, `'+'`, `' '`, or `'\0'`
  */
-template <OutputSink Sink, FormatProfile Profile>
+template <OutputSink Sink>
 template <typename T>
-char Writer::Executor<Sink, Profile>::ResolveFloatSignChar(T value, const Spec& spec)
+char Writer::Executor<Sink>::ResolveFloatSignChar(T value, const Spec& spec)
 {
   if (std::isnan(value))
   {
@@ -73,9 +73,9 @@ char Writer::Executor<Sink, Profile>::ResolveFloatSignChar(T value, const Spec& 
  * @param value 待写出的整数值 / Integer value to write
  * @return 返回共享整数字段路径的写出结果 / Returns the shared integer-field write result
  */
-template <OutputSink Sink, FormatProfile Profile>
+template <OutputSink Sink>
 template <std::signed_integral Int>
-ErrorCode Writer::Executor<Sink, Profile>::WriteSigned(const Spec& spec, Int value)
+ErrorCode Writer::Executor<Sink>::WriteSigned(const Spec& spec, Int value)
 {
   using UInt = std::make_unsigned_t<Int>;
   char digit_buffer[UnsignedDigitCapacity<UInt, 10>()];
@@ -103,10 +103,10 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteSigned(const Spec& spec, Int val
  * @param value 待写出的整数值 / Integer value to write
  * @return 返回共享整数字段路径的写出结果 / Returns the shared integer-field write result
  */
-template <OutputSink Sink, FormatProfile Profile>
+template <OutputSink Sink>
 template <uint8_t Base, bool UpperCase, bool PrependOctalZero,
           std::unsigned_integral UInt>
-ErrorCode Writer::Executor<Sink, Profile>::WriteUnsignedDigits(std::string_view prefix,
+ErrorCode Writer::Executor<Sink>::WriteUnsignedDigits(std::string_view prefix,
                                                                const Spec& spec,
                                                                UInt value)
 {
@@ -140,9 +140,9 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteUnsignedDigits(std::string_view 
  * 这个桥接函数本身不直接格式化数字；它只负责把运行期整数语义类型映射到上面的
  * 编译期进制/大小写共享辅助路径。
  */
-template <OutputSink Sink, FormatProfile Profile>
+template <OutputSink Sink>
 template <FormatType Type, std::unsigned_integral UInt>
-ErrorCode Writer::Executor<Sink, Profile>::DispatchUnsigned(const Spec& spec, UInt value)
+ErrorCode Writer::Executor<Sink>::DispatchUnsigned(const Spec& spec, UInt value)
 {
   auto prefix = IntegerPrefix(Type, spec, value);
 
@@ -176,8 +176,8 @@ ErrorCode Writer::Executor<Sink, Profile>::DispatchUnsigned(const Spec& spec, UI
  * @param value 以 `uintptr_t` 编码的指针值 / Pointer value encoded as `uintptr_t`
  * @return 返回指针字段写出结果 / Returns the pointer-field write result
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::WritePointer(const Spec& spec,
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::WritePointer(const Spec& spec,
                                                         uintptr_t value)
 {
   char digit_buffer[UnsignedDigitCapacity<uintptr_t, 16>()];
@@ -199,8 +199,8 @@ ErrorCode Writer::Executor<Sink, Profile>::WritePointer(const Spec& spec,
  * @param ch 待写出的字符值 / Character value to write
  * @return 返回字符字段写出结果 / Returns the character-field write result
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::WriteCharacter(const Spec& spec, char ch)
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::WriteCharacter(const Spec& spec, char ch)
 {
   return WriteTextField(std::string_view(&ch, 1), spec);
 }
@@ -211,8 +211,8 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteCharacter(const Spec& spec, char
  * @param text 待写出的字符串载荷 / String payload to write
  * @return 返回字符串字段写出结果 / Returns the string-field write result
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::WriteString(const Spec& spec,
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::WriteString(const Spec& spec,
                                                        std::string_view text)
 {
   auto view = text;
@@ -233,9 +233,9 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteString(const Spec& spec,
  * @return 返回浮点字段写出结果 / Returns the float-field write result
  */
 #if LIBXR_PRINT_ENABLE_FLOAT
-template <OutputSink Sink, FormatProfile Profile>
+template <OutputSink Sink>
 template <typename T>
-ErrorCode Writer::Executor<Sink, Profile>::WriteFloat(FormatType type,
+ErrorCode Writer::Executor<Sink>::WriteFloat(FormatType type,
                                                       const Spec& spec, T value)
 {
   if (!UsesFloatTextBackend(type))
@@ -296,8 +296,8 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteFloat(FormatType type,
  * @param value Unsigned value to write. / 待写出的无符号值。
  * @return Returns the sink write result. / 返回 sink 写出结果。
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::WriteU32Dec(uint32_t value)
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::WriteU32Dec(uint32_t value)
 {
   char digit_buffer[UnsignedDigitCapacity<uint32_t, 10>()];
   size_t digit_count = AppendUnsigned<10>(digit_buffer, value);
@@ -309,8 +309,8 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteU32Dec(uint32_t value)
  * @param value Signed value to write. / 待写出的有符号值。
  * @return Returns the sink write result. / 返回 sink 写出结果。
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::WriteI32Dec(int32_t value)
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::WriteI32Dec(int32_t value)
 {
   using UInt = std::make_unsigned_t<int32_t>;
   char digit_buffer[UnsignedDigitCapacity<UInt, 10>()];
@@ -336,9 +336,9 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteI32Dec(int32_t value)
  * @param value Unsigned value to write. / 待写出的无符号值。
  * @return Returns the sink write result. / 返回 sink 写出结果。
  */
-template <OutputSink Sink, FormatProfile Profile>
+template <OutputSink Sink>
 template <uint8_t Base, bool UpperCase>
-ErrorCode Writer::Executor<Sink, Profile>::WriteU32Base(uint32_t value)
+ErrorCode Writer::Executor<Sink>::WriteU32Base(uint32_t value)
 {
   char digit_buffer[UnsignedDigitCapacity<uint32_t, Base>()];
   size_t digit_count = AppendUnsigned<Base, UpperCase>(digit_buffer, value);
@@ -351,8 +351,8 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteU32Base(uint32_t value)
  * @param value 待写出的无符号值 / Unsigned value to write
  * @return 返回该快路径的写出结果 / Returns the fast-path write result
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::WriteU32ZeroPadWidth(uint8_t width,
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::WriteU32ZeroPadWidth(uint8_t width,
                                                                 uint32_t value)
 {
   char digit_buffer[UnsignedDigitCapacity<uint32_t, 10>()];
@@ -370,8 +370,8 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteU32ZeroPadWidth(uint8_t width,
  * @param text String payload to write. / 待写出的字符串载荷。
  * @return Returns the sink write result. / 返回 sink 写出结果。
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::WriteStringRaw(std::string_view text)
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::WriteStringRaw(std::string_view text)
 {
   return WriteRaw(text);
 }
@@ -381,8 +381,8 @@ ErrorCode Writer::Executor<Sink, Profile>::WriteStringRaw(std::string_view text)
  * @param ch Character payload to write. / 待写出的字符载荷。
  * @return Returns the sink write result. / 返回 sink 写出结果。
  */
-template <OutputSink Sink, FormatProfile Profile>
-ErrorCode Writer::Executor<Sink, Profile>::WriteCharacterRaw(char ch)
+template <OutputSink Sink>
+ErrorCode Writer::Executor<Sink>::WriteCharacterRaw(char ch)
 {
   return WriteRaw(std::string_view(&ch, 1));
 }

--- a/test/base/print/print_literal_test_common.hpp
+++ b/test/base/print/print_literal_test_common.hpp
@@ -90,7 +90,8 @@ using FormatGenericFloatFormat = LibXR::Format<"{:5.2f}">::Compiled<float>;
 // Otherwise the default float-enabled profile retains float dispatch.
 static_assert(
     !HasProfileBit<PrintfRawIntegerFormat>(LibXR::Print::FormatProfile::Generic));
-static_assert(HasProfileBit<PrintfRawIntegerFormat>(LibXR::Print::FormatProfile::NarrowInt));
+static_assert(
+    HasProfileBit<PrintfRawIntegerFormat>(LibXR::Print::FormatProfile::NarrowInt));
 static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::I32Dec));
 static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::U32Dec));
 static_assert(HasOp<PrintfRawIntegerFormat>(LibXR::Print::FormatOp::U32Binary));
@@ -108,7 +109,8 @@ static_assert(HasOp<PrintfIntTextFormat>(LibXR::Print::FormatOp::CharacterRaw));
 
 static_assert(
     !HasProfileBit<FormatRawIntegerFormat>(LibXR::Print::FormatProfile::Generic));
-static_assert(HasProfileBit<FormatRawIntegerFormat>(LibXR::Print::FormatProfile::NarrowInt));
+static_assert(
+    HasProfileBit<FormatRawIntegerFormat>(LibXR::Print::FormatProfile::NarrowInt));
 static_assert(
     HasProfileBit<FormatRawIntegerFormat>(LibXR::Print::FormatProfile::TextArg));
 static_assert(HasOp<FormatRawIntegerFormat>(LibXR::Print::FormatOp::I32Dec));
@@ -121,8 +123,8 @@ static_assert(!HasProfileBit<FormatGenericIntegerFormat>(
     LibXR::Print::FormatProfile::GenericString));
 static_assert(!HasProfileBit<FormatGenericIntegerFormat>(
     LibXR::Print::FormatProfile::GenericFloatFixed));
-static_assert(HasProfileBit<FormatGenericTextFormat>(
-    LibXR::Print::FormatProfile::GenericString));
+static_assert(
+    HasProfileBit<FormatGenericTextFormat>(LibXR::Print::FormatProfile::GenericString));
 static_assert(!HasProfileBit<FormatGenericTextFormat>(
     LibXR::Print::FormatProfile::GenericSigned32));
 static_assert(!HasProfileBit<FormatGenericTextFormat>(
@@ -131,8 +133,8 @@ static_assert(HasProfileBit<FormatGenericFloatFormat>(
     LibXR::Print::FormatProfile::GenericFloatFixed));
 static_assert(!HasProfileBit<FormatGenericFloatFormat>(
     LibXR::Print::FormatProfile::GenericSigned32));
-static_assert(!HasProfileBit<FormatGenericFloatFormat>(
-    LibXR::Print::FormatProfile::GenericString));
+static_assert(
+    !HasProfileBit<FormatGenericFloatFormat>(LibXR::Print::FormatProfile::GenericString));
 }  // namespace LibXRPrintTest::CompileProfile
 
 using LoggerFrontend = LibXR::Detail::LoggerLiteral::Frontend;

--- a/test/base/print/print_literal_test_common.hpp
+++ b/test/base/print/print_literal_test_common.hpp
@@ -80,6 +80,9 @@ using PrintfIntTextFormat =
     decltype(LibXR::Print::Printf::Build<"id=%d hex=%x msg=%s ch=%c">());
 using FormatRawIntegerFormat =
     LibXR::Format<"{} {:x} {:c}">::Compiled<int, unsigned, int>;
+using FormatGenericIntegerFormat = LibXR::Format<"{:5d}">::Compiled<int>;
+using FormatGenericTextFormat = LibXR::Format<"{:.2s}">::Compiled<const char*>;
+using FormatGenericFloatFormat = LibXR::Format<"{:5.2f}">::Compiled<float>;
 
 // 裁剪边界：常见裸整数/文本字段不能退回 GenericField。
 // 否则 float 默认开启时会留下浮点分发后端。
@@ -111,6 +114,25 @@ static_assert(
 static_assert(HasOp<FormatRawIntegerFormat>(LibXR::Print::FormatOp::I32Dec));
 static_assert(HasOp<FormatRawIntegerFormat>(LibXR::Print::FormatOp::U32HexLower));
 static_assert(HasOp<FormatRawIntegerFormat>(LibXR::Print::FormatOp::CharacterRaw));
+
+static_assert(HasProfileBit<FormatGenericIntegerFormat>(
+    LibXR::Print::FormatProfile::GenericSigned32));
+static_assert(!HasProfileBit<FormatGenericIntegerFormat>(
+    LibXR::Print::FormatProfile::GenericString));
+static_assert(!HasProfileBit<FormatGenericIntegerFormat>(
+    LibXR::Print::FormatProfile::GenericFloatFixed));
+static_assert(HasProfileBit<FormatGenericTextFormat>(
+    LibXR::Print::FormatProfile::GenericString));
+static_assert(!HasProfileBit<FormatGenericTextFormat>(
+    LibXR::Print::FormatProfile::GenericSigned32));
+static_assert(!HasProfileBit<FormatGenericTextFormat>(
+    LibXR::Print::FormatProfile::GenericFloatFixed));
+static_assert(HasProfileBit<FormatGenericFloatFormat>(
+    LibXR::Print::FormatProfile::GenericFloatFixed));
+static_assert(!HasProfileBit<FormatGenericFloatFormat>(
+    LibXR::Print::FormatProfile::GenericSigned32));
+static_assert(!HasProfileBit<FormatGenericFloatFormat>(
+    LibXR::Print::FormatProfile::GenericString));
 }  // namespace LibXRPrintTest::CompileProfile
 
 using LoggerFrontend = LibXR::Detail::LoggerLiteral::Frontend;

--- a/test/print_config/test_float_fixed_only.cpp
+++ b/test/print_config/test_float_fixed_only.cpp
@@ -5,7 +5,7 @@
  * @details
  * 1. `%f` / `{:f}` 可用。
  * 2. scientific、general 和 long double 被拒绝。
- * 3. `LIBXR_PRINT_FLOAT_ENABLE_DOUBLE=0` 时 brace `double` 降到 F32 打包。
+ * 3. `LIBXR_PRINT_FLOAT_ENABLE_DOUBLE=0` 时拒绝隐式 `double` 降精度。
  */
 #include "print_config_reset.hpp"
 
@@ -27,7 +27,6 @@
 
 #include "print_config_probe.hpp"
 
-using LibXR::Print::FormatPackKind;
 using LibXR::Print::Printf;
 using LibXR::Print::Config::enable_float_double;
 using LibXR::Print::Detail::FormatFrontend::Error;
@@ -39,7 +38,7 @@ static_assert(!enable_float_double);
 // Brace frontend: fixed is accepted; scientific/general/long double are rejected.
 static_assert(LibXR::Format<"{}">::Matches<float>());
 static_assert(LibXR::Format<"{:.2f}">::Matches<float>());
-static_assert(LibXR::Format<"{:.2F}">::Matches<double>());
+static_assert(!LibXR::Format<"{:.2F}">::Matches<double>());
 static_assert(!LibXR::Format<"{:.2e}">::Matches<float>());
 static_assert(!LibXR::Format<"{:g}">::Matches<double>());
 static_assert(!LibXR::Format<"{:.2f}">::Matches<long double>());
@@ -54,8 +53,9 @@ static_assert(PrintfSourceError<"%F">() == Printf::Error::None);
 static_assert(PrintfSourceError<"%e">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%g">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%Lf">() == Printf::Error::InvalidSpecifier);
+static_assert(Printf::Matches<"%f", float>());
+static_assert(!Printf::Matches<"%f", double>());
 
-// double 存储关闭时，brace `double` 参数仍可用，但按 F32 打包。
-// With double storage disabled, brace `double` remains accepted but packs as F32.
-using DoubleFixed = LibXR::Format<"{:.2f}">::Compiled<double>;
-static_assert(DoubleFixed::ArgumentList()[0].pack == FormatPackKind::F32);
+// double 存储关闭时，brace `double` 参数必须显式转成 float 或打开 double 支持。
+// With double storage disabled, brace `double` must be cast to float or enabled explicitly.
+static_assert(FormatCompileError<"{:.2f}", double>() == Error::ArgumentTypeMismatch);

--- a/test/print_config/test_float_fixed_only.cpp
+++ b/test/print_config/test_float_fixed_only.cpp
@@ -57,5 +57,6 @@ static_assert(Printf::Matches<"%f", float>());
 static_assert(!Printf::Matches<"%f", double>());
 
 // double 存储关闭时，brace `double` 参数必须显式转成 float 或打开 double 支持。
-// With double storage disabled, brace `double` must be cast to float or enabled explicitly.
+// With double storage disabled, brace `double` must be cast to float or enabled
+// explicitly.
 static_assert(FormatCompileError<"{:.2f}", double>() == Error::ArgumentTypeMismatch);

--- a/test/print_config/test_float_fixed_only.cpp
+++ b/test/print_config/test_float_fixed_only.cpp
@@ -5,7 +5,7 @@
  * @details
  * 1. `%f` / `{:f}` 可用。
  * 2. scientific、general 和 long double 被拒绝。
- * 3. `LIBXR_PRINT_FLOAT_ENABLE_DOUBLE=0` 时拒绝隐式 `double` 降精度。
+ * 3. `LIBXR_PRINT_FLOAT_ENABLE_DOUBLE=0` 时 `double` 降到 F32 打包。
  */
 #include "print_config_reset.hpp"
 
@@ -27,6 +27,7 @@
 
 #include "print_config_probe.hpp"
 
+using LibXR::Print::FormatPackKind;
 using LibXR::Print::Printf;
 using LibXR::Print::Config::enable_float_double;
 using LibXR::Print::Detail::FormatFrontend::Error;
@@ -38,7 +39,7 @@ static_assert(!enable_float_double);
 // Brace frontend: fixed is accepted; scientific/general/long double are rejected.
 static_assert(LibXR::Format<"{}">::Matches<float>());
 static_assert(LibXR::Format<"{:.2f}">::Matches<float>());
-static_assert(!LibXR::Format<"{:.2F}">::Matches<double>());
+static_assert(LibXR::Format<"{:.2F}">::Matches<double>());
 static_assert(!LibXR::Format<"{:.2e}">::Matches<float>());
 static_assert(!LibXR::Format<"{:g}">::Matches<double>());
 static_assert(!LibXR::Format<"{:.2f}">::Matches<long double>());
@@ -54,9 +55,11 @@ static_assert(PrintfSourceError<"%e">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%g">() == Printf::Error::InvalidSpecifier);
 static_assert(PrintfSourceError<"%Lf">() == Printf::Error::InvalidSpecifier);
 static_assert(Printf::Matches<"%f", float>());
-static_assert(!Printf::Matches<"%f", double>());
+static_assert(Printf::Matches<"%f", double>());
 
-// double 存储关闭时，brace `double` 参数必须显式转成 float 或打开 double 支持。
-// With double storage disabled, brace `double` must be cast to float or enabled
-// explicitly.
-static_assert(FormatCompileError<"{:.2f}", double>() == Error::ArgumentTypeMismatch);
+// double 存储关闭时，brace 和 printf 都接受 double，但按 F32 打包并降精度。
+// With double storage disabled, brace and printf accept double but pack it as F32.
+using BraceDoubleFixed = LibXR::Format<"{:.2f}">::Compiled<double>;
+using PrintfDoubleFixed = decltype(Printf::Build<"%f">());
+static_assert(BraceDoubleFixed::ArgumentList()[0].pack == FormatPackKind::F32);
+static_assert(PrintfDoubleFixed::ArgumentList()[0].pack == FormatPackKind::F32);


### PR DESCRIPTION
## Summary

- share heavy print executor backends per sink while keeping opcode dispatch profile-specialized
- track each generic field's exact `FormatType` so unrelated integer, text, pointer, and float families remain prunable
- keep double support default-off while accepting `double` input through the documented reduced-precision F32 path
- add compile-time profile, mask, and configuration-contract assertions

## Cortex-M4 size results

GCC 14.2, Cortex-M4, `-Os`, function/data sections and `--gc-sections`:

| Scenario | master | this PR | Delta |
| --- | ---: | ---: | ---: |
| `%f` | 5488 B | 3844 B | -1644 B |
| `%f + %d` | 6004 B | 4648 B | -1356 B |
| `%f + %d + %s` | 6072 B | 4716 B | -1356 B |
| two coexisting profiles | 7356 B | 4848 B | -2508 B |
| three coexisting profiles | 9160 B | 5372 B | -3788 B |

Cross-feature checks show exact pruning in both LTO and no-LTO builds:

- `%5d`: 1082 B with LTO / 1274 B without LTO, independent of unrelated float, base, and text switches
- `%.2s`: 814 B / 942 B, independent of unrelated integer and float switches
- `%f`: 3844 B / 4292 B, independent of unrelated integer, base, and text switches

Reduced-precision `double -> F32` has the same measured text size as passing `float` directly: 3844 B with LTO and 4292 B without LTO. Enabling the true double backend measures 5136 B / 5648 B.

The rejected alternative widened every generic profile to `NarrowInt | TextArg | Generic`; it increased a single `%f` image by 580 B, so this PR does not canonicalize or widen profiles.

## Verification

- GCC 13.3 full Linux build and `test/test`: passed
- Clang 18.1.3 full Linux build and `test/test`: passed
- clang-format 21.1.8 check for `driver/` and `src/`: passed
- touched test formatting and `git diff --check`: passed
- Cortex-M4 LTO/no-LTO ELF and map matrices: passed

## Summary by Sourcery

重构 print writer 执行器，以在共享针对不同 sink 的后端实现的同时，为每次调用使用精确的格式配置（FormatProfile）进行 opcode 分派，从而能够对未使用的整数、文本、指针和浮点路径进行细粒度裁剪，并在禁用完整 double 支持时保持对 double 的降精度处理。

Enhancements:
- 通过扩展的 `FormatProfile` 位掩码精确跟踪泛型字段的语义类型，使无关的后端可以在链接时被裁剪掉。
- 将 `Writer::Executor` 修改为仅以输出 sink 为模板参数，并在调用点通过 `FormatProfile` 进行参数化，以实现更轻量级的复用。
- 收紧泛型字段的分派逻辑，在启用每个后端路径之前同时检查配置标志和精确的 profile 位。
- 记录并强制约定：当 double 格式化被禁用时，brace 风格和 printf 风格的 double 参数都被接受，但通过 F32 路径进行格式化。

Tests:
- 扩展编译期格式/配置（format/profile）测试，验证泛型整数、文本和浮点的 profile 被隔离且标记正确。
- 更新浮点配置测试，以确认在 brace 和 printf 前端中，double 参数都被接受并降级为 F32。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the print writer executor to share sink-specific backends while using precise, per-call format profiles for opcode dispatch, enabling fine-grained pruning of unused integer, text, pointer, and float paths and maintaining reduced-precision handling for double when full double support is disabled.

Enhancements:
- Track exact semantic types for generic fields through an expanded FormatProfile bitmask so unrelated backends can be link-time pruned.
- Change Writer::Executor to be templated only on the output sink and parameterized at call sites by FormatProfile for lighter-weight reuse.
- Tighten generic-field dispatch to check both configuration flags and precise profile bits before enabling each backend path.
- Document and enforce that when double formatting is disabled, both brace and printf-style double arguments are accepted but formatted via the F32 path.

Tests:
- Extend compile-time format/profile tests to verify generic integer, text, and float profiles are isolated and correctly flagged.
- Update float configuration tests to confirm double arguments are accepted and demoted to F32 in both brace and printf frontends.

</details>