### PR TITLE
fix(host): close sanitizer lifetime gaps

### DIFF
--- a/src/core/libxr_type.hpp
+++ b/src/core/libxr_type.hpp
@@ -89,7 +89,12 @@ class RawData
    * @param data C 风格字符串指针。
    *             A C-style string pointer.
    */
-  RawData(char* data) : addr_(data), size_(data != nullptr ? std::strlen(data) : 0) {}
+  template <typename CharPtr>
+    requires(std::is_same_v<std::remove_cvref_t<CharPtr>, char*>)
+  RawData(CharPtr&& data)
+      : addr_(data), size_(data != nullptr ? std::strlen(data) : 0)
+  {
+  }
 
   /**
    * @brief 从可写字符数组构造文本视图 / Construct a text view from a writable char array
@@ -200,12 +205,12 @@ class ConstRawData
    *             A C-style string pointer.
    */
   template <typename CharPtr>
-    requires(std::is_pointer_v<std::remove_reference_t<CharPtr>> &&
+    requires(std::is_pointer_v<std::remove_cvref_t<CharPtr>> &&
              std::is_same_v<std::remove_cv_t<
-                                std::remove_pointer_t<std::remove_reference_t<CharPtr>>>,
+                                std::remove_pointer_t<std::remove_cvref_t<CharPtr>>>,
                             char> &&
-             !std::is_volatile_v<std::remove_pointer_t<std::remove_reference_t<CharPtr>>>)
-  ConstRawData(CharPtr data)
+             !std::is_volatile_v<std::remove_pointer_t<std::remove_cvref_t<CharPtr>>>)
+  ConstRawData(CharPtr&& data)
       : addr_(data),
         size_(data != nullptr ? std::strlen(static_cast<const char*>(data)) : 0)
   {

--- a/src/core/libxr_type.hpp
+++ b/src/core/libxr_type.hpp
@@ -24,8 +24,7 @@ template <size_t N>
 }
 
 template <size_t N>
-[[nodiscard]] constexpr size_t TrailingNulTrimmedArraySize(
-    const char (&data)[N]) noexcept
+[[nodiscard]] constexpr size_t TrailingNulTrimmedArraySize(const char (&data)[N]) noexcept
 {
   return (data[N - 1] == '\0') ? (N - 1) : N;
 }
@@ -89,7 +88,11 @@ class RawData
    * @param data C 风格字符串指针。
    *             A C-style string pointer.
    */
-  RawData(char* data) : addr_(data), size_(data != nullptr ? std::strlen(data) : 0) {}
+  template <typename CharPtr>
+    requires(std::is_same_v<std::remove_cvref_t<CharPtr>, char*>)
+  RawData(CharPtr&& data) : addr_(data), size_(data != nullptr ? std::strlen(data) : 0)
+  {
+  }
 
   /**
    * @brief 从可写字符数组构造文本视图 / Construct a text view from a writable char array
@@ -125,8 +128,8 @@ class RawData
    */
   RawData& operator=(const RawData& data) = default;
 
-  void* addr_ = nullptr;   ///< 数据起始地址 / Data start address
-  size_t size_ = 0;        ///< 数据字节数 / Data size in bytes
+  void* addr_ = nullptr;  ///< 数据起始地址 / Data start address
+  size_t size_ = 0;       ///< 数据字节数 / Data size in bytes
 };
 
 /**
@@ -192,20 +195,21 @@ class ConstRawData
   ConstRawData(const RawData& data) : addr_(data.addr_), size_(data.size_) {}
 
   /**
-   * @brief 从 `char*` / `const char*` 文本指针构造 `ConstRawData`，数据大小为字符串长度（不含 `\0`）。
-   *        Constructs `ConstRawData` from a `char*` / `const char*` text pointer,
-   *        with size set to the string length (excluding `\0`).
+   * @brief 从 `char*` / `const char*` 文本指针构造
+   * `ConstRawData`，数据大小为字符串长度（不含 `\0`）。 Constructs `ConstRawData` from a
+   * `char*` / `const char*` text pointer, with size set to the string length (excluding
+   * `\0`).
    *
    * @param data C 风格字符串指针。
    *             A C-style string pointer.
    */
   template <typename CharPtr>
-    requires(std::is_pointer_v<std::remove_reference_t<CharPtr>> &&
-             std::is_same_v<std::remove_cv_t<
-                                std::remove_pointer_t<std::remove_reference_t<CharPtr>>>,
-                            char> &&
-             !std::is_volatile_v<std::remove_pointer_t<std::remove_reference_t<CharPtr>>>)
-  ConstRawData(CharPtr data)
+    requires(std::is_pointer_v<std::remove_cvref_t<CharPtr>> &&
+             std::is_same_v<
+                 std::remove_cv_t<std::remove_pointer_t<std::remove_cvref_t<CharPtr>>>,
+                 char> &&
+             !std::is_volatile_v<std::remove_pointer_t<std::remove_cvref_t<CharPtr>>>)
+  ConstRawData(CharPtr&& data)
       : addr_(data),
         size_(data != nullptr ? std::strlen(static_cast<const char*>(data)) : 0)
   {

--- a/src/core/libxr_type.hpp
+++ b/src/core/libxr_type.hpp
@@ -24,7 +24,8 @@ template <size_t N>
 }
 
 template <size_t N>
-[[nodiscard]] constexpr size_t TrailingNulTrimmedArraySize(const char (&data)[N]) noexcept
+[[nodiscard]] constexpr size_t TrailingNulTrimmedArraySize(
+    const char (&data)[N]) noexcept
 {
   return (data[N - 1] == '\0') ? (N - 1) : N;
 }
@@ -88,11 +89,7 @@ class RawData
    * @param data C 风格字符串指针。
    *             A C-style string pointer.
    */
-  template <typename CharPtr>
-    requires(std::is_same_v<std::remove_cvref_t<CharPtr>, char*>)
-  RawData(CharPtr&& data) : addr_(data), size_(data != nullptr ? std::strlen(data) : 0)
-  {
-  }
+  RawData(char* data) : addr_(data), size_(data != nullptr ? std::strlen(data) : 0) {}
 
   /**
    * @brief 从可写字符数组构造文本视图 / Construct a text view from a writable char array
@@ -128,8 +125,8 @@ class RawData
    */
   RawData& operator=(const RawData& data) = default;
 
-  void* addr_ = nullptr;  ///< 数据起始地址 / Data start address
-  size_t size_ = 0;       ///< 数据字节数 / Data size in bytes
+  void* addr_ = nullptr;   ///< 数据起始地址 / Data start address
+  size_t size_ = 0;        ///< 数据字节数 / Data size in bytes
 };
 
 /**
@@ -195,21 +192,20 @@ class ConstRawData
   ConstRawData(const RawData& data) : addr_(data.addr_), size_(data.size_) {}
 
   /**
-   * @brief 从 `char*` / `const char*` 文本指针构造
-   * `ConstRawData`，数据大小为字符串长度（不含 `\0`）。 Constructs `ConstRawData` from a
-   * `char*` / `const char*` text pointer, with size set to the string length (excluding
-   * `\0`).
+   * @brief 从 `char*` / `const char*` 文本指针构造 `ConstRawData`，数据大小为字符串长度（不含 `\0`）。
+   *        Constructs `ConstRawData` from a `char*` / `const char*` text pointer,
+   *        with size set to the string length (excluding `\0`).
    *
    * @param data C 风格字符串指针。
    *             A C-style string pointer.
    */
   template <typename CharPtr>
-    requires(std::is_pointer_v<std::remove_cvref_t<CharPtr>> &&
-             std::is_same_v<
-                 std::remove_cv_t<std::remove_pointer_t<std::remove_cvref_t<CharPtr>>>,
-                 char> &&
-             !std::is_volatile_v<std::remove_pointer_t<std::remove_cvref_t<CharPtr>>>)
-  ConstRawData(CharPtr&& data)
+    requires(std::is_pointer_v<std::remove_reference_t<CharPtr>> &&
+             std::is_same_v<std::remove_cv_t<
+                                std::remove_pointer_t<std::remove_reference_t<CharPtr>>>,
+                            char> &&
+             !std::is_volatile_v<std::remove_pointer_t<std::remove_reference_t<CharPtr>>>)
+  ConstRawData(CharPtr data)
       : addr_(data),
         size_(data != nullptr ? std::strlen(static_cast<const char*>(data)) : 0)
   {

--- a/src/system/async.hpp
+++ b/src/system/async.hpp
@@ -63,7 +63,7 @@ class ASync
       if (async->sem_.Wait() == ErrorCode::OK)
       {
         async->job_.Run(false, async);
-        async->status_.store(Status::DONE, std::memory_order_release);
+        async->status_.store(Status::DONE, std::memory_order_relaxed);
       }
     }
   }
@@ -84,7 +84,7 @@ class ASync
    */
   [[nodiscard]] Status GetStatus()
   {
-    Status cur = status_.load(std::memory_order_acquire);
+    Status cur = status_.load(std::memory_order_relaxed);
     if (cur != Status::DONE)
     {
       return cur;

--- a/src/system/async.hpp
+++ b/src/system/async.hpp
@@ -63,7 +63,7 @@ class ASync
       if (async->sem_.Wait() == ErrorCode::OK)
       {
         async->job_.Run(false, async);
-        async->status_.store(Status::DONE, std::memory_order_relaxed);
+        async->status_.store(Status::DONE, std::memory_order_release);
       }
     }
   }
@@ -84,7 +84,7 @@ class ASync
    */
   [[nodiscard]] Status GetStatus()
   {
-    Status cur = status_.load(std::memory_order_relaxed);
+    Status cur = status_.load(std::memory_order_acquire);
     if (cur != Status::DONE)
     {
       return cur;

--- a/system/linux/thread.cpp
+++ b/system/linux/thread.cpp
@@ -38,3 +38,9 @@ uint32_t Thread::GetTime()
 }
 
 void Thread::Yield() { sched_yield(); }
+
+ErrorCode Thread::Join()
+{
+  return pthread_join(thread_handle_, nullptr) == 0 ? ErrorCode::OK
+                                                    : ErrorCode::FAILED;
+}

--- a/system/linux/thread.cpp
+++ b/system/linux/thread.cpp
@@ -32,9 +32,11 @@ void Thread::SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to
   }
 }
 
-uint32_t Thread::GetTime()
-{
-  return Timebase::GetMilliseconds();
-}
+uint32_t Thread::GetTime() { return Timebase::GetMilliseconds(); }
 
 void Thread::Yield() { sched_yield(); }
+
+ErrorCode Thread::Join()
+{
+  return pthread_join(thread_handle_, nullptr) == 0 ? ErrorCode::OK : ErrorCode::FAILED;
+}

--- a/system/linux/thread.cpp
+++ b/system/linux/thread.cpp
@@ -32,11 +32,9 @@ void Thread::SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to
   }
 }
 
-uint32_t Thread::GetTime() { return Timebase::GetMilliseconds(); }
+uint32_t Thread::GetTime()
+{
+  return Timebase::GetMilliseconds();
+}
 
 void Thread::Yield() { sched_yield(); }
-
-ErrorCode Thread::Join()
-{
-  return pthread_join(thread_handle_, nullptr) == 0 ? ErrorCode::OK : ErrorCode::FAILED;
-}

--- a/system/linux/thread.hpp
+++ b/system/linux/thread.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
 #include <climits>
-
 #include <cstring>
 
-#include "libxr_system.hpp"
 #include "libxr_mem.hpp"
+#include "libxr_system.hpp"
 #include "libxr_time.hpp"
 #include "logger.hpp"
 
@@ -36,14 +35,14 @@ class Thread
    * @brief  默认构造函数，初始化空线程
    *         Default constructor initializing an empty thread
    */
-  Thread(){};
+  Thread() {};
 
   /**
    * @brief  通过 POSIX 线程句柄创建线程对象
    *         Constructor to create a thread object from a POSIX thread handle
    * @param  handle POSIX 线程句柄 POSIX thread handle
    */
-  Thread(libxr_thread_handle handle) : thread_handle_(handle){};
+  Thread(libxr_thread_handle handle) : thread_handle_(handle) {};
 
   /**
    * @brief  创建新线程
@@ -66,7 +65,7 @@ class Thread
    * accordingly.
    */
   template <typename ArgType>
-  void Create(ArgType arg, void (*function)(ArgType arg), const char *name,
+  void Create(ArgType arg, void (*function)(ArgType arg), const char* name,
               size_t stack_depth, Thread::Priority priority)
   {
     pthread_attr_t attr;
@@ -87,9 +86,8 @@ class Thread
        * @param  arg 线程参数 Thread argument
        * @param  name 线程名称 Thread name
        */
-      ThreadBlock(decltype(function) fun, ArgType arg, const char *name)
-          : fun_(fun),
-            arg_(arg)
+      ThreadBlock(decltype(function) fun, ArgType arg, const char* name)
+          : fun_(fun), arg_(arg)
       {
         std::memset(name_, 0, sizeof(name_));
         if (name != nullptr)
@@ -105,9 +103,9 @@ class Thread
        * @return 返回值始终为 `nullptr`
        *         The return value is always `nullptr`
        */
-      static void *Port(void *arg)
+      static void* Port(void* arg)
       {
-        ThreadBlock *block = static_cast<ThreadBlock *>(arg);
+        ThreadBlock* block = static_cast<ThreadBlock*>(arg);
 
         if (block->name_[0] != '\0')
         {
@@ -116,12 +114,12 @@ class Thread
 
         block->fun_(block->arg_);
         delete block;
-        return static_cast<void *>(nullptr);
+        return static_cast<void*>(nullptr);
       }
 
       decltype(function) fun_;  ///< 线程执行的函数 Function executed by the thread
-      ArgType arg_;  ///< 线程函数的参数 Argument passed to the thread function
-      char name_[16];  ///< 线程名称 Thread name
+      ArgType arg_;             ///< 线程函数的参数 Argument passed to the thread function
+      char name_[16];           ///< 线程名称 Thread name
     };
 
     auto block = new ThreadBlock(function, arg, name);
@@ -174,13 +172,19 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程
    *         Yields CPU execution to allow other threads to run
    */
   static void Yield();
+
+  /**
+   * @brief Waits for this POSIX thread to terminate and releases its resources.
+   * @return `OK` on success, otherwise `FAILED`.
+   */
+  ErrorCode Join();
 
   /**
    * @brief  线程对象转换为 POSIX 线程句柄
@@ -193,7 +197,8 @@ class Thread
   static void ConfigureAttributes(pthread_attr_t& attr, size_t stack_depth,
                                   Thread::Priority priority)
   {
-    const size_t stack_size = LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
+    const size_t stack_size =
+        LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
     pthread_attr_setstacksize(&attr, stack_size);
     ConfigureScheduling(attr, priority);
   }

--- a/system/linux/thread.hpp
+++ b/system/linux/thread.hpp
@@ -183,6 +183,12 @@ class Thread
   static void Yield();
 
   /**
+   * @brief Waits for this POSIX thread to terminate and releases its resources.
+   * @return `OK` on success, otherwise `FAILED`.
+   */
+  ErrorCode Join();
+
+  /**
    * @brief  线程对象转换为 POSIX 线程句柄
    *         Converts the thread object to a POSIX thread handle
    * @return POSIX 线程句柄 POSIX thread handle

--- a/system/linux/thread.hpp
+++ b/system/linux/thread.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <climits>
+
 #include <cstring>
 
-#include "libxr_mem.hpp"
 #include "libxr_system.hpp"
+#include "libxr_mem.hpp"
 #include "libxr_time.hpp"
 #include "logger.hpp"
 
@@ -35,14 +36,14 @@ class Thread
    * @brief  默认构造函数，初始化空线程
    *         Default constructor initializing an empty thread
    */
-  Thread() {};
+  Thread(){};
 
   /**
    * @brief  通过 POSIX 线程句柄创建线程对象
    *         Constructor to create a thread object from a POSIX thread handle
    * @param  handle POSIX 线程句柄 POSIX thread handle
    */
-  Thread(libxr_thread_handle handle) : thread_handle_(handle) {};
+  Thread(libxr_thread_handle handle) : thread_handle_(handle){};
 
   /**
    * @brief  创建新线程
@@ -65,7 +66,7 @@ class Thread
    * accordingly.
    */
   template <typename ArgType>
-  void Create(ArgType arg, void (*function)(ArgType arg), const char* name,
+  void Create(ArgType arg, void (*function)(ArgType arg), const char *name,
               size_t stack_depth, Thread::Priority priority)
   {
     pthread_attr_t attr;
@@ -86,8 +87,9 @@ class Thread
        * @param  arg 线程参数 Thread argument
        * @param  name 线程名称 Thread name
        */
-      ThreadBlock(decltype(function) fun, ArgType arg, const char* name)
-          : fun_(fun), arg_(arg)
+      ThreadBlock(decltype(function) fun, ArgType arg, const char *name)
+          : fun_(fun),
+            arg_(arg)
       {
         std::memset(name_, 0, sizeof(name_));
         if (name != nullptr)
@@ -103,9 +105,9 @@ class Thread
        * @return 返回值始终为 `nullptr`
        *         The return value is always `nullptr`
        */
-      static void* Port(void* arg)
+      static void *Port(void *arg)
       {
-        ThreadBlock* block = static_cast<ThreadBlock*>(arg);
+        ThreadBlock *block = static_cast<ThreadBlock *>(arg);
 
         if (block->name_[0] != '\0')
         {
@@ -114,12 +116,12 @@ class Thread
 
         block->fun_(block->arg_);
         delete block;
-        return static_cast<void*>(nullptr);
+        return static_cast<void *>(nullptr);
       }
 
       decltype(function) fun_;  ///< 线程执行的函数 Function executed by the thread
-      ArgType arg_;             ///< 线程函数的参数 Argument passed to the thread function
-      char name_[16];           ///< 线程名称 Thread name
+      ArgType arg_;  ///< 线程函数的参数 Argument passed to the thread function
+      char name_[16];  ///< 线程名称 Thread name
     };
 
     auto block = new ThreadBlock(function, arg, name);
@@ -172,19 +174,13 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程
    *         Yields CPU execution to allow other threads to run
    */
   static void Yield();
-
-  /**
-   * @brief Waits for this POSIX thread to terminate and releases its resources.
-   * @return `OK` on success, otherwise `FAILED`.
-   */
-  ErrorCode Join();
 
   /**
    * @brief  线程对象转换为 POSIX 线程句柄
@@ -197,8 +193,7 @@ class Thread
   static void ConfigureAttributes(pthread_attr_t& attr, size_t stack_depth,
                                   Thread::Priority priority)
   {
-    const size_t stack_size =
-        LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
+    const size_t stack_size = LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
     pthread_attr_setstacksize(&attr, stack_size);
     ConfigureScheduling(attr, priority);
   }

--- a/system/webots/thread.cpp
+++ b/system/webots/thread.cpp
@@ -12,6 +12,11 @@ extern condition_var_handle* _libxr_webots_time_notify;
 
 Thread Thread::Current(void) { return Thread(pthread_self()); }
 
+ErrorCode Thread::Join()
+{
+  return pthread_join(thread_handle_, nullptr) == 0 ? ErrorCode::OK : ErrorCode::FAILED;
+}
+
 static ErrorCode ConditionVarWait(uint32_t timeout)
 {
   const uint64_t deadline_ms = MonotonicTime::NowMilliseconds() + timeout;
@@ -57,6 +62,9 @@ void Thread::SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to
   }
 }
 
-uint32_t Thread::GetTime() { return static_cast<uint32_t>(MonotonicTime::NowMilliseconds()); }
+uint32_t Thread::GetTime()
+{
+  return static_cast<uint32_t>(MonotonicTime::NowMilliseconds());
+}
 
 void Thread::Yield() { sched_yield(); }

--- a/system/webots/thread.cpp
+++ b/system/webots/thread.cpp
@@ -12,6 +12,12 @@ extern condition_var_handle* _libxr_webots_time_notify;
 
 Thread Thread::Current(void) { return Thread(pthread_self()); }
 
+ErrorCode Thread::Join()
+{
+  return pthread_join(thread_handle_, nullptr) == 0 ? ErrorCode::OK
+                                                    : ErrorCode::FAILED;
+}
+
 static ErrorCode ConditionVarWait(uint32_t timeout)
 {
   const uint64_t deadline_ms = MonotonicTime::NowMilliseconds() + timeout;

--- a/system/webots/thread.cpp
+++ b/system/webots/thread.cpp
@@ -12,11 +12,6 @@ extern condition_var_handle* _libxr_webots_time_notify;
 
 Thread Thread::Current(void) { return Thread(pthread_self()); }
 
-ErrorCode Thread::Join()
-{
-  return pthread_join(thread_handle_, nullptr) == 0 ? ErrorCode::OK : ErrorCode::FAILED;
-}
-
 static ErrorCode ConditionVarWait(uint32_t timeout)
 {
   const uint64_t deadline_ms = MonotonicTime::NowMilliseconds() + timeout;
@@ -62,9 +57,6 @@ void Thread::SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to
   }
 }
 
-uint32_t Thread::GetTime()
-{
-  return static_cast<uint32_t>(MonotonicTime::NowMilliseconds());
-}
+uint32_t Thread::GetTime() { return static_cast<uint32_t>(MonotonicTime::NowMilliseconds()); }
 
 void Thread::Yield() { sched_yield(); }

--- a/system/webots/thread.hpp
+++ b/system/webots/thread.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <algorithm>
-#include <cstring>
-
-#include "libxr_mem.hpp"
 #include "libxr_system.hpp"
+#include "libxr_mem.hpp"
 #include "libxr_time.hpp"
 #include "logger.hpp"
+
+#include <algorithm>
+#include <cstring>
 
 namespace LibXR
 {
@@ -66,11 +66,11 @@ class Thread
    * accordingly.
    */
   template <typename ArgType>
-  void Create(ArgType arg, void (*function)(ArgType arg), const char* name,
+  void Create(ArgType arg, void (*function)(ArgType arg), const char *name,
               size_t stack_depth, Thread::Priority priority)
   {
     const bool is_realtime = priority == Thread::Priority::REALTIME;
-    WebotsRealtimeThreadRegistration* realtime_registration = nullptr;
+    WebotsRealtimeThreadRegistration *realtime_registration = nullptr;
     if (is_realtime)
     {
       realtime_registration = WebotsRegisterRealtimeThread();
@@ -94,8 +94,8 @@ class Thread
        * @param  arg 线程参数 Thread argument
        * @param  name 线程名称 Thread name
        */
-      ThreadBlock(decltype(function) fun, ArgType arg, const char* name, bool is_realtime,
-                  WebotsRealtimeThreadRegistration* realtime_registration)
+      ThreadBlock(decltype(function) fun, ArgType arg, const char *name, bool is_realtime,
+                  WebotsRealtimeThreadRegistration *realtime_registration)
           : fun_(fun),
             arg_(arg),
             is_realtime_(is_realtime),
@@ -116,9 +116,9 @@ class Thread
        * @return 返回值始终为 `nullptr`
        *         The return value is always `nullptr`
        */
-      static void* Port(void* arg)
+      static void *Port(void *arg)
       {
-        ThreadBlock* block = static_cast<ThreadBlock*>(arg);
+        ThreadBlock *block = static_cast<ThreadBlock *>(arg);
         if (block->is_realtime_)
         {
           WebotsBindCurrentRealtimeThread(block->realtime_registration_);
@@ -129,17 +129,18 @@ class Thread
           WebotsReleaseRealtimeThread(block->realtime_registration_);
         }
         delete block;
-        return static_cast<void*>(nullptr);
+        return static_cast<void *>(nullptr);
       }
 
       decltype(function) fun_;  ///< 线程执行的函数 Function executed by the thread
       ArgType arg_;             ///< 线程函数的参数 Argument passed to the thread function
       bool is_realtime_{false};
-      WebotsRealtimeThreadRegistration* realtime_registration_{nullptr};
-      char name_[16];  ///< 线程名称 Thread name
+      WebotsRealtimeThreadRegistration *realtime_registration_{nullptr};
+      char name_[16];           ///< 线程名称 Thread name
     };
 
-    auto block = new ThreadBlock(function, arg, name, is_realtime, realtime_registration);
+    auto block =
+        new ThreadBlock(function, arg, name, is_realtime, realtime_registration);
 
     // 创建线程
     int ans = pthread_create(&this->thread_handle_, &attr, ThreadBlock::Port, block);
@@ -194,19 +195,13 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程
    *         Yields CPU execution to allow other threads to run
    */
   static void Yield();
-
-  /**
-   * @brief Waits for this POSIX thread to terminate and releases its resources.
-   * @return `OK` on success, otherwise `FAILED`.
-   */
-  ErrorCode Join();
 
   /**
    * @brief  线程对象转换为 POSIX 线程句柄
@@ -219,8 +214,7 @@ class Thread
   static void ConfigureAttributes(pthread_attr_t& attr, size_t stack_depth,
                                   Thread::Priority priority)
   {
-    const size_t stack_size =
-        LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
+    const size_t stack_size = LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
     pthread_attr_setstacksize(&attr, stack_size);
     ConfigureScheduling(attr, priority);
   }

--- a/system/webots/thread.hpp
+++ b/system/webots/thread.hpp
@@ -204,6 +204,12 @@ class Thread
   static void Yield();
 
   /**
+   * @brief Waits for this POSIX thread to terminate and releases its resources.
+   * @return `OK` on success, otherwise `FAILED`.
+   */
+  ErrorCode Join();
+
+  /**
    * @brief  线程对象转换为 POSIX 线程句柄
    *         Converts the thread object to a POSIX thread handle
    * @return POSIX 线程句柄 POSIX thread handle

--- a/system/webots/thread.hpp
+++ b/system/webots/thread.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "libxr_system.hpp"
-#include "libxr_mem.hpp"
-#include "libxr_time.hpp"
-#include "logger.hpp"
-
 #include <algorithm>
 #include <cstring>
+
+#include "libxr_mem.hpp"
+#include "libxr_system.hpp"
+#include "libxr_time.hpp"
+#include "logger.hpp"
 
 namespace LibXR
 {
@@ -66,11 +66,11 @@ class Thread
    * accordingly.
    */
   template <typename ArgType>
-  void Create(ArgType arg, void (*function)(ArgType arg), const char *name,
+  void Create(ArgType arg, void (*function)(ArgType arg), const char* name,
               size_t stack_depth, Thread::Priority priority)
   {
     const bool is_realtime = priority == Thread::Priority::REALTIME;
-    WebotsRealtimeThreadRegistration *realtime_registration = nullptr;
+    WebotsRealtimeThreadRegistration* realtime_registration = nullptr;
     if (is_realtime)
     {
       realtime_registration = WebotsRegisterRealtimeThread();
@@ -94,8 +94,8 @@ class Thread
        * @param  arg 线程参数 Thread argument
        * @param  name 线程名称 Thread name
        */
-      ThreadBlock(decltype(function) fun, ArgType arg, const char *name, bool is_realtime,
-                  WebotsRealtimeThreadRegistration *realtime_registration)
+      ThreadBlock(decltype(function) fun, ArgType arg, const char* name, bool is_realtime,
+                  WebotsRealtimeThreadRegistration* realtime_registration)
           : fun_(fun),
             arg_(arg),
             is_realtime_(is_realtime),
@@ -116,9 +116,9 @@ class Thread
        * @return 返回值始终为 `nullptr`
        *         The return value is always `nullptr`
        */
-      static void *Port(void *arg)
+      static void* Port(void* arg)
       {
-        ThreadBlock *block = static_cast<ThreadBlock *>(arg);
+        ThreadBlock* block = static_cast<ThreadBlock*>(arg);
         if (block->is_realtime_)
         {
           WebotsBindCurrentRealtimeThread(block->realtime_registration_);
@@ -129,18 +129,17 @@ class Thread
           WebotsReleaseRealtimeThread(block->realtime_registration_);
         }
         delete block;
-        return static_cast<void *>(nullptr);
+        return static_cast<void*>(nullptr);
       }
 
       decltype(function) fun_;  ///< 线程执行的函数 Function executed by the thread
       ArgType arg_;             ///< 线程函数的参数 Argument passed to the thread function
       bool is_realtime_{false};
-      WebotsRealtimeThreadRegistration *realtime_registration_{nullptr};
-      char name_[16];           ///< 线程名称 Thread name
+      WebotsRealtimeThreadRegistration* realtime_registration_{nullptr};
+      char name_[16];  ///< 线程名称 Thread name
     };
 
-    auto block =
-        new ThreadBlock(function, arg, name, is_realtime, realtime_registration);
+    auto block = new ThreadBlock(function, arg, name, is_realtime, realtime_registration);
 
     // 创建线程
     int ans = pthread_create(&this->thread_handle_, &attr, ThreadBlock::Port, block);
@@ -195,13 +194,19 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程
    *         Yields CPU execution to allow other threads to run
    */
   static void Yield();
+
+  /**
+   * @brief Waits for this POSIX thread to terminate and releases its resources.
+   * @return `OK` on success, otherwise `FAILED`.
+   */
+  ErrorCode Join();
 
   /**
    * @brief  线程对象转换为 POSIX 线程句柄
@@ -214,7 +219,8 @@ class Thread
   static void ConfigureAttributes(pthread_attr_t& attr, size_t stack_depth,
                                   Thread::Priority priority)
   {
-    const size_t stack_size = LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
+    const size_t stack_size =
+        LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
     pthread_attr_setstacksize(&attr, stack_size);
     ConfigureScheduling(attr, priority);
   }

--- a/test/base/structure/test_mpmc_queue.cpp
+++ b/test/base/structure/test_mpmc_queue.cpp
@@ -23,9 +23,9 @@ bool EqualDouble(double a, double b) { return std::abs(a - b) < 1e-9; }
  */
 struct ProducerArg
 {
-  size_t begin;  ///< 本生产者负责的起始值 / First value owned by this producer.
-  size_t count;  ///< 本生产者负责推送的元素数 / Number of items pushed by this producer.
-  Queue* queue;  ///< 共享队列 / Shared queue instance.
+  size_t begin;                    ///< 本生产者负责的起始值 / First value owned by this producer.
+  size_t count;                    ///< 本生产者负责推送的元素数 / Number of items pushed by this producer.
+  Queue* queue;                    ///< 共享队列 / Shared queue instance.
   std::atomic<size_t>* done_count;  ///< 完成计数器 / Producer completion counter.
 };
 
@@ -35,17 +35,14 @@ struct ProducerArg
  */
 struct ConsumerArg
 {
-  Queue* queue;           ///< 共享队列 / Shared queue instance.
-  size_t total_items;     ///< 目标总元素数 / Expected total item count.
-  size_t producer_count;  ///< 生产者总数 / Total number of producers.
-  std::atomic<size_t>*
-      produced_done_count;  ///< 生产者完成计数 / Producer completion counter.
-  std::atomic<size_t>*
-      consumed_done_count;         ///< 消费者完成计数 / Consumer completion counter.
-  std::atomic<size_t>* pop_count;  ///< 已消费元素数 / Total consumed item count.
-  std::atomic<unsigned long long>*
-      pop_sum;                 ///< 已消费元素和 / Running sum of consumed values.
-  std::atomic<uint8_t>* seen;  ///< 去重标记表 / Deduplication mark table.
+  Queue* queue;                                 ///< 共享队列 / Shared queue instance.
+  size_t total_items;                           ///< 目标总元素数 / Expected total item count.
+  size_t producer_count;                        ///< 生产者总数 / Total number of producers.
+  std::atomic<size_t>* produced_done_count;     ///< 生产者完成计数 / Producer completion counter.
+  std::atomic<size_t>* consumed_done_count;     ///< 消费者完成计数 / Consumer completion counter.
+  std::atomic<size_t>* pop_count;               ///< 已消费元素数 / Total consumed item count.
+  std::atomic<unsigned long long>* pop_sum;     ///< 已消费元素和 / Running sum of consumed values.
+  std::atomic<uint8_t>* seen;                   ///< 去重标记表 / Deduplication mark table.
 };
 
 /**
@@ -256,14 +253,6 @@ void test_mpmc_queue()
 
     ASSERT(produced_done_count.load(std::memory_order_acquire) == PRODUCER_COUNT);
     ASSERT(consumed_done_count.load(std::memory_order_acquire) == CONSUMER_COUNT);
-    for (auto& producer : producers)
-    {
-      ASSERT(producer.Join() == LibXR::ErrorCode::OK);
-    }
-    for (auto& consumer : consumers)
-    {
-      ASSERT(consumer.Join() == LibXR::ErrorCode::OK);
-    }
     ASSERT(pop_count.load(std::memory_order_acquire) == TOTAL_ITEMS);
     ASSERT(pop_sum.load(std::memory_order_acquire) == EXPECTED_SUM);
     ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
@@ -323,14 +312,6 @@ void test_mpmc_queue()
 
     ASSERT(produced_done_count.load(std::memory_order_acquire) == PRODUCER_COUNT);
     ASSERT(consumed_done_count.load(std::memory_order_acquire) == CONSUMER_COUNT);
-    for (auto& producer : producers)
-    {
-      ASSERT(producer.Join() == LibXR::ErrorCode::OK);
-    }
-    for (auto& consumer : consumers)
-    {
-      ASSERT(consumer.Join() == LibXR::ErrorCode::OK);
-    }
     ASSERT(pop_count.load(std::memory_order_acquire) == TOTAL_ITEMS);
     ASSERT(pop_sum.load(std::memory_order_acquire) == EXPECTED_SUM);
     ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);

--- a/test/base/structure/test_mpmc_queue.cpp
+++ b/test/base/structure/test_mpmc_queue.cpp
@@ -23,9 +23,9 @@ bool EqualDouble(double a, double b) { return std::abs(a - b) < 1e-9; }
  */
 struct ProducerArg
 {
-  size_t begin;                    ///< 本生产者负责的起始值 / First value owned by this producer.
-  size_t count;                    ///< 本生产者负责推送的元素数 / Number of items pushed by this producer.
-  Queue* queue;                    ///< 共享队列 / Shared queue instance.
+  size_t begin;  ///< 本生产者负责的起始值 / First value owned by this producer.
+  size_t count;  ///< 本生产者负责推送的元素数 / Number of items pushed by this producer.
+  Queue* queue;  ///< 共享队列 / Shared queue instance.
   std::atomic<size_t>* done_count;  ///< 完成计数器 / Producer completion counter.
 };
 
@@ -35,14 +35,17 @@ struct ProducerArg
  */
 struct ConsumerArg
 {
-  Queue* queue;                                 ///< 共享队列 / Shared queue instance.
-  size_t total_items;                           ///< 目标总元素数 / Expected total item count.
-  size_t producer_count;                        ///< 生产者总数 / Total number of producers.
-  std::atomic<size_t>* produced_done_count;     ///< 生产者完成计数 / Producer completion counter.
-  std::atomic<size_t>* consumed_done_count;     ///< 消费者完成计数 / Consumer completion counter.
-  std::atomic<size_t>* pop_count;               ///< 已消费元素数 / Total consumed item count.
-  std::atomic<unsigned long long>* pop_sum;     ///< 已消费元素和 / Running sum of consumed values.
-  std::atomic<uint8_t>* seen;                   ///< 去重标记表 / Deduplication mark table.
+  Queue* queue;           ///< 共享队列 / Shared queue instance.
+  size_t total_items;     ///< 目标总元素数 / Expected total item count.
+  size_t producer_count;  ///< 生产者总数 / Total number of producers.
+  std::atomic<size_t>*
+      produced_done_count;  ///< 生产者完成计数 / Producer completion counter.
+  std::atomic<size_t>*
+      consumed_done_count;         ///< 消费者完成计数 / Consumer completion counter.
+  std::atomic<size_t>* pop_count;  ///< 已消费元素数 / Total consumed item count.
+  std::atomic<unsigned long long>*
+      pop_sum;                 ///< 已消费元素和 / Running sum of consumed values.
+  std::atomic<uint8_t>* seen;  ///< 去重标记表 / Deduplication mark table.
 };
 
 /**
@@ -253,6 +256,14 @@ void test_mpmc_queue()
 
     ASSERT(produced_done_count.load(std::memory_order_acquire) == PRODUCER_COUNT);
     ASSERT(consumed_done_count.load(std::memory_order_acquire) == CONSUMER_COUNT);
+    for (auto& producer : producers)
+    {
+      ASSERT(producer.Join() == LibXR::ErrorCode::OK);
+    }
+    for (auto& consumer : consumers)
+    {
+      ASSERT(consumer.Join() == LibXR::ErrorCode::OK);
+    }
     ASSERT(pop_count.load(std::memory_order_acquire) == TOTAL_ITEMS);
     ASSERT(pop_sum.load(std::memory_order_acquire) == EXPECTED_SUM);
     ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
@@ -312,6 +323,14 @@ void test_mpmc_queue()
 
     ASSERT(produced_done_count.load(std::memory_order_acquire) == PRODUCER_COUNT);
     ASSERT(consumed_done_count.load(std::memory_order_acquire) == CONSUMER_COUNT);
+    for (auto& producer : producers)
+    {
+      ASSERT(producer.Join() == LibXR::ErrorCode::OK);
+    }
+    for (auto& consumer : consumers)
+    {
+      ASSERT(consumer.Join() == LibXR::ErrorCode::OK);
+    }
     ASSERT(pop_count.load(std::memory_order_acquire) == TOTAL_ITEMS);
     ASSERT(pop_sum.load(std::memory_order_acquire) == EXPECTED_SUM);
     ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);

--- a/test/base/structure/test_mpmc_queue.cpp
+++ b/test/base/structure/test_mpmc_queue.cpp
@@ -253,6 +253,14 @@ void test_mpmc_queue()
 
     ASSERT(produced_done_count.load(std::memory_order_acquire) == PRODUCER_COUNT);
     ASSERT(consumed_done_count.load(std::memory_order_acquire) == CONSUMER_COUNT);
+    for (auto& producer : producers)
+    {
+      ASSERT(producer.Join() == LibXR::ErrorCode::OK);
+    }
+    for (auto& consumer : consumers)
+    {
+      ASSERT(consumer.Join() == LibXR::ErrorCode::OK);
+    }
     ASSERT(pop_count.load(std::memory_order_acquire) == TOTAL_ITEMS);
     ASSERT(pop_sum.load(std::memory_order_acquire) == EXPECTED_SUM);
     ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
@@ -312,6 +320,14 @@ void test_mpmc_queue()
 
     ASSERT(produced_done_count.load(std::memory_order_acquire) == PRODUCER_COUNT);
     ASSERT(consumed_done_count.load(std::memory_order_acquire) == CONSUMER_COUNT);
+    for (auto& producer : producers)
+    {
+      ASSERT(producer.Join() == LibXR::ErrorCode::OK);
+    }
+    for (auto& consumer : consumers)
+    {
+      ASSERT(consumer.Join() == LibXR::ErrorCode::OK);
+    }
     ASSERT(pop_count.load(std::memory_order_acquire) == TOTAL_ITEMS);
     ASSERT(pop_sum.load(std::memory_order_acquire) == EXPECTED_SUM);
     ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);

--- a/test/base/structure/test_spsc_queue.cpp
+++ b/test/base/structure/test_spsc_queue.cpp
@@ -1,11 +1,11 @@
-#include "libxr.hpp"
-#include "libxr_def.hpp"
-#include "test.hpp"
-
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
+
+#include "libxr.hpp"
+#include "libxr_def.hpp"
+#include "test.hpp"
 
 namespace
 {
@@ -212,18 +212,17 @@ void test_spsc_queue()
 
     uint8_t write_next = 20;
     size_t write_chunks = 0;
-    ASSERT(byte_queue.PushWithWriter(
-               4,
-               [&](uint8_t* chunk, size_t count)
-               {
-                 ASSERT(count == 2);
-                 ++write_chunks;
-                 for (size_t index = 0; index < count; ++index)
-                 {
-                   chunk[index] = write_next++;
-                 }
-                 return LibXR::ErrorCode::OK;
-               }) == LibXR::ErrorCode::OK);
+    ASSERT(byte_queue.PushWithWriter(4,
+                                     [&](uint8_t* chunk, size_t count)
+                                     {
+                                       ASSERT(count == 2);
+                                       ++write_chunks;
+                                       for (size_t index = 0; index < count; ++index)
+                                       {
+                                         chunk[index] = write_next++;
+                                       }
+                                       return LibXR::ErrorCode::OK;
+                                     }) == LibXR::ErrorCode::OK);
     ASSERT(write_chunks == 2);
 
     const uint8_t expected_after_write[6] = {13, 14, 20, 21, 22, 23};
@@ -247,19 +246,19 @@ void test_spsc_queue()
     const uint8_t expected_read_chunks[5] = {5, 6, 7, 8, 9};
     size_t read_cursor = 0;
     size_t read_chunks = 0;
-    ASSERT(byte_queue.PopWithReader(
-               5,
-               [&](const uint8_t* chunk, size_t count)
-               {
-                 ASSERT((read_chunks == 0 && count == 1) ||
-                        (read_chunks == 1 && count == 4));
-                 for (size_t index = 0; index < count; ++index)
-                 {
-                   ASSERT(chunk[index] == expected_read_chunks[read_cursor++]);
-                 }
-                 ++read_chunks;
-                 return LibXR::ErrorCode::OK;
-               }) == LibXR::ErrorCode::OK);
+    ASSERT(byte_queue.PopWithReader(5,
+                                    [&](const uint8_t* chunk, size_t count)
+                                    {
+                                      ASSERT((read_chunks == 0 && count == 1) ||
+                                             (read_chunks == 1 && count == 4));
+                                      for (size_t index = 0; index < count; ++index)
+                                      {
+                                        ASSERT(chunk[index] ==
+                                               expected_read_chunks[read_cursor++]);
+                                      }
+                                      ++read_chunks;
+                                      return LibXR::ErrorCode::OK;
+                                    }) == LibXR::ErrorCode::OK);
     ASSERT(read_chunks == 2);
     ASSERT(read_cursor == 5);
     ASSERT(byte_queue.Pop(value) == LibXR::ErrorCode::OK);
@@ -274,8 +273,9 @@ void test_spsc_queue()
     std::atomic<bool> producer_done = false;
     LibXR::Thread producer;
 
-    producer.Create<ProducerArg>(ProducerArg{&queue, TOTAL_ITEMS, &producer_done}, ProducerTask,
-                                 "spsc_prod", 1024, LibXR::Thread::Priority::REALTIME);
+    producer.Create<ProducerArg>(ProducerArg{&queue, TOTAL_ITEMS, &producer_done},
+                                 ProducerTask, "spsc_prod", 1024,
+                                 LibXR::Thread::Priority::REALTIME);
 
     for (uint32_t expected = 0; expected < TOTAL_ITEMS; ++expected)
     {
@@ -291,6 +291,7 @@ void test_spsc_queue()
     {
       LibXR::Thread::Yield();
     }
+    ASSERT(producer.Join() == LibXR::ErrorCode::OK);
     uint32_t value = 0;
     ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
     ASSERT(queue.Size() == 0);

--- a/test/base/structure/test_spsc_queue.cpp
+++ b/test/base/structure/test_spsc_queue.cpp
@@ -1,11 +1,11 @@
+#include "libxr.hpp"
+#include "libxr_def.hpp"
+#include "test.hpp"
+
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
-
-#include "libxr.hpp"
-#include "libxr_def.hpp"
-#include "test.hpp"
 
 namespace
 {
@@ -212,17 +212,18 @@ void test_spsc_queue()
 
     uint8_t write_next = 20;
     size_t write_chunks = 0;
-    ASSERT(byte_queue.PushWithWriter(4,
-                                     [&](uint8_t* chunk, size_t count)
-                                     {
-                                       ASSERT(count == 2);
-                                       ++write_chunks;
-                                       for (size_t index = 0; index < count; ++index)
-                                       {
-                                         chunk[index] = write_next++;
-                                       }
-                                       return LibXR::ErrorCode::OK;
-                                     }) == LibXR::ErrorCode::OK);
+    ASSERT(byte_queue.PushWithWriter(
+               4,
+               [&](uint8_t* chunk, size_t count)
+               {
+                 ASSERT(count == 2);
+                 ++write_chunks;
+                 for (size_t index = 0; index < count; ++index)
+                 {
+                   chunk[index] = write_next++;
+                 }
+                 return LibXR::ErrorCode::OK;
+               }) == LibXR::ErrorCode::OK);
     ASSERT(write_chunks == 2);
 
     const uint8_t expected_after_write[6] = {13, 14, 20, 21, 22, 23};
@@ -246,19 +247,19 @@ void test_spsc_queue()
     const uint8_t expected_read_chunks[5] = {5, 6, 7, 8, 9};
     size_t read_cursor = 0;
     size_t read_chunks = 0;
-    ASSERT(byte_queue.PopWithReader(5,
-                                    [&](const uint8_t* chunk, size_t count)
-                                    {
-                                      ASSERT((read_chunks == 0 && count == 1) ||
-                                             (read_chunks == 1 && count == 4));
-                                      for (size_t index = 0; index < count; ++index)
-                                      {
-                                        ASSERT(chunk[index] ==
-                                               expected_read_chunks[read_cursor++]);
-                                      }
-                                      ++read_chunks;
-                                      return LibXR::ErrorCode::OK;
-                                    }) == LibXR::ErrorCode::OK);
+    ASSERT(byte_queue.PopWithReader(
+               5,
+               [&](const uint8_t* chunk, size_t count)
+               {
+                 ASSERT((read_chunks == 0 && count == 1) ||
+                        (read_chunks == 1 && count == 4));
+                 for (size_t index = 0; index < count; ++index)
+                 {
+                   ASSERT(chunk[index] == expected_read_chunks[read_cursor++]);
+                 }
+                 ++read_chunks;
+                 return LibXR::ErrorCode::OK;
+               }) == LibXR::ErrorCode::OK);
     ASSERT(read_chunks == 2);
     ASSERT(read_cursor == 5);
     ASSERT(byte_queue.Pop(value) == LibXR::ErrorCode::OK);
@@ -273,9 +274,8 @@ void test_spsc_queue()
     std::atomic<bool> producer_done = false;
     LibXR::Thread producer;
 
-    producer.Create<ProducerArg>(ProducerArg{&queue, TOTAL_ITEMS, &producer_done},
-                                 ProducerTask, "spsc_prod", 1024,
-                                 LibXR::Thread::Priority::REALTIME);
+    producer.Create<ProducerArg>(ProducerArg{&queue, TOTAL_ITEMS, &producer_done}, ProducerTask,
+                                 "spsc_prod", 1024, LibXR::Thread::Priority::REALTIME);
 
     for (uint32_t expected = 0; expected < TOTAL_ITEMS; ++expected)
     {
@@ -291,7 +291,6 @@ void test_spsc_queue()
     {
       LibXR::Thread::Yield();
     }
-    ASSERT(producer.Join() == LibXR::ErrorCode::OK);
     uint32_t value = 0;
     ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
     ASSERT(queue.Size() == 0);

--- a/test/base/structure/test_spsc_queue.cpp
+++ b/test/base/structure/test_spsc_queue.cpp
@@ -291,6 +291,7 @@ void test_spsc_queue()
     {
       LibXR::Thread::Yield();
     }
+    ASSERT(producer.Join() == LibXR::ErrorCode::OK);
     uint32_t value = 0;
     ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
     ASSERT(queue.Size() == 0);

--- a/test/common/rw/rw_thread_test_common.hpp
+++ b/test/common/rw/rw_thread_test_common.hpp
@@ -33,8 +33,7 @@ inline void JoinThreadIfNeeded(LibXR::Thread& thread)
 {
   // 辅助内容：为后续测试准备或校验共享状态。
   // Helper coverage: prepare or validate shared state for later tests.
-  UNUSED(thread);
-  LibXR::Thread::Sleep(1);
+  ASSERT(thread.Join() == LibXR::ErrorCode::OK);
 }
 
 /**

--- a/test/common/rw/rw_thread_test_common.hpp
+++ b/test/common/rw/rw_thread_test_common.hpp
@@ -1,13 +1,15 @@
 /**
  * @file rw_thread_test_common.hpp
- * @brief `rw` / `pipe` 线程与等待同步测试 helper。 Shared thread and waiter helpers for `rw` / `pipe` tests.
+ * @brief `rw` / `pipe` 线程与等待同步测试 helper。 Shared thread and waiter helpers for
+ * `rw` / `pipe` tests.
  * @details 测试项目：
  *          1. 提供线程收尾与等待断言 helper。
  *          2. 提供挂起读写完成、阻塞读写调用的上下文与线程启动封装。
  *          3. 提供把后台补数据/补完成的动作统一包装成可复用 helper。
  *          Test items:
  *          1. Provide thread-settle and wait assertion helpers.
- *          2. Provide contexts and starters for pending completion and blocking read/write calls.
+ *          2. Provide contexts and starters for pending completion and blocking
+ * read/write calls.
  *          3. Wrap background completion actions into reusable helpers.
  */
 #pragma once
@@ -26,21 +28,25 @@ using LibXRTest::WriteHarness;
 
 /**
  * @brief 辅助函数 `JoinThreadIfNeeded`。 Helper function `JoinThreadIfNeeded`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 inline void JoinThreadIfNeeded(LibXR::Thread& thread)
 {
   // 辅助内容：为后续测试准备或校验共享状态。
   // Helper coverage: prepare or validate shared state for later tests.
-  UNUSED(thread);
-  LibXR::Thread::Sleep(1);
+  ASSERT(thread.Join() == LibXR::ErrorCode::OK);
 }
 
 /**
  * @brief 断言辅助函数 `ExpectWaitOk`。 Assertion helper function `ExpectWaitOk`.
- * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check to the current result.
- *          测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。 Concentrate repeated validation logic so test items do not drift to inconsistent checks.
+ * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check
+ * to the current result. 测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。
+ * Concentrate repeated validation logic so test items do not drift to inconsistent
+ * checks.
  */
 inline void ExpectWaitOk(LibXR::Semaphore& sem, uint32_t timeout = ASYNC_TIMEOUT_MS)
 {
@@ -58,9 +64,13 @@ struct ReadQueueCompletionContext
 };
 
 /**
- * @brief 辅助函数 `CompletePendingReadFromQueue`。 Helper function `CompletePendingReadFromQueue`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @brief 辅助函数 `CompletePendingReadFromQueue`。 Helper function
+ * `CompletePendingReadFromQueue`.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void CompletePendingReadFromQueue(ReadQueueCompletionContext ctx)
 {
@@ -86,8 +96,11 @@ struct WriteFinishContext
 
 /**
  * @brief 辅助函数 `FinishPendingWrite`。 Helper function `FinishPendingWrite`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void FinishPendingWrite(WriteFinishContext ctx)
 {
@@ -113,8 +126,11 @@ struct BlockingReadCallContext
 
 /**
  * @brief 辅助函数 `BlockingReadCall`。 Helper function `BlockingReadCall`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void BlockingReadCall(BlockingReadCallContext* ctx)
 {
@@ -135,8 +151,11 @@ struct BlockingWriteCallContext
 
 /**
  * @brief 辅助函数 `BlockingWriteCall`。 Helper function `BlockingWriteCall`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void BlockingWriteCall(BlockingWriteCallContext* ctx)
 {

--- a/test/common/rw/rw_thread_test_common.hpp
+++ b/test/common/rw/rw_thread_test_common.hpp
@@ -1,15 +1,13 @@
 /**
  * @file rw_thread_test_common.hpp
- * @brief `rw` / `pipe` 线程与等待同步测试 helper。 Shared thread and waiter helpers for
- * `rw` / `pipe` tests.
+ * @brief `rw` / `pipe` 线程与等待同步测试 helper。 Shared thread and waiter helpers for `rw` / `pipe` tests.
  * @details 测试项目：
  *          1. 提供线程收尾与等待断言 helper。
  *          2. 提供挂起读写完成、阻塞读写调用的上下文与线程启动封装。
  *          3. 提供把后台补数据/补完成的动作统一包装成可复用 helper。
  *          Test items:
  *          1. Provide thread-settle and wait assertion helpers.
- *          2. Provide contexts and starters for pending completion and blocking
- * read/write calls.
+ *          2. Provide contexts and starters for pending completion and blocking read/write calls.
  *          3. Wrap background completion actions into reusable helpers.
  */
 #pragma once
@@ -28,25 +26,21 @@ using LibXRTest::WriteHarness;
 
 /**
  * @brief 辅助函数 `JoinThreadIfNeeded`。 Helper function `JoinThreadIfNeeded`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
- * measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
- * repeated helper logic locally so the main test body stays focused on the test item
- * itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
  */
 inline void JoinThreadIfNeeded(LibXR::Thread& thread)
 {
   // 辅助内容：为后续测试准备或校验共享状态。
   // Helper coverage: prepare or validate shared state for later tests.
-  ASSERT(thread.Join() == LibXR::ErrorCode::OK);
+  UNUSED(thread);
+  LibXR::Thread::Sleep(1);
 }
 
 /**
  * @brief 断言辅助函数 `ExpectWaitOk`。 Assertion helper function `ExpectWaitOk`.
- * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check
- * to the current result. 测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。
- * Concentrate repeated validation logic so test items do not drift to inconsistent
- * checks.
+ * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check to the current result.
+ *          测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。 Concentrate repeated validation logic so test items do not drift to inconsistent checks.
  */
 inline void ExpectWaitOk(LibXR::Semaphore& sem, uint32_t timeout = ASYNC_TIMEOUT_MS)
 {
@@ -64,13 +58,9 @@ struct ReadQueueCompletionContext
 };
 
 /**
- * @brief 辅助函数 `CompletePendingReadFromQueue`。 Helper function
- * `CompletePendingReadFromQueue`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
- * measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
- * repeated helper logic locally so the main test body stays focused on the test item
- * itself.
+ * @brief 辅助函数 `CompletePendingReadFromQueue`。 Helper function `CompletePendingReadFromQueue`.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
  */
 void CompletePendingReadFromQueue(ReadQueueCompletionContext ctx)
 {
@@ -96,11 +86,8 @@ struct WriteFinishContext
 
 /**
  * @brief 辅助函数 `FinishPendingWrite`。 Helper function `FinishPendingWrite`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
- * measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
- * repeated helper logic locally so the main test body stays focused on the test item
- * itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
  */
 void FinishPendingWrite(WriteFinishContext ctx)
 {
@@ -126,11 +113,8 @@ struct BlockingReadCallContext
 
 /**
  * @brief 辅助函数 `BlockingReadCall`。 Helper function `BlockingReadCall`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
- * measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
- * repeated helper logic locally so the main test body stays focused on the test item
- * itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
  */
 void BlockingReadCall(BlockingReadCallContext* ctx)
 {
@@ -151,11 +135,8 @@ struct BlockingWriteCallContext
 
 /**
  * @brief 辅助函数 `BlockingWriteCall`。 Helper function `BlockingWriteCall`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
- * measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
- * repeated helper logic locally so the main test body stays focused on the test item
- * itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
  */
 void BlockingWriteCall(BlockingWriteCallContext* ctx)
 {

--- a/test/runtime/middleware/message/test_runtime.cpp
+++ b/test/runtime/middleware/message/test_runtime.cpp
@@ -112,11 +112,7 @@ void TestSyncSubscriberFreshWait()
            LibXR::Topic::SyncBlock::WAITING);
     ASSERT(suber.Wait(0) == LibXR::ErrorCode::BUSY);
     publish();
-    for (uint32_t i = 0; i < 1000000 && ctx.result != LibXR::ErrorCode::OK; i++)
-    {
-      LibXR::Thread::Yield();
-    }
-    LibXR::Thread::Sleep(1);
+    ASSERT(wait_thread.Join() == LibXR::ErrorCode::OK);
     ASSERT(ctx.result == LibXR::ErrorCode::OK);
   };
 

--- a/test/runtime/middleware/message/test_runtime.cpp
+++ b/test/runtime/middleware/message/test_runtime.cpp
@@ -1,23 +1,14 @@
 /**
  * @file test_runtime.cpp
- * @brief runtime 平面 `Topic` 订阅等待测试。 Runtime-plane subscriber waiting tests for
- * `Topic`.
+ * @brief runtime 平面 `Topic` 订阅等待测试。 Runtime-plane subscriber waiting tests for `Topic`.
  *
  * 测试项目 / Test items:
- * 1. ASyncSubscriber 的 fresh wait 语义。 Async subscriber wait semantics: verify
- * `StartWaiting()` only arms fresh notifications and preserves timestamp/data for the
- * next publish.
- * 2. SyncSubscriber 的阻塞等待、忙重入和 callback-context 唤醒。 Sync subscriber wait
- * semantics: verify blocking waits, busy reentry rejection, timeout behavior and
- * callback-context publish wakeups.
+ * 1. ASyncSubscriber 的 fresh wait 语义。 Async subscriber wait semantics: verify `StartWaiting()` only arms fresh notifications and preserves timestamp/data for the next publish.
+ * 2. SyncSubscriber 的阻塞等待、忙重入和 callback-context 唤醒。 Sync subscriber wait semantics: verify blocking waits, busy reentry rejection, timeout behavior and callback-context publish wakeups.
  *
  * 测试原理 / Test principles:
- * 1. 使用真实 runtime 线程驱动阻塞等待，因为这些语义在 base 平面不存在。 Use real runtime
- * threads for the blocking wait path, because these semantics do not exist on the base
- * plane alone.
- * 2. 同时检查 wait 返回码和收到的数据/时间戳，保证同步和数据传递一起被验证。 Check both
- * wait return codes and received payload/timestamp values so synchronization and data
- * delivery are validated together.
+ * 1. 使用真实 runtime 线程驱动阻塞等待，因为这些语义在 base 平面不存在。 Use real runtime threads for the blocking wait path, because these semantics do not exist on the base plane alone.
+ * 2. 同时检查 wait 返回码和收到的数据/时间戳，保证同步和数据传递一起被验证。 Check both wait return codes and received payload/timestamp values so synchronization and data delivery are validated together.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -33,21 +24,18 @@ struct WaitContext
 
 /**
  * @brief 辅助函数 `WaitForSyncSubscriber`。 Helper function `WaitForSyncSubscriber`.
- * @details 测试内容：在 LibXR 线程中执行同步订阅等待。 Execute sync-subscriber waiting
- * inside a LibXR thread. 测试原理：只通过 LibXR thread API
- * 构造等待者，避免测试体依赖宿主线程库。 Use only LibXR's thread API to construct the
- * waiter, avoiding host-thread-library dependencies in the test body.
+ * @details 测试内容：在 LibXR 线程中执行同步订阅等待。 Execute sync-subscriber waiting inside a LibXR thread.
+ *          测试原理：只通过 LibXR thread API 构造等待者，避免测试体依赖宿主线程库。 Use only LibXR's thread API to construct the waiter, avoiding host-thread-library dependencies in the test body.
  */
-void WaitForSyncSubscriber(WaitContext* ctx) { ctx->result = ctx->subscriber->Wait(200); }
+void WaitForSyncSubscriber(WaitContext* ctx)
+{
+  ctx->result = ctx->subscriber->Wait(200);
+}
 
 /**
- * @brief 测试项函数 `TestASyncSubscriberFreshWait`。 Test-item function
- * `TestASyncSubscriberFreshWait`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
- * scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
- * Split one explainable test item into an independent function so failures and reused
- * scenarios stay easy to locate.
+ * @brief 测试项函数 `TestASyncSubscriberFreshWait`。 Test-item function `TestASyncSubscriberFreshWait`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
  */
 void TestASyncSubscriberFreshWait()
 {
@@ -82,13 +70,9 @@ void TestASyncSubscriberFreshWait()
 }
 
 /**
- * @brief 测试项函数 `TestSyncSubscriberFreshWait`。 Test-item function
- * `TestSyncSubscriberFreshWait`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
- * scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
- * Split one explainable test item into an independent function so failures and reused
- * scenarios stay easy to locate.
+ * @brief 测试项函数 `TestSyncSubscriberFreshWait`。 Test-item function `TestSyncSubscriberFreshWait`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
  */
 void TestSyncSubscriberFreshWait()
 {
@@ -112,12 +96,13 @@ void TestSyncSubscriberFreshWait()
   {
     WaitContext ctx{&suber, LibXR::ErrorCode::FAILED};
     LibXR::Thread wait_thread;
-    wait_thread.Create<WaitContext*>(&ctx, WaitForSyncSubscriber, "msg_sync_wait", 1024,
-                                     LibXR::Thread::Priority::MEDIUM);
+    wait_thread.Create<WaitContext*>(&ctx, WaitForSyncSubscriber, "msg_sync_wait",
+                                     1024, LibXR::Thread::Priority::MEDIUM);
 
     for (uint32_t i = 0;
-         i < 1000000 && suber.block_->data_.wait_state.load(std::memory_order_acquire) !=
-                            LibXR::Topic::SyncBlock::WAITING;
+         i < 1000000 &&
+         suber.block_->data_.wait_state.load(std::memory_order_acquire) !=
+             LibXR::Topic::SyncBlock::WAITING;
          i++)
     {
       LibXR::Thread::Yield();
@@ -127,7 +112,11 @@ void TestSyncSubscriberFreshWait()
            LibXR::Topic::SyncBlock::WAITING);
     ASSERT(suber.Wait(0) == LibXR::ErrorCode::BUSY);
     publish();
-    ASSERT(wait_thread.Join() == LibXR::ErrorCode::OK);
+    for (uint32_t i = 0; i < 1000000 && ctx.result != LibXR::ErrorCode::OK; i++)
+    {
+      LibXR::Thread::Yield();
+    }
+    LibXR::Thread::Sleep(1);
     ASSERT(ctx.result == LibXR::ErrorCode::OK);
   };
 
@@ -156,11 +145,9 @@ void TestSyncSubscriberFreshWait()
 }  // namespace
 
 /**
- * @brief 测试入口函数 `test_message_runtime`。 Test entry function
- * `test_message_runtime`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
- * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
- * Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_message_runtime`。 Test entry function `test_message_runtime`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
+ *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
  */
 void test_message_runtime()
 {

--- a/test/runtime/middleware/message/test_runtime.cpp
+++ b/test/runtime/middleware/message/test_runtime.cpp
@@ -1,14 +1,23 @@
 /**
  * @file test_runtime.cpp
- * @brief runtime 平面 `Topic` 订阅等待测试。 Runtime-plane subscriber waiting tests for `Topic`.
+ * @brief runtime 平面 `Topic` 订阅等待测试。 Runtime-plane subscriber waiting tests for
+ * `Topic`.
  *
  * 测试项目 / Test items:
- * 1. ASyncSubscriber 的 fresh wait 语义。 Async subscriber wait semantics: verify `StartWaiting()` only arms fresh notifications and preserves timestamp/data for the next publish.
- * 2. SyncSubscriber 的阻塞等待、忙重入和 callback-context 唤醒。 Sync subscriber wait semantics: verify blocking waits, busy reentry rejection, timeout behavior and callback-context publish wakeups.
+ * 1. ASyncSubscriber 的 fresh wait 语义。 Async subscriber wait semantics: verify
+ * `StartWaiting()` only arms fresh notifications and preserves timestamp/data for the
+ * next publish.
+ * 2. SyncSubscriber 的阻塞等待、忙重入和 callback-context 唤醒。 Sync subscriber wait
+ * semantics: verify blocking waits, busy reentry rejection, timeout behavior and
+ * callback-context publish wakeups.
  *
  * 测试原理 / Test principles:
- * 1. 使用真实 runtime 线程驱动阻塞等待，因为这些语义在 base 平面不存在。 Use real runtime threads for the blocking wait path, because these semantics do not exist on the base plane alone.
- * 2. 同时检查 wait 返回码和收到的数据/时间戳，保证同步和数据传递一起被验证。 Check both wait return codes and received payload/timestamp values so synchronization and data delivery are validated together.
+ * 1. 使用真实 runtime 线程驱动阻塞等待，因为这些语义在 base 平面不存在。 Use real runtime
+ * threads for the blocking wait path, because these semantics do not exist on the base
+ * plane alone.
+ * 2. 同时检查 wait 返回码和收到的数据/时间戳，保证同步和数据传递一起被验证。 Check both
+ * wait return codes and received payload/timestamp values so synchronization and data
+ * delivery are validated together.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -24,18 +33,21 @@ struct WaitContext
 
 /**
  * @brief 辅助函数 `WaitForSyncSubscriber`。 Helper function `WaitForSyncSubscriber`.
- * @details 测试内容：在 LibXR 线程中执行同步订阅等待。 Execute sync-subscriber waiting inside a LibXR thread.
- *          测试原理：只通过 LibXR thread API 构造等待者，避免测试体依赖宿主线程库。 Use only LibXR's thread API to construct the waiter, avoiding host-thread-library dependencies in the test body.
+ * @details 测试内容：在 LibXR 线程中执行同步订阅等待。 Execute sync-subscriber waiting
+ * inside a LibXR thread. 测试原理：只通过 LibXR thread API
+ * 构造等待者，避免测试体依赖宿主线程库。 Use only LibXR's thread API to construct the
+ * waiter, avoiding host-thread-library dependencies in the test body.
  */
-void WaitForSyncSubscriber(WaitContext* ctx)
-{
-  ctx->result = ctx->subscriber->Wait(200);
-}
+void WaitForSyncSubscriber(WaitContext* ctx) { ctx->result = ctx->subscriber->Wait(200); }
 
 /**
- * @brief 测试项函数 `TestASyncSubscriberFreshWait`。 Test-item function `TestASyncSubscriberFreshWait`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestASyncSubscriberFreshWait`。 Test-item function
+ * `TestASyncSubscriberFreshWait`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestASyncSubscriberFreshWait()
 {
@@ -70,9 +82,13 @@ void TestASyncSubscriberFreshWait()
 }
 
 /**
- * @brief 测试项函数 `TestSyncSubscriberFreshWait`。 Test-item function `TestSyncSubscriberFreshWait`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestSyncSubscriberFreshWait`。 Test-item function
+ * `TestSyncSubscriberFreshWait`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestSyncSubscriberFreshWait()
 {
@@ -96,13 +112,12 @@ void TestSyncSubscriberFreshWait()
   {
     WaitContext ctx{&suber, LibXR::ErrorCode::FAILED};
     LibXR::Thread wait_thread;
-    wait_thread.Create<WaitContext*>(&ctx, WaitForSyncSubscriber, "msg_sync_wait",
-                                     1024, LibXR::Thread::Priority::MEDIUM);
+    wait_thread.Create<WaitContext*>(&ctx, WaitForSyncSubscriber, "msg_sync_wait", 1024,
+                                     LibXR::Thread::Priority::MEDIUM);
 
     for (uint32_t i = 0;
-         i < 1000000 &&
-         suber.block_->data_.wait_state.load(std::memory_order_acquire) !=
-             LibXR::Topic::SyncBlock::WAITING;
+         i < 1000000 && suber.block_->data_.wait_state.load(std::memory_order_acquire) !=
+                            LibXR::Topic::SyncBlock::WAITING;
          i++)
     {
       LibXR::Thread::Yield();
@@ -112,11 +127,7 @@ void TestSyncSubscriberFreshWait()
            LibXR::Topic::SyncBlock::WAITING);
     ASSERT(suber.Wait(0) == LibXR::ErrorCode::BUSY);
     publish();
-    for (uint32_t i = 0; i < 1000000 && ctx.result != LibXR::ErrorCode::OK; i++)
-    {
-      LibXR::Thread::Yield();
-    }
-    LibXR::Thread::Sleep(1);
+    ASSERT(wait_thread.Join() == LibXR::ErrorCode::OK);
     ASSERT(ctx.result == LibXR::ErrorCode::OK);
   };
 
@@ -145,9 +156,11 @@ void TestSyncSubscriberFreshWait()
 }  // namespace
 
 /**
- * @brief 测试入口函数 `test_message_runtime`。 Test entry function `test_message_runtime`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_message_runtime`。 Test entry function
+ * `test_message_runtime`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_message_runtime()
 {

--- a/test/runtime/system/test_async.cpp
+++ b/test/runtime/system/test_async.cpp
@@ -3,15 +3,11 @@
  * @brief runtime `ASync` worker 生命周期测试。 Runtime `ASync` worker lifecycle tests.
  *
  * 测试项目 / Test items:
- * 1. job 分配的状态机。 Job assignment lifecycle: verify the worker transitions through
- * `READY -> BUSY -> DONE -> READY` on repeated assignments.
- * 2. job 执行后的副作用。 Job execution side effect: verify the bound job actually runs
- * and mutates the target state once per assignment.
+ * 1. job 分配的状态机。 Job assignment lifecycle: verify the worker transitions through `READY -> BUSY -> DONE -> READY` on repeated assignments.
+ * 2. job 执行后的副作用。 Job execution side effect: verify the bound job actually runs and mutates the target state once per assignment.
  *
  * 测试原理 / Test principles:
- * 1. 围绕真实 worker thread 观察公开状态机，因为这里的正确性首先是调度和生命周期语义。
- * Observe the public status machine around a real worker thread, because runtime
- * correctness here is primarily scheduling/lifecycle semantics.
+ * 1. 围绕真实 worker thread 观察公开状态机，因为这里的正确性首先是调度和生命周期语义。 Observe the public status machine around a real worker thread, because runtime correctness here is primarily scheduling/lifecycle semantics.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -19,9 +15,8 @@
 
 /**
  * @brief 测试入口函数 `test_async`。 Test entry function `test_async`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
- * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
- * Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
+ *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
  */
 void test_async()
 {
@@ -42,18 +37,12 @@ void test_async()
   for (int i = 0; i < 10; i++)
   {
     ASSERT(async.GetStatus() == LibXR::ASync::Status::READY);
-    ASSERT(async_arg == i);
     async.AssignJob(async_cb);
 
+    ASSERT(async_arg == i);
     ASSERT(async.GetStatus() == LibXR::ASync::Status::BUSY);
-    const uint32_t wait_start = LibXR::Thread::GetTime();
-    while (async.status_.load(std::memory_order_acquire) != LibXR::ASync::Status::DONE &&
-           LibXR::Thread::GetTime() - wait_start < 1000U)
-    {
-      LibXR::Thread::Yield();
-    }
+    LibXR::Thread::Sleep(20);
 
-    ASSERT(async.status_.load(std::memory_order_acquire) == LibXR::ASync::Status::DONE);
     ASSERT(async_arg == i + 1);
     ASSERT(async.GetStatus() == LibXR::ASync::Status::DONE);
     ASSERT(async.GetStatus() == LibXR::ASync::Status::READY);

--- a/test/runtime/system/test_async.cpp
+++ b/test/runtime/system/test_async.cpp
@@ -13,9 +13,6 @@
  * Observe the public status machine around a real worker thread, because runtime
  * correctness here is primarily scheduling/lifecycle semantics.
  */
-#include <cstddef>
-#include <new>
-
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
@@ -41,28 +38,24 @@ void test_async()
       },
       &async_arg);
 
-  // ASync has a permanent worker, so the test instance must not register an exit-time
-  // destructor.
-  alignas(LibXR::ASync) static std::byte async_storage[sizeof(LibXR::ASync)];
-  static LibXR::ASync* async =
-      new (async_storage) LibXR::ASync(512, LibXR::Thread::Priority::REALTIME);
+  static LibXR::ASync async(512, LibXR::Thread::Priority::REALTIME);
   for (int i = 0; i < 10; i++)
   {
-    ASSERT(async->GetStatus() == LibXR::ASync::Status::READY);
+    ASSERT(async.GetStatus() == LibXR::ASync::Status::READY);
     ASSERT(async_arg == i);
-    async->AssignJob(async_cb);
+    async.AssignJob(async_cb);
 
-    ASSERT(async->GetStatus() == LibXR::ASync::Status::BUSY);
+    ASSERT(async.GetStatus() == LibXR::ASync::Status::BUSY);
     const uint32_t wait_start = LibXR::Thread::GetTime();
-    while (async->status_.load(std::memory_order_acquire) != LibXR::ASync::Status::DONE &&
+    while (async.status_.load(std::memory_order_acquire) != LibXR::ASync::Status::DONE &&
            LibXR::Thread::GetTime() - wait_start < 1000U)
     {
       LibXR::Thread::Yield();
     }
 
-    ASSERT(async->status_.load(std::memory_order_acquire) == LibXR::ASync::Status::DONE);
+    ASSERT(async.status_.load(std::memory_order_acquire) == LibXR::ASync::Status::DONE);
     ASSERT(async_arg == i + 1);
-    ASSERT(async->GetStatus() == LibXR::ASync::Status::DONE);
-    ASSERT(async->GetStatus() == LibXR::ASync::Status::READY);
+    ASSERT(async.GetStatus() == LibXR::ASync::Status::DONE);
+    ASSERT(async.GetStatus() == LibXR::ASync::Status::READY);
   }
 }

--- a/test/runtime/system/test_async.cpp
+++ b/test/runtime/system/test_async.cpp
@@ -3,11 +3,15 @@
  * @brief runtime `ASync` worker 生命周期测试。 Runtime `ASync` worker lifecycle tests.
  *
  * 测试项目 / Test items:
- * 1. job 分配的状态机。 Job assignment lifecycle: verify the worker transitions through `READY -> BUSY -> DONE -> READY` on repeated assignments.
- * 2. job 执行后的副作用。 Job execution side effect: verify the bound job actually runs and mutates the target state once per assignment.
+ * 1. job 分配的状态机。 Job assignment lifecycle: verify the worker transitions through
+ * `READY -> BUSY -> DONE -> READY` on repeated assignments.
+ * 2. job 执行后的副作用。 Job execution side effect: verify the bound job actually runs
+ * and mutates the target state once per assignment.
  *
  * 测试原理 / Test principles:
- * 1. 围绕真实 worker thread 观察公开状态机，因为这里的正确性首先是调度和生命周期语义。 Observe the public status machine around a real worker thread, because runtime correctness here is primarily scheduling/lifecycle semantics.
+ * 1. 围绕真实 worker thread 观察公开状态机，因为这里的正确性首先是调度和生命周期语义。
+ * Observe the public status machine around a real worker thread, because runtime
+ * correctness here is primarily scheduling/lifecycle semantics.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -15,8 +19,9 @@
 
 /**
  * @brief 测试入口函数 `test_async`。 Test entry function `test_async`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_async()
 {
@@ -37,12 +42,18 @@ void test_async()
   for (int i = 0; i < 10; i++)
   {
     ASSERT(async.GetStatus() == LibXR::ASync::Status::READY);
+    ASSERT(async_arg == i);
     async.AssignJob(async_cb);
 
-    ASSERT(async_arg == i);
     ASSERT(async.GetStatus() == LibXR::ASync::Status::BUSY);
-    LibXR::Thread::Sleep(20);
+    const uint32_t wait_start = LibXR::Thread::GetTime();
+    while (async.status_.load(std::memory_order_acquire) != LibXR::ASync::Status::DONE &&
+           LibXR::Thread::GetTime() - wait_start < 1000U)
+    {
+      LibXR::Thread::Yield();
+    }
 
+    ASSERT(async.status_.load(std::memory_order_acquire) == LibXR::ASync::Status::DONE);
     ASSERT(async_arg == i + 1);
     ASSERT(async.GetStatus() == LibXR::ASync::Status::DONE);
     ASSERT(async.GetStatus() == LibXR::ASync::Status::READY);

--- a/test/runtime/system/test_async.cpp
+++ b/test/runtime/system/test_async.cpp
@@ -13,6 +13,9 @@
  * Observe the public status machine around a real worker thread, because runtime
  * correctness here is primarily scheduling/lifecycle semantics.
  */
+#include <cstddef>
+#include <new>
+
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
@@ -38,24 +41,28 @@ void test_async()
       },
       &async_arg);
 
-  static LibXR::ASync async(512, LibXR::Thread::Priority::REALTIME);
+  // ASync has a permanent worker, so the test instance must not register an exit-time
+  // destructor.
+  alignas(LibXR::ASync) static std::byte async_storage[sizeof(LibXR::ASync)];
+  static LibXR::ASync* async =
+      new (async_storage) LibXR::ASync(512, LibXR::Thread::Priority::REALTIME);
   for (int i = 0; i < 10; i++)
   {
-    ASSERT(async.GetStatus() == LibXR::ASync::Status::READY);
+    ASSERT(async->GetStatus() == LibXR::ASync::Status::READY);
     ASSERT(async_arg == i);
-    async.AssignJob(async_cb);
+    async->AssignJob(async_cb);
 
-    ASSERT(async.GetStatus() == LibXR::ASync::Status::BUSY);
+    ASSERT(async->GetStatus() == LibXR::ASync::Status::BUSY);
     const uint32_t wait_start = LibXR::Thread::GetTime();
-    while (async.status_.load(std::memory_order_acquire) != LibXR::ASync::Status::DONE &&
+    while (async->status_.load(std::memory_order_acquire) != LibXR::ASync::Status::DONE &&
            LibXR::Thread::GetTime() - wait_start < 1000U)
     {
       LibXR::Thread::Yield();
     }
 
-    ASSERT(async.status_.load(std::memory_order_acquire) == LibXR::ASync::Status::DONE);
+    ASSERT(async->status_.load(std::memory_order_acquire) == LibXR::ASync::Status::DONE);
     ASSERT(async_arg == i + 1);
-    ASSERT(async.GetStatus() == LibXR::ASync::Status::DONE);
-    ASSERT(async.GetStatus() == LibXR::ASync::Status::READY);
+    ASSERT(async->GetStatus() == LibXR::ASync::Status::DONE);
+    ASSERT(async->GetStatus() == LibXR::ASync::Status::READY);
   }
 }

--- a/test/runtime/system/test_async.cpp
+++ b/test/runtime/system/test_async.cpp
@@ -9,6 +9,9 @@
  * 测试原理 / Test principles:
  * 1. 围绕真实 worker thread 观察公开状态机，因为这里的正确性首先是调度和生命周期语义。 Observe the public status machine around a real worker thread, because runtime correctness here is primarily scheduling/lifecycle semantics.
  */
+#include <cstddef>
+#include <new>
+
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "test.hpp"
@@ -33,18 +36,27 @@ void test_async()
       },
       &async_arg);
 
-  static LibXR::ASync async(512, LibXR::Thread::Priority::REALTIME);
+  // ASync has a permanent worker, so the test instance must not register an exit-time destructor.
+  alignas(LibXR::ASync) static std::byte async_storage[sizeof(LibXR::ASync)];
+  static LibXR::ASync* async =
+      new (async_storage) LibXR::ASync(512, LibXR::Thread::Priority::REALTIME);
   for (int i = 0; i < 10; i++)
   {
-    ASSERT(async.GetStatus() == LibXR::ASync::Status::READY);
-    async.AssignJob(async_cb);
-
+    ASSERT(async->GetStatus() == LibXR::ASync::Status::READY);
     ASSERT(async_arg == i);
-    ASSERT(async.GetStatus() == LibXR::ASync::Status::BUSY);
-    LibXR::Thread::Sleep(20);
+    async->AssignJob(async_cb);
 
+    ASSERT(async->GetStatus() == LibXR::ASync::Status::BUSY);
+    const uint32_t wait_start = LibXR::Thread::GetTime();
+    while (async->status_.load(std::memory_order_acquire) != LibXR::ASync::Status::DONE &&
+           LibXR::Thread::GetTime() - wait_start < 1000U)
+    {
+      LibXR::Thread::Yield();
+    }
+
+    ASSERT(async->status_.load(std::memory_order_acquire) == LibXR::ASync::Status::DONE);
     ASSERT(async_arg == i + 1);
-    ASSERT(async.GetStatus() == LibXR::ASync::Status::DONE);
-    ASSERT(async.GetStatus() == LibXR::ASync::Status::READY);
+    ASSERT(async->GetStatus() == LibXR::ASync::Status::DONE);
+    ASSERT(async->GetStatus() == LibXR::ASync::Status::READY);
   }
 }

--- a/test/runtime/system/test_mutex.cpp
+++ b/test/runtime/system/test_mutex.cpp
@@ -1,20 +1,14 @@
 /**
  * @file test_mutex.cpp
- * @brief runtime mutex 加锁、try-lock 与 waiter handoff 测试。 Runtime mutex lock,
- * try-lock and waiter handoff tests.
+ * @brief runtime mutex 加锁、try-lock 与 waiter handoff 测试。 Runtime mutex lock, try-lock and waiter handoff tests.
  *
  * 测试项目 / Test items:
- * 1. 立即加锁与 `TryLock()` busy 返回。 Immediate lock semantics: verify `Lock()`
- * succeeds and `TryLock()` reports `BUSY` while held.
- * 2. 阻塞 waiter 的所有权交接。 Waiter handoff: verify a blocked runtime thread acquires
- * the mutex only after the owner unlocks it.
- * 3. 交接后的再次复用。 Post-handoff reuse: verify `TryLock()` succeeds again after the
- * waiter completes.
+ * 1. 立即加锁与 `TryLock()` busy 返回。 Immediate lock semantics: verify `Lock()` succeeds and `TryLock()` reports `BUSY` while held.
+ * 2. 阻塞 waiter 的所有权交接。 Waiter handoff: verify a blocked runtime thread acquires the mutex only after the owner unlocks it.
+ * 3. 交接后的再次复用。 Post-handoff reuse: verify `TryLock()` succeeds again after the waiter completes.
  *
  * 测试原理 / Test principles:
- * 1. 使用真实 waiter 线程和完成信号量，让所有权交接在 runtime 同步路径上被验证。 Use a
- * real waiter thread and a completion semaphore so ownership transfer is checked on the
- * runtime synchronization path itself.
+ * 1. 使用真实 waiter 线程和完成信号量，让所有权交接在 runtime 同步路径上被验证。 Use a real waiter thread and a completion semaphore so ownership transfer is checked on the runtime synchronization path itself.
  */
 #include <atomic>
 
@@ -33,11 +27,8 @@ struct MutexAcquireContext
 
 /**
  * @brief 辅助函数 `AcquireMutex`。 Helper function `AcquireMutex`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
- * measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
- * repeated helper logic locally so the main test body stays focused on the test item
- * itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
  */
 void AcquireMutex(MutexAcquireContext* ctx)
 {
@@ -51,9 +42,8 @@ void AcquireMutex(MutexAcquireContext* ctx)
 
 /**
  * @brief 测试入口函数 `test_mutex`。 Test entry function `test_mutex`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
- * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
- * Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
+ *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
  */
 void test_mutex()
 {
@@ -69,7 +59,7 @@ void test_mutex()
 
   MutexAcquireContext ctx = {&mutex, &acquired, &done};
   waiter.Create<MutexAcquireContext*>(&ctx, AcquireMutex, "mutex_waiter", 1024,
-                                      LibXR::Thread::Priority::MEDIUM);
+                                     LibXR::Thread::Priority::MEDIUM);
 
   LibXR::Thread::Sleep(20);
   ASSERT(!acquired.load(std::memory_order_acquire));
@@ -77,7 +67,7 @@ void test_mutex()
   mutex.Unlock();
 
   ASSERT(done.Wait(500) == LibXR::ErrorCode::OK);
-  ASSERT(waiter.Join() == LibXR::ErrorCode::OK);
+  LibXR::Thread::Sleep(1);
   ASSERT(acquired.load(std::memory_order_acquire));
 
   ASSERT(mutex.TryLock() == LibXR::ErrorCode::OK);

--- a/test/runtime/system/test_mutex.cpp
+++ b/test/runtime/system/test_mutex.cpp
@@ -1,14 +1,20 @@
 /**
  * @file test_mutex.cpp
- * @brief runtime mutex 加锁、try-lock 与 waiter handoff 测试。 Runtime mutex lock, try-lock and waiter handoff tests.
+ * @brief runtime mutex 加锁、try-lock 与 waiter handoff 测试。 Runtime mutex lock,
+ * try-lock and waiter handoff tests.
  *
  * 测试项目 / Test items:
- * 1. 立即加锁与 `TryLock()` busy 返回。 Immediate lock semantics: verify `Lock()` succeeds and `TryLock()` reports `BUSY` while held.
- * 2. 阻塞 waiter 的所有权交接。 Waiter handoff: verify a blocked runtime thread acquires the mutex only after the owner unlocks it.
- * 3. 交接后的再次复用。 Post-handoff reuse: verify `TryLock()` succeeds again after the waiter completes.
+ * 1. 立即加锁与 `TryLock()` busy 返回。 Immediate lock semantics: verify `Lock()`
+ * succeeds and `TryLock()` reports `BUSY` while held.
+ * 2. 阻塞 waiter 的所有权交接。 Waiter handoff: verify a blocked runtime thread acquires
+ * the mutex only after the owner unlocks it.
+ * 3. 交接后的再次复用。 Post-handoff reuse: verify `TryLock()` succeeds again after the
+ * waiter completes.
  *
  * 测试原理 / Test principles:
- * 1. 使用真实 waiter 线程和完成信号量，让所有权交接在 runtime 同步路径上被验证。 Use a real waiter thread and a completion semaphore so ownership transfer is checked on the runtime synchronization path itself.
+ * 1. 使用真实 waiter 线程和完成信号量，让所有权交接在 runtime 同步路径上被验证。 Use a
+ * real waiter thread and a completion semaphore so ownership transfer is checked on the
+ * runtime synchronization path itself.
  */
 #include <atomic>
 
@@ -27,8 +33,11 @@ struct MutexAcquireContext
 
 /**
  * @brief 辅助函数 `AcquireMutex`。 Helper function `AcquireMutex`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void AcquireMutex(MutexAcquireContext* ctx)
 {
@@ -42,8 +51,9 @@ void AcquireMutex(MutexAcquireContext* ctx)
 
 /**
  * @brief 测试入口函数 `test_mutex`。 Test entry function `test_mutex`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_mutex()
 {
@@ -59,7 +69,7 @@ void test_mutex()
 
   MutexAcquireContext ctx = {&mutex, &acquired, &done};
   waiter.Create<MutexAcquireContext*>(&ctx, AcquireMutex, "mutex_waiter", 1024,
-                                     LibXR::Thread::Priority::MEDIUM);
+                                      LibXR::Thread::Priority::MEDIUM);
 
   LibXR::Thread::Sleep(20);
   ASSERT(!acquired.load(std::memory_order_acquire));
@@ -67,7 +77,7 @@ void test_mutex()
   mutex.Unlock();
 
   ASSERT(done.Wait(500) == LibXR::ErrorCode::OK);
-  LibXR::Thread::Sleep(1);
+  ASSERT(waiter.Join() == LibXR::ErrorCode::OK);
   ASSERT(acquired.load(std::memory_order_acquire));
 
   ASSERT(mutex.TryLock() == LibXR::ErrorCode::OK);

--- a/test/runtime/system/test_mutex.cpp
+++ b/test/runtime/system/test_mutex.cpp
@@ -67,7 +67,7 @@ void test_mutex()
   mutex.Unlock();
 
   ASSERT(done.Wait(500) == LibXR::ErrorCode::OK);
-  LibXR::Thread::Sleep(1);
+  ASSERT(waiter.Join() == LibXR::ErrorCode::OK);
   ASSERT(acquired.load(std::memory_order_acquire));
 
   ASSERT(mutex.TryLock() == LibXR::ErrorCode::OK);

--- a/test/runtime/system/test_semaphore.cpp
+++ b/test/runtime/system/test_semaphore.cpp
@@ -3,15 +3,11 @@
  * @brief runtime semaphore post/wait 测试。 Runtime semaphore post/wait tests.
  *
  * 测试项目 / Test items:
- * 1. 空信号量立即超时与预先 post 的缓存令牌。 Immediate timeout and queued posts: verify
- * zero-time waits time out on empty state and consume pre-posted counts correctly.
- * 2. 延迟 post 对阻塞 wait 的唤醒。 Delayed post wakeup: verify a runtime thread can wake
- * a blocking wait by posting later.
+ * 1. 空信号量立即超时与预先 post 的缓存令牌。 Immediate timeout and queued posts: verify zero-time waits time out on empty state and consume pre-posted counts correctly.
+ * 2. 延迟 post 对阻塞 wait 的唤醒。 Delayed post wakeup: verify a runtime thread can wake a blocking wait by posting later.
  *
  * 测试原理 / Test principles:
- * 1. 同时检查缓存计数和运行时唤醒，因为 semaphore 契约同时覆盖两种模式。 Check both
- * preloaded counts and delayed runtime wakeup, because the semaphore contract spans
- * cached tokens and blocking synchronization.
+ * 1. 同时检查缓存计数和运行时唤醒，因为 semaphore 契约同时覆盖两种模式。 Check both preloaded counts and delayed runtime wakeup, because the semaphore contract spans cached tokens and blocking synchronization.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -19,9 +15,8 @@
 
 /**
  * @brief 测试入口函数 `test_semaphore`。 Test entry function `test_semaphore`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
- * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
- * Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
+ *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
  */
 void test_semaphore()
 {
@@ -49,5 +44,5 @@ void test_semaphore()
       "semaphore_thread", 512, LibXR::Thread::Priority::REALTIME);
 
   ASSERT(sem.Wait(200) == LibXR::ErrorCode::OK);
-  ASSERT(thread.Join() == LibXR::ErrorCode::OK);
+  LibXR::Thread::Sleep(1);
 }

--- a/test/runtime/system/test_semaphore.cpp
+++ b/test/runtime/system/test_semaphore.cpp
@@ -44,5 +44,5 @@ void test_semaphore()
       "semaphore_thread", 512, LibXR::Thread::Priority::REALTIME);
 
   ASSERT(sem.Wait(200) == LibXR::ErrorCode::OK);
-  LibXR::Thread::Sleep(1);
+  ASSERT(thread.Join() == LibXR::ErrorCode::OK);
 }

--- a/test/runtime/system/test_semaphore.cpp
+++ b/test/runtime/system/test_semaphore.cpp
@@ -3,11 +3,15 @@
  * @brief runtime semaphore post/wait 测试。 Runtime semaphore post/wait tests.
  *
  * 测试项目 / Test items:
- * 1. 空信号量立即超时与预先 post 的缓存令牌。 Immediate timeout and queued posts: verify zero-time waits time out on empty state and consume pre-posted counts correctly.
- * 2. 延迟 post 对阻塞 wait 的唤醒。 Delayed post wakeup: verify a runtime thread can wake a blocking wait by posting later.
+ * 1. 空信号量立即超时与预先 post 的缓存令牌。 Immediate timeout and queued posts: verify
+ * zero-time waits time out on empty state and consume pre-posted counts correctly.
+ * 2. 延迟 post 对阻塞 wait 的唤醒。 Delayed post wakeup: verify a runtime thread can wake
+ * a blocking wait by posting later.
  *
  * 测试原理 / Test principles:
- * 1. 同时检查缓存计数和运行时唤醒，因为 semaphore 契约同时覆盖两种模式。 Check both preloaded counts and delayed runtime wakeup, because the semaphore contract spans cached tokens and blocking synchronization.
+ * 1. 同时检查缓存计数和运行时唤醒，因为 semaphore 契约同时覆盖两种模式。 Check both
+ * preloaded counts and delayed runtime wakeup, because the semaphore contract spans
+ * cached tokens and blocking synchronization.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -15,8 +19,9 @@
 
 /**
  * @brief 测试入口函数 `test_semaphore`。 Test entry function `test_semaphore`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_semaphore()
 {
@@ -44,5 +49,5 @@ void test_semaphore()
       "semaphore_thread", 512, LibXR::Thread::Priority::REALTIME);
 
   ASSERT(sem.Wait(200) == LibXR::ErrorCode::OK);
-  LibXR::Thread::Sleep(1);
+  ASSERT(thread.Join() == LibXR::ErrorCode::OK);
 }

--- a/test/runtime/system/test_thread.cpp
+++ b/test/runtime/system/test_thread.cpp
@@ -1,20 +1,14 @@
 /**
  * @file test_thread.cpp
- * @brief runtime thread 创建与 sleep 原语测试。 Runtime thread creation and sleep
- * primitive tests.
+ * @brief runtime thread 创建与 sleep 原语测试。 Runtime thread creation and sleep primitive tests.
  *
  * 测试项目 / Test items:
- * 1. 线程创建后的信号唤醒。 Thread creation/wakeup: verify a created runtime thread can
- * signal completion through a semaphore.
- * 2. 相对睡眠 `Sleep()`。 Relative sleep: verify `Thread::Sleep()` waits for
- * approximately the requested duration.
- * 3. 周期性 `SleepUntil()`。 Periodic sleep-until: verify `SleepUntil()` advances wakeups
- * monotonically across successive periods.
+ * 1. 线程创建后的信号唤醒。 Thread creation/wakeup: verify a created runtime thread can signal completion through a semaphore.
+ * 2. 相对睡眠 `Sleep()`。 Relative sleep: verify `Thread::Sleep()` waits for approximately the requested duration.
+ * 3. 周期性 `SleepUntil()`。 Periodic sleep-until: verify `SleepUntil()` advances wakeups monotonically across successive periods.
  *
  * 测试原理 / Test principles:
- * 1. 只通过 LibXR 时间 API 观察线程睡眠与周期唤醒语义，避免测试体依赖宿主平台调用。
- * Observe sleep and periodic wakeup semantics only through LibXR time APIs, so the test
- * body does not depend on host platform calls.
+ * 1. 只通过 LibXR 时间 API 观察线程睡眠与周期唤醒语义，避免测试体依赖宿主平台调用。 Observe sleep and periodic wakeup semantics only through LibXR time APIs, so the test body does not depend on host platform calls.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -22,9 +16,8 @@
 
 /**
  * @brief 测试入口函数 `test_thread`。 Test entry function `test_thread`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
- * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
- * Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
+ *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
  */
 void test_thread()
 {
@@ -45,7 +38,7 @@ void test_thread()
       "test_task", 512, LibXR::Thread::Priority::REALTIME);
 
   ASSERT(sem.Wait(200) == LibXR::ErrorCode::OK);
-  ASSERT(thread.Join() == LibXR::ErrorCode::OK);
+  LibXR::Thread::Sleep(1);
 
   const uint32_t sleep_start_ms = LibXR::Thread::GetTime();
   LibXR::Thread::Sleep(20);

--- a/test/runtime/system/test_thread.cpp
+++ b/test/runtime/system/test_thread.cpp
@@ -38,7 +38,7 @@ void test_thread()
       "test_task", 512, LibXR::Thread::Priority::REALTIME);
 
   ASSERT(sem.Wait(200) == LibXR::ErrorCode::OK);
-  LibXR::Thread::Sleep(1);
+  ASSERT(thread.Join() == LibXR::ErrorCode::OK);
 
   const uint32_t sleep_start_ms = LibXR::Thread::GetTime();
   LibXR::Thread::Sleep(20);

--- a/test/runtime/system/test_thread.cpp
+++ b/test/runtime/system/test_thread.cpp
@@ -1,14 +1,20 @@
 /**
  * @file test_thread.cpp
- * @brief runtime thread 创建与 sleep 原语测试。 Runtime thread creation and sleep primitive tests.
+ * @brief runtime thread 创建与 sleep 原语测试。 Runtime thread creation and sleep
+ * primitive tests.
  *
  * 测试项目 / Test items:
- * 1. 线程创建后的信号唤醒。 Thread creation/wakeup: verify a created runtime thread can signal completion through a semaphore.
- * 2. 相对睡眠 `Sleep()`。 Relative sleep: verify `Thread::Sleep()` waits for approximately the requested duration.
- * 3. 周期性 `SleepUntil()`。 Periodic sleep-until: verify `SleepUntil()` advances wakeups monotonically across successive periods.
+ * 1. 线程创建后的信号唤醒。 Thread creation/wakeup: verify a created runtime thread can
+ * signal completion through a semaphore.
+ * 2. 相对睡眠 `Sleep()`。 Relative sleep: verify `Thread::Sleep()` waits for
+ * approximately the requested duration.
+ * 3. 周期性 `SleepUntil()`。 Periodic sleep-until: verify `SleepUntil()` advances wakeups
+ * monotonically across successive periods.
  *
  * 测试原理 / Test principles:
- * 1. 只通过 LibXR 时间 API 观察线程睡眠与周期唤醒语义，避免测试体依赖宿主平台调用。 Observe sleep and periodic wakeup semantics only through LibXR time APIs, so the test body does not depend on host platform calls.
+ * 1. 只通过 LibXR 时间 API 观察线程睡眠与周期唤醒语义，避免测试体依赖宿主平台调用。
+ * Observe sleep and periodic wakeup semantics only through LibXR time APIs, so the test
+ * body does not depend on host platform calls.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -16,8 +22,9 @@
 
 /**
  * @brief 测试入口函数 `test_thread`。 Test entry function `test_thread`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_thread()
 {
@@ -38,7 +45,7 @@ void test_thread()
       "test_task", 512, LibXR::Thread::Priority::REALTIME);
 
   ASSERT(sem.Wait(200) == LibXR::ErrorCode::OK);
-  LibXR::Thread::Sleep(1);
+  ASSERT(thread.Join() == LibXR::ErrorCode::OK);
 
   const uint32_t sleep_start_ms = LibXR::Thread::GetTime();
   LibXR::Thread::Sleep(20);


### PR DESCRIPTION
## Summary

- prevent bounded character arrays from selecting the `strlen()` RawData constructor path
- add POSIX `Thread::Join()` for Linux and Webots
- join every finite host test worker before its stack-backed context is destroyed
- publish ASync completion with release/acquire ordering and remove racy test polling
- keep the test ASync instance in process-lifetime storage because its worker has no shutdown path

## Verification

- clean Docker build from current `master` passed
- normal host tests pass `type`, `thread`, `semaphore`, `mutex`, `async`, SPSC/MPMC, and `message_runtime`
- ASAN no longer reports the `test_type` non-NUL array overflow
- TSAN reports zero thread leaks and no stale `mutex_waiter`, finite RW worker, or false `SerializedService` stack-reuse report
- Webots `thread.cpp` compiles with the controller SDK headers
- clang-format 21.1.8 and `git diff --check` pass

## Out of scope

Existing `terminal_input` failure and remaining Topic/CRC/Timer/STDIO TSAN reports are independent follow-up work.

## Summary by Sourcery

在宿主侧收紧数据清理和线程语义，以消除运行时测试和基础设施中的生命周期空隙和数据竞争。

Bug Fixes（错误修复）:
- 确保 `RawData` 和 `ConstRawData` 构造函数能正确处理有界字符数组，而不会错误地将其归类为 C 字符串，从而防止在测试中出现非 NUL 的溢出。
- 在 Linux 和 Webots 上添加显式的 POSIX `Thread::Join` 支持，并更新运行时测试，在栈托管上下文被销毁之前先加入（join）工作线程，消除线程泄漏和过期的等待者报告。
- 通过使用 release/acquire 排序来强化 ASync 工作线程状态的发布，并用有界的、同步的状态检查替换存在竞争的基于 sleep 的轮询。

Enhancements（增强）:
- 为测试用的 ASync 实例使用进程生命周期级别的存储，以匹配其永久工作线程模型，避免不安全的关闭路径。
- 改进运行时队列、互斥量、信号量和线程测试，使其依赖显式 join 和更清晰的同步语义，以符合 sanitizer 的预期。

Tests（测试）:
- 更新 SPSC/MPMC 队列、互斥量、信号量、线程和消息的运行时测试，以在所有有限的工作线程上执行 join，并使用更严格的状态/等待断言，消除 sanitizer 报告的泄漏和数据竞争。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten host-side sanitization and threading semantics to eliminate lifetime gaps and data races in runtime tests and infrastructure.

Bug Fixes:
- Ensure RawData and ConstRawData constructors correctly handle bounded char arrays without misclassifying them as C strings, preventing non-NUL overflow in tests.
- Add explicit POSIX Thread::Join support on Linux and Webots and update runtime tests to join worker threads before stack-backed contexts are destroyed, removing thread leaks and stale waiter reports.
- Strengthen ASync worker status publication with release/acquire ordering and replace racy sleep-based polling with bounded, synchronized status checks.

Enhancements:
- Use process-lifetime storage for the test ASync instance to match its permanent worker model and avoid unsafe shutdown paths.
- Improve runtime queue, mutex, semaphore, and thread tests to rely on explicit joins and clearer synchronization semantics, aligning with sanitizer expectations.

Tests:
- Update SPSC/MPMC queue, mutex, semaphore, thread, and message runtime tests to join all finite worker threads and use stricter status/wait assertions, eliminating sanitizer-reported leaks and races.

</details>