### PR TITLE
[codex] make RBTree integer comparators overflow-safe

### DIFF
--- a/src/middleware/message/server/server.cpp
+++ b/src/middleware/message/server/server.cpp
@@ -11,7 +11,7 @@ using namespace LibXR;
 
 Topic::Server::Server(size_t buffer_length)
     : topic_map_([](const uint32_t& a, const uint32_t& b)
-                 { return static_cast<int>(a) - static_cast<int>(b); }),
+                 { return (a > b) - (a < b); }),
       queue_(1, buffer_length)
 {
   ASSERT(buffer_length > PACK_BASE_SIZE);

--- a/src/middleware/message/server/server.cpp
+++ b/src/middleware/message/server/server.cpp
@@ -10,8 +10,7 @@
 using namespace LibXR;
 
 Topic::Server::Server(size_t buffer_length)
-    : topic_map_([](const uint32_t& a, const uint32_t& b)
-                 { return (a > b) - (a < b); }),
+    : topic_map_([](const uint32_t& a, const uint32_t& b) { return (a > b) - (a < b); }),
       queue_(1, buffer_length)
 {
   ASSERT(buffer_length > PACK_BASE_SIZE);

--- a/src/middleware/message/topic.cpp
+++ b/src/middleware/message/topic.cpp
@@ -106,8 +106,7 @@ Topic::Domain::Domain(const char* name)
   }
 
   node_ = new LibXR::RBTree<uint32_t>::Node<LibXR::RBTree<uint32_t>>(
-      [](const uint32_t& a, const uint32_t& b)
-      { return (a > b) - (a < b); });
+      [](const uint32_t& a, const uint32_t& b) { return (a > b) - (a < b); });
 
   domain_->Insert(*node_, crc32);
 }

--- a/src/middleware/message/topic.cpp
+++ b/src/middleware/message/topic.cpp
@@ -15,7 +15,7 @@ void Topic::EnsureDomainRegistry()
   if (!domain_)
   {
     domain_ = new RBTree<uint32_t>([](const uint32_t& a, const uint32_t& b)
-                                   { return static_cast<int>(a) - static_cast<int>(b); });
+                                   { return (a > b) - (a < b); });
   }
 }
 
@@ -107,7 +107,7 @@ Topic::Domain::Domain(const char* name)
 
   node_ = new LibXR::RBTree<uint32_t>::Node<LibXR::RBTree<uint32_t>>(
       [](const uint32_t& a, const uint32_t& b)
-      { return static_cast<int>(a) - static_cast<int>(b); });
+      { return (a > b) - (a < b); });
 
   domain_->Insert(*node_, crc32);
 }

--- a/test/base/structure/test_rbt.cpp
+++ b/test/base/structure/test_rbt.cpp
@@ -23,7 +23,8 @@ void test_rbt()
 {
   // 测试内容：按文件头列出的测试项目顺序执行当前测试入口。
   // Test coverage: execute the test items listed in this file header in sequence.
-  LibXR::RBTree<int> rbtree([](const int& a, const int& b) { return a - b; });
+  LibXR::RBTree<int> rbtree(
+      [](const int& a, const int& b) { return (a > b) - (a < b); });
 
   LibXR::RBTree<int>::Node<int> nodes[100];
 
@@ -59,4 +60,24 @@ void test_rbt()
   }
 
   ASSERT(rbtree.GetNum() == 0);
+
+  LibXR::RBTree<uint32_t> uint32_tree(
+      [](const uint32_t& a, const uint32_t& b) { return (a > b) - (a < b); });
+  constexpr uint32_t keys[] = {0U, 1U, 0x7FFFFFFFU, 0x80000000U, 0xFFFFFFFFU};
+  LibXR::RBTree<uint32_t>::Node<uint32_t> uint32_nodes[std::size(keys)];
+
+  for (size_t i = 0; i < std::size(keys); i++)
+  {
+    uint32_nodes[i] = keys[i];
+    uint32_tree.Insert(uint32_nodes[i], keys[i]);
+  }
+
+  LibXR::RBTree<uint32_t>::Node<uint32_t>* uint32_node_pos = nullptr;
+  for (size_t i = 0; i < std::size(keys); i++)
+  {
+    uint32_node_pos = uint32_tree.ForeachDisc(uint32_node_pos);
+    ASSERT(uint32_node_pos != nullptr);
+    ASSERT(*uint32_node_pos == keys[i]);
+    ASSERT(uint32_tree.Search<uint32_t>(keys[i]) == &uint32_nodes[i]);
+  }
 }


### PR DESCRIPTION
## Problem

The message middleware constructed several `RBTree<uint32_t>` instances with comparators that converted both keys to `int` and subtracted them. CRC32-derived topic and domain keys can use the full `uint32_t` range, so values above `INT_MAX` could be converted or subtracted incorrectly.

This could violate the red-black tree's required negative/zero/positive ordering contract. In affected cases, topic or domain lookup could follow the wrong branch, fail to find an existing entry, or mishandle duplicate keys.

## Root cause

The comparators used this pattern:

```cpp
return static_cast<int>(a) - static_cast<int>(b);
```

Converting an out-of-range `uint32_t` to `int` is implementation-defined, and subtracting the converted values can overflow signed `int`. The tree only needs the relative ordering, not the arithmetic difference.

## Fix

- Replace the Topic domain registry comparator with explicit three-way comparison.
- Replace each per-domain Topic tree comparator with explicit three-way comparison.
- Replace the `Topic::Server` topic map comparator with explicit three-way comparison.
- Update the test-only signed integer comparator to use the same overflow-safe form.
- Add `uint32_t` RBTree coverage across the signed boundary and maximum value.

The new comparator is:

```cpp
return (a > b) - (a < b);
```

## Audit

All production `RBTree` construction points were checked. Event already uses explicit three-way comparison, and RamFS uses `strcmp`, so no changes were required there.

## Validation

- `git diff --check` passed.
- Repository scan found no remaining subtraction-based RBTree comparator under `src/` or `test/`.
- Ubuntu24 clean CMake/Ninja build passed with `LIBXR_TEST_BUILD=True`.
- The full test binary completed successfully.
- Explicitly observed passes: `rbt`, `ramfs`, `event`, `message_topic`, and `message_packet`.
- Final test output reached `All tests completed.`

## Summary by Sourcery

使用于消息主题和域的 RBTree 比较器在溢出情况下保持安全，并扩展测试以覆盖跨越有符号边界的 `uint32_t` 键。

Bug Fixes:
- 防止在 `uint32_t` 主题和域键上使用基于减法的比较器导致的 RBTree 排序和查找错误。

Tests:
- 更新 RBTree 测试比较器，改用在溢出情况下安全的三路比较方式，并增加对跨越有符号边界和最大值边界的 `uint32_t` 树的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make RBTree comparators for message topics and domains overflow-safe and extend tests to cover uint32_t keys across the signed boundary.

Bug Fixes:
- Prevent incorrect RBTree ordering and lookups caused by subtraction-based comparators on uint32_t topic and domain keys.

Tests:
- Update RBTree test comparators to use overflow-safe three-way comparison and add coverage for uint32_t trees spanning signed and maximum value boundaries.

</details>

Bug 修复：
- 防止由于对 `uint32_t` 类型的 topic 和 domain 键使用不安全的基于 `int` 的比较而导致的 RBTree 排序和查找错误。

测试：
- 更新 RBTree 测试中的比较器，采用具备溢出安全性的“三方比较”（three-way comparison），并为 `uint32_t` 树添加覆盖，以测试跨有符号边界及最大值边界的场景。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使用于消息主题和域的 RBTree 比较器在溢出情况下保持安全，并扩展测试以覆盖跨越有符号边界的 `uint32_t` 键。

Bug Fixes:
- 防止在 `uint32_t` 主题和域键上使用基于减法的比较器导致的 RBTree 排序和查找错误。

Tests:
- 更新 RBTree 测试比较器，改用在溢出情况下安全的三路比较方式，并增加对跨越有符号边界和最大值边界的 `uint32_t` 树的测试覆盖。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make RBTree comparators for message topics and domains overflow-safe and extend tests to cover uint32_t keys across the signed boundary.

Bug Fixes:
- Prevent incorrect RBTree ordering and lookups caused by subtraction-based comparators on uint32_t topic and domain keys.

Tests:
- Update RBTree test comparators to use overflow-safe three-way comparison and add coverage for uint32_t trees spanning signed and maximum value boundaries.

</details>

</details>