### PR TITLE
style: establish full C++ format baseline

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -38,7 +38,7 @@ jobs:
     - name: check clang-format via script
       shell: bash
       run: |
-        tools/format_driver_src.sh --check
+        tools/format_cpp_files.sh --check
 
   cmake-format:
 

--- a/driver/ch/ch32_usb_rcc.hpp
+++ b/driver/ch/ch32_usb_rcc.hpp
@@ -160,7 +160,8 @@ inline void ConfigureUsb48M()
   // 部分 CH32V30x 可以从 USBHS PHY PLL 提供共享 48 MHz USB 时钟；
   // 这种情况下先选 PHY 路径，再让各控制器自己打开总线时钟。
   // Some CH32V30x parts can source the shared 48 MHz USB clock from the USBHS PHY PLL;
-  // in that case, select the PHY path first and let each controller enable its own bus clock.
+  // in that case, select the PHY path first and let each controller enable its own bus
+  // clock.
   ConfigureUsbHsPhyFromHse();
   RCC_USBCLK48MConfig(RCC_USBCLK48MCLKSource_USBPHY);
 #else

--- a/driver/esp/esp32_nvs_flash_database.hpp
+++ b/driver/esp/esp32_nvs_flash_database.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include "esp_def.hpp"
-
 #include <cstring>
 
+#include "esp_def.hpp"
 #include "libxr.hpp"
 #include "libxr_def.hpp"
 #include "libxr_type.hpp"

--- a/driver/esp/esp_adc.hpp
+++ b/driver/esp/esp_adc.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "esp_def.hpp"
-
 #include <cstddef>
 #include <cstdint>
 
 #include "adc.hpp"
 #include "esp_adc/adc_cali.h"
 #include "esp_adc/adc_oneshot.h"
+#include "esp_def.hpp"
 #include "hal/adc_types.h"
 #include "soc/soc_caps.h"
 
@@ -50,10 +49,8 @@ class ESP32ADC
       adc_unit_t unit, const adc_channel_t* channels, uint8_t num_channels,
       uint32_t freq = SOC_ADC_SAMPLE_FREQ_THRES_LOW,
       adc_atten_t attenuation = ADC_ATTEN_DB_12,
-      adc_bitwidth_t bitwidth =
-          static_cast<adc_bitwidth_t>(SOC_ADC_DIGI_MAX_BITWIDTH),
+      adc_bitwidth_t bitwidth = static_cast<adc_bitwidth_t>(SOC_ADC_DIGI_MAX_BITWIDTH),
       float reference_voltage = 3.3f, size_t dma_buf_size = 256);
-
 
   Channel& GetChannel(uint8_t idx);
 

--- a/driver/esp/esp_cdc_jtag.hpp
+++ b/driver/esp/esp_cdc_jtag.hpp
@@ -1,18 +1,17 @@
 #pragma once
 
-#include "esp_def.hpp"
-
 #include <cstddef>
 #include <cstdint>
 
+#include "esp_def.hpp"
 #include "esp_intr_alloc.h"
 #include "esp_tx_double_buffer.hpp"
 #include "flag.hpp"
 #include "soc/soc_caps.h"
 #include "uart.hpp"
 
-#if SOC_USB_SERIAL_JTAG_SUPPORTED &&                                              \
-    ((defined(CONFIG_IDF_TARGET_ESP32C3) && CONFIG_IDF_TARGET_ESP32C3) ||         \
+#if SOC_USB_SERIAL_JTAG_SUPPORTED &&                                      \
+    ((defined(CONFIG_IDF_TARGET_ESP32C3) && CONFIG_IDF_TARGET_ESP32C3) || \
      (defined(CONFIG_IDF_TARGET_ESP32C6) && CONFIG_IDF_TARGET_ESP32C6))
 
 namespace LibXR
@@ -76,17 +75,19 @@ class ESP32CDCJtag : public UART
 
  public:
   /**
-   * @brief 构造并初始化 USB Serial/JTAG 后端状态 / Construct and initialize the USB Serial/JTAG backend state
+   * @brief 构造并初始化 USB Serial/JTAG 后端状态 / Construct and initialize the USB
+   * Serial/JTAG backend state
    *
    * @param rx_buffer_size RX 队列容量（字节） / RX queue capacity in bytes
-   * @param tx_buffer_size TX payload 半缓冲大小（字节） / TX payload half-buffer size in bytes
+   * @param tx_buffer_size TX payload 半缓冲大小（字节） / TX payload half-buffer size in
+   * bytes
    * @param tx_queue_size TX 请求队列深度 / Number of queued TX requests
    * @param config 初始 UART 帧格式配置 / Initial UART framing configuration
    */
-  explicit ESP32CDCJtag(
-      size_t rx_buffer_size = 1024, size_t tx_buffer_size = 512,
-      uint32_t tx_queue_size = 5,
-      UART::Configuration config = {115200, UART::Parity::NO_PARITY, 8, 1});
+  explicit ESP32CDCJtag(size_t rx_buffer_size = 1024, size_t tx_buffer_size = 512,
+                        uint32_t tx_queue_size = 5,
+                        UART::Configuration config = {115200, UART::Parity::NO_PARITY, 8,
+                                                      1});
 
   /**
    * @brief 应用 UART 帧格式配置 / Apply a UART framing configuration to the backend
@@ -99,7 +100,8 @@ class ESP32CDCJtag : public UART
   static ErrorCode WriteFun(WritePort& port, bool in_isr);
 
   /**
-   * @brief USB Serial/JTAG RX 路径的 ReadPort 入口 / ReadPort entry point for the USB Serial/JTAG RX path
+   * @brief USB Serial/JTAG RX 路径的 ReadPort 入口 / ReadPort entry point for the USB
+   * Serial/JTAG RX path
    */
   static ErrorCode ReadFun(ReadPort& port, bool in_isr);
 
@@ -110,7 +112,8 @@ class ESP32CDCJtag : public UART
   static void IsrEntry(void* arg);
 
   /**
-   * @brief 初始化 USB Serial/JTAG 中断和硬件状态 / Initialize the USB Serial/JTAG interrupt and hardware state
+   * @brief 初始化 USB Serial/JTAG 中断和硬件状态 / Initialize the USB Serial/JTAG
+   * interrupt and hardware state
    */
   ErrorCode InitHardware();
 
@@ -120,7 +123,8 @@ class ESP32CDCJtag : public UART
   void HandleInterrupt();
 
   /**
-   * @brief 尝试将硬件 RX FIFO 数据推进软件队列 / Try draining hardware RX FIFO into the software queue
+   * @brief 尝试将硬件 RX FIFO 数据推进软件队列 / Try draining hardware RX FIFO into the
+   * software queue
    */
   void DrainRxToQueue(bool in_isr);
 
@@ -140,12 +144,14 @@ class ESP32CDCJtag : public UART
   bool LoadPendingTxFromQueue(bool in_isr);
 
   /**
-   * @brief 硬件空闲时把 pending TX 提升为 active 状态 / Promote pending TX into active state if hardware is idle
+   * @brief 硬件空闲时把 pending TX 提升为 active 状态 / Promote pending TX into active
+   * state if hardware is idle
    */
   bool StartPendingTxIfIdle(bool in_isr);
 
   /**
-   * @brief 将一条排队的 TX payload 拷入选定 slot / Copy one queued TX payload into the selected slot
+   * @brief 将一条排队的 TX payload 拷入选定 slot / Copy one queued TX payload into the
+   * selected slot
    */
   bool DequeueTxToSlot(uint8_t* slot, size_t& size, WriteInfoBlock& info, bool in_isr);
 
@@ -155,7 +161,8 @@ class ESP32CDCJtag : public UART
   bool StartActiveTransfer(bool in_isr);
 
   /**
-   * @brief 启动 active TX 并上报队列所有权交接 / Start active TX and report queue ownership transfer
+   * @brief 启动 active TX 并上报队列所有权交接 / Start active TX and report queue
+   * ownership transfer
    */
   bool StartAndReportActive(bool in_isr);
 
@@ -194,8 +201,8 @@ class ESP32CDCJtag : public UART
    */
   void ResetTxState(bool in_isr);
 
-  UART::Configuration config_;  ///< Current UART framing configuration.
-  uint8_t* tx_slot_storage_ = nullptr;  ///< Backing storage for the TX helper.
+  UART::Configuration config_;           ///< Current UART framing configuration.
+  uint8_t* tx_slot_storage_ = nullptr;   ///< Backing storage for the TX helper.
   ESPTxDoubleBuffer tx_double_buffer_;   ///< TX helper for active/pending payloads.
   intr_handle_t intr_handle_ = nullptr;  ///< Registered interrupt handle.
   bool intr_installed_ = false;          ///< Whether the interrupt was installed.
@@ -204,8 +211,8 @@ class ESP32CDCJtag : public UART
   Flag::Atomic rx_draining_{};           ///< RX FIFO draining gate.
   Flag::Plain in_tx_isr_;                ///< Reentry guard while servicing TX IRQs.
 
-  ESP32CDCJtagReadPort _read_port;   ///< Read-side queue bridge exposed to `UART`.
-  WritePort _write_port; ///< Write-side queue bridge exposed to `UART`.
+  ESP32CDCJtagReadPort _read_port;  ///< Read-side queue bridge exposed to `UART`.
+  WritePort _write_port;            ///< Write-side queue bridge exposed to `UART`.
 };
 
 }  // namespace LibXR

--- a/driver/esp/esp_dac.hpp
+++ b/driver/esp/esp_dac.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
-#include "esp_def.hpp"
-
 #include <cstdint>
 
 #include "dac.hpp"
+#include "esp_def.hpp"
 #include "soc/soc_caps.h"
 
 #if SOC_DAC_SUPPORTED
@@ -40,7 +39,6 @@ class ESP32DAC : public DAC
     (void)init_voltage;
 #endif
   }
-
 
   ErrorCode Write(float voltage) override
   {

--- a/driver/esp/esp_def.hpp
+++ b/driver/esp/esp_def.hpp
@@ -3,8 +3,9 @@
 // Shared ESP driver definitions/header hygiene entry point.
 // Keep ESP-IDF/FreeRTOS integration quirks localized here so the
 // rest of the ESP driver headers can include one clean common header.
-#include "sdkconfig.h"
 #include <FreeRTOS.h>
+
+#include "sdkconfig.h"
 
 // Xtensa/FreeRTOS headers may expose INTERRUPT macro and collide with
 // Endpoint::Type::INTERRUPT in generic USB core headers.

--- a/driver/esp/esp_gpio.hpp
+++ b/driver/esp/esp_gpio.hpp
@@ -1,17 +1,13 @@
 #pragma once
 
-#include "esp_def.hpp"
-
 #include <cstdint>
 
 #include "driver/gpio.h"
+#include "esp_def.hpp"
 #include "gpio.hpp"
 #include "hal/gpio_hal.h"
 
-static inline gpio_dev_t* LibXREspGpioHw()
-{
-  return GPIO_HAL_GET_HW(0);
-}
+static inline gpio_dev_t* LibXREspGpioHw() { return GPIO_HAL_GET_HW(0); }
 
 namespace LibXR
 {
@@ -79,9 +75,9 @@ class ESP32GPIO : public GPIO
 
     if (!isr_handler_added_)
     {
-      if (gpio_isr_handler_add(gpio_num_, ESP32GPIO::InterruptDispatcher,
-                               reinterpret_cast<void*>(
-                                   static_cast<uintptr_t>(gpio_num_))) != ESP_OK)
+      if (gpio_isr_handler_add(
+              gpio_num_, ESP32GPIO::InterruptDispatcher,
+              reinterpret_cast<void*>(static_cast<uintptr_t>(gpio_num_))) != ESP_OK)
       {
         return ErrorCode::INIT_ERR;
       }

--- a/driver/esp/esp_i2c.hpp
+++ b/driver/esp/esp_i2c.hpp
@@ -1,12 +1,11 @@
 #pragma once
 
-#include "esp_def.hpp"
-
 #include <array>
 #include <cstddef>
 #include <cstdint>
 
 #include "driver/gpio.h"
+#include "esp_def.hpp"
 #include "esp_intr_alloc.h"
 #include "hal/i2c_hal.h"
 #include "hal/i2c_types.h"
@@ -22,10 +21,8 @@ class ESP32I2C : public I2C
  public:
   static constexpr int PIN_NO_CHANGE = -1;
 
-  ESP32I2C(i2c_port_t port_num, int scl_pin, int sda_pin,
-           uint32_t clock_speed = 400000U,
-           bool enable_internal_pullup = true,
-           uint32_t timeout_ms = 100U,
+  ESP32I2C(i2c_port_t port_num, int scl_pin, int sda_pin, uint32_t clock_speed = 400000U,
+           bool enable_internal_pullup = true, uint32_t timeout_ms = 100U,
            uint32_t isr_enable_min_size = 32U);
 
   ErrorCode Read(uint16_t slave_addr, RawData read_data, ReadOperation& op,
@@ -41,8 +38,8 @@ class ESP32I2C : public I2C
                     MemAddrLength mem_addr_size = MemAddrLength::BYTE_8,
                     bool in_isr = false) override;
 
-  ErrorCode MemWrite(uint16_t slave_addr, uint16_t mem_addr,
-                     ConstRawData write_data, WriteOperation& op,
+  ErrorCode MemWrite(uint16_t slave_addr, uint16_t mem_addr, ConstRawData write_data,
+                     WriteOperation& op,
                      MemAddrLength mem_addr_size = MemAddrLength::BYTE_8,
                      bool in_isr = false) override;
 
@@ -51,8 +48,7 @@ class ESP32I2C : public I2C
  private:
   static constexpr size_t FIFO_LEN = SOC_I2C_FIFO_LEN;
   static constexpr size_t MAX_WRITE_PAYLOAD = (FIFO_LEN > 4U) ? (FIFO_LEN - 4U) : 0U;
-  static constexpr size_t MAX_WRITE_READ_PREFIX =
-      (FIFO_LEN > 5U) ? (FIFO_LEN - 5U) : 0U;
+  static constexpr size_t MAX_WRITE_READ_PREFIX = (FIFO_LEN > 5U) ? (FIFO_LEN - 5U) : 0U;
   static constexpr size_t MAX_READ_PAYLOAD = (FIFO_LEN > 4U) ? (FIFO_LEN - 4U) : FIFO_LEN;
 
   bool Acquire();
@@ -72,10 +68,9 @@ class ESP32I2C : public I2C
                                size_t read_size);
   ErrorCode StartAsyncTransaction(uint16_t slave_addr,
                                   const uint8_t* write_prefix_payload,
-                                  size_t write_prefix_size,
-                                  const uint8_t* write_payload, size_t write_size,
-                                  uint8_t* read_payload, size_t read_size,
-                                  ReadOperation& op);
+                                  size_t write_prefix_size, const uint8_t* write_payload,
+                                  size_t write_size, uint8_t* read_payload,
+                                  size_t read_size, ReadOperation& op);
   ErrorCode KickAsyncTransaction();
   void FinishAsync(bool in_isr, ErrorCode ec);
   static bool IsValid7BitAddr(uint16_t addr);

--- a/driver/esp/esp_pwm.hpp
+++ b/driver/esp/esp_pwm.hpp
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "esp_def.hpp"
-
 #include "driver/ledc.h"
+#include "esp_def.hpp"
 #include "esp_err.h"
 #include "hal/ledc_hal.h"
 #include "pwm.hpp"
@@ -119,4 +118,3 @@ class ESP32PWM : public PWM
 };
 
 }  // namespace LibXR
-

--- a/driver/esp/esp_spi.hpp
+++ b/driver/esp/esp_spi.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "esp_def.hpp"
-
 #include <cstddef>
 #include <cstdint>
 
 #include "driver/gpio.h"
+#include "esp_def.hpp"
 #include "esp_intr_alloc.h"
 #include "flag.hpp"
 #include "hal/spi_ll.h"
@@ -19,17 +18,16 @@ namespace LibXR
 class ESP32SPI : public SPI
 {
  public:
-  ESP32SPI(
-      spi_host_device_t host, int sclk_pin, int miso_pin, int mosi_pin, RawData dma_rx,
-      RawData dma_tx,
-      SPI::Configuration config = {
-          SPI::ClockPolarity::LOW,
-          SPI::ClockPhase::EDGE_1,
-          SPI::Prescaler::DIV_8,
-          false,
-      },
-      uint32_t dma_enable_min_size = 3U, bool enable_dma = true);
-
+  ESP32SPI(spi_host_device_t host, int sclk_pin, int miso_pin, int mosi_pin,
+           RawData dma_rx, RawData dma_tx,
+           SPI::Configuration config =
+               {
+                   SPI::ClockPolarity::LOW,
+                   SPI::ClockPhase::EDGE_1,
+                   SPI::Prescaler::DIV_8,
+                   false,
+               },
+           uint32_t dma_enable_min_size = 3U, bool enable_dma = true);
 
   ErrorCode ReadAndWrite(RawData read_data, ConstRawData write_data, OperationRW& op,
                          bool in_isr = false) override;
@@ -62,16 +60,13 @@ class ESP32SPI : public SPI
 
   ErrorCode InitializeHardware();
 
-
   ErrorCode ConfigurePins();
 
   ErrorCode ResolveClockSource(uint32_t& source_hz);
 
   ErrorCode InstallInterrupt();
 
-
   ErrorCode InitDmaBackend();
-
 
   static void SpiIsrEntry(void* arg);
 
@@ -89,9 +84,9 @@ class ESP32SPI : public SPI
 
   ErrorCode ReturnAsyncStartResult(ErrorCode ec, bool started);
 
-  ErrorCode StartAsyncTransfer(const uint8_t* tx, uint8_t* rx, size_t size, bool enable_rx,
-                               RawData read_back, bool mem_read, OperationRW& op,
-                               bool& started);
+  ErrorCode StartAsyncTransfer(const uint8_t* tx, uint8_t* rx, size_t size,
+                               bool enable_rx, RawData read_back, bool mem_read,
+                               OperationRW& op, bool& started);
 
   void ConfigureTransferRegisters(size_t size);
 

--- a/driver/esp/esp_timebase.hpp
+++ b/driver/esp/esp_timebase.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "esp_def.hpp"
-
 #include "esp_timer.h"
 #include "soc/soc_caps.h"
 #if SOC_SYSTIMER_SUPPORTED

--- a/driver/esp/esp_tx_double_buffer.hpp
+++ b/driver/esp/esp_tx_double_buffer.hpp
@@ -2,6 +2,7 @@
 
 #include <cstddef>
 #include <cstdint>
+
 #include "double_buffer.hpp"
 #include "flag.hpp"
 #include "libxr_assert.hpp"
@@ -59,28 +60,19 @@ class ESPTxDoubleBuffer
    * @brief 获取当前 active payload 缓冲区指针。
    * @brief Return the current active payload buffer pointer.
    */
-  uint8_t* ActiveBuffer() const
-  {
-    return bytes_.ActiveBuffer();
-  }
+  uint8_t* ActiveBuffer() const { return bytes_.ActiveBuffer(); }
 
   /**
    * @brief 获取当前 pending payload 缓冲区指针。
    * @brief Return the current pending payload buffer pointer.
    */
-  uint8_t* PendingBuffer() const
-  {
-    return bytes_.PendingBuffer();
-  }
+  uint8_t* PendingBuffer() const { return bytes_.PendingBuffer(); }
 
   /**
    * @brief 获取单个半缓冲区大小。
    * @brief Return the size of one half-buffer.
    */
-  size_t BufferSize() const
-  {
-    return bytes_.Size();
-  }
+  size_t BufferSize() const { return bytes_.Size(); }
 
   /**
    * @brief 判断是否存在有效 active 请求。
@@ -223,14 +215,16 @@ class ESPTxDoubleBuffer
   }
 
  private:
-  DoubleBuffer bytes_{};          ///< payload 双缓冲对象。 Payload double-buffer object.
-  size_t active_length_ = 0U;    ///< active payload 长度。 Active payload length.
-  size_t pending_length_ = 0U;   ///< pending payload 长度。 Pending payload length.
-  size_t active_offset_ = 0U;    ///< active payload 已推进偏移。 Active progressed offset.
+  DoubleBuffer bytes_{};        ///< payload 双缓冲对象。 Payload double-buffer object.
+  size_t active_length_ = 0U;   ///< active payload 长度。 Active payload length.
+  size_t pending_length_ = 0U;  ///< pending payload 长度。 Pending payload length.
+  size_t active_offset_ = 0U;   ///< active payload 已推进偏移。 Active progressed offset.
   WriteInfoBlock active_info_ = {};   ///< active 请求元数据。 Active request metadata.
   WriteInfoBlock pending_info_ = {};  ///< pending 请求元数据。 Pending request metadata.
-  bool active_valid_ = false;         ///< active 请求是否有效。 Whether an active request is valid.
-  Flag::Atomic pending_valid_{};      ///< pending 请求是否有效。 Whether a pending request is valid.
+  bool active_valid_ =
+      false;  ///< active 请求是否有效。 Whether an active request is valid.
+  Flag::Atomic
+      pending_valid_{};  ///< pending 请求是否有效。 Whether a pending request is valid.
 };
 
 }  // namespace LibXR

--- a/driver/esp/esp_uart.hpp
+++ b/driver/esp/esp_uart.hpp
@@ -1,13 +1,12 @@
 #pragma once
 
-#include "esp_def.hpp"
-
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
 
-#include "driver/gpio.h"
 #include "double_buffer.hpp"
+#include "driver/gpio.h"
+#include "esp_def.hpp"
 #include "esp_intr_alloc.h"
 #include "flag.hpp"
 #include "hal/uart_hal.h"
@@ -84,10 +83,9 @@ class ESP32UART : public UART
    * @brief Create and initialize one ESP32 UART instance.
    * @brief 创建并初始化一个 ESP32 UART 实例。
    */
-  ESP32UART(uart_port_t uart_num, int tx_pin, int rx_pin,
-            int rts_pin = PIN_NO_CHANGE, int cts_pin = PIN_NO_CHANGE,
-            size_t rx_buffer_size = 1024, size_t tx_buffer_size = 512,
-            uint32_t tx_queue_size = 5,
+  ESP32UART(uart_port_t uart_num, int tx_pin, int rx_pin, int rts_pin = PIN_NO_CHANGE,
+            int cts_pin = PIN_NO_CHANGE, size_t rx_buffer_size = 1024,
+            size_t tx_buffer_size = 512, uint32_t tx_queue_size = 5,
             UART::Configuration config = {115200, UART::Parity::NO_PARITY, 8, 1},
             bool enable_dma = true);
 
@@ -158,32 +156,28 @@ class ESP32UART : public UART
    * @brief GDMA TX 完成回调。
    */
   static bool DmaTxEofCallback(gdma_channel_handle_t dma_chan,
-                               gdma_event_data_t* event_data,
-                               void* user_data);
+                               gdma_event_data_t* event_data, void* user_data);
 
   /**
    * @brief GDMA TX descriptor error callback.
    * @brief GDMA TX 描述符错误回调。
    */
   static bool DmaTxDescrErrCallback(gdma_channel_handle_t dma_chan,
-                                    gdma_event_data_t* event_data,
-                                    void* user_data);
+                                    gdma_event_data_t* event_data, void* user_data);
 
   /**
    * @brief GDMA RX completion callback.
    * @brief GDMA RX 完成回调。
    */
   static bool DmaRxDoneCallback(gdma_channel_handle_t dma_chan,
-                                gdma_event_data_t* event_data,
-                                void* user_data);
+                                gdma_event_data_t* event_data, void* user_data);
 
   /**
    * @brief GDMA RX descriptor error callback.
    * @brief GDMA RX 描述符错误回调。
    */
   static bool DmaRxDescrErrCallback(gdma_channel_handle_t dma_chan,
-                                    gdma_event_data_t* event_data,
-                                    void* user_data);
+                                    gdma_event_data_t* event_data, void* user_data);
 #endif
 
   /**
@@ -362,34 +356,34 @@ class ESP32UART : public UART
   uint8_t* rx_isr_buffer_ = nullptr;  ///< Scratch buffer used by the RX ISR path.
   size_t rx_isr_buffer_size_ = 0;     ///< Size of `rx_isr_buffer_`.
 
-  uint8_t* tx_storage_ = nullptr;      ///< Backing storage for the TX half-buffers.
-  DoubleBuffer tx_dma_buffer_{};       ///< TX double-buffer view for the DMA path.
-  WriteInfoBlock tx_active_info_ = {}; ///< Metadata for the active TX request.
-  size_t tx_active_length_ = 0U;       ///< Active TX payload length in bytes.
-  size_t tx_active_offset_ = 0U;       ///< Bytes already emitted for the active request.
-  bool tx_active_valid_ = false;       ///< Whether the active TX metadata is valid.
-  Flag::Plain tx_busy_;                ///< Hardware TX engine currently owns the request.
-  Flag::Plain in_tx_isr_;              ///< Reentry guard while processing TX ISR work.
+  uint8_t* tx_storage_ = nullptr;       ///< Backing storage for the TX half-buffers.
+  DoubleBuffer tx_dma_buffer_{};        ///< TX double-buffer view for the DMA path.
+  WriteInfoBlock tx_active_info_ = {};  ///< Metadata for the active TX request.
+  size_t tx_active_length_ = 0U;        ///< Active TX payload length in bytes.
+  size_t tx_active_offset_ = 0U;        ///< Bytes already emitted for the active request.
+  bool tx_active_valid_ = false;        ///< Whether the active TX metadata is valid.
+  Flag::Plain tx_busy_;    ///< Hardware TX engine currently owns the request.
+  Flag::Plain in_tx_isr_;  ///< Reentry guard while processing TX ISR work.
 
-  bool uart_hw_enabled_ = false;            ///< UART hardware block was initialized.
-  uart_hal_context_t uart_hal_ = {};        ///< ESP-IDF UART HAL context.
+  bool uart_hw_enabled_ = false;              ///< UART hardware block was initialized.
+  uart_hal_context_t uart_hal_ = {};          ///< ESP-IDF UART HAL context.
   intr_handle_t uart_intr_handle_ = nullptr;  ///< Registered UART interrupt handle.
-  bool uart_isr_installed_ = false;         ///< UART ISR installation state.
-  bool dma_requested_ = true;               ///< Constructor preference for DMA mode.
+  bool uart_isr_installed_ = false;           ///< UART ISR installation state.
+  bool dma_requested_ = true;                 ///< Constructor preference for DMA mode.
 
-  ESP32UARTReadPort _read_port;   ///< Read-side queue bridge exposed to `UART`.
-  WritePort _write_port; ///< Write-side queue bridge exposed to `UART`.
+  ESP32UARTReadPort _read_port;  ///< Read-side queue bridge exposed to `UART`.
+  WritePort _write_port;         ///< Write-side queue bridge exposed to `UART`.
 
 #if SOC_GDMA_SUPPORTED && SOC_UHCI_SUPPORTED
-  bool dma_backend_enabled_ = false;   ///< UHCI/GDMA backend is active.
-  uhci_hal_context_t uhci_hal_ = {};   ///< UHCI HAL context bound to this UART.
+  bool dma_backend_enabled_ = false;  ///< UHCI/GDMA backend is active.
+  uhci_hal_context_t uhci_hal_ = {};  ///< UHCI HAL context bound to this UART.
   gdma_channel_handle_t tx_dma_channel_ = nullptr;  ///< TX GDMA channel handle.
   gdma_channel_handle_t rx_dma_channel_ = nullptr;  ///< RX GDMA channel handle.
-  uintptr_t tx_dma_head_addr_[2] = {0U, 0U};   ///< TX list head addresses.
-  gdma_link_list_handle_t rx_dma_link_ = nullptr;  ///< RX GDMA ring list.
-  uint8_t* rx_dma_storage_ = nullptr;            ///< RX DMA ring backing storage.
-  size_t rx_dma_chunk_size_ = 0;                 ///< Size of one RX DMA ring node.
-  uint32_t rx_dma_node_index_ = 0;               ///< Software consumer index in the RX ring.
+  uintptr_t tx_dma_head_addr_[2] = {0U, 0U};        ///< TX list head addresses.
+  gdma_link_list_handle_t rx_dma_link_ = nullptr;   ///< RX GDMA ring list.
+  uint8_t* rx_dma_storage_ = nullptr;               ///< RX DMA ring backing storage.
+  size_t rx_dma_chunk_size_ = 0;                    ///< Size of one RX DMA ring node.
+  uint32_t rx_dma_node_index_ = 0;  ///< Software consumer index in the RX ring.
 #endif
 
   Flag::Atomic rx_fifo_draining_{};  ///< RX FIFO drain reentry gate.

--- a/driver/esp/esp_usb.hpp
+++ b/driver/esp/esp_usb.hpp
@@ -1,15 +1,15 @@
 #pragma once
 
-#include "esp_def.hpp"
-
 #include <cstddef>
 #include <cstdint>
 
+#include "esp_def.hpp"
 #include "esp_dma_utils.h"
 #include "esp_heap_caps.h"
 #include "usb/core/ep.hpp"
 
-#if SOC_USB_OTG_SUPPORTED && defined(CONFIG_IDF_TARGET_ESP32S3) && CONFIG_IDF_TARGET_ESP32S3
+#if SOC_USB_OTG_SUPPORTED && defined(CONFIG_IDF_TARGET_ESP32S3) && \
+    CONFIG_IDF_TARGET_ESP32S3
 
 #include "soc/usb_dwc_struct.h"
 

--- a/driver/esp/esp_usb_dev.hpp
+++ b/driver/esp/esp_usb_dev.hpp
@@ -30,28 +30,34 @@ class ESP32USBDevice : public USB::EndpointPool, public USB::DeviceCore
   struct EPConfig
   {
     /**
-     * @brief 该配置项应如何生成 endpoint 方向 / How this config entry should populate endpoint directions
+     * @brief 该配置项应如何生成 endpoint 方向 / How this config entry should populate
+     * endpoint directions
      */
     enum class DirectionHint : int8_t
     {
-      BothDirections = -1,  ///< 同时生成 IN/OUT endpoint / Create both IN and OUT endpoints
-      OutOnly = 0,          ///< 仅生成 OUT endpoint / Create only the OUT endpoint
-      InOnly = 1,           ///< 仅生成 IN endpoint / Create only the IN endpoint
+      BothDirections =
+          -1,       ///< 同时生成 IN/OUT endpoint / Create both IN and OUT endpoints
+      OutOnly = 0,  ///< 仅生成 OUT endpoint / Create only the OUT endpoint
+      InOnly = 1,   ///< 仅生成 IN endpoint / Create only the IN endpoint
     };
 
-    RawData buffer;  ///< 该 endpoint 共享的 payload buffer / Shared payload buffer for this endpoint entry
+    RawData buffer;  ///< 该 endpoint 共享的 payload buffer / Shared payload buffer for
+                     ///< this endpoint entry
     DirectionHint direction_hint =
-        DirectionHint::BothDirections;  ///< 该配置项的方向生成提示 / Direction-population hint for this entry
+        DirectionHint::BothDirections;  ///< 该配置项的方向生成提示 / Direction-population
+                                        ///< hint for this entry
 
     EPConfig() = delete;
 
     /**
-     * @brief 使用同一块 buffer 同时生成 IN/OUT endpoint / Create both IN and OUT endpoints from one shared buffer
+     * @brief 使用同一块 buffer 同时生成 IN/OUT endpoint / Create both IN and OUT
+     * endpoints from one shared buffer
      */
     explicit EPConfig(RawData buffer) : buffer(buffer) {}
 
     /**
-     * @brief 使用同一块 buffer 生成单方向 endpoint / Create a single-direction endpoint from one shared buffer
+     * @brief 使用同一块 buffer 生成单方向 endpoint / Create a single-direction endpoint
+     * from one shared buffer
      */
     EPConfig(RawData buffer, bool is_in)
         : buffer(buffer),
@@ -92,7 +98,8 @@ class ESP32USBDevice : public USB::EndpointPool, public USB::DeviceCore
   void Deinit(bool in_isr) override;
 
   /**
-   * @brief 在控制传输阶段写入设备地址 / Write the device address during control-transfer sequencing
+   * @brief 在控制传输阶段写入设备地址 / Write the device address during control-transfer
+   * sequencing
    */
   ErrorCode SetAddress(uint8_t address, USB::DeviceCore::Context context) override;
 
@@ -120,29 +127,42 @@ class ESP32USBDevice : public USB::EndpointPool, public USB::DeviceCore
    */
   struct ControlState
   {
-    bool setup_direction_out = false;  ///< 最近一笔 setup 请求是否面向 OUT data stage / Whether the latest setup requests an OUT data stage
+    bool setup_direction_out =
+        false;  ///< 最近一笔 setup 请求是否面向 OUT data stage / Whether the latest setup
+                ///< requests an OUT data stage
   };
 
   /**
-   * @brief 按方向索引的 endpoint 指针表 / Direction-indexed endpoint pointer table owned by the device core
+   * @brief 按方向索引的 endpoint 指针表 / Direction-indexed endpoint pointer table owned
+   * by the device core
    */
   struct EndpointMap
   {
-    USB::Endpoint* in[ENDPOINT_COUNT] = {};   ///< IN endpoint 指针表 / IN endpoint pointer table
-    USB::Endpoint* out[ENDPOINT_COUNT] = {};  ///< OUT endpoint 指针表 / OUT endpoint pointer table
+    USB::Endpoint* in[ENDPOINT_COUNT] =
+        {};  ///< IN endpoint 指针表 / IN endpoint pointer table
+    USB::Endpoint* out[ENDPOINT_COUNT] =
+        {};  ///< OUT endpoint 指针表 / OUT endpoint pointer table
   };
 
   /**
-   * @brief DWC2 FIFO 分配状态 / DWC2 FIFO allocation state tracked across endpoint configuration
+   * @brief DWC2 FIFO 分配状态 / DWC2 FIFO allocation state tracked across endpoint
+   * configuration
    */
   struct FifoState
   {
-    uint16_t depth_words = 0U;                ///< 硬件 FIFO 总深度（word）/ Total hardware FIFO depth in words
-    uint16_t rx_words = 0U;                   ///< 当前 RX FIFO 配置深度（word）/ Current RX FIFO depth in words
-    uint16_t tx_next_words = 0U;              ///< 下一个 TX FIFO 起始偏移（word）/ Next TX FIFO start offset in words
-    uint16_t tx_words[ENDPOINT_COUNT] = {};   ///< 各 endpoint 已分配 TX FIFO 深度（word）/ Allocated TX FIFO depth per endpoint in words
-    bool tx_bound[ENDPOINT_COUNT] = {};       ///< 各 endpoint 是否已绑定 TX FIFO / Whether each endpoint already has a bound TX FIFO
-    uint8_t allocated_in = 0U;                ///< 已占用的硬件 IN endpoint 个数 / Number of allocated hardware IN endpoints
+    uint16_t depth_words =
+        0U;  ///< 硬件 FIFO 总深度（word）/ Total hardware FIFO depth in words
+    uint16_t rx_words =
+        0U;  ///< 当前 RX FIFO 配置深度（word）/ Current RX FIFO depth in words
+    uint16_t tx_next_words =
+        0U;  ///< 下一个 TX FIFO 起始偏移（word）/ Next TX FIFO start offset in words
+    uint16_t tx_words[ENDPOINT_COUNT] =
+        {};  ///< 各 endpoint 已分配 TX FIFO 深度（word）/ Allocated TX FIFO depth per
+             ///< endpoint in words
+    bool tx_bound[ENDPOINT_COUNT] = {};  ///< 各 endpoint 是否已绑定 TX FIFO / Whether
+                                         ///< each endpoint already has a bound TX FIFO
+    uint8_t allocated_in = 0U;  ///< 已占用的硬件 IN endpoint 个数 / Number of allocated
+                                ///< hardware IN endpoints
   };
 
   /**
@@ -150,12 +170,15 @@ class ESP32USBDevice : public USB::EndpointPool, public USB::DeviceCore
    */
   struct RuntimeState
   {
-    intr_handle_t intr_handle = nullptr;  ///< 注册的 USB 中断句柄 / Registered USB interrupt handle
-    void* phy_handle = nullptr;           ///< USB PHY 句柄 / USB PHY handle
-    bool phy_ready = false;               ///< PHY 是否已准备完成 / Whether the PHY has been prepared
-    bool irq_ready = false;               ///< 中断是否已准备完成 / Whether the interrupt has been prepared
-    bool started = false;                 ///< 控制器是否处于启动态 / Whether the controller is started
-    bool rom_usb_cleaned = false;         ///< ROM USB 默认状态是否已清理 / Whether the ROM USB default state has been cleaned
+    intr_handle_t intr_handle =
+        nullptr;  ///< 注册的 USB 中断句柄 / Registered USB interrupt handle
+    void* phy_handle = nullptr;  ///< USB PHY 句柄 / USB PHY handle
+    bool phy_ready = false;  ///< PHY 是否已准备完成 / Whether the PHY has been prepared
+    bool irq_ready =
+        false;  ///< 中断是否已准备完成 / Whether the interrupt has been prepared
+    bool started = false;  ///< 控制器是否处于启动态 / Whether the controller is started
+    bool rom_usb_cleaned = false;  ///< ROM USB 默认状态是否已清理 / Whether the ROM USB
+                                   ///< default state has been cleaned
   };
 
   /**
@@ -244,7 +267,8 @@ class ESP32USBDevice : public USB::EndpointPool, public USB::DeviceCore
   void UpdateSetupState(const uint8_t* setup);
 
   /**
-   * @brief 返回最近 setup 的 data stage 是否面向 OUT / Return whether the latest setup uses an OUT data stage
+   * @brief 返回最近 setup 的 data stage 是否面向 OUT / Return whether the latest setup
+   * uses an OUT data stage
    */
   bool LastSetupDirectionOut() const { return control_.setup_direction_out; }
 
@@ -260,16 +284,20 @@ class ESP32USBDevice : public USB::EndpointPool, public USB::DeviceCore
                       uint16_t& fifo_words);
 
   /**
-   * @brief 确保 RX FIFO 容量满足当前 endpoint 需求 / Ensure the RX FIFO is large enough for the current endpoint need
+   * @brief 确保 RX FIFO 容量满足当前 endpoint 需求 / Ensure the RX FIFO is large enough
+   * for the current endpoint need
    */
   bool EnsureRxFifo(uint16_t packet_size);
 
   EndpointMap endpoint_map_ = {};  ///< Endpoint 所有权映射表 / Endpoint ownership map
-  FifoState fifo_state_ = {};      ///< FIFO 尺寸与分配账本 / FIFO sizing and allocation bookkeeping
-  RuntimeState runtime_ = {};      ///< 运行时资源与全局状态 / Runtime resource ownership and global flags
-  alignas(SETUP_DMA_BUFFER_BYTES)
-  uint8_t setup_packet_[SETUP_DMA_BUFFER_BYTES] = {};  ///< DMA 可见的共享 setup 包缓冲区 / Shared DMA-visible setup-packet buffer
-  ControlState control_ = {};  ///< 需跨 status completion 保留的 EP0 setup 状态 / EP0 setup state that must survive until status completion
+  FifoState fifo_state_ =
+      {};  ///< FIFO 尺寸与分配账本 / FIFO sizing and allocation bookkeeping
+  RuntimeState runtime_ =
+      {};  ///< 运行时资源与全局状态 / Runtime resource ownership and global flags
+  alignas(SETUP_DMA_BUFFER_BYTES) uint8_t setup_packet_[SETUP_DMA_BUFFER_BYTES] =
+      {};  ///< DMA 可见的共享 setup 包缓冲区 / Shared DMA-visible setup-packet buffer
+  ControlState control_ = {};  ///< 需跨 status completion 保留的 EP0 setup 状态 / EP0
+                               ///< setup state that must survive until status completion
 };
 
 }  // namespace LibXR

--- a/driver/esp/esp_usb_ep.hpp
+++ b/driver/esp/esp_usb_ep.hpp
@@ -2,7 +2,8 @@
 
 #include "usb/core/ep.hpp"
 
-#if SOC_USB_OTG_SUPPORTED && defined(CONFIG_IDF_TARGET_ESP32S3) && CONFIG_IDF_TARGET_ESP32S3
+#if SOC_USB_OTG_SUPPORTED && defined(CONFIG_IDF_TARGET_ESP32S3) && \
+    CONFIG_IDF_TARGET_ESP32S3
 
 namespace LibXR
 {
@@ -15,7 +16,8 @@ class ESP32USBDevice;
 class ESP32USBEndpoint : public USB::Endpoint
 {
  public:
-  ESP32USBEndpoint(ESP32USBDevice& device, EPNumber number, Direction direction, RawData buffer);
+  ESP32USBEndpoint(ESP32USBDevice& device, EPNumber number, Direction direction,
+                   RawData buffer);
 
   friend class ESP32USBDevice;
 

--- a/driver/esp/esp_watchdog.hpp
+++ b/driver/esp/esp_watchdog.hpp
@@ -1,9 +1,8 @@
 #pragma once
 
-#include "esp_def.hpp"
-
 #include <cstdint>
 
+#include "esp_def.hpp"
 #include "hal/wdt_hal.h"
 #include "soc/soc_caps.h"
 #include "watchdog.hpp"

--- a/driver/esp/esp_wifi_client.hpp
+++ b/driver/esp/esp_wifi_client.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "esp_def.hpp"
-
 #include "esp_event.h"
 #include "esp_netif.h"
 #include "esp_wifi.h"
@@ -20,7 +19,6 @@ class ESP32WifiClient : public WifiClient
 {
  public:
   ESP32WifiClient();
-
 
   bool Enable() override;
 
@@ -61,7 +59,7 @@ class ESP32WifiClient : public WifiClient
   static inline esp_netif_t* netif_ = nullptr;  ///< ESP 默认 netif 对象 / Default netif
 
   bool init_ok_ = false;
-  bool enabled_ = false;    ///< 是否启用 / Whether WiFi is enabled
+  bool enabled_ = false;  ///< 是否启用 / Whether WiFi is enabled
   bool handlers_registered_ = false;
   bool connected_ = false;  ///< 是否连接 / Whether WiFi is connected
   bool got_ip_ = false;     ///< 是否获取 IP / Whether IP is acquired

--- a/driver/hpm/hpm_gpio.hpp
+++ b/driver/hpm/hpm_gpio.hpp
@@ -140,9 +140,9 @@ class HPMGPIO final : public GPIO
    * `HPM_FGPIO` or when the SDK does not provide the both-edge enum.
    * @note 该接口会将 PAD 复用强制切换为 GPIO，不负责外设复用配置 /
    * This API forces pad mux to GPIO function (no peripheral alternate-function setup).
-   * @note 在可解析到 PAD 时会自动开启 IOC loopback，用于输出模式下直接通过 `Read()` 读取实际引脚电平 /
-   * When PAD can be resolved, IOC loopback is enabled so `Read()` can return the actual pad
-   * level even in output mode.
+   * @note 在可解析到 PAD 时会自动开启 IOC loopback，用于输出模式下直接通过 `Read()`
+   * 读取实际引脚电平 / When PAD can be resolved, IOC loopback is enabled so `Read()` can
+   * return the actual pad level even in output mode.
    */
   ErrorCode SetConfig(Configuration config) override;
 
@@ -202,9 +202,11 @@ class HPMGPIO final : public GPIO
 #else
   static constexpr uint32_t PORT_COUNT = 15u;  ///< 支持的端口数量 / Supported port count.
 #endif
-  static constexpr uint32_t PIN_COUNT = 32;   ///< 每个端口引脚数 / Pins per port.
-  static constexpr uint32_t INVALID_IRQ = 0xFFFFFFFFu;    ///< 无效 IRQ 标记 / Invalid IRQ marker.
-  static constexpr uint16_t INVALID_PAD_INDEX = 0xFFFFu;   ///< 无效 PAD 标记 / Invalid PAD marker.
+  static constexpr uint32_t PIN_COUNT = 32;  ///< 每个端口引脚数 / Pins per port.
+  static constexpr uint32_t INVALID_IRQ =
+      0xFFFFFFFFu;  ///< 无效 IRQ 标记 / Invalid IRQ marker.
+  static constexpr uint16_t INVALID_PAD_INDEX =
+      0xFFFFu;  ///< 无效 PAD 标记 / Invalid PAD marker.
 
   /**
    * @brief 端口级 IRQ 路由状态 / Shared port-level IRQ routing state.
@@ -243,7 +245,8 @@ class HPMGPIO final : public GPIO
   uint8_t pin_;         ///< GPIO 引脚号 / GPIO pin index.
   uint32_t irq_;        ///< 当前 port 对应 IRQ 号 / IRQ number for the current port.
   uint16_t pad_index_;  ///< IOC PAD 编号 / IOC PAD index.
-  bool interrupt_enabled_ = false;  ///< 当前 pin IRQ 使能状态 / Per-instance IRQ enabled flag.
+  bool interrupt_enabled_ =
+      false;  ///< 当前 pin IRQ 使能状态 / Per-instance IRQ enabled flag.
 };
 
 }  // namespace LibXR

--- a/driver/hpm/hpm_pwm.hpp
+++ b/driver/hpm/hpm_pwm.hpp
@@ -1,10 +1,9 @@
 ﻿#pragma once
 
-#include "pwm.hpp"
-
-#include "hpm_soc.h"
 #include "hpm_clock_drv.h"
 #include "hpm_gptmr_drv.h"
+#include "hpm_soc.h"
+#include "pwm.hpp"
 
 #if defined(PWM_SOC_CMP_MAX_COUNT) && defined(PWM_SOC_OUTPUT_TO_PWM_MAX_COUNT)
 #define LIBXR_HPM_PWM_SUPPORTED 1

--- a/driver/hpm/hpm_timebase.hpp
+++ b/driver/hpm/hpm_timebase.hpp
@@ -1,10 +1,9 @@
 #pragma once
 
-#include "timebase.hpp"
-
 #include "hpm_clock_drv.h"
 #include "hpm_mchtmr_drv.h"
 #include "hpm_soc.h"
+#include "timebase.hpp"
 
 namespace LibXR
 {

--- a/driver/linux/linux_uart.hpp
+++ b/driver/linux/linux_uart.hpp
@@ -11,9 +11,9 @@
 #include <termios.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <algorithm>
 #include <filesystem>
 #include <system_error>
 #include <vector>
@@ -98,8 +98,8 @@ class LinuxUART : public UART
             unsigned int baudrate = 115200, Parity parity = Parity::NO_PARITY,
             uint8_t data_bits = 8, uint8_t stop_bits = 1, uint32_t tx_queue_size = 5,
             size_t buffer_size = 512, size_t thread_stack_size = 65536)
-      : LinuxUART(vid, pid, "", "", baudrate, parity, data_bits, stop_bits,
-                  tx_queue_size, buffer_size, thread_stack_size)
+      : LinuxUART(vid, pid, "", "", baudrate, parity, data_bits, stop_bits, tx_queue_size,
+                  buffer_size, thread_stack_size)
   {
   }
 
@@ -114,10 +114,10 @@ class LinuxUART : public UART
    *       interface name.
    */
   LinuxUART(const std::string& vid, const std::string& pid,
-            const std::string& control_interface_name,
-            unsigned int baudrate = 115200, Parity parity = Parity::NO_PARITY,
-            uint8_t data_bits = 8, uint8_t stop_bits = 1, uint32_t tx_queue_size = 5,
-            size_t buffer_size = 512, size_t thread_stack_size = 65536)
+            const std::string& control_interface_name, unsigned int baudrate = 115200,
+            Parity parity = Parity::NO_PARITY, uint8_t data_bits = 8,
+            uint8_t stop_bits = 1, uint32_t tx_queue_size = 5, size_t buffer_size = 512,
+            size_t thread_stack_size = 65536)
       : LinuxUART(vid, pid, control_interface_name, "", baudrate, parity, data_bits,
                   stop_bits, tx_queue_size, buffer_size, thread_stack_size)
   {
@@ -148,7 +148,8 @@ class LinuxUART : public UART
     while (!FindUSBTTYByVidPid(vid, pid, control_interface_name, serial, device_path_))
     {
       XR_LOG_WARN(
-          "Cannot find USB TTY device with VID=%s PID=%s SERIAL=%s CONTROL_INTERFACE=%s, retrying...",
+          "Cannot find USB TTY device with VID=%s PID=%s SERIAL=%s CONTROL_INTERFACE=%s, "
+          "retrying...",
           vid.c_str(), pid.c_str(), serial.empty() ? "*" : serial.c_str(),
           control_interface_name.empty() ? "*" : control_interface_name.c_str());
       Thread::Sleep(100);
@@ -221,8 +222,7 @@ class LinuxUART : public UART
   }
 
   static bool FindUSBTTYByVidPid(const std::string& target_vid,
-                                 const std::string& target_pid,
-                                 std::string& tty_path)
+                                 const std::string& target_pid, std::string& tty_path)
   {
     return FindUSBTTYByVidPid(target_vid, target_pid, "", "", tty_path);
   }
@@ -267,8 +267,8 @@ class LinuxUART : public UART
 
       struct udev_device* usb_dev =
           udev_device_get_parent_with_subsystem_devtype(tty_dev, "usb", "usb_device");
-      struct udev_device* usb_interface = udev_device_get_parent_with_subsystem_devtype(
-          tty_dev, "usb", "usb_interface");
+      struct udev_device* usb_interface =
+          udev_device_get_parent_with_subsystem_devtype(tty_dev, "usb", "usb_interface");
 
       if (usb_dev)
       {
@@ -314,7 +314,9 @@ class LinuxUART : public UART
     if (matches.size() > 1)
     {
       XR_LOG_WARN(
-          "Multiple USB TTY devices found with VID=%s PID=%s SERIAL=%s CONTROL_INTERFACE=%s, using %s. Specify serial or control interface name to disambiguate.",
+          "Multiple USB TTY devices found with VID=%s PID=%s SERIAL=%s "
+          "CONTROL_INTERFACE=%s, using %s. Specify serial or control interface name to "
+          "disambiguate.",
           target_vid.c_str(), target_pid.c_str(),
           target_serial.empty() ? "*" : target_serial.c_str(),
           target_control_interface_name.empty() ? "*"

--- a/driver/mspm0/mspm0_gpio.hpp
+++ b/driver/mspm0/mspm0_gpio.hpp
@@ -1,17 +1,18 @@
 #pragma once
 
 #include <ti/driverlib/dl_gpio.h>
+
 #include "gpio.hpp"
 
 namespace LibXR
 {
 
 #ifdef GPIOC_BASE
-    constexpr uint8_t MAX_PORTS = 3;
+constexpr uint8_t MAX_PORTS = 3;
 #elif defined(GPIOB_BASE)
-    constexpr uint8_t MAX_PORTS = 2;
+constexpr uint8_t MAX_PORTS = 2;
 #else
-    constexpr uint8_t MAX_PORTS = 1;
+constexpr uint8_t MAX_PORTS = 1;
 #endif
 
 class MSPM0GPIO : public GPIO

--- a/driver/mspm0/mspm0_group1_shared.hpp
+++ b/driver/mspm0/mspm0_group1_shared.hpp
@@ -48,7 +48,6 @@ inline constexpr bool K_HAS_TRNG = true;
 inline constexpr bool K_HAS_TRNG = false;
 #endif
 
-
 inline IrqFn gpioa_irq_cb{nullptr};
 inline IrqFn gpiob_irq_cb{nullptr};
 inline IrqFn gpioc_irq_cb{nullptr};

--- a/driver/mspm0/mspm0_i2c.hpp
+++ b/driver/mspm0/mspm0_i2c.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ti/driverlib/dl_i2c.h>
+
 #include "i2c.hpp"
 #include "ti_msp_dl_config.h"
 
@@ -93,11 +94,11 @@ class MSPM0I2C : public I2C
   bool dma_enabled_ = false;
 };
 
-#define MSPM0_I2C_INIT(name, stage_addr, stage_size, dma_min_size)                          \
-  ::LibXR::MSPM0I2C::Resources{name##_INST, name##_INST_INT_IRQN,                           \
-                               static_cast<uint32_t>(CPUCLK_FREQ),                           \
-                               static_cast<uint32_t>(name##_BUS_SPEED_HZ),                   \
-                               ::LibXR::MSPM0I2C::ResolveIndex(name##_INST_INT_IRQN)},       \
+#define MSPM0_I2C_INIT(name, stage_addr, stage_size, dma_min_size)                     \
+  ::LibXR::MSPM0I2C::Resources{name##_INST, name##_INST_INT_IRQN,                      \
+                               static_cast<uint32_t>(CPUCLK_FREQ),                     \
+                               static_cast<uint32_t>(name##_BUS_SPEED_HZ),             \
+                               ::LibXR::MSPM0I2C::ResolveIndex(name##_INST_INT_IRQN)}, \
       ::LibXR::RawData{(stage_addr), (stage_size)}, (dma_min_size)
 
 }  // namespace LibXR

--- a/driver/mspm0/mspm0_spi.hpp
+++ b/driver/mspm0/mspm0_spi.hpp
@@ -2,6 +2,7 @@
 
 #include <ti/driverlib/dl_dma.h>
 #include <ti/driverlib/dl_spi.h>
+
 #include "spi.hpp"
 #include "ti_msp_dl_config.h"
 

--- a/driver/mspm0/mspm0_timebase.hpp
+++ b/driver/mspm0/mspm0_timebase.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ti/driverlib/m0p/dl_systick.h>
+
 #include "timebase.hpp"
 
 namespace LibXR

--- a/driver/mspm0/mspm0_uart.hpp
+++ b/driver/mspm0/mspm0_uart.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <ti/driverlib/dl_uart_main.h>
+
 #include "ti_msp_dl_config.h"
 #include "uart.hpp"
 

--- a/driver/st/stm32_adc.hpp
+++ b/driver/st/stm32_adc.hpp
@@ -11,8 +11,8 @@
 #endif
 
 #include "adc.hpp"
-#include "libxr_def.hpp"
 #include "libxr.hpp"
+#include "libxr_def.hpp"
 
 namespace LibXR
 {

--- a/driver/st/stm32_dcache.hpp
+++ b/driver/st/stm32_dcache.hpp
@@ -13,8 +13,7 @@ namespace LibXR
  * @brief D-Cache API 可直接接受 `void*`
  */
 template <typename FunctionType>
-concept DCacheFunctionAcceptsVoidPtr =
-    std::is_invocable_v<FunctionType, void*, int32_t>;
+concept DCacheFunctionAcceptsVoidPtr = std::is_invocable_v<FunctionType, void*, int32_t>;
 
 /**
  * @brief D-Cache API accepts `volatile void*`
@@ -30,23 +29,23 @@ concept DCacheFunctionAcceptsVolatileVoidPtr =
  * @brief 按当前工具链接受的指针类型调用 CMSIS D-Cache 接口
  */
 template <typename FunctionType>
-requires DCacheFunctionAcceptsVoidPtr<FunctionType>
+  requires DCacheFunctionAcceptsVoidPtr<FunctionType>
 inline void STM32_CallDCacheByAddr(FunctionType function, void* addr, int32_t dsize)
 {
   function(addr, dsize);
 }
 
 template <typename FunctionType>
-requires(!DCacheFunctionAcceptsVoidPtr<FunctionType> &&
-         DCacheFunctionAcceptsVolatileVoidPtr<FunctionType>)
+  requires(!DCacheFunctionAcceptsVoidPtr<FunctionType> &&
+           DCacheFunctionAcceptsVolatileVoidPtr<FunctionType>)
 inline void STM32_CallDCacheByAddr(FunctionType function, void* addr, int32_t dsize)
 {
   function(reinterpret_cast<volatile void*>(addr), dsize);
 }
 
 template <typename FunctionType>
-requires(!DCacheFunctionAcceptsVoidPtr<FunctionType> &&
-         !DCacheFunctionAcceptsVolatileVoidPtr<FunctionType>)
+  requires(!DCacheFunctionAcceptsVoidPtr<FunctionType> &&
+           !DCacheFunctionAcceptsVolatileVoidPtr<FunctionType>)
 inline void STM32_CallDCacheByAddr(FunctionType function, void* addr, int32_t dsize)
 {
   function(reinterpret_cast<uint32_t*>(addr), dsize);

--- a/driver/st/stm32_gpio.hpp
+++ b/driver/st/stm32_gpio.hpp
@@ -12,34 +12,35 @@
 #define XR_STM32_GPIO_HAS_F1_LAYOUT 0
 #endif
 
-#if defined(GPIO_MODER_MODE0) || defined(GPIO_MODER_MODE0_Msk) || defined(GPIO_MODER_MODER0) || \
-    defined(GPIO_MODER_MODER0_Msk)
+#if defined(GPIO_MODER_MODE0) || defined(GPIO_MODER_MODE0_Msk) || \
+    defined(GPIO_MODER_MODER0) || defined(GPIO_MODER_MODER0_Msk)
 #define XR_STM32_GPIO_HAS_MODER_FIELD 1
 #else
 #define XR_STM32_GPIO_HAS_MODER_FIELD 0
 #endif
 
-#if defined(GPIO_OTYPER_OT0) || defined(GPIO_OTYPER_OT0_Msk) || defined(GPIO_OTYPER_OT_0) || \
-    defined(GPIO_OTYPER_OT_0_Msk)
+#if defined(GPIO_OTYPER_OT0) || defined(GPIO_OTYPER_OT0_Msk) || \
+    defined(GPIO_OTYPER_OT_0) || defined(GPIO_OTYPER_OT_0_Msk)
 #define XR_STM32_GPIO_HAS_OTYPER_FIELD 1
 #else
 #define XR_STM32_GPIO_HAS_OTYPER_FIELD 0
 #endif
 
-#if defined(GPIO_PUPDR_PUPD0) || defined(GPIO_PUPDR_PUPD0_Msk) || defined(GPIO_PUPDR_PUPDR0) || \
-    defined(GPIO_PUPDR_PUPDR0_Msk)
+#if defined(GPIO_PUPDR_PUPD0) || defined(GPIO_PUPDR_PUPD0_Msk) || \
+    defined(GPIO_PUPDR_PUPDR0) || defined(GPIO_PUPDR_PUPDR0_Msk)
 #define XR_STM32_GPIO_HAS_PUPDR_FIELD 1
 #else
 #define XR_STM32_GPIO_HAS_PUPDR_FIELD 0
 #endif
 
-#if XR_STM32_GPIO_HAS_MODER_FIELD && XR_STM32_GPIO_HAS_OTYPER_FIELD && XR_STM32_GPIO_HAS_PUPDR_FIELD
+#if XR_STM32_GPIO_HAS_MODER_FIELD && XR_STM32_GPIO_HAS_OTYPER_FIELD && \
+    XR_STM32_GPIO_HAS_PUPDR_FIELD
 #define XR_STM32_GPIO_HAS_MODER_LAYOUT 1
 #else
 #define XR_STM32_GPIO_HAS_MODER_LAYOUT 0
 #endif
 
-#if defined(GPIO_OSPEEDR_OSPEED0) || defined(GPIO_OSPEEDR_OSPEED0_Msk) || \
+#if defined(GPIO_OSPEEDR_OSPEED0) || defined(GPIO_OSPEEDR_OSPEED0_Msk) ||   \
     defined(GPIO_OSPEEDR_OSPEEDR0) || defined(GPIO_OSPEEDR_OSPEEDR0_Msk) || \
     defined(GPIO_OSPEEDER_OSPEEDR0) || defined(GPIO_OSPEEDER_OSPEEDR0_Msk)
 #define XR_STM32_GPIO_HAS_OSPEEDR 1
@@ -48,7 +49,8 @@
 #endif
 
 #if XR_STM32_GPIO_HAS_F1_LAYOUT && XR_STM32_GPIO_HAS_MODER_LAYOUT
-#error "Ambiguous STM32 GPIO layout detection: both F1 and MODER layout signatures are present."
+#error \
+    "Ambiguous STM32 GPIO layout detection: both F1 and MODER layout signatures are present."
 #endif
 
 namespace LibXR

--- a/src/core/assert/diag.hpp
+++ b/src/core/assert/diag.hpp
@@ -8,7 +8,8 @@
 namespace LibXR::Assert
 {
 /**
- * @brief Fatal 错误回调类型，参数为文件名与行号 / Fatal error callback type taking file name and line number
+ * @brief Fatal 错误回调类型，参数为文件名与行号 / Fatal error callback type taking file
+ * name and line number
  */
 using FatalCallback = LibXR::Callback<const char*, uint32_t>;
 
@@ -29,8 +30,10 @@ inline void RegisterFatalErrorCallback(FatalCallback cb)
 }
 
 /**
- * @brief 返回当前注册的 fatal 错误回调对象 / Return the currently registered fatal error callback object
- * @return 当前注册的 fatal 错误回调对象 / Returns the currently registered fatal error callback object
+ * @brief 返回当前注册的 fatal 错误回调对象 / Return the currently registered fatal error
+ * callback object
+ * @return 当前注册的 fatal 错误回调对象 / Returns the currently registered fatal error
+ * callback object
  */
 [[nodiscard]] inline FatalCallback FatalErrorCallback()
 {

--- a/src/core/libxr_cb.hpp
+++ b/src/core/libxr_cb.hpp
@@ -16,8 +16,7 @@ namespace LibXR
  * @brief Callable convertible to the exact callback function pointer
  */
 template <typename CallableType, typename BoundArgType, typename... CallbackArgs>
-concept CallbackFunctionCompatible = requires(CallableType callable)
-{
+concept CallbackFunctionCompatible = requires(CallableType callable) {
   static_cast<void (*)(bool, BoundArgType, CallbackArgs...)>(callable);
 };
 
@@ -163,13 +162,12 @@ class Callback
    *       the intended model.
    */
   template <typename BoundArgType, typename CallableType>
-  requires CallbackFunctionCompatible<CallableType, BoundArgType, Args...>
+    requires CallbackFunctionCompatible<CallableType, BoundArgType, Args...>
   [[nodiscard]] static Callback Create(CallableType fun, BoundArgType arg)
   {
     using FunctionType = typename CallbackBlock<BoundArgType, Args...>::FunctionType;
-    auto cb_block =
-        new CallbackBlock<BoundArgType, Args...>(static_cast<FunctionType>(fun),
-                                                 std::move(arg));
+    auto cb_block = new CallbackBlock<BoundArgType, Args...>(
+        static_cast<FunctionType>(fun), std::move(arg));
     return Callback(cb_block);
   }
 
@@ -188,13 +186,12 @@ class Callback
    *       logical callback chain, not arbitrary multi-context serialization.
    */
   template <typename BoundArgType, typename CallableType>
-  requires CallbackFunctionCompatible<CallableType, BoundArgType, Args...>
+    requires CallbackFunctionCompatible<CallableType, BoundArgType, Args...>
   [[nodiscard]] static Callback CreateGuarded(CallableType fun, BoundArgType arg)
   {
     using FunctionType = typename CallbackBlock<BoundArgType, Args...>::FunctionType;
-    auto cb_block =
-        new GuardedCallbackBlock<BoundArgType, Args...>(static_cast<FunctionType>(fun),
-                                                        std::move(arg));
+    auto cb_block = new GuardedCallbackBlock<BoundArgType, Args...>(
+        static_cast<FunctionType>(fun), std::move(arg));
     return Callback(cb_block);
   }
 

--- a/src/core/libxr_color.hpp
+++ b/src/core/libxr_color.hpp
@@ -87,9 +87,8 @@ enum class Preset : uint8_t
 /**
  * @brief ANSI escape sequences for text styles / ANSI转义序列 - 文本样式
  */
-inline constexpr const char* LIBXR_TEXT_STYLE_STR[] = {"",        "\033[1m", "\033[2m",
-                                                       "\033[4m", "\033[5m", "\033[7m",
-                                                       "\033[8m"};
+inline constexpr const char* LIBXR_TEXT_STYLE_STR[] = {
+    "", "\033[1m", "\033[2m", "\033[4m", "\033[5m", "\033[7m", "\033[8m"};
 
 /**
  * @brief ANSI escape sequences for terminal controls / ANSI转义序列 - 终端控制
@@ -113,8 +112,8 @@ inline constexpr const char* LIBXR_BACKGROUND_STR[] = {
 /**
  * @brief ANSI escape sequences for text presets / ANSI转义序列 - 文本预设
  */
-inline constexpr const char* LIBXR_PRESET_STR[] = {
-    "", "\033[33m\033[1m", "\033[31m\033[1m", "\033[1m\033[41m"};
+inline constexpr const char* LIBXR_PRESET_STR[] = {"", "\033[33m\033[1m",
+                                                   "\033[31m\033[1m", "\033[1m\033[41m"};
 
 }  // namespace LibXR
 

--- a/src/core/libxr_def.hpp
+++ b/src/core/libxr_def.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <concepts>
 #include <cmath>
+#include <concepts>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
@@ -50,10 +50,12 @@ inline constexpr double TWO_PI = 2.0 * PI;
 /// \brief 标准重力加速度（m/s²） / Standard gravitational acceleration (m/s²)
 inline constexpr double STANDARD_GRAVITY = 9.80665;
 
-/// \brief 真实硬件缓存行大小（用于 DMA / cache coherency） / Hardware cache-line size used for DMA/cache-coherency boundaries
+/// \brief 真实硬件缓存行大小（用于 DMA / cache coherency） / Hardware cache-line size
+/// used for DMA/cache-coherency boundaries
 inline constexpr size_t HW_CACHE_LINE_SIZE = (sizeof(void*) == 8) ? 64 : 32;
 
-/// \brief 并发结构对齐粒度（用于降低多核伪共享） / Alignment policy used by concurrency-oriented structures
+/// \brief 并发结构对齐粒度（用于降低多核伪共享） / Alignment policy used by
+/// concurrency-oriented structures
 #if LIBXR_SINGLE_CORE
 inline constexpr size_t CONCURRENCY_ALIGNMENT = sizeof(size_t);
 #else
@@ -79,21 +81,21 @@ concept MemberObjectPointer = std::is_member_object_pointer_v<MemberType OwnerTy
  */
 template <typename LeftType, typename RightType>
 concept CommonOrdered = std::common_with<LeftType, RightType> &&
-                        requires(const LeftType& left, const RightType& right)
-{
-  { left < right } -> std::convertible_to<bool>;
-  { left > right } -> std::convertible_to<bool>;
-};
+                        requires(const LeftType& left, const RightType& right) {
+                          { left < right } -> std::convertible_to<bool>;
+                          { left > right } -> std::convertible_to<bool>;
+                        };
 
 /**
  * @brief 计算成员在宿主对象中的偏移量
  * @brief Computes the offset of a member within the owning object
- * @param member 指向成员的成员指针，如 `&Type::member` | Member pointer such as `&Type::member`
+ * @param member 指向成员的成员指针，如 `&Type::member` | Member pointer such as
+ * `&Type::member`
  * @return 成员偏移量 | Member offset
  */
 template <typename OwnerType, typename MemberType>
-requires MemberObjectPointer<OwnerType, MemberType>
-[[nodiscard]] inline size_t OffsetOf(MemberType OwnerType::*member) noexcept
+  requires MemberObjectPointer<OwnerType, MemberType>
+[[nodiscard]] inline size_t OffsetOf(MemberType OwnerType::* member) noexcept
 {
   return reinterpret_cast<size_t>(
       &(reinterpret_cast<const volatile OwnerType*>(0)->*member));
@@ -103,22 +105,23 @@ requires MemberObjectPointer<OwnerType, MemberType>
  * @brief 通过成员指针恢复其所属对象指针
  * @brief Recover the owning object pointer from a member pointer
  * @param ptr 指向成员的指针 | Pointer to the member
- * @param member 指向成员的成员指针，如 `&Type::member` | Member pointer such as `&Type::member`
+ * @param member 指向成员的成员指针，如 `&Type::member` | Member pointer such as
+ * `&Type::member`
  * @return 所属对象指针 | Pointer to the owning object
  */
 template <typename OwnerType, typename MemberType>
-requires MemberObjectPointer<OwnerType, MemberType>
+  requires MemberObjectPointer<OwnerType, MemberType>
 [[nodiscard]] inline OwnerType* ContainerOf(MemberType* ptr,
-                                            MemberType OwnerType::*member) noexcept
+                                            MemberType OwnerType::* member) noexcept
 {
   return reinterpret_cast<OwnerType*>(reinterpret_cast<std::byte*>(ptr) -
                                       OffsetOf(member));
 }
 
 template <typename OwnerType, typename MemberType>
-requires MemberObjectPointer<OwnerType, MemberType>
+  requires MemberObjectPointer<OwnerType, MemberType>
 [[nodiscard]] inline const OwnerType* ContainerOf(const MemberType* ptr,
-                                                  MemberType OwnerType::*member) noexcept
+                                                  MemberType OwnerType::* member) noexcept
 {
   return reinterpret_cast<const OwnerType*>(reinterpret_cast<const std::byte*>(ptr) -
                                             OffsetOf(member));
@@ -239,13 +242,13 @@ enum class SizeLimitMode : uint8_t
  * @param arg    要检查的条件 | Condition to check
  * @param in_isr 当前是否在中断上下文 | Whether currently in ISR context
  */
-#define ASSERT_FROM_CALLBACK(arg, in_isr)             \
-  do                                                  \
-  {                                                   \
-    if (!(arg))                                       \
-    {                                                 \
+#define ASSERT_FROM_CALLBACK(arg, in_isr)              \
+  do                                                   \
+  {                                                    \
+    if (!(arg))                                        \
+    {                                                  \
       libxr_fatal_error(__FILE__, __LINE__, (in_isr)); \
-    }                                                 \
+    }                                                  \
   } while (0)
 #else
 #define ASSERT(arg) (void(arg), (void)0)
@@ -263,13 +266,13 @@ enum class SizeLimitMode : uint8_t
  * @param arg 要检查的条件 | Condition to check
  */
 #ifdef LIBXR_DEV_ASSERT_BUILD
-#define DEV_ASSERT(arg)                            \
-  do                                               \
-  {                                                \
-    if (!(arg))                                    \
-    {                                              \
+#define DEV_ASSERT(arg)                             \
+  do                                                \
+  {                                                 \
+    if (!(arg))                                     \
+    {                                               \
       libxr_fatal_error(__FILE__, __LINE__, false); \
-    }                                              \
+    }                                               \
   } while (0)
 
 /**
@@ -279,13 +282,13 @@ enum class SizeLimitMode : uint8_t
  * @param arg    要检查的条件 | Condition to check
  * @param in_isr 当前是否在中断上下文 | Whether currently in ISR context
  */
-#define DEV_ASSERT_FROM_CALLBACK(arg, in_isr)        \
-  do                                                 \
-  {                                                  \
-    if (!(arg))                                      \
-    {                                                \
+#define DEV_ASSERT_FROM_CALLBACK(arg, in_isr)          \
+  do                                                   \
+  {                                                    \
+    if (!(arg))                                        \
+    {                                                  \
       libxr_fatal_error(__FILE__, __LINE__, (in_isr)); \
-    }                                                \
+    }                                                  \
   } while (0)
 #else
 #define DEV_ASSERT(arg) (void(arg), (void)0)
@@ -318,13 +321,13 @@ enum class SizeLimitMode : uint8_t
  * @param arg    要检查的条件 | Condition to check
  * @param in_isr 当前是否在中断上下文 | Whether currently in ISR context
  */
-#define REQUIRE_FROM_CALLBACK(arg, in_isr)          \
-  do                                                \
-  {                                                 \
-    if (!(arg))                                     \
-    {                                               \
+#define REQUIRE_FROM_CALLBACK(arg, in_isr)             \
+  do                                                   \
+  {                                                    \
+    if (!(arg))                                        \
+    {                                                  \
       libxr_fatal_error(__FILE__, __LINE__, (in_isr)); \
-    }                                               \
+    }                                                  \
   } while (0)
 
 /**
@@ -348,7 +351,7 @@ namespace LibXR
  * @return 两数中的较大值 | The larger of the two numbers
  */
 template <typename LeftType, typename RightType>
-requires CommonOrdered<LeftType, RightType>
+  requires CommonOrdered<LeftType, RightType>
 constexpr auto max(LeftType a, RightType b) -> std::common_type_t<LeftType, RightType>
 {
   return (a > b) ? a : b;
@@ -364,7 +367,7 @@ constexpr auto max(LeftType a, RightType b) -> std::common_type_t<LeftType, Righ
  * @return 两数中的较小值 | The smaller of the two numbers
  */
 template <typename LeftType, typename RightType>
-requires CommonOrdered<LeftType, RightType>
+  requires CommonOrdered<LeftType, RightType>
 constexpr auto min(LeftType a, RightType b) -> std::common_type_t<LeftType, RightType>
 {
   return (a < b) ? a : b;

--- a/src/core/libxr_string.hpp
+++ b/src/core/libxr_string.hpp
@@ -87,21 +87,20 @@ inline constexpr size_t runtime_string_max_field_width =
     case Print::FormatPackKind::U64:
       return 2U + precision;
     case Print::FormatPackKind::Pointer:
-      return 2U + (precision > 2U * sizeof(uintptr_t) ? precision
-                                                       : 2U * sizeof(uintptr_t));
+      return 2U +
+             (precision > 2U * sizeof(uintptr_t) ? precision : 2U * sizeof(uintptr_t));
     case Print::FormatPackKind::Character:
       return width;
     case Print::FormatPackKind::StringView:
       return runtime_string_unbounded_capacity;
     case Print::FormatPackKind::F32:
-      return 1U + static_cast<size_t>(std::numeric_limits<float>::max_exponent10) +
-             2U + 1U + precision;
+      return 1U + static_cast<size_t>(std::numeric_limits<float>::max_exponent10) + 2U +
+             1U + precision;
     case Print::FormatPackKind::F64:
-      return 1U + static_cast<size_t>(std::numeric_limits<double>::max_exponent10) +
-             2U + 1U + precision;
+      return 1U + static_cast<size_t>(std::numeric_limits<double>::max_exponent10) + 2U +
+             1U + precision;
     case Print::FormatPackKind::LongDouble:
-      return 1U +
-             static_cast<size_t>(std::numeric_limits<long double>::max_exponent10) +
+      return 1U + static_cast<size_t>(std::numeric_limits<long double>::max_exponent10) +
              2U + 1U + precision;
   }
 
@@ -157,13 +156,12 @@ struct RuntimeStringArgumentTraits
       std::is_same_v<Decayed, std::string_view>;
 
   static constexpr bool is_pointer =
-      std::is_pointer_v<Decayed> &&
-      !std::is_function_v<std::remove_pointer_t<Decayed>>;
+      std::is_pointer_v<Decayed> && !std::is_function_v<std::remove_pointer_t<Decayed>>;
 
   static constexpr bool has_static_capacity =
-      !is_text && (std::is_same_v<Decayed, std::nullptr_t> || is_pointer ||
-                   std::is_integral_v<Normalized> ||
-                   std::is_floating_point_v<Normalized>);
+      !is_text &&
+      (std::is_same_v<Decayed, std::nullptr_t> || is_pointer ||
+       std::is_integral_v<Normalized> || std::is_floating_point_v<Normalized>);
 };
 
 /**
@@ -176,10 +174,9 @@ template <typename... Args>
 struct RuntimeStringArgumentTypes
 {
   template <typename... CallArgs>
-  static constexpr bool matches =
-      std::is_same_v<RuntimeStringTypeList<
-                         typename RuntimeStringArgumentTraits<CallArgs>::Decayed...>,
-                     RuntimeStringTypeList<Args...>>;
+  static constexpr bool matches = std::is_same_v<
+      RuntimeStringTypeList<typename RuntimeStringArgumentTraits<CallArgs>::Decayed...>,
+      RuntimeStringTypeList<Args...>>;
 };
 
 /**
@@ -254,7 +251,7 @@ class RuntimeStringView
 {
  public:
   static_assert((std::is_same_v<
-                    Args, typename Detail::RuntimeStringArgumentTraits<Args>::Decayed> &&
+                     Args, typename Detail::RuntimeStringArgumentTraits<Args>::Decayed> &&
                  ...),
                 "LibXR::RuntimeStringView argument types must be unqualified "
                 "value types");
@@ -268,7 +265,8 @@ class RuntimeStringView
   RuntimeStringView(const RuntimeStringView&) = delete;
   RuntimeStringView& operator=(const RuntimeStringView&) = delete;
 
-  /// Move-constructs by taking the retained storage handle. / 移动构造并接管保留存储句柄。
+  /// Move-constructs by taking the retained storage handle. /
+  /// 移动构造并接管保留存储句柄。
   RuntimeStringView(RuntimeStringView&& other) noexcept
       : data_(other.data_),
         size_(other.size_),
@@ -290,7 +288,8 @@ class RuntimeStringView
     static_cast<void>(AssignCopy(text));
   }
 
-  /// Copies one bounded mutable char array as text. / 按文本语义拷贝一个有界可变字符数组。
+  /// Copies one bounded mutable char array as text. /
+  /// 按文本语义拷贝一个有界可变字符数组。
   template <size_t N>
   explicit RuntimeStringView(char (&text)[N])
     requires(Source.Size() == 0 && sizeof...(Args) == 0)
@@ -306,16 +305,18 @@ class RuntimeStringView
     static_cast<void>(AssignCopy(std::string_view(text, BoundedTextLength(text, N))));
   }
 
-  /// Copies a NUL-terminated C-string pointer into retained storage. / 拷贝 NUL 结尾 C 字符串指针到保留存储。
+  /// Copies a NUL-terminated C-string pointer into retained storage. / 拷贝 NUL 结尾 C
+  /// 字符串指针到保留存储。
   template <typename CharPtr>
-  requires(Source.Size() == 0 && sizeof...(Args) == 0 &&
-           (std::is_same_v<CharPtr, char*> || std::is_same_v<CharPtr, const char*>))
+    requires(Source.Size() == 0 && sizeof...(Args) == 0 &&
+             (std::is_same_v<CharPtr, char*> || std::is_same_v<CharPtr, const char*>))
   explicit RuntimeStringView(CharPtr text)
   {
     static_cast<void>(AssignCopy(text));
   }
 
-  /// Preserves the old bare-nullptr entry for runtime null checks. / 保留裸 nullptr 入口以维持运行期空指针检查语义。
+  /// Preserves the old bare-nullptr entry for runtime null checks. / 保留裸 nullptr
+  /// 入口以维持运行期空指针检查语义。
   explicit RuntimeStringView(std::nullptr_t text)
     requires(Source.Size() == 0 && sizeof...(Args) == 0)
   {
@@ -351,9 +352,9 @@ class RuntimeStringView
                   "LibXR::RuntimeStringView cannot retain unbounded formatted "
                   "runtime strings");
 
-    return AssignFormatted(max_size, [&](auto& sink) {
-      return Print::FormatTo<Source>(sink, std::forward<CallArgs>(args)...);
-    });
+    return AssignFormatted(
+        max_size, [&](auto& sink)
+        { return Print::FormatTo<Source>(sink, std::forward<CallArgs>(args)...); });
   }
 
   /**
@@ -375,9 +376,9 @@ class RuntimeStringView
                   "LibXR::RuntimeStringView cannot retain unbounded formatted "
                   "runtime strings");
 
-    return AssignFormatted(max_size, [&](auto& sink) {
-      return Print::PrintfTo<Source>(sink, std::forward<CallArgs>(args)...);
-    });
+    return AssignFormatted(
+        max_size, [&](auto& sink)
+        { return Print::PrintfTo<Source>(sink, std::forward<CallArgs>(args)...); });
   }
 
   /// Returns the current read-only view. / 返回当前只读视图。
@@ -622,7 +623,8 @@ class RuntimeStringView
    *        formatting must go through `Reformat()` or `Reprintf()`.
    */
   template <typename T>
-  [[nodiscard]] static constexpr Detail::RuntimeStringTextPart NormalizeConcatPart(T&& text)
+  [[nodiscard]] static constexpr Detail::RuntimeStringTextPart NormalizeConcatPart(
+      T&& text)
   {
     using Bare = std::remove_cvref_t<T>;
     if constexpr (Detail::runtime_string_is_view_v<T>)
@@ -635,7 +637,8 @@ class RuntimeStringView
     else if constexpr (std::is_array_v<Bare> &&
                        std::is_same_v<std::remove_cv_t<std::remove_extent_t<Bare>>, char>)
     {
-      return {.view = std::string_view(text, BoundedTextLength(text, std::extent_v<Bare>))};
+      return {.view =
+                  std::string_view(text, BoundedTextLength(text, std::extent_v<Bare>))};
     }
     else if constexpr (std::is_same_v<Bare, std::string_view>)
     {
@@ -665,22 +668,28 @@ class RuntimeStringView
     }
   }
 
-  /// 长期保留的 NUL 结尾存储；对象析构时不释放。 / Retained NUL-terminated storage; not released by the destructor.
+  /// 长期保留的 NUL 结尾存储；对象析构时不释放。 / Retained NUL-terminated storage; not
+  /// released by the destructor.
   char* data_ = nullptr;
-  /// 不含结尾 NUL 的当前可见文本长度。 / Current visible payload size excluding the trailing NUL.
+  /// 不含结尾 NUL 的当前可见文本长度。 / Current visible payload size excluding the
+  /// trailing NUL.
   size_t size_ = 0;
-  /// 不含结尾 NUL 的已探测/分配容量。 / Probed/allocated payload capacity excluding the trailing NUL.
+  /// 不含结尾 NUL 的已探测/分配容量。 / Probed/allocated payload capacity excluding the
+  /// trailing NUL.
   size_t capacity_ = 0;
   /// 最近一次构造或重写状态。 / Status of the latest construction or rewrite.
   ErrorCode status_ = ErrorCode::OK;
 };
 
-/// 单参数文本构造推导为普通保留字符串。 / Single text argument deduces a plain retained string.
+/// 单参数文本构造推导为普通保留字符串。 / Single text argument deduces a plain retained
+/// string.
 RuntimeStringView(std::string_view) -> RuntimeStringView<>;
-/// C 字符串构造推导为普通保留字符串。 / C-string construction deduces a plain retained string.
+/// C 字符串构造推导为普通保留字符串。 / C-string construction deduces a plain retained
+/// string.
 RuntimeStringView(const char*) -> RuntimeStringView<>;
 
-/// 多片段构造推导为普通拼接字符串。 / Multi-part construction deduces a plain concatenated string.
+/// 多片段构造推导为普通拼接字符串。 / Multi-part construction deduces a plain
+/// concatenated string.
 template <typename First, typename Second, typename... Rest>
 RuntimeStringView(First&&, Second&&, Rest&&...) -> RuntimeStringView<>;
 

--- a/src/core/libxr_time.hpp
+++ b/src/core/libxr_time.hpp
@@ -201,19 +201,13 @@ class MillisecondTimestamp
      * @brief 转换为秒 / Convert the duration to seconds
      * @return 秒 / Seconds
      */
-    [[nodiscard]] double ToSecond() const
-    {
-      return static_cast<double>(diff_) / 1000.0;
-    }
+    [[nodiscard]] double ToSecond() const { return static_cast<double>(diff_) / 1000.0; }
 
     /**
      * @brief 转换为单精度秒 / Convert the duration to seconds in single precision
      * @return 单精度秒 / Seconds in single precision
      */
-    [[nodiscard]] float ToSecondf() const
-    {
-      return static_cast<float>(diff_) / 1000.0f;
-    }
+    [[nodiscard]] float ToSecondf() const { return static_cast<float>(diff_) / 1000.0f; }
 
     /**
      * @brief 转换为毫秒 / Convert the duration to milliseconds

--- a/src/core/libxr_type.hpp
+++ b/src/core/libxr_type.hpp
@@ -24,8 +24,7 @@ template <size_t N>
 }
 
 template <size_t N>
-[[nodiscard]] constexpr size_t TrailingNulTrimmedArraySize(
-    const char (&data)[N]) noexcept
+[[nodiscard]] constexpr size_t TrailingNulTrimmedArraySize(const char (&data)[N]) noexcept
 {
   return (data[N - 1] == '\0') ? (N - 1) : N;
 }
@@ -91,8 +90,7 @@ class RawData
    */
   template <typename CharPtr>
     requires(std::is_same_v<std::remove_cvref_t<CharPtr>, char*>)
-  RawData(CharPtr&& data)
-      : addr_(data), size_(data != nullptr ? std::strlen(data) : 0)
+  RawData(CharPtr&& data) : addr_(data), size_(data != nullptr ? std::strlen(data) : 0)
   {
   }
 
@@ -130,8 +128,8 @@ class RawData
    */
   RawData& operator=(const RawData& data) = default;
 
-  void* addr_ = nullptr;   ///< 数据起始地址 / Data start address
-  size_t size_ = 0;        ///< 数据字节数 / Data size in bytes
+  void* addr_ = nullptr;  ///< 数据起始地址 / Data start address
+  size_t size_ = 0;       ///< 数据字节数 / Data size in bytes
 };
 
 /**
@@ -197,18 +195,19 @@ class ConstRawData
   ConstRawData(const RawData& data) : addr_(data.addr_), size_(data.size_) {}
 
   /**
-   * @brief 从 `char*` / `const char*` 文本指针构造 `ConstRawData`，数据大小为字符串长度（不含 `\0`）。
-   *        Constructs `ConstRawData` from a `char*` / `const char*` text pointer,
-   *        with size set to the string length (excluding `\0`).
+   * @brief 从 `char*` / `const char*` 文本指针构造
+   * `ConstRawData`，数据大小为字符串长度（不含 `\0`）。 Constructs `ConstRawData` from a
+   * `char*` / `const char*` text pointer, with size set to the string length (excluding
+   * `\0`).
    *
    * @param data C 风格字符串指针。
    *             A C-style string pointer.
    */
   template <typename CharPtr>
     requires(std::is_pointer_v<std::remove_cvref_t<CharPtr>> &&
-             std::is_same_v<std::remove_cv_t<
-                                std::remove_pointer_t<std::remove_cvref_t<CharPtr>>>,
-                            char> &&
+             std::is_same_v<
+                 std::remove_cv_t<std::remove_pointer_t<std::remove_cvref_t<CharPtr>>>,
+                 char> &&
              !std::is_volatile_v<std::remove_pointer_t<std::remove_cvref_t<CharPtr>>>)
   ConstRawData(CharPtr&& data)
       : addr_(data),

--- a/src/core/print/format/format_frontend_binding_base.hpp
+++ b/src/core/print/format/format_frontend_binding_base.hpp
@@ -1,15 +1,18 @@
 #pragma once
 
 /**
- * @brief brace 前端共享的参数分类与字段形状构造辅助函数 / Shared brace-frontend argument classification and field-shape helpers
+ * @brief brace 前端共享的参数分类与字段形状构造辅助函数 / Shared brace-frontend argument
+ * classification and field-shape helpers
  */
 namespace ArgumentResolution
 {
 
 /**
- * @brief 将一个 C++ 参数类型归类到 brace 前端使用的本地参数类别 / Classify one C++ argument type into the brace frontend's local category
+ * @brief 将一个 C++ 参数类型归类到 brace 前端使用的本地参数类别 / Classify one C++
+ * argument type into the brace frontend's local category
  * @tparam Arg 待归类的 C++ 参数类型 / C++ argument type to classify
- * @return 返回后续字段解析要使用的本地前端参数摘要 / Returns the local frontend summary used by later field resolution
+ * @return 返回后续字段解析要使用的本地前端参数摘要 / Returns the local frontend summary
+ * used by later field resolution
  */
 template <typename Arg>
 [[nodiscard]] consteval ArgumentSummary ClassifyArgument()
@@ -67,9 +70,11 @@ template <typename Arg>
 }
 
 /**
- * @brief 为 brace 前端归类整组 C++ 参数类型 / Classify one full C++ argument list for the brace frontend
+ * @brief 为 brace 前端归类整组 C++ 参数类型 / Classify one full C++ argument list for the
+ * brace frontend
  * @tparam Args 待归类的 C++ 实参类型列表 / C++ argument types to classify
- * @return 按源参数顺序返回每个参数对应的一份 `ArgumentSummary` / Returns one `ArgumentSummary` per argument in source order
+ * @return 按源参数顺序返回每个参数对应的一份 `ArgumentSummary` / Returns one
+ * `ArgumentSummary` per argument in source order
  */
 template <typename... Args>
 [[nodiscard]] consteval auto ClassifyArguments()
@@ -78,9 +83,11 @@ template <typename... Args>
 }
 
 /**
- * @brief 判断某个已解析字段是否请求了显式符号策略 / Return whether one parsed field requested an explicit sign policy
+ * @brief 判断某个已解析字段是否请求了显式符号策略 / Return whether one parsed field
+ * requested an explicit sign policy
  * @param field 待检查的已解析字段 / Parsed field to inspect
- * @return 若请求了 `+` 或空格符号策略则返回 `true`，否则返回 `false` / Returns `true` when `+` or space-sign was requested, otherwise `false`
+ * @return 若请求了 `+` 或空格符号策略则返回 `true`，否则返回 `false` / Returns `true`
+ * when `+` or space-sign was requested, otherwise `false`
  */
 [[nodiscard]] constexpr bool HasSignOption(const ParsedField& field)
 {
@@ -88,8 +95,10 @@ template <typename... Args>
 }
 
 /**
- * @brief 返回“未指定精度”的本地哨兵值 / Return the local sentinel meaning "precision not specified"
- * @return 返回 brace 前端内部使用的精度哨兵值 / Returns the precision sentinel byte used inside the brace frontend
+ * @brief 返回“未指定精度”的本地哨兵值 / Return the local sentinel meaning "precision not
+ * specified"
+ * @return 返回 brace 前端内部使用的精度哨兵值 / Returns the precision sentinel byte used
+ * inside the brace frontend
  */
 [[nodiscard]] constexpr uint8_t UnspecifiedPrecision()
 {
@@ -97,10 +106,13 @@ template <typename... Args>
 }
 
 /**
- * @brief 根据一个已解析 brace 字段构造共享 FormatFlag 位集合 / Build the shared `FormatFlag` bitset from one parsed brace field
+ * @brief 根据一个已解析 brace 字段构造共享 FormatFlag 位集合 / Build the shared
+ * `FormatFlag` bitset from one parsed brace field
  * @param parsed 已解析的 brace 字段 / Parsed brace field
- * @param upper_case 最终展示是否使用大写字母 / Whether the final presentation should use uppercase letters
- * @return 返回该字段对应的共享 `FormatFlag` 位集合 / Returns the shared `FormatFlag` bitset for this field
+ * @param upper_case 最终展示是否使用大写字母 / Whether the final presentation should use
+ * uppercase letters
+ * @return 返回该字段对应的共享 `FormatFlag` 位集合 / Returns the shared `FormatFlag`
+ * bitset for this field
  */
 [[nodiscard]] constexpr uint8_t BuildFlags(const ParsedField& parsed, bool upper_case)
 {
@@ -137,15 +149,19 @@ template <typename... Args>
 }
 
 /**
- * @brief 根据 brace 字段属性构造一条共享 `FormatField` 记录 / Build one shared `FormatField` record from parsed brace-field properties
+ * @brief 根据 brace 字段属性构造一条共享 `FormatField` 记录 / Build one shared
+ * `FormatField` record from parsed brace-field properties
  * @param parsed 已解析的 brace 字段 / Parsed brace field
  * @param type 共享运行期字段类型 / Shared runtime field type
  * @param pack 运行期参数打包类型 / Runtime packed-argument kind
- * @param upper_case 最终展示是否使用大写字母 / Whether the final presentation should use uppercase letters
- * @return 返回共享编译后端要消费的 `FormatField` 记录 / Returns the shared `FormatField` record consumed by the compile-time backend
+ * @param upper_case 最终展示是否使用大写字母 / Whether the final presentation should use
+ * uppercase letters
+ * @return 返回共享编译后端要消费的 `FormatField` 记录 / Returns the shared `FormatField`
+ * record consumed by the compile-time backend
  */
 [[nodiscard]] constexpr FormatField MakeField(const ParsedField& parsed, FormatType type,
-                                              FormatPackKind pack, bool upper_case = false)
+                                              FormatPackKind pack,
+                                              bool upper_case = false)
 {
   return FormatField{
       .type = type,
@@ -159,10 +175,13 @@ template <typename... Args>
 }
 
 /**
- * @brief 判断展示字符是否缺省或等于目标字符 / Return whether the presentation is absent or matches the expected token
- * @param presentation 已解析展示字符；缺省时为 0 / Parsed presentation token, or zero when absent
+ * @brief 判断展示字符是否缺省或等于目标字符 / Return whether the presentation is absent
+ * or matches the expected token
+ * @param presentation 已解析展示字符；缺省时为 0 / Parsed presentation token, or zero
+ * when absent
  * @param expected 期望的展示字符 / Expected presentation token
- * @return 若展示字符缺省或等于 `expected` 则返回 `true` / Returns `true` when the presentation is absent or matches `expected`
+ * @return 若展示字符缺省或等于 `expected` 则返回 `true` / Returns `true` when the
+ * presentation is absent or matches `expected`
  */
 [[nodiscard]] constexpr bool IsDefaultOr(char presentation, char expected)
 {
@@ -170,9 +189,11 @@ template <typename... Args>
 }
 
 /**
- * @brief 判断展示字符是否选择了非十进制整数族 / Return whether the presentation selects one non-decimal integer family
+ * @brief 判断展示字符是否选择了非十进制整数族 / Return whether the presentation selects
+ * one non-decimal integer family
  * @param presentation 已解析展示字符 / Parsed presentation token
- * @return 若选择了二进制、八进制或十六进制展示则返回 `true`，否则返回 `false` / Returns `true` for binary, octal, or hex presentations, otherwise `false`
+ * @return 若选择了二进制、八进制或十六进制展示则返回 `true`，否则返回 `false` / Returns
+ * `true` for binary, octal, or hex presentations, otherwise `false`
  */
 [[nodiscard]] constexpr bool IsNonDecimalPresentation(char presentation)
 {
@@ -181,8 +202,10 @@ template <typename... Args>
 }
 
 /**
- * @brief 在当前功能开关下选择前端默认浮点展示字符 / Choose the frontend default float presentation under current feature gates
- * @return 返回默认浮点展示字符；若全部浮点展示都被关闭则返回 0 / Returns the default float presentation token, or zero when all float presentations are disabled
+ * @brief 在当前功能开关下选择前端默认浮点展示字符 / Choose the frontend default float
+ * presentation under current feature gates
+ * @return 返回默认浮点展示字符；若全部浮点展示都被关闭则返回 0 / Returns the default
+ * float presentation token, or zero when all float presentations are disabled
  */
 [[nodiscard]] constexpr char DefaultFloatPresentation()
 {

--- a/src/core/print/format/format_frontend_binding_float.hpp
+++ b/src/core/print/format/format_frontend_binding_float.hpp
@@ -1,17 +1,22 @@
 #pragma once
 
 /**
- * @brief brace 前端里处理浮点参数字段的辅助函数 / Brace-frontend helpers for fields that point to float arguments
+ * @brief brace 前端里处理浮点参数字段的辅助函数 / Brace-frontend helpers for fields that
+ * point to float arguments
  */
 namespace ArgumentResolution
 {
 
 /**
- * @brief 针对 float、double 或 long double 参数解析一个已解析的 brace 字段 / Resolve one parsed brace field for a float, double, or long double argument
+ * @brief 针对 float、double 或 long double 参数解析一个已解析的 brace 字段 / Resolve one
+ * parsed brace field for a float, double, or long double argument
  * @param parsed 已解析的 brace 字段 / Parsed brace field
- * @param kind 当前字段选中的前端参数类别 / Frontend-side argument family selected for this field
- * @return 返回解析后的共享字段；精度或类型不匹配时返回首个错误 / Returns the resolved shared field, or the first precision or type mismatch error
- * @note double 支持关闭时，double 参数会降为 F32 存储与格式化 / When double support is disabled, double arguments are reduced to F32 storage and formatting
+ * @param kind 当前字段选中的前端参数类别 / Frontend-side argument family selected for
+ * this field
+ * @return 返回解析后的共享字段；精度或类型不匹配时返回首个错误 / Returns the resolved
+ * shared field, or the first precision or type mismatch error
+ * @note double 支持关闭时，double 参数会降为 F32 存储与格式化 / When double support is
+ * disabled, double arguments are reduced to F32 storage and formatting
  */
 [[nodiscard]] consteval ResolvedField ResolveFloatField(const ParsedField& parsed,
                                                         ArgumentKind kind)
@@ -27,14 +32,14 @@ namespace ArgumentResolution
   {
     return ResolvedField{.error = Error::ArgumentTypeMismatch};
   }
-  bool upper_case =
-      presentation == 'F' || presentation == 'E' || presentation == 'G';
+  bool upper_case = presentation == 'F' || presentation == 'E' || presentation == 'G';
 
   FormatType type = FormatType::End;
   FormatPackKind pack = FormatPackKind::F32;
 
   auto pick_type = [&](FormatType f32_type, FormatType f64_type,
-                       FormatType ld_type) consteval -> bool {
+                       FormatType ld_type) consteval -> bool
+  {
     switch (kind)
     {
       case ArgumentKind::Float32:
@@ -95,10 +100,12 @@ namespace ArgumentResolution
 }
 
 /**
- * @brief 先判断一个已解析 brace 字段指向哪类参数，再选择匹配的字段构造逻辑 / Check which argument family a parsed brace field points to, then choose the matching field builder
+ * @brief 先判断一个已解析 brace 字段指向哪类参数，再选择匹配的字段构造逻辑 / Check which
+ * argument family a parsed brace field points to, then choose the matching field builder
  * @tparam Args 已绑定的 C++ 实参类型列表 / Bound C++ argument types
  * @param parsed 已解析的 brace 字段 / Parsed brace field
- * @return 返回解析后的共享字段；缺参或类型不支持时返回首个错误 / Returns the resolved shared field, or the first missing-argument or unsupported-type error
+ * @return 返回解析后的共享字段；缺参或类型不支持时返回首个错误 / Returns the resolved
+ * shared field, or the first missing-argument or unsupported-type error
  */
 template <typename... Args>
 [[nodiscard]] consteval ResolvedField ResolveField(const ParsedField& parsed)

--- a/src/core/print/format/format_frontend_binding_integer.hpp
+++ b/src/core/print/format/format_frontend_binding_integer.hpp
@@ -1,17 +1,23 @@
 #pragma once
 
 /**
- * @brief brace 前端里处理 bool、整数、字符、字符串与指针参数字段的辅助函数 / Brace-frontend helpers for fields that point to bool, integer, character, string, and pointer arguments
+ * @brief brace 前端里处理 bool、整数、字符、字符串与指针参数字段的辅助函数 /
+ * Brace-frontend helpers for fields that point to bool, integer, character, string, and
+ * pointer arguments
  */
 namespace ArgumentResolution
 {
 
 /**
- * @brief 针对整数类参数解析一个已解析的 brace 字段 / Resolve one parsed brace field for an integer-like argument
+ * @brief 针对整数类参数解析一个已解析的 brace 字段 / Resolve one parsed brace field for
+ * an integer-like argument
  * @param parsed 已解析的 brace 字段 / Parsed brace field
- * @param signed_decimal 选中的参数是否按有符号十进制族处理 / Whether the selected argument should be treated as a signed decimal family
- * @param uses_64bit_storage 选中的参数是否需要 64 位打包存储 / Whether the selected argument requires 64-bit packed storage
- * @return 返回解析后的共享字段；不匹配时返回首个类型错误 / Returns the resolved shared field, or the first type-mismatch error
+ * @param signed_decimal 选中的参数是否按有符号十进制族处理 / Whether the selected
+ * argument should be treated as a signed decimal family
+ * @param uses_64bit_storage 选中的参数是否需要 64 位打包存储 / Whether the selected
+ * argument requires 64-bit packed storage
+ * @return 返回解析后的共享字段；不匹配时返回首个类型错误 / Returns the resolved shared
+ * field, or the first type-mismatch error
  */
 [[nodiscard]] consteval ResolvedField ResolveIntegerField(const ParsedField& parsed,
                                                           bool signed_decimal,
@@ -37,8 +43,8 @@ namespace ArgumentResolution
     {
       return ResolvedField{.error = Error::ArgumentTypeMismatch};
     }
-    return ResolvedField{.field = MakeField(parsed, FormatType::Character,
-                                            FormatPackKind::Character)};
+    return ResolvedField{
+        .field = MakeField(parsed, FormatType::Character, FormatPackKind::Character)};
   }
 
   if (IsDefaultOr(parsed.presentation, 'd'))
@@ -54,20 +60,16 @@ namespace ArgumentResolution
 
     if (signed_decimal)
     {
-      return ResolvedField{.field = MakeField(
-                              parsed,
-                              uses_64bit_storage ? FormatType::Signed64
-                                                 : FormatType::Signed32,
-                              uses_64bit_storage ? FormatPackKind::I64
-                                                 : FormatPackKind::I32)};
+      return ResolvedField{
+          .field = MakeField(
+              parsed, uses_64bit_storage ? FormatType::Signed64 : FormatType::Signed32,
+              uses_64bit_storage ? FormatPackKind::I64 : FormatPackKind::I32)};
     }
 
-    return ResolvedField{.field = MakeField(
-                            parsed,
-                            uses_64bit_storage ? FormatType::Unsigned64
-                                               : FormatType::Unsigned32,
-                            uses_64bit_storage ? FormatPackKind::U64
-                                               : FormatPackKind::U32)};
+    return ResolvedField{
+        .field = MakeField(
+            parsed, uses_64bit_storage ? FormatType::Unsigned64 : FormatType::Unsigned32,
+            uses_64bit_storage ? FormatPackKind::U64 : FormatPackKind::U32)};
   }
 
   if (!Config::enable_integer_base8_16 || HasSignOption(parsed))
@@ -78,51 +80,43 @@ namespace ArgumentResolution
   switch (parsed.presentation)
   {
     case 'b':
-      return ResolvedField{.field = MakeField(
-                              parsed,
-                              uses_64bit_storage ? FormatType::Binary64
-                                                 : FormatType::Binary32,
-                              uses_64bit_storage ? FormatPackKind::U64
-                                                 : FormatPackKind::U32)};
+      return ResolvedField{
+          .field = MakeField(
+              parsed, uses_64bit_storage ? FormatType::Binary64 : FormatType::Binary32,
+              uses_64bit_storage ? FormatPackKind::U64 : FormatPackKind::U32)};
     case 'B':
-      return ResolvedField{.field = MakeField(
-                              parsed,
-                              uses_64bit_storage ? FormatType::Binary64
-                                                 : FormatType::Binary32,
-                              uses_64bit_storage ? FormatPackKind::U64
-                                                 : FormatPackKind::U32,
-                              true)};
+      return ResolvedField{
+          .field = MakeField(
+              parsed, uses_64bit_storage ? FormatType::Binary64 : FormatType::Binary32,
+              uses_64bit_storage ? FormatPackKind::U64 : FormatPackKind::U32, true)};
     case 'o':
-      return ResolvedField{.field = MakeField(
-                              parsed,
-                              uses_64bit_storage ? FormatType::Octal64
-                                                 : FormatType::Octal32,
-                              uses_64bit_storage ? FormatPackKind::U64
-                                                 : FormatPackKind::U32)};
+      return ResolvedField{
+          .field = MakeField(
+              parsed, uses_64bit_storage ? FormatType::Octal64 : FormatType::Octal32,
+              uses_64bit_storage ? FormatPackKind::U64 : FormatPackKind::U32)};
     case 'x':
-      return ResolvedField{.field = MakeField(
-                              parsed,
-                              uses_64bit_storage ? FormatType::HexLower64
-                                                 : FormatType::HexLower32,
-                              uses_64bit_storage ? FormatPackKind::U64
-                                                 : FormatPackKind::U32)};
+      return ResolvedField{
+          .field = MakeField(
+              parsed,
+              uses_64bit_storage ? FormatType::HexLower64 : FormatType::HexLower32,
+              uses_64bit_storage ? FormatPackKind::U64 : FormatPackKind::U32)};
     case 'X':
-      return ResolvedField{.field = MakeField(
-                              parsed,
-                              uses_64bit_storage ? FormatType::HexUpper64
-                                                 : FormatType::HexUpper32,
-                              uses_64bit_storage ? FormatPackKind::U64
-                                                 : FormatPackKind::U32,
-                              true)};
+      return ResolvedField{
+          .field = MakeField(
+              parsed,
+              uses_64bit_storage ? FormatType::HexUpper64 : FormatType::HexUpper32,
+              uses_64bit_storage ? FormatPackKind::U64 : FormatPackKind::U32, true)};
     default:
       return ResolvedField{.error = Error::ArgumentTypeMismatch};
   }
 }
 
 /**
- * @brief 针对 bool 参数解析一个已解析的 brace 字段 / Resolve one parsed brace field for a bool argument
+ * @brief 针对 bool 参数解析一个已解析的 brace 字段 / Resolve one parsed brace field for a
+ * bool argument
  * @param parsed 已解析的 brace 字段 / Parsed brace field
- * @return 返回解析后的共享字段；不匹配时返回首个类型错误 / Returns the resolved shared field, or the first type-mismatch error
+ * @return 返回解析后的共享字段；不匹配时返回首个类型错误 / Returns the resolved shared
+ * field, or the first type-mismatch error
  */
 [[nodiscard]] consteval ResolvedField ResolveBoolField(const ParsedField& parsed)
 {
@@ -134,9 +128,11 @@ namespace ArgumentResolution
 }
 
 /**
- * @brief 针对字符参数解析一个已解析的 brace 字段 / Resolve one parsed brace field for a character argument
+ * @brief 针对字符参数解析一个已解析的 brace 字段 / Resolve one parsed brace field for a
+ * character argument
  * @param parsed 已解析的 brace 字段 / Parsed brace field
- * @return 返回解析后的共享字段；不匹配时返回首个类型错误 / Returns the resolved shared field, or the first type-mismatch error
+ * @return 返回解析后的共享字段；不匹配时返回首个类型错误 / Returns the resolved shared
+ * field, or the first type-mismatch error
  */
 [[nodiscard]] consteval ResolvedField ResolveCharacterField(const ParsedField& parsed)
 {
@@ -144,7 +140,8 @@ namespace ArgumentResolution
   {
     return ResolvedField{.error = Error::ArgumentTypeMismatch};
   }
-  if (parsed.alternate || HasSignOption(parsed) || parsed.zero_pad || parsed.has_precision)
+  if (parsed.alternate || HasSignOption(parsed) || parsed.zero_pad ||
+      parsed.has_precision)
   {
     return ResolvedField{.error = Error::ArgumentTypeMismatch};
   }
@@ -164,9 +161,11 @@ namespace ArgumentResolution
 }
 
 /**
- * @brief 针对字符串类参数解析一个已解析的 brace 字段 / Resolve one parsed brace field for a string-like argument
+ * @brief 针对字符串类参数解析一个已解析的 brace 字段 / Resolve one parsed brace field for
+ * a string-like argument
  * @param parsed 已解析的 brace 字段 / Parsed brace field
- * @return 返回解析后的共享字段；不匹配时返回首个类型错误 / Returns the resolved shared field, or the first type-mismatch error
+ * @return 返回解析后的共享字段；不匹配时返回首个类型错误 / Returns the resolved shared
+ * field, or the first type-mismatch error
  */
 [[nodiscard]] consteval ResolvedField ResolveStringField(const ParsedField& parsed)
 {
@@ -194,9 +193,11 @@ namespace ArgumentResolution
 }
 
 /**
- * @brief 针对指针类参数解析一个已解析的 brace 字段 / Resolve one parsed brace field for a pointer-like argument
+ * @brief 针对指针类参数解析一个已解析的 brace 字段 / Resolve one parsed brace field for a
+ * pointer-like argument
  * @param parsed 已解析的 brace 字段 / Parsed brace field
- * @return 返回解析后的共享字段；不匹配时返回首个类型错误 / Returns the resolved shared field, or the first type-mismatch error
+ * @return 返回解析后的共享字段；不匹配时返回首个类型错误 / Returns the resolved shared
+ * field, or the first type-mismatch error
  */
 [[nodiscard]] consteval ResolvedField ResolvePointerField(const ParsedField& parsed)
 {
@@ -204,7 +205,8 @@ namespace ArgumentResolution
   {
     return ResolvedField{.error = Error::ArgumentTypeMismatch};
   }
-  if (parsed.alternate || HasSignOption(parsed) || parsed.zero_pad || parsed.has_precision)
+  if (parsed.alternate || HasSignOption(parsed) || parsed.zero_pad ||
+      parsed.has_precision)
   {
     return ResolvedField{.error = Error::ArgumentTypeMismatch};
   }

--- a/src/core/print/format/format_frontend_detail.hpp
+++ b/src/core/print/format/format_frontend_detail.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 /**
- * @brief brace 前端的编译期分析与降级入口层 / Brace frontend compile-time analysis and lowering entry surface
+ * @brief brace 前端的编译期分析与降级入口层 / Brace frontend compile-time analysis and
+ * lowering entry surface
  */
 
 #include <array>
@@ -11,38 +12,51 @@
 #include <string_view>
 #include <type_traits>
 
-#include "../format_compile.hpp"
 #include "../format_argument.hpp"
+#include "../format_compile.hpp"
 #include "../printf.hpp"
 
 namespace LibXR::Print::Detail::FormatFrontend
 {
 /**
- * @brief brace 风格 format 前端的编译期失败类别。 / Compile-time failure categories for the brace-style format frontend.
+ * @brief brace 风格 format 前端的编译期失败类别。 / Compile-time failure categories for
+ * the brace-style format frontend.
  */
 enum class Error : uint8_t
 {
-  None,                    ///< success / 成功
-  NumberOverflow,          ///< index / width / precision does not fit its target field / 索引、宽度或精度超出目标字段容量
-  FloatPrecisionLimitExceeded,  ///< float precision exceeds the configured frontend limit / 浮点精度超出当前配置的前端上限
-  UnexpectedEnd,           ///< source ended in the middle of one field / 字段尚未结束时源串已结束
-  EmbeddedNul,             ///< embedded NUL before the terminator / 终止字节之前出现嵌入式 NUL
-  UnmatchedBrace,          ///< unmatched { or } / 花括号未正确配对
-  MixedIndexing,           ///< automatic and manual indexing were mixed / 混用了自动索引与手动索引
-  ManualIndexingDisabled,  ///< explicit {0}/{1} argument indexing is disabled by configuration / 显式 {0}/{1} 参数索引已被配置关闭
-  DynamicField,            ///< nested replacement field in width / precision is unsupported / 不支持宽度或精度中的嵌套替换字段
-  InvalidArgumentIndex,    ///< field head is not a valid decimal argument index / 字段开头不是合法的十进制参数索引
-  InvalidSpecifier,        ///< malformed format-spec grammar / format-spec 语法非法
-  InvalidPresentation,     ///< unsupported presentation type character / 不支持的展示类型字符
-  MissingArgument,         ///< referenced argument index is out of range / 引用的参数索引超出实参数量
-  ArgumentTypeMismatch,    ///< format options are incompatible with the selected argument type / 格式选项与选中的参数类型不兼容
-  UnsupportedArgumentType,  ///< C++ argument type is not supported by this frontend / 当前前端不支持该 C++ 参数类型
-  TextOffsetOverflow,      ///< referenced text offset no longer fits in uint16_t / 文本池偏移超出 uint16_t
-  TextSizeOverflow,        ///< referenced text size no longer fits in uint16_t / 文本长度超出 uint16_t
+  None,            ///< success / 成功
+  NumberOverflow,  ///< index / width / precision does not fit its target field /
+                   ///< 索引、宽度或精度超出目标字段容量
+  FloatPrecisionLimitExceeded,  ///< float precision exceeds the configured frontend limit
+                                ///< / 浮点精度超出当前配置的前端上限
+  UnexpectedEnd,   ///< source ended in the middle of one field / 字段尚未结束时源串已结束
+  EmbeddedNul,     ///< embedded NUL before the terminator / 终止字节之前出现嵌入式 NUL
+  UnmatchedBrace,  ///< unmatched { or } / 花括号未正确配对
+  MixedIndexing,  ///< automatic and manual indexing were mixed / 混用了自动索引与手动索引
+  ManualIndexingDisabled,  ///< explicit {0}/{1} argument indexing is disabled by
+                           ///< configuration / 显式 {0}/{1} 参数索引已被配置关闭
+  DynamicField,  ///< nested replacement field in width / precision is unsupported /
+                 ///< 不支持宽度或精度中的嵌套替换字段
+  InvalidArgumentIndex,  ///< field head is not a valid decimal argument index /
+                         ///< 字段开头不是合法的十进制参数索引
+  InvalidSpecifier,      ///< malformed format-spec grammar / format-spec 语法非法
+  InvalidPresentation,   ///< unsupported presentation type character /
+                         ///< 不支持的展示类型字符
+  MissingArgument,       ///< referenced argument index is out of range /
+                         ///< 引用的参数索引超出实参数量
+  ArgumentTypeMismatch,  ///< format options are incompatible with the selected argument
+                         ///< type / 格式选项与选中的参数类型不兼容
+  UnsupportedArgumentType,  ///< C++ argument type is not supported by this frontend /
+                            ///< 当前前端不支持该 C++ 参数类型
+  TextOffsetOverflow,       ///< referenced text offset no longer fits in uint16_t /
+                            ///< 文本池偏移超出 uint16_t
+  TextSizeOverflow,  ///< referenced text size no longer fits in uint16_t / 文本长度超出
+                     ///< uint16_t
 };
 
 /**
- * @brief 降为 FormatFlag 位之前的已解析对齐方式。 / Parsed alignment directive before lowering into FormatFlag bits.
+ * @brief 降为 FormatFlag 位之前的已解析对齐方式。 / Parsed alignment directive before
+ * lowering into FormatFlag bits.
  */
 enum class Align : uint8_t
 {
@@ -53,25 +67,29 @@ enum class Align : uint8_t
 };
 
 /**
- * @brief 在绑定到具体 C++ 参数类型之前的 brace 字段解析结果。 / Parsed brace field before binding it to one concrete C++ argument type.
+ * @brief 在绑定到具体 C++ 参数类型之前的 brace 字段解析结果。 / Parsed brace field before
+ * binding it to one concrete C++ argument type.
  */
 struct ParsedField
 {
-  size_t arg_index = 0;     ///< selected source argument index / 选中的源参数索引
+  size_t arg_index = 0;       ///< selected source argument index / 选中的源参数索引
   Align align = Align::None;  ///< parsed alignment / 已解析对齐方式
-  char fill = ' ';          ///< parsed fill character / 已解析填充字符
-  bool force_sign = false;  ///< parsed plus-sign option / 已解析正号选项
-  bool space_sign = false;  ///< parsed space-sign option / 已解析空格符号选项
-  bool alternate = false;   ///< parsed alternate-form option / 已解析备用格式选项
-  bool zero_pad = false;    ///< parsed zero-pad option / 已解析零填充选项
-  uint8_t width = 0;        ///< parsed constant width / 已解析常量宽度
-  bool has_precision = false;  ///< whether precision was explicitly present / 是否显式给出了精度
-  uint8_t precision = 0;    ///< parsed precision when present / 显式给出时的精度值
-  char presentation = 0;    ///< parsed presentation character, or 0 for default / 展示类型字符；缺省时为 0
+  char fill = ' ';            ///< parsed fill character / 已解析填充字符
+  bool force_sign = false;    ///< parsed plus-sign option / 已解析正号选项
+  bool space_sign = false;    ///< parsed space-sign option / 已解析空格符号选项
+  bool alternate = false;     ///< parsed alternate-form option / 已解析备用格式选项
+  bool zero_pad = false;      ///< parsed zero-pad option / 已解析零填充选项
+  uint8_t width = 0;          ///< parsed constant width / 已解析常量宽度
+  bool has_precision =
+      false;  ///< whether precision was explicitly present / 是否显式给出了精度
+  uint8_t precision = 0;  ///< parsed precision when present / 显式给出时的精度值
+  char presentation =
+      0;  ///< parsed presentation character, or 0 for default / 展示类型字符；缺省时为 0
 };
 
 /**
- * @brief 前端侧的参数类别，用来选择字段该走哪条解析路径。 / Frontend-side argument categories used to choose one field-resolution path.
+ * @brief 前端侧的参数类别，用来选择字段该走哪条解析路径。 / Frontend-side argument
+ * categories used to choose one field-resolution path.
  */
 enum class ArgumentKind : uint8_t
 {
@@ -88,16 +106,20 @@ enum class ArgumentKind : uint8_t
 };
 
 /**
- * @brief 单个 C++ 参数在前端里的类别摘要，以及对应的宽度策略。 / Frontend summary of one C++ argument category plus width policy.
+ * @brief 单个 C++ 参数在前端里的类别摘要，以及对应的宽度策略。 / Frontend summary of one
+ * C++ argument category plus width policy.
  */
 struct ArgumentSummary
 {
-  ArgumentKind kind = ArgumentKind::Unsupported;  ///< frontend-side argument category / 前端侧参数类别
-  bool uses_64bit_storage = false;          ///< whether integer storage must be 64-bit / 整数是否必须走 64 位存储
+  ArgumentKind kind =
+      ArgumentKind::Unsupported;  ///< frontend-side argument category / 前端侧参数类别
+  bool uses_64bit_storage =
+      false;  ///< whether integer storage must be 64-bit / 整数是否必须走 64 位存储
 };
 
 /**
- * @brief 将单个已解析 brace 字段解析成共享格式协议后的结果。 / Result of resolving one parsed brace field into the shared format protocol.
+ * @brief 将单个已解析 brace 字段解析成共享格式协议后的结果。 / Result of resolving one
+ * parsed brace field into the shared format protocol.
  */
 struct ResolvedField
 {
@@ -105,16 +127,22 @@ struct ResolvedField
   FormatField field{};        ///< resolved shared field / 解析后的共享字段
 };
 
+// These implementation headers form an ordered dependency chain.
+// clang-format off
 #include "format_frontend_source.hpp"
 
 #include "format_frontend_binding_base.hpp"
 #include "format_frontend_binding_integer.hpp"
 #include "format_frontend_binding_float.hpp"
+// clang-format on
 
 /**
- * @brief 对单条 brace 风格字面量执行仅源串分析 / Run source-only analysis for one brace-style literal
+ * @brief 对单条 brace 风格字面量执行仅源串分析 / Run source-only analysis for one
+ * brace-style literal
  * @tparam Source brace 风格格式串字面量 / Brace-style format literal
- * @return 源串分析结果，包含字段顺序、所需参数个数与首个源级错误 / Returns the source analysis result, including field order, required argument count, and the first source-level error
+ * @return 源串分析结果，包含字段顺序、所需参数个数与首个源级错误 / Returns the source
+ * analysis result, including field order, required argument count, and the first
+ * source-level error
  */
 template <Text Source>
 [[nodiscard]] consteval auto Analyze()
@@ -123,11 +151,16 @@ template <Text Source>
 }
 
 /**
- * @brief 遍历一条 brace 风格字面量，并针对具体 C++ 参数列表产出共享 `FormatField` 记录 / Walk one brace-style literal and emit shared `FormatField` records selected for the concrete C++ argument list
+ * @brief 遍历一条 brace 风格字面量，并针对具体 C++ 参数列表产出共享 `FormatField` 记录 /
+ * Walk one brace-style literal and emit shared `FormatField` records selected for the
+ * concrete C++ argument list
  * @tparam Source brace 风格格式串字面量 / Brace-style format literal
- * @tparam Args 这次绑定使用的 C++ 实参类型列表 / Concrete C++ argument types used for this binding
- * @param visitor 接收文本片段与最终 `FormatField` 记录的 visitor / Visitor receiving text spans and final `FormatField` records
- * @return 首个源级错误或字段解析错误；成功时返回 `Error::None` / Returns the first source-level or field-resolution error; returns `Error::None` on success
+ * @tparam Args 这次绑定使用的 C++ 实参类型列表 / Concrete C++ argument types used for
+ * this binding
+ * @param visitor 接收文本片段与最终 `FormatField` 记录的 visitor / Visitor receiving text
+ * spans and final `FormatField` records
+ * @return 首个源级错误或字段解析错误；成功时返回 `Error::None` / Returns the first
+ * source-level or field-resolution error; returns `Error::None` on success
  */
 template <Text Source, typename... Args>
 [[nodiscard]] consteval Error WalkSourceAsFormatFields(auto& visitor)
@@ -158,9 +191,11 @@ template <Text Source, typename... Args>
 }
 
 /**
- * @brief 将一条 brace 风格源字面量绑定到一组具体 C++ 参数类型上的前端适配器 / Frontend adapter that binds one brace-style source literal to one concrete C++ argument list
+ * @brief 将一条 brace 风格源字面量绑定到一组具体 C++ 参数类型上的前端适配器 / Frontend
+ * adapter that binds one brace-style source literal to one concrete C++ argument list
  * @tparam Source brace 风格格式串字面量 / Brace-style format literal
- * @tparam Args 这次绑定使用的 C++ 实参类型列表 / Concrete C++ argument types used for this binding
+ * @tparam Args 这次绑定使用的 C++ 实参类型列表 / Concrete C++ argument types used for
+ * this binding
  */
 template <Text Source, typename... Args>
 class Compiler
@@ -169,20 +204,25 @@ class Compiler
   using ErrorType = Error;
 
   /**
-   * @brief 返回不含结尾零字节的源字符串字节序列 / Return the source string bytes without a terminating zero byte
+   * @brief 返回不含结尾零字节的源字符串字节序列 / Return the source string bytes without
+   * a terminating zero byte
    * @return 指向当前格式字面量正文的指针 / Returns a pointer to the literal body
    */
   [[nodiscard]] static constexpr const char* SourceData() { return Source.Data(); }
   /**
-   * @brief 返回不含结尾零字节的源字符串长度 / Return the source string length without a terminating zero byte
+   * @brief 返回不含结尾零字节的源字符串长度 / Return the source string length without a
+   * terminating zero byte
    * @return 当前格式字面量正文长度 / Returns the literal-body size
    */
   [[nodiscard]] static constexpr size_t SourceSize() { return Source.Size(); }
 
   /**
-   * @brief 遍历当前已绑定前端，并产出文本片段和最终 `FormatField` 记录 / Walk this bound frontend and emit text spans plus final `FormatField` records
-   * @param visitor 接收文本片段与最终字段记录的 visitor / Visitor receiving text spans and final field records
-   * @return 首个源级错误或字段解析错误；成功时返回 `Error::None` / Returns the first source-level or field-resolution error; returns `Error::None` on success
+   * @brief 遍历当前已绑定前端，并产出文本片段和最终 `FormatField` 记录 / Walk this bound
+   * frontend and emit text spans plus final `FormatField` records
+   * @param visitor 接收文本片段与最终字段记录的 visitor / Visitor receiving text spans
+   * and final field records
+   * @return 首个源级错误或字段解析错误；成功时返回 `Error::None` / Returns the first
+   * source-level or field-resolution error; returns `Error::None` on success
    */
   [[nodiscard]] static consteval ErrorType Walk(auto& visitor)
   {

--- a/src/core/print/format/format_frontend_parser.hpp
+++ b/src/core/print/format/format_frontend_parser.hpp
@@ -1,22 +1,24 @@
 #pragma once
 
 /**
- * @brief brace 风格语法的源串解析辅助函数 / Source parser helpers for the brace-style grammar
+ * @brief brace 风格语法的源串解析辅助函数 / Source parser helpers for the brace-style
+ * grammar
  */
 /**
- * @brief 判断一个源字节是否为 ASCII 十进制数字 / Return whether one source byte is an ASCII decimal digit
+ * @brief 判断一个源字节是否为 ASCII 十进制数字 / Return whether one source byte is an
+ * ASCII decimal digit
  * @param ch 待检查的源字节 / Source byte to inspect
- * @return 若是 ASCII 十进制数字则返回 `true`，否则返回 `false` / Returns `true` for an ASCII decimal digit, otherwise `false`
+ * @return 若是 ASCII 十进制数字则返回 `true`，否则返回 `false` / Returns `true` for an
+ * ASCII decimal digit, otherwise `false`
  */
-[[nodiscard]] constexpr bool IsDigit(char ch)
-{
-  return ch >= '0' && ch <= '9';
-}
+[[nodiscard]] constexpr bool IsDigit(char ch) { return ch >= '0' && ch <= '9'; }
 
 /**
- * @brief 判断一个源字符是否为合法的 brace 格式对齐标记 / Return whether one source character is a valid brace-format align token
+ * @brief 判断一个源字符是否为合法的 brace 格式对齐标记 / Return whether one source
+ * character is a valid brace-format align token
  * @param ch 待检查的源字符 / Source character to inspect
- * @return 合法对齐字符返回 `true`，否则返回 `false` / Returns `true` for a valid align token, otherwise `false`
+ * @return 合法对齐字符返回 `true`，否则返回 `false` / Returns `true` for a valid align
+ * token, otherwise `false`
  */
 [[nodiscard]] constexpr bool IsAlign(char ch)
 {
@@ -24,9 +26,11 @@
 }
 
 /**
- * @brief 将一个 brace 格式对齐字符转换为前端枚举值 / Convert one brace-format align token to the frontend enum value
+ * @brief 将一个 brace 格式对齐字符转换为前端枚举值 / Convert one brace-format align token
+ * to the frontend enum value
  * @param ch 对齐字符 / Align token
- * @return 对应的 `Align` 枚举；未知字符返回 `Align::None` / Returns the corresponding `Align` enum; unknown tokens map to `Align::None`
+ * @return 对应的 `Align` 枚举；未知字符返回 `Align::None` / Returns the corresponding
+ * `Align` enum; unknown tokens map to `Align::None`
  */
 [[nodiscard]] constexpr Align ParseAlign(char ch)
 {
@@ -44,9 +48,11 @@
 }
 
 /**
- * @brief 判断源字符串在终止前是否包含嵌入式 NUL / Return whether the source contains an embedded NUL before the terminator
+ * @brief 判断源字符串在终止前是否包含嵌入式 NUL / Return whether the source contains an
+ * embedded NUL before the terminator
  * @param source 待检查的源字符串 / Source string to inspect
- * @return 若终止前包含 `\\0` 则返回 `true`，否则返回 `false` / Returns `true` when `\\0` appears before the terminator, otherwise `false`
+ * @return 若终止前包含 `\\0` 则返回 `true`，否则返回 `false` / Returns `true` when `\\0`
+ * appears before the terminator, otherwise `false`
  */
 [[nodiscard]] constexpr bool HasEmbeddedNul(std::string_view source)
 {
@@ -61,9 +67,11 @@
 }
 
 /**
- * @brief 判断一个展示字符是否被 brace 前端支持 / Return whether one presentation token is supported by the brace frontend
+ * @brief 判断一个展示字符是否被 brace 前端支持 / Return whether one presentation token is
+ * supported by the brace frontend
  * @param ch 展示字符 / Presentation token
- * @return 支持返回 `true`，否则返回 `false` / Returns `true` when the token is supported, otherwise `false`
+ * @return 支持返回 `true`，否则返回 `false` / Returns `true` when the token is supported,
+ * otherwise `false`
  */
 [[nodiscard]] constexpr bool IsSupportedPresentation(char ch)
 {
@@ -91,13 +99,16 @@
 }
 
 /**
- * @brief 解析一个十进制整数字段片段，并检查是否溢出 / Parse one decimal integer fragment with overflow checking
+ * @brief 解析一个十进制整数字段片段，并检查是否溢出 / Parse one decimal integer fragment
+ * with overflow checking
  * @tparam UInt 目标无符号整数类型 / Target unsigned integer type
  * @param source 源字符串 / Source string
- * @param pos 当前解析位置，成功时推进到片段之后 / Current parse position; advanced past the fragment on success
+ * @param pos 当前解析位置，成功时推进到片段之后 / Current parse position; advanced past
+ * the fragment on success
  * @param limit 允许的最大值 / Inclusive upper bound accepted by this field
  * @param value 输出解析结果 / Parsed result output
- * @return 成功返回 `Error::None`；溢出或语法不合法时返回对应错误 / Returns `Error::None` on success, or the first overflow or syntax error
+ * @return 成功返回 `Error::None`；溢出或语法不合法时返回对应错误 / Returns `Error::None`
+ * on success, or the first overflow or syntax error
  */
 template <typename UInt>
 [[nodiscard]] consteval Error ParseUnsigned(std::string_view source, size_t& pos,
@@ -126,26 +137,29 @@ template <typename UInt>
 }
 
 /**
- * @brief brace 字段自动索引与手动索引的源级状态 / Source-level indexing mode for automatic versus manual brace fields
+ * @brief brace 字段自动索引与手动索引的源级状态 / Source-level indexing mode for
+ * automatic versus manual brace fields
  */
 struct IndexingState
 {
-  bool uses_manual = false;  ///< manual field numbering is in use / 正在使用手动编号
-  bool uses_auto = false;    ///< automatic field numbering is in use / 正在使用自动编号
+  bool uses_manual = false;    ///< manual field numbering is in use / 正在使用手动编号
+  bool uses_auto = false;      ///< automatic field numbering is in use / 正在使用自动编号
   size_t next_auto_index = 0;  ///< next automatic argument index / 下一个自动参数索引
 };
 
 /**
- * @brief 解析 `:` 或 `}` 之前的字段头，包括自动或手动参数索引选择 / Parse the field head before `:` or `}`, including automatic or manual argument index selection
+ * @brief 解析 `:` 或 `}` 之前的字段头，包括自动或手动参数索引选择 / Parse the field head
+ * before `:` or `}`, including automatic or manual argument index selection
  * @param source 源字符串 / Source string
- * @param pos 当前解析位置，成功时推进到字段头之后 / Current parse position; advanced past the field head on success
+ * @param pos 当前解析位置，成功时推进到字段头之后 / Current parse position; advanced past
+ * the field head on success
  * @param indexing 自动或手动索引状态 / Auto or manual indexing state
  * @param field 输出字段头结果 / Parsed field-head output
- * @return 成功返回 `Error::None`；语法或索引模式不合法时返回对应错误 / Returns `Error::None` on success, or the first syntax or indexing error
+ * @return 成功返回 `Error::None`；语法或索引模式不合法时返回对应错误 / Returns
+ * `Error::None` on success, or the first syntax or indexing error
  */
 [[nodiscard]] consteval Error ParseFieldHead(std::string_view source, size_t& pos,
-                                             IndexingState& indexing,
-                                             ParsedField& field)
+                                             IndexingState& indexing, ParsedField& field)
 {
   if (pos >= source.size())
   {
@@ -170,8 +184,7 @@ struct IndexingState
   }
 
   size_t index = 0;
-  auto error =
-      ParseUnsigned(source, pos, std::numeric_limits<size_t>::max(), index);
+  auto error = ParseUnsigned(source, pos, std::numeric_limits<size_t>::max(), index);
   if (error != Error::None)
   {
     return error;
@@ -193,11 +206,14 @@ struct IndexingState
 }
 
 /**
- * @brief 解析一个 brace 字段中 `:` 之后的可选 format-spec 部分 / Parse the optional format-spec portion after `:` inside one brace field
+ * @brief 解析一个 brace 字段中 `:` 之后的可选 format-spec 部分 / Parse the optional
+ * format-spec portion after `:` inside one brace field
  * @param source 源字符串 / Source string
- * @param pos 当前解析位置，成功时推进到 format-spec 之后 / Current parse position; advanced past the format-spec on success
+ * @param pos 当前解析位置，成功时推进到 format-spec 之后 / Current parse position;
+ * advanced past the format-spec on success
  * @param field 待填充的字段结果 / Parsed field output being filled
- * @return 成功返回 `Error::None`；format-spec 非法时返回对应错误 / Returns `Error::None` on success, or the first format-spec error
+ * @return 成功返回 `Error::None`；format-spec 非法时返回对应错误 / Returns `Error::None`
+ * on success, or the first format-spec error
  */
 [[nodiscard]] consteval Error ParseFormatSpec(std::string_view source, size_t& pos,
                                               ParsedField& field)
@@ -267,8 +283,8 @@ struct IndexingState
     {
       return Error::InvalidSpecifier;
     }
-    auto error = ParseUnsigned(source, pos, std::numeric_limits<uint8_t>::max(),
-                               field.width);
+    auto error =
+        ParseUnsigned(source, pos, std::numeric_limits<uint8_t>::max(), field.width);
     if (error != Error::None)
     {
       return error;
@@ -311,16 +327,18 @@ struct IndexingState
 }
 
 /**
- * @brief 解析一个完整 brace 字段，从 `{` 一直到匹配的 `}` / Parse one complete brace field from `{` through the matching `}`
+ * @brief 解析一个完整 brace 字段，从 `{` 一直到匹配的 `}` / Parse one complete brace
+ * field from `{` through the matching `}`
  * @param source 源字符串 / Source string
- * @param pos 当前解析位置，进入时应指向 `{`，成功时推进到 `}` 之后 / Current parse position; must point at `{` on entry and lands after `}` on success
+ * @param pos 当前解析位置，进入时应指向 `{`，成功时推进到 `}` 之后 / Current parse
+ * position; must point at `{` on entry and lands after `}` on success
  * @param indexing 自动或手动索引状态 / Auto or manual indexing state
  * @param field 输出字段结果 / Parsed field output
- * @return 成功返回 `Error::None`；字段语法不合法时返回对应错误 / Returns `Error::None` on success, or the first field-syntax error
+ * @return 成功返回 `Error::None`；字段语法不合法时返回对应错误 / Returns `Error::None` on
+ * success, or the first field-syntax error
  */
 [[nodiscard]] consteval Error ParseField(std::string_view source, size_t& pos,
-                                         IndexingState& indexing,
-                                         ParsedField& field)
+                                         IndexingState& indexing, ParsedField& field)
 {
   ++pos;
   if (pos >= source.size())

--- a/src/core/print/format/format_frontend_source.hpp
+++ b/src/core/print/format/format_frontend_source.hpp
@@ -3,28 +3,36 @@
 namespace SourceSyntax
 {
 /**
- * @brief 单条 brace 风格格式字面量的仅源串分析数据 / Source-only analysis data for one brace-style format literal
+ * @brief 单条 brace 风格格式字面量的仅源串分析数据 / Source-only analysis data for one
+ * brace-style format literal
  * @tparam FieldCount 最终解析出的字段数量 / Final parsed field count
  */
 template <size_t FieldCount>
 struct SourceAnalysis
 {
-  std::array<size_t, FieldCount> argument_order{};  ///< source-ordered argument references / 按源串顺序引用的参数索引
-  size_t required_argument_count = 0;  ///< minimum call-site argument count / 调用点至少需要的参数个数
-  Error error = Error::None;           ///< first source-only parse error / 首个仅源串解析错误
+  std::array<size_t, FieldCount>
+      argument_order{};  ///< source-ordered argument references /
+                         ///< 按源串顺序引用的参数索引
+  size_t required_argument_count =
+      0;  ///< minimum call-site argument count / 调用点至少需要的参数个数
+  Error error = Error::None;  ///< first source-only parse error / 首个仅源串解析错误
 };
 
 /**
- * @brief 仅源串分析阶段使用的保守临时累加器 / Conservative temporary accumulator used during source-only analysis
- * @tparam MaxFieldCount 已解析字段数量的保守上界 / Conservative upper bound for parsed field count
+ * @brief 仅源串分析阶段使用的保守临时累加器 / Conservative temporary accumulator used
+ * during source-only analysis
+ * @tparam MaxFieldCount 已解析字段数量的保守上界 / Conservative upper bound for parsed
+ * field count
  */
 template <size_t MaxFieldCount>
 struct SourceAnalysisScratch
 {
-  std::array<size_t, MaxFieldCount> order{};  ///< conservative field-order scratch buffer / 按字段顺序记录参数索引的临时缓冲区
-  size_t field_count = 0;                     ///< parsed replacement-field count / 已解析的替换字段数量
-  size_t required_argument_count = 0;         ///< minimum call-site argument count / 调用点至少需要的参数个数
-  Error error = Error::None;                  ///< first parse error / 首个解析错误
+  std::array<size_t, MaxFieldCount> order{};  ///< conservative field-order scratch buffer
+                                              ///< / 按字段顺序记录参数索引的临时缓冲区
+  size_t field_count = 0;  ///< parsed replacement-field count / 已解析的替换字段数量
+  size_t required_argument_count =
+      0;  ///< minimum call-site argument count / 调用点至少需要的参数个数
+  Error error = Error::None;  ///< first parse error / 首个解析错误
 
   [[nodiscard]] consteval Error Text(size_t, size_t) const { return Error::None; }
 
@@ -43,10 +51,13 @@ struct SourceAnalysisScratch
 #include "format_frontend_parser.hpp"
 
 /**
- * @brief 遍历一个 brace 源字符串，并发射字面文本片段与已解析字段 / Walk one brace source string and emit literal-text spans plus parsed fields
+ * @brief 遍历一个 brace 源字符串，并发射字面文本片段与已解析字段 / Walk one brace source
+ * string and emit literal-text spans plus parsed fields
  * @param source 当前待解析的 brace 源字符串 / Brace source string to walk
- * @param visitor 接收文本片段与已解析字段的 visitor / Visitor receiving text spans and parsed fields
- * @return 首个源级解析错误；成功时返回 `Error::None` / Returns the first source-level parse error, or `Error::None` on success
+ * @param visitor 接收文本片段与已解析字段的 visitor / Visitor receiving text spans and
+ * parsed fields
+ * @return 首个源级解析错误；成功时返回 `Error::None` / Returns the first source-level
+ * parse error, or `Error::None` on success
  */
 [[nodiscard]] consteval Error WalkSource(std::string_view source, auto& visitor)
 {
@@ -132,14 +143,19 @@ struct SourceAnalysisScratch
 }
 
 /**
- * @brief 对一个 brace 字面量执行仅源串分析，并返回按顺序整理的参数索引摘要 / Run source-only analysis for one brace literal and return the ordered argument-index summary
+ * @brief 对一个 brace 字面量执行仅源串分析，并返回按顺序整理的参数索引摘要 / Run
+ * source-only analysis for one brace literal and return the ordered argument-index
+ * summary
  * @tparam Source brace 风格格式串字面量 / Brace-style format literal
- * @return 源串分析结果，包含字段顺序、所需参数个数与首个源级错误 / Returns the source analysis result, including field order, required argument count, and the first source-level error
+ * @return 源串分析结果，包含字段顺序、所需参数个数与首个源级错误 / Returns the source
+ * analysis result, including field order, required argument count, and the first
+ * source-level error
  */
 template <Text Source>
 [[nodiscard]] consteval auto Analyze()
 {
-  constexpr auto scratch = []() consteval {
+  constexpr auto scratch = []() consteval
+  {
     SourceAnalysisScratch<Source.Size()> visitor{};
     visitor.error = WalkSource(std::string_view(Source.Data(), Source.Size()), visitor);
     return visitor;

--- a/src/core/print/format_argument.hpp
+++ b/src/core/print/format_argument.hpp
@@ -30,12 +30,12 @@ struct TypeTraits
       typename std::conditional_t<std::is_enum_v<Decayed>, std::underlying_type<Decayed>,
                                   std::type_identity<Decayed>>::type;
 
-  static constexpr bool is_signed_integer =
-      std::is_integral_v<Normalized> && !std::is_same_v<Normalized, bool> &&
-      std::is_signed_v<Normalized>;
-  static constexpr bool is_unsigned_integer =
-      std::is_integral_v<Normalized> && !std::is_same_v<Normalized, bool> &&
-      std::is_unsigned_v<Normalized>;
+  static constexpr bool is_signed_integer = std::is_integral_v<Normalized> &&
+                                            !std::is_same_v<Normalized, bool> &&
+                                            std::is_signed_v<Normalized>;
+  static constexpr bool is_unsigned_integer = std::is_integral_v<Normalized> &&
+                                              !std::is_same_v<Normalized, bool> &&
+                                              std::is_unsigned_v<Normalized>;
   static constexpr bool is_default_signed_integer =
       is_signed_integer && sizeof(Normalized) <= sizeof(int);
   static constexpr bool is_default_unsigned_integer =
@@ -43,23 +43,23 @@ struct TypeTraits
   static constexpr bool is_char_array =
       std::is_array_v<Decayed> &&
       std::is_same_v<std::remove_cv_t<std::remove_extent_t<Decayed>>, char>;
-  static constexpr bool is_c_string =
-      std::is_same_v<Decayed, const char*> || std::is_same_v<Decayed, char*> ||
-      is_char_array;
-  static constexpr bool is_string_like =
-      is_c_string || std::is_same_v<Decayed, std::string_view> ||
-      std::is_same_v<Decayed, std::string>;
+  static constexpr bool is_c_string = std::is_same_v<Decayed, const char*> ||
+                                      std::is_same_v<Decayed, char*> || is_char_array;
+  static constexpr bool is_string_like = is_c_string ||
+                                         std::is_same_v<Decayed, std::string_view> ||
+                                         std::is_same_v<Decayed, std::string>;
   static constexpr bool is_pointer_like =
       (std::is_pointer_v<Decayed> &&
        !std::is_function_v<std::remove_pointer_t<Decayed>>) ||
       std::is_same_v<Decayed, std::nullptr_t>;
   static constexpr bool is_character_like = std::is_integral_v<Normalized>;
-  static constexpr bool is_float = std::is_same_v<Decayed, float> ||
-                                   std::is_same_v<Decayed, double>;
+  static constexpr bool is_float =
+      std::is_same_v<Decayed, float> || std::is_same_v<Decayed, double>;
   static constexpr bool is_long_double = std::is_same_v<Decayed, long double>;
 
   /**
-   * @brief 判断当前 C++ 实参类型是否满足某条编译期匹配规则。 / Returns whether this C++ argument type satisfies one compile-time rule.
+   * @brief 判断当前 C++ 实参类型是否满足某条编译期匹配规则。 / Returns whether this C++
+   * argument type satisfies one compile-time rule.
    * @param rule Compile-time matching rule to test. / 待测试的编译期匹配规则。
    * @return Returns `true` when the current type satisfies `rule`, otherwise
    *         `false`. / 当前类型满足 `rule` 时返回 `true`，否则返回 `false`。
@@ -122,12 +122,14 @@ struct TypeTraits
 };
 
 /**
- * @brief 将一组模板实参与一组规则数组逐项展开比对 / Expand one argument list against one rule array
+ * @brief 将一组模板实参与一组规则数组逐项展开比对 / Expand one argument list against one
+ * rule array
  * @tparam Args 参与匹配的 C++ 实参类型列表 / C++ argument types being matched
  * @tparam N 规则数组元素个数 / Rule-array element count
  * @tparam I 展开的索引序列 / Expanded index sequence
  * @param arguments 编译后的参数元信息数组 / Compiled argument metadata array
- * @return 仅当每个参数都满足对应规则时返回 `true` / Returns `true` only when every argument satisfies its matching rule
+ * @return 仅当每个参数都满足对应规则时返回 `true` / Returns `true` only when every
+ * argument satisfies its matching rule
  */
 template <typename... Args, size_t N, size_t... I>
 [[nodiscard]] consteval bool MatchesImpl(
@@ -137,11 +139,13 @@ template <typename... Args, size_t N, size_t... I>
 }
 
 /**
- * @brief 判断给定实参列表是否与编译得到的参数元信息数组完全匹配 / Return whether the provided argument list exactly matches the compiled argument metadata array
+ * @brief 判断给定实参列表是否与编译得到的参数元信息数组完全匹配 / Return whether the
+ * provided argument list exactly matches the compiled argument metadata array
  * @tparam Args 参与匹配的 C++ 实参类型列表 / C++ argument types being matched
  * @tparam N 元信息数组元素个数 / Metadata-array element count
  * @param arguments 编译后的参数元信息数组 / Compiled argument metadata array
- * @return 当参数个数和每一项规则都完全匹配时返回 `true`，否则返回 `false` / Returns `true` when the argument count and every argument rule match exactly, otherwise `false`
+ * @return 当参数个数和每一项规则都完全匹配时返回 `true`，否则返回 `false` / Returns
+ * `true` when the argument count and every argument rule match exactly, otherwise `false`
  */
 template <typename... Args, size_t N>
 [[nodiscard]] consteval bool Matches(const std::array<FormatArgumentInfo, N>& arguments)

--- a/src/core/print/format_compile.hpp
+++ b/src/core/print/format_compile.hpp
@@ -13,7 +13,8 @@
 namespace LibXR::Print
 {
 /**
- * @brief 共享编译期后端，把前端事件整理成最终字节流和参数表。 / Shared compile-time backend that turns frontend events into the final byte stream plus argument table.
+ * @brief 共享编译期后端，把前端事件整理成最终字节流和参数表。 / Shared compile-time
+ * backend that turns frontend events into the final byte stream plus argument table.
  *
  * Frontend contract:
  * The frontend must provide the members using ErrorType, static constexpr
@@ -57,7 +58,8 @@ class FormatCompiler
   using Error = typename Frontend::ErrorType;
 
   /**
-   * @brief 当前后端实例产出的最终精确尺寸编译格式 / Final exact-size compiled format produced by this backend instance
+   * @brief 当前后端实例产出的最终精确尺寸编译格式 / Final exact-size compiled format
+   * produced by this backend instance
    * @tparam BlobBytes 最终保留字节块大小 / Final retained byte-block size
    * @tparam ArgCount 最终参数元信息个数 / Final argument metadata count
    */
@@ -68,19 +70,24 @@ class FormatCompiler
         std::array<uint8_t, BlobBytes>;  ///< final runtime byte block / 最终运行期字节块
     using ArgumentListData =
         std::array<FormatArgumentInfo,
-                   ArgCount>;  ///< ordered compile-time argument metadata / 按顺序排列的编译期参数元信息
+                   ArgCount>;  ///< ordered compile-time argument metadata /
+                               ///< 按顺序排列的编译期参数元信息
 
-    CodeList codes{};                    ///< code stream first, text pool second / 前半记录流，后半文本池
-    ArgumentListData arg_info{};         ///< ordered argument metadata / 按参数顺序排列的参数元信息
-    FormatProfile profile = FormatProfile::None;  ///< compile-time executor profile / 编译期执行器配置
-    Error compile_error = Error::None;   ///< first compile-time failure, if any / 首个编译期失败原因
+    CodeList codes{};  ///< code stream first, text pool second / 前半记录流，后半文本池
+    ArgumentListData
+        arg_info{};  ///< ordered argument metadata / 按参数顺序排列的参数元信息
+    FormatProfile profile =
+        FormatProfile::None;  ///< compile-time executor profile / 编译期执行器配置
+    Error compile_error =
+        Error::None;  ///< first compile-time failure, if any / 首个编译期失败原因
   };
 
   template <size_t BlobBytes, size_t ArgCount>
   using Result = ResultData<BlobBytes, ArgCount>;
 
   /**
-   * @brief 超过该长度后，字面文本会从内嵌模式切换为 TextRef / Maximum inline literal size before the backend spills to TextRef.
+   * @brief 超过该长度后，字面文本会从内嵌模式切换为 TextRef / Maximum inline literal size
+   * before the backend spills to TextRef.
    */
   static constexpr size_t inline_text_limit = 2 * sizeof(size_t) - 1;
 
@@ -96,11 +103,11 @@ class FormatCompiler
   static constexpr size_t max_code_bytes = 3 * Frontend::SourceSize() + 1;
   static constexpr size_t max_text_pool_bytes = Frontend::SourceSize();
   static constexpr size_t max_arg_count = Frontend::SourceSize();
-  static constexpr uint8_t unspecified_precision =
-      std::numeric_limits<uint8_t>::max();
+  static constexpr uint8_t unspecified_precision = std::numeric_limits<uint8_t>::max();
 
   /**
-   * @brief 向临时或最终字节缓冲区追加一个原始字节 / Append one raw byte into a scratch or final byte buffer
+   * @brief 向临时或最终字节缓冲区追加一个原始字节 / Append one raw byte into a scratch or
+   * final byte buffer
    * @param data 目标字节缓冲区 / Target byte buffer
    * @param out 当前写位置；会前进一个字节 / Current write position; advanced by one byte
    * @param value 待追加的字节值 / Byte value to append
@@ -111,10 +118,12 @@ class FormatCompiler
   }
 
   /**
-   * @brief 向临时或最终字节缓冲区追加一个按本机字节序编码的 POD 值 / Append one native-endian POD value into a scratch or final byte buffer
+   * @brief 向临时或最终字节缓冲区追加一个按本机字节序编码的 POD 值 / Append one
+   * native-endian POD value into a scratch or final byte buffer
    * @tparam T 待编码的 POD 类型 / POD type to encode
    * @param data 目标字节缓冲区 / Target byte buffer
-   * @param out 当前写位置；会前进 `sizeof(T)` / Current write position; advanced by `sizeof(T)`
+   * @param out 当前写位置；会前进 `sizeof(T)` / Current write position; advanced by
+   * `sizeof(T)`
    * @param value 待追加的 POD 值 / POD value to append
    */
   template <typename T>
@@ -128,10 +137,12 @@ class FormatCompiler
   }
 
   /**
-   * @brief 从临时字节缓冲区读取一个按本机字节序编码的 POD 值 / Read one native-endian POD value from a scratch byte buffer
+   * @brief 从临时字节缓冲区读取一个按本机字节序编码的 POD 值 / Read one native-endian POD
+   * value from a scratch byte buffer
    * @tparam T 待读取的 POD 类型 / POD type to decode
    * @param data 源字节缓冲区 / Source byte buffer
-   * @param pos 当前读取位置；会前进 `sizeof(T)` / Current read position; advanced by `sizeof(T)`
+   * @param pos 当前读取位置；会前进 `sizeof(T)` / Current read position; advanced by
+   * `sizeof(T)`
    * @return 返回解码后的 POD 值 / Returns the decoded POD value
    */
   template <typename T>
@@ -146,7 +157,8 @@ class FormatCompiler
   }
 
   /**
-   * @brief 构造只携带编译错误的最小失败结果。 / Builds the minimal failed result carrying only the compile error.
+   * @brief 构造只携带编译错误的最小失败结果。 / Builds the minimal failed result carrying
+   * only the compile error.
    * @param error Compile-time failure category. / 编译期失败类别。
    * @return Returns a minimal failed result object. / 返回最小失败结果对象。
    */
@@ -158,9 +170,11 @@ class FormatCompiler
   }
 
   /**
-   * @brief 指出某个操作码族需要打开哪一个 writer-profile 位。 / Says which writer-profile bit one opcode family needs.
+   * @brief 指出某个操作码族需要打开哪一个 writer-profile 位。 / Says which writer-profile
+   * bit one opcode family needs.
    * @param op 待分类的操作码 / Opcode to classify
-   * @return 对应的窄路径 profile 位；无需窄路径时返回 `None` / Required narrow-path profile bit, or `None` when no narrow path is needed
+   * @return 对应的窄路径 profile 位；无需窄路径时返回 `None` / Required narrow-path
+   * profile bit, or `None` when no narrow path is needed
    */
   [[nodiscard]] static consteval FormatProfile ProfileForOp(FormatOp op)
   {
@@ -190,7 +204,8 @@ class FormatCompiler
   }
 
   /**
-   * @brief 为一个字段选择仍能正确打印它的最小操作码。 / Chooses the smallest opcode that can still print this field correctly.
+   * @brief 为一个字段选择仍能正确打印它的最小操作码。 / Chooses the smallest opcode that
+   * can still print this field correctly.
    */
   [[nodiscard]] static consteval FormatOp FastFieldOp(const FormatField& field)
   {
@@ -246,9 +261,8 @@ class FormatCompiler
     }
 
     if (field.type == FormatType::Unsigned32 && field.pack == FormatPackKind::U32 &&
-        field.flags == static_cast<uint8_t>(FormatFlag::ZeroPad) &&
-        field.fill == ' ' && field.width != 0 &&
-        field.precision == unspecified_precision)
+        field.flags == static_cast<uint8_t>(FormatFlag::ZeroPad) && field.fill == ' ' &&
+        field.width != 0 && field.precision == unspecified_precision)
     {
       return FormatOp::U32ZeroPadWidth;
     }
@@ -257,7 +271,8 @@ class FormatCompiler
   }
 
   /**
-   * @brief 判断字段是否满足裸整数快路径条件。 / Tests whether one field matches the raw integer fast-path gate.
+   * @brief 判断字段是否满足裸整数快路径条件。 / Tests whether one field matches the raw
+   * integer fast-path gate.
    */
   [[nodiscard]] static consteval bool IsRawIntegerField(const FormatField& field)
   {
@@ -266,32 +281,42 @@ class FormatCompiler
   }
 
   /**
-   * @brief 判断字段是否满足裸文本快路径条件。 / Tests whether one field matches the raw text fast-path gate.
+   * @brief 判断字段是否满足裸文本快路径条件。 / Tests whether one field matches the raw
+   * text fast-path gate.
    */
   [[nodiscard]] static consteval bool IsRawTextField(const FormatField& field)
   {
-    return (field.flags == 0 || field.flags == static_cast<uint8_t>(FormatFlag::LeftAlign)) &&
+    return (field.flags == 0 ||
+            field.flags == static_cast<uint8_t>(FormatFlag::LeftAlign)) &&
            field.fill == ' ' && field.width == 0 &&
            field.precision == unspecified_precision;
   }
 
   /**
-   * @brief 由前端文本/字段事件直接喂给的单遍临时构建器。 / One-pass scratch builder fed directly by frontend text/field events.
+   * @brief 由前端文本/字段事件直接喂给的单遍临时构建器。 / One-pass scratch builder fed
+   * directly by frontend text/field events.
    */
   struct ScratchBuilder
   {
-    std::array<uint8_t, max_code_bytes> code_scratch{};            ///< temporary record stream without final End / 临时记录流，不含最终 End
-    std::array<uint8_t, max_text_pool_bytes> text_scratch{};       ///< temporary trailing text pool / 临时尾部文本池
-    std::array<FormatArgumentInfo, max_arg_count> arg_scratch{};   ///< temporary ordered argument metadata / 临时参数元信息表
+    std::array<uint8_t, max_code_bytes>
+        code_scratch{};  ///< temporary record stream without final End /
+                         ///< 临时记录流，不含最终 End
+    std::array<uint8_t, max_text_pool_bytes>
+        text_scratch{};  ///< temporary trailing text pool / 临时尾部文本池
+    std::array<FormatArgumentInfo, max_arg_count>
+        arg_scratch{};  ///< temporary ordered argument metadata / 临时参数元信息表
 
-    size_t code_bytes = 0;       ///< scratch record-stream bytes, excluding End / 临时记录流字节数，不含 End
+    size_t code_bytes =
+        0;  ///< scratch record-stream bytes, excluding End / 临时记录流字节数，不含 End
     size_t text_pool_bytes = 0;  ///< scratch text-pool bytes / 临时文本池字节数
     size_t arg_count = 0;        ///< consumed runtime arguments / 运行期参数个数
-    FormatProfile profile = FormatProfile::None;  ///< required runtime executor profile / 需要的运行期执行器配置
-    Error frontend_error = Error::None;   ///< first frontend failure / 首个前端失败原因
+    FormatProfile profile = FormatProfile::None;  ///< required runtime executor profile /
+                                                  ///< 需要的运行期执行器配置
+    Error frontend_error = Error::None;  ///< first frontend failure / 首个前端失败原因
 
     /**
-     * @brief 将单个字面文本片段追加到临时缓冲区。 / Appends one literal-text span into the scratch buffers.
+     * @brief 将单个字面文本片段追加到临时缓冲区。 / Appends one literal-text span into
+     * the scratch buffers.
      * @param offset Text offset inside `Frontend::SourceData()`. /
      *        文本在 `Frontend::SourceData()` 中的偏移。
      * @param text_size Text byte count. / 文本字节数。
@@ -347,7 +372,8 @@ class FormatCompiler
     }
 
     /**
-     * @brief 将一个值字段追加到临时字节流和临时参数表中。 / Appends one value field into the scratch byte stream and scratch argument table.
+     * @brief 将一个值字段追加到临时字节流和临时参数表中。 / Appends one value field into
+     * the scratch byte stream and scratch argument table.
      * @param field Shared field record produced by the frontend. /
      *        前端产出的共享字段记录。
      * @return Returns the field append result. / 返回字段追加结果。
@@ -385,8 +411,8 @@ class FormatCompiler
           break;
       }
 
-      profile |= op == FormatOp::GenericField ? GenericProfileFor(field.type)
-                                              : ProfileForOp(op);
+      profile |=
+          op == FormatOp::GenericField ? GenericProfileFor(field.type) : ProfileForOp(op);
 
       arg_scratch[arg_count++] = FormatArgumentInfo{
           .pack = field.pack,
@@ -396,12 +422,14 @@ class FormatCompiler
     }
 
     /**
-     * @brief 含 End 结束标记在内的最终记录流字节数 / Final record-stream size including the End marker.
+     * @brief 含 End 结束标记在内的最终记录流字节数 / Final record-stream size including
+     * the End marker.
      * @return Returns the final record-stream byte count. / 返回最终记录流字节数。
      */
     [[nodiscard]] constexpr size_t FinalCodeBytes() const { return code_bytes + 1; }
     /**
-     * @brief 含尾部文本池在内的最终保留字节块大小 / Final retained byte-block size including the trailing text pool.
+     * @brief 含尾部文本池在内的最终保留字节块大小 / Final retained byte-block size
+     * including the trailing text pool.
      * @return Returns the total retained byte-block size. / 返回最终保留字节块总大小。
      */
     [[nodiscard]] constexpr size_t FinalBlobBytes() const
@@ -410,7 +438,8 @@ class FormatCompiler
     }
 
     /**
-     * @brief 把临时缓冲打包成最终精确尺寸的编译格式。 / Packs the scratch buffers into the final exact-size compiled format.
+     * @brief 把临时缓冲打包成最终精确尺寸的编译格式。 / Packs the scratch buffers into
+     * the final exact-size compiled format.
      *
      * TextRef records store temporary offsets relative to the text scratch pool.
      * Finalization rebases those offsets so they point at the trailing text pool
@@ -507,14 +536,16 @@ class FormatCompiler
 
  public:
   /**
-   * @brief 把一个前端编译成最终字节流、参数表和 writer 摘要。 / Compiles one frontend into the final byte stream, argument table, and writer profile.
+   * @brief 把一个前端编译成最终字节流、参数表和 writer 摘要。 / Compiles one frontend
+   * into the final byte stream, argument table, and writer profile.
    * @return Returns the final compiled result object, or a failed result that
    *         carries the first compile-time error. / 返回最终编译结果对象；
    *         若失败则返回携带首个编译期错误的失败结果。
    */
   [[nodiscard]] static consteval auto Compile()
   {
-    constexpr auto scratch = []() consteval {
+    constexpr auto scratch = []() consteval
+    {
       ScratchBuilder builder{};
       builder.frontend_error = Frontend::Walk(builder);
       return builder;
@@ -526,8 +557,8 @@ class FormatCompiler
     }
     else
     {
-      return scratch.template Finish<scratch.FinalCodeBytes(),
-                                     scratch.FinalBlobBytes(), scratch.arg_count>();
+      return scratch.template Finish<scratch.FinalCodeBytes(), scratch.FinalBlobBytes(),
+                                     scratch.arg_count>();
     }
   }
 };

--- a/src/core/print/format_protocol.hpp
+++ b/src/core/print/format_protocol.hpp
@@ -7,7 +7,8 @@
 #include <type_traits>
 
 /**
- * @brief 供直接包含头文件的用户使用的打印功能默认值。 / Print feature defaults for direct header consumers.
+ * @brief 供直接包含头文件的用户使用的打印功能默认值。 / Print feature defaults for direct
+ * header consumers.
  *
  * CMake exports the same names as 0 or 1 target compile definitions. When the
  * headers are used without CMake, these fallback values match the ordinary
@@ -91,7 +92,8 @@
 namespace LibXR::Print::Config
 {
 /**
- * @brief 启用有符号与无符号十进制整数转换 / Enables signed and unsigned decimal integer conversions.
+ * @brief 启用有符号与无符号十进制整数转换 / Enables signed and unsigned decimal integer
+ * conversions.
  */
 inline constexpr bool enable_integer = LIBXR_PRINT_ENABLE_INTEGER;
 /**
@@ -108,39 +110,46 @@ inline constexpr bool enable_pointer = LIBXR_PRINT_ENABLE_POINTER;
 inline constexpr bool enable_float = LIBXR_PRINT_ENABLE_FLOAT;
 
 /**
- * @brief 在整数功能开启时启用二进制、八进制和十六进制转换 / Enables binary, octal, and hexadecimal integer conversions when integers are enabled.
+ * @brief 在整数功能开启时启用二进制、八进制和十六进制转换 / Enables binary, octal, and
+ * hexadecimal integer conversions when integers are enabled.
  */
 inline constexpr bool enable_integer_base8_16 =
     enable_integer && LIBXR_PRINT_INTEGER_ENABLE_BASE8_16;
 /**
- * @brief 在整数功能开启时启用 64 位整数格式化族 / Enables 64-bit integer formatting families when integers are enabled.
+ * @brief 在整数功能开启时启用 64 位整数格式化族 / Enables 64-bit integer formatting
+ * families when integers are enabled.
  */
 inline constexpr bool enable_integer_64bit =
     enable_integer && LIBXR_PRINT_INTEGER_ENABLE_64BIT;
 
 /**
- * @brief 在浮点功能开启时启用 %f / %F / Enables %f / %F when floating-point support is enabled.
+ * @brief 在浮点功能开启时启用 %f / %F / Enables %f / %F when floating-point support is
+ * enabled.
  */
-inline constexpr bool enable_float_fixed =
-    enable_float && LIBXR_PRINT_FLOAT_ENABLE_FIXED;
+inline constexpr bool enable_float_fixed = enable_float && LIBXR_PRINT_FLOAT_ENABLE_FIXED;
 /**
- * @brief 在浮点功能开启时启用基于 double 的默认浮点格式化 / Enables double-backed default float formatting when floating-point support is enabled.
- * @note 关闭时仍接受 double 输入，但会按 F32 降精度格式化 / When disabled, double input remains accepted but is formatted at reduced F32 precision
+ * @brief 在浮点功能开启时启用基于 double 的默认浮点格式化 / Enables double-backed default
+ * float formatting when floating-point support is enabled.
+ * @note 关闭时仍接受 double 输入，但会按 F32 降精度格式化 / When disabled, double input
+ * remains accepted but is formatted at reduced F32 precision
  */
 inline constexpr bool enable_float_double =
     enable_float && LIBXR_PRINT_FLOAT_ENABLE_DOUBLE;
 /**
- * @brief 在浮点功能开启时启用 %e / %E / Enables %e / %E when floating-point support is enabled.
+ * @brief 在浮点功能开启时启用 %e / %E / Enables %e / %E when floating-point support is
+ * enabled.
  */
 inline constexpr bool enable_float_scientific =
     enable_float && LIBXR_PRINT_FLOAT_ENABLE_SCIENTIFIC;
 /**
- * @brief 在浮点功能开启时启用 %g / %G / Enables %g / %G when floating-point support is enabled.
+ * @brief 在浮点功能开启时启用 %g / %G / Enables %g / %G when floating-point support is
+ * enabled.
  */
 inline constexpr bool enable_float_general =
     enable_float && LIBXR_PRINT_FLOAT_ENABLE_GENERAL;
 /**
- * @brief 在浮点功能开启时启用 L 长度修饰 / Enables the L floating-point length modifier when floating-point support is enabled.
+ * @brief 在浮点功能开启时启用 L 长度修饰 / Enables the L floating-point length modifier
+ * when floating-point support is enabled.
  */
 inline constexpr bool enable_float_long_double =
     enable_float_double && LIBXR_PRINT_FLOAT_ENABLE_LONG_DOUBLE;
@@ -151,12 +160,14 @@ static_assert(LIBXR_PRINT_FLOAT_MAX_PRECISION <=
 static_assert(LIBXR_PRINT_FLOAT_MAX_INTEGER_DIGITS > 0,
               "LibXR::Print: LIBXR_PRINT_FLOAT_MAX_INTEGER_DIGITS must be positive");
 /**
- * @brief 前端接受的浮点显式精度上限 / Maximum explicit float precision accepted by the frontend.
+ * @brief 前端接受的浮点显式精度上限 / Maximum explicit float precision accepted by the
+ * frontend.
  */
 inline constexpr uint8_t max_float_precision =
     static_cast<uint8_t>(LIBXR_PRINT_FLOAT_MAX_PRECISION);
 /**
- * @brief 定点浮点格式接受的整数位数上限 / Maximum integer-digit count accepted by fixed float formatting.
+ * @brief 定点浮点格式接受的整数位数上限 / Maximum integer-digit count accepted by fixed
+ * float formatting.
  */
 inline constexpr size_t max_float_integer_digits =
     static_cast<size_t>(LIBXR_PRINT_FLOAT_MAX_INTEGER_DIGITS);
@@ -170,11 +181,13 @@ inline constexpr bool enable_width = LIBXR_PRINT_ENABLE_WIDTH;
  */
 inline constexpr bool enable_precision = LIBXR_PRINT_ENABLE_PRECISION;
 /**
- * @brief 启用备用格式语法，例如用于整数前缀和浮点保留小数点的 # / Enables alternate-form syntax such as # for integer prefixes and float decimal-point retention.
+ * @brief 启用备用格式语法，例如用于整数前缀和浮点保留小数点的 # / Enables alternate-form
+ * syntax such as # for integer prefixes and float decimal-point retention.
  */
 inline constexpr bool enable_alternate = LIBXR_PRINT_ENABLE_ALTERNATE;
 /**
- * @brief 启用源级显式参数索引，例如 printf 的 n$ 和 format 的 {1} / Enables source-level explicit argument indexing such as printf n$ and format {1}.
+ * @brief 启用源级显式参数索引，例如 printf 的 n$ 和 format 的 {1} / Enables source-level
+ * explicit argument indexing such as printf n$ and format {1}.
  */
 inline constexpr bool enable_explicit_argument_indexing =
     LIBXR_PRINT_ENABLE_EXPLICIT_ARGUMENT_INDEXING;
@@ -183,7 +196,8 @@ inline constexpr bool enable_explicit_argument_indexing =
 namespace LibXR::Print
 {
 /**
- * @brief 编译期解析层与运行期写出层之间共用的打印格式协议。 / Shared print-format protocol used between compile-time parsing and runtime writing.
+ * @brief 编译期解析层与运行期写出层之间共用的打印格式协议。 / Shared print-format
+ * protocol used between compile-time parsing and runtime writing.
  *
  * The frontends first decide:
  * - which C++ argument types are allowed
@@ -200,18 +214,19 @@ namespace LibXR::Print
  * 运行期 writer 随后直接读取这套协议，不再重新解析原始格式串。
  */
 /**
- * @brief 每个运行期参数附带的编译期匹配规则。 / Compile-time argument matching rules attached to each runtime argument.
+ * @brief 每个运行期参数附带的编译期匹配规则。 / Compile-time argument matching rules
+ * attached to each runtime argument.
  */
 enum class FormatArgumentRule : uint8_t
 {
-  None,              ///< no runtime argument is consumed / 不消耗运行期参数
-  SignedAny,         ///< default-width signed integer family / 默认宽度有符号整数族
-  SignedChar,        ///< exact signed char / 精确匹配 signed char
-  SignedShort,       ///< exact short / 精确匹配 short
-  SignedLong,        ///< exact long / 精确匹配 long
-  SignedLongLong,    ///< exact long long / 精确匹配 long long
-  SignedIntMax,      ///< exact intmax_t / 精确匹配 intmax_t
-  SignedSize,        ///< exact signed counterpart of size_t / 精确匹配 size_t 的有符号对应类型
+  None,            ///< no runtime argument is consumed / 不消耗运行期参数
+  SignedAny,       ///< default-width signed integer family / 默认宽度有符号整数族
+  SignedChar,      ///< exact signed char / 精确匹配 signed char
+  SignedShort,     ///< exact short / 精确匹配 short
+  SignedLong,      ///< exact long / 精确匹配 long
+  SignedLongLong,  ///< exact long long / 精确匹配 long long
+  SignedIntMax,    ///< exact intmax_t / 精确匹配 intmax_t
+  SignedSize,  ///< exact signed counterpart of size_t / 精确匹配 size_t 的有符号对应类型
   SignedPtrDiff,     ///< exact ptrdiff_t / 精确匹配 ptrdiff_t
   UnsignedAny,       ///< default-width unsigned integer family / 默认宽度无符号整数族
   UnsignedChar,      ///< exact unsigned char / 精确匹配 unsigned char
@@ -220,16 +235,18 @@ enum class FormatArgumentRule : uint8_t
   UnsignedLongLong,  ///< exact unsigned long long / 精确匹配 unsigned long long
   UnsignedIntMax,    ///< exact uintmax_t / 精确匹配 uintmax_t
   UnsignedSize,      ///< exact size_t / 精确匹配 size_t
-  UnsignedPtrDiff,   ///< exact unsigned counterpart of ptrdiff_t / 精确匹配 ptrdiff_t 的无符号对应类型
+  UnsignedPtrDiff,   ///< exact unsigned counterpart of ptrdiff_t / 精确匹配 ptrdiff_t
+                     ///< 的无符号对应类型
   Pointer,           ///< object pointer or nullptr / 对象指针或 nullptr
   Character,         ///< any integral or enum accepted by %c / 可按 %c 接受的整数或枚举
-  String,            ///< C string, string_view, or string / C 字符串、string_view 或 string
-  Float,             ///< float or double / float 或 double
-  LongDouble,        ///< exact long double / 精确匹配 long double
+  String,      ///< C string, string_view, or string / C 字符串、string_view 或 string
+  Float,       ///< float or double / float 或 double
+  LongDouble,  ///< exact long double / 精确匹配 long double
 };
 
 /**
- * @brief 保存在值记录字段描述字节中的位标志。 / Bit flags stored in a value record's field-spec byte.
+ * @brief 保存在值记录字段描述字节中的位标志。 / Bit flags stored in a value record's
+ * field-spec byte.
  *
  * These bits are not stored in the record-op byte, so their numeric values may
  * overlap with FormatOp values.
@@ -237,17 +254,18 @@ enum class FormatArgumentRule : uint8_t
  */
 enum class FormatFlag : uint8_t
 {
-  LeftAlign = 1U << 0,  ///< - flag; left-align field output / 左对齐输出字段
-  ForceSign = 1U << 1,  ///< + flag; always emit sign for signed values / 总是输出符号位
-  SpaceSign = 1U << 2,  ///< leading space for positive signed values / 正数前补空格
-  Alternate = 1U << 3,  ///< # flag; alternate form such as prefixes / 备用格式，如前缀
-  ZeroPad = 1U << 4,    ///< 0 flag; pad field with 0 when allowed / 允许时用 0 填充
-  UpperCase = 1U << 5,  ///< uppercase hex / float output / 使用大写十六进制或浮点格式
+  LeftAlign = 1U << 0,    ///< - flag; left-align field output / 左对齐输出字段
+  ForceSign = 1U << 1,    ///< + flag; always emit sign for signed values / 总是输出符号位
+  SpaceSign = 1U << 2,    ///< leading space for positive signed values / 正数前补空格
+  Alternate = 1U << 3,    ///< # flag; alternate form such as prefixes / 备用格式，如前缀
+  ZeroPad = 1U << 4,      ///< 0 flag; pad field with 0 when allowed / 允许时用 0 填充
+  UpperCase = 1U << 5,    ///< uppercase hex / float output / 使用大写十六进制或浮点格式
   CenterAlign = 1U << 6,  ///< centered field output / 居中对齐输出字段
 };
 
 /**
- * @brief Writer 消费的运行期字节码操作。 / Runtime bytecode operations consumed by Writer.
+ * @brief Writer 消费的运行期字节码操作。 / Runtime bytecode operations consumed by
+ * Writer.
  *
  * Small common cases lower directly to narrow opcodes with only the immediates
  * they actually need. Everything else falls back to GenericField, which keeps
@@ -269,24 +287,29 @@ enum class FormatFlag : uint8_t
  */
 enum class FormatOp : uint8_t
 {
-  TextInline = 0x01,       ///< short inline literal text / 直接内嵌在码流中的短字面文本
-  TextRef = 0x02,          ///< text span stored in the trailing pool / 引用尾部文本池中的文本片段
+  TextInline = 0x01,  ///< short inline literal text / 直接内嵌在码流中的短字面文本
+  TextRef = 0x02,  ///< text span stored in the trailing pool / 引用尾部文本池中的文本片段
   TextSpace = 0x03,        ///< one literal space / 单个字面空格
   U32Dec = 0x10,           ///< raw uint32_t decimal output / 直接输出 uint32_t 十进制
-  U32ZeroPadWidth = 0x11,  ///< uint32_t decimal with zero-pad width byte / 带零填充宽度字节的 uint32_t 十进制
+  U32ZeroPadWidth = 0x11,  ///< uint32_t decimal with zero-pad width byte /
+                           ///< 带零填充宽度字节的 uint32_t 十进制
   I32Dec = 0x12,           ///< raw int32_t decimal output / 直接输出 int32_t 十进制
   U32Binary = 0x13,        ///< raw uint32_t binary output / 直接输出 uint32_t 二进制
   U32Octal = 0x14,         ///< raw uint32_t octal output / 直接输出 uint32_t 八进制
-  U32HexLower = 0x15,      ///< raw uint32_t lowercase hex output / 直接输出 uint32_t 小写十六进制
-  U32HexUpper = 0x16,      ///< raw uint32_t uppercase hex output / 直接输出 uint32_t 大写十六进制
-  StringRaw = 0x20,        ///< raw string_view output / 直接输出 string_view
-  CharacterRaw = 0x21,     ///< raw character output / 直接输出字符
-  GenericField = 0xF0,     ///< wide fallback payload: type, flags, fill, width, precision / 宽回退载荷：type、flags、fill、width、precision
-  End = 0xFF,              ///< terminates the compiled record stream / 结束整条编译记录流
+  U32HexLower =
+      0x15,  ///< raw uint32_t lowercase hex output / 直接输出 uint32_t 小写十六进制
+  U32HexUpper =
+      0x16,  ///< raw uint32_t uppercase hex output / 直接输出 uint32_t 大写十六进制
+  StringRaw = 0x20,     ///< raw string_view output / 直接输出 string_view
+  CharacterRaw = 0x21,  ///< raw character output / 直接输出字符
+  GenericField = 0xF0,  ///< wide fallback payload: type, flags, fill, width, precision /
+                        ///< 宽回退载荷：type、flags、fill、width、precision
+  End = 0xFF,           ///< terminates the compiled record stream / 结束整条编译记录流
 };
 
 /**
- * @brief 编码后的单个操作码后面跟随的载荷字节数 / Number of payload bytes that follow one encoded opcode.
+ * @brief 编码后的单个操作码后面跟随的载荷字节数 / Number of payload bytes that follow one
+ * encoded opcode.
  */
 [[nodiscard]] constexpr size_t FormatOpPayloadBytes(FormatOp op)
 {
@@ -319,37 +342,48 @@ enum class FormatOp : uint8_t
 }
 
 /**
- * @brief 编译期分析和运行期分发共用的语义处理类别。 / Semantic handler categories used by compile-time analysis and runtime dispatch.
+ * @brief 编译期分析和运行期分发共用的语义处理类别。 / Semantic handler categories used by
+ * compile-time analysis and runtime dispatch.
  */
 enum class FormatType : uint8_t
 {
-  End,                   ///< semantic sentinel only; not the byte-stream terminator FormatOp::End / 仅语义哨兵；不等于字节流结束符 FormatOp::End
-  TextInline,            ///< short inline text stored in the code stream / 直接内嵌在码流中的短文本
-  TextRef,               ///< long text stored in the trailing text pool / 引用尾部文本池中的长文本
-  TextSpace,             ///< one literal space / 单个字面空格
-  Signed32,              ///< runtime signed decimal stored as int32_t / 运行期按 int32_t 存储的有符号十进制
-  Signed64,              ///< runtime signed decimal stored as int64_t / 运行期按 int64_t 存储的有符号十进制
-  Unsigned32,            ///< runtime unsigned decimal stored as uint32_t / 运行期按 uint32_t 存储的无符号十进制
-  Unsigned64,            ///< runtime unsigned decimal stored as uint64_t / 运行期按 uint64_t 存储的无符号十进制
-  Binary32,              ///< runtime binary stored as uint32_t / 运行期按 uint32_t 存储的二进制
-  Binary64,              ///< runtime binary stored as uint64_t / 运行期按 uint64_t 存储的二进制
-  Octal32,               ///< runtime octal stored as uint32_t / 运行期按 uint32_t 存储的八进制
-  Octal64,               ///< runtime octal stored as uint64_t / 运行期按 uint64_t 存储的八进制
-  HexLower32,            ///< runtime lowercase hex stored as uint32_t / 运行期按 uint32_t 存储的小写十六进制
-  HexLower64,            ///< runtime lowercase hex stored as uint64_t / 运行期按 uint64_t 存储的小写十六进制
-  HexUpper32,            ///< runtime uppercase hex stored as uint32_t / 运行期按 uint32_t 存储的大写十六进制
-  HexUpper64,            ///< runtime uppercase hex stored as uint64_t / 运行期按 uint64_t 存储的大写十六进制
-  Pointer,               ///< pointer value / 指针值
-  Character,             ///< character / 单个字符
-  String,                ///< string / string view / C string / 字符串、字符串视图或 C 字符串
-  FloatFixed,            ///< %f / %F fixed-point float32 / 定点 float32 输出
+  End,         ///< semantic sentinel only; not the byte-stream terminator FormatOp::End /
+               ///< 仅语义哨兵；不等于字节流结束符 FormatOp::End
+  TextInline,  ///< short inline text stored in the code stream / 直接内嵌在码流中的短文本
+  TextRef,     ///< long text stored in the trailing text pool / 引用尾部文本池中的长文本
+  TextSpace,   ///< one literal space / 单个字面空格
+  Signed32,    ///< runtime signed decimal stored as int32_t / 运行期按 int32_t
+               ///< 存储的有符号十进制
+  Signed64,    ///< runtime signed decimal stored as int64_t / 运行期按 int64_t
+               ///< 存储的有符号十进制
+  Unsigned32,  ///< runtime unsigned decimal stored as uint32_t / 运行期按 uint32_t
+               ///< 存储的无符号十进制
+  Unsigned64,  ///< runtime unsigned decimal stored as uint64_t / 运行期按 uint64_t
+               ///< 存储的无符号十进制
+  Binary32,    ///< runtime binary stored as uint32_t / 运行期按 uint32_t 存储的二进制
+  Binary64,    ///< runtime binary stored as uint64_t / 运行期按 uint64_t 存储的二进制
+  Octal32,     ///< runtime octal stored as uint32_t / 运行期按 uint32_t 存储的八进制
+  Octal64,     ///< runtime octal stored as uint64_t / 运行期按 uint64_t 存储的八进制
+  HexLower32,  ///< runtime lowercase hex stored as uint32_t / 运行期按 uint32_t
+               ///< 存储的小写十六进制
+  HexLower64,  ///< runtime lowercase hex stored as uint64_t / 运行期按 uint64_t
+               ///< 存储的小写十六进制
+  HexUpper32,  ///< runtime uppercase hex stored as uint32_t / 运行期按 uint32_t
+               ///< 存储的大写十六进制
+  HexUpper64,  ///< runtime uppercase hex stored as uint64_t / 运行期按 uint64_t
+               ///< 存储的大写十六进制
+  Pointer,     ///< pointer value / 指针值
+  Character,   ///< character / 单个字符
+  String,      ///< string / string view / C string / 字符串、字符串视图或 C 字符串
+  FloatFixed,  ///< %f / %F fixed-point float32 / 定点 float32 输出
   FloatScientific,       ///< %e / %E scientific float32 / 科学计数法 float32 输出
   FloatGeneral,          ///< %g / %G general float32 / 通用 float32 输出
   DoubleFixed,           ///< %f / %F fixed-point double / 定点 double 输出
   DoubleScientific,      ///< %e / %E scientific double / 科学计数法 double 输出
   DoubleGeneral,         ///< %g / %G general double / 通用 double 输出
   LongDoubleFixed,       ///< %Lf / %LF fixed-point long double / long double 定点输出
-  LongDoubleScientific,  ///< %Le / %LE scientific long double / long double 科学计数法输出
+  LongDoubleScientific,  ///< %Le / %LE scientific long double / long double
+                         ///< 科学计数法输出
   LongDoubleGeneral,     ///< %Lg / %LG general long double / long double 通用输出
 };
 
@@ -375,7 +409,8 @@ enum class FormatPackKind : uint8_t
 };
 
 /**
- * @brief 编译期选出的精确运行期执行器配置。 / Precise runtime executor profiles selected at compile time.
+ * @brief 编译期选出的精确运行期执行器配置。 / Precise runtime executor profiles selected
+ * at compile time.
  *
  * The low bits describe which narrow fast-path families appear in the bytecode.
  * The remaining bits identify the exact semantic types used by generic fields,
@@ -385,34 +420,46 @@ enum class FormatPackKind : uint8_t
  */
 enum class FormatProfile : uint32_t
 {
-  None = 0,            ///< text-only stream / 只有文本记录的流
-  NarrowInt = 1U << 0, ///< narrow integer fast-path family / 窄整数快路径族
-  TextArg = 1U << 1,   ///< raw text argument fast-path family / 原始文本参数快路径族
-  GenericSigned32 = 1U << 2,   ///< generic signed 32-bit decimal / 通用 32 位有符号十进制
-  GenericSigned64 = 1U << 3,   ///< generic signed 64-bit decimal / 通用 64 位有符号十进制
-  GenericUnsigned32 = 1U << 4, ///< generic unsigned 32-bit decimal / 通用 32 位无符号十进制
-  GenericUnsigned64 = 1U << 5, ///< generic unsigned 64-bit decimal / 通用 64 位无符号十进制
-  GenericBinary32 = 1U << 6,   ///< generic 32-bit binary / 通用 32 位二进制
-  GenericBinary64 = 1U << 7,   ///< generic 64-bit binary / 通用 64 位二进制
-  GenericOctal32 = 1U << 8,    ///< generic 32-bit octal / 通用 32 位八进制
-  GenericOctal64 = 1U << 9,    ///< generic 64-bit octal / 通用 64 位八进制
-  GenericHexLower32 = 1U << 10, ///< generic lowercase 32-bit hex / 通用小写 32 位十六进制
-  GenericHexLower64 = 1U << 11, ///< generic lowercase 64-bit hex / 通用小写 64 位十六进制
-  GenericHexUpper32 = 1U << 12, ///< generic uppercase 32-bit hex / 通用大写 32 位十六进制
-  GenericHexUpper64 = 1U << 13, ///< generic uppercase 64-bit hex / 通用大写 64 位十六进制
-  GenericPointer = 1U << 14,   ///< generic pointer field / 通用指针字段
-  GenericCharacter = 1U << 15, ///< generic character field / 通用字符字段
-  GenericString = 1U << 16,    ///< generic string field / 通用字符串字段
-  GenericFloatFixed = 1U << 17, ///< generic float fixed-point / 通用 float 定点格式
-  GenericFloatScientific = 1U << 18, ///< generic float scientific / 通用 float 科学计数法
-  GenericFloatGeneral = 1U << 19, ///< generic float general / 通用 float 通用格式
-  GenericDoubleFixed = 1U << 20, ///< generic double fixed-point / 通用 double 定点格式
-  GenericDoubleScientific = 1U << 21, ///< generic double scientific / 通用 double 科学计数法
-  GenericDoubleGeneral = 1U << 22, ///< generic double general / 通用 double 通用格式
-  GenericLongDoubleFixed = 1U << 23, ///< generic long double fixed-point / 通用 long double 定点格式
-  GenericLongDoubleScientific = 1U << 24, ///< generic long double scientific / 通用 long double 科学计数法
-  GenericLongDoubleGeneral = 1U << 25, ///< generic long double general / 通用 long double 通用格式
-  Generic = 0x03FFFFFCU, ///< compatibility mask for every generic field / 所有通用字段的兼容掩码
+  None = 0,             ///< text-only stream / 只有文本记录的流
+  NarrowInt = 1U << 0,  ///< narrow integer fast-path family / 窄整数快路径族
+  TextArg = 1U << 1,    ///< raw text argument fast-path family / 原始文本参数快路径族
+  GenericSigned32 = 1U << 2,  ///< generic signed 32-bit decimal / 通用 32 位有符号十进制
+  GenericSigned64 = 1U << 3,  ///< generic signed 64-bit decimal / 通用 64 位有符号十进制
+  GenericUnsigned32 =
+      1U << 4,  ///< generic unsigned 32-bit decimal / 通用 32 位无符号十进制
+  GenericUnsigned64 =
+      1U << 5,  ///< generic unsigned 64-bit decimal / 通用 64 位无符号十进制
+  GenericBinary32 = 1U << 6,  ///< generic 32-bit binary / 通用 32 位二进制
+  GenericBinary64 = 1U << 7,  ///< generic 64-bit binary / 通用 64 位二进制
+  GenericOctal32 = 1U << 8,   ///< generic 32-bit octal / 通用 32 位八进制
+  GenericOctal64 = 1U << 9,   ///< generic 64-bit octal / 通用 64 位八进制
+  GenericHexLower32 =
+      1U << 10,  ///< generic lowercase 32-bit hex / 通用小写 32 位十六进制
+  GenericHexLower64 =
+      1U << 11,  ///< generic lowercase 64-bit hex / 通用小写 64 位十六进制
+  GenericHexUpper32 =
+      1U << 12,  ///< generic uppercase 32-bit hex / 通用大写 32 位十六进制
+  GenericHexUpper64 =
+      1U << 13,                 ///< generic uppercase 64-bit hex / 通用大写 64 位十六进制
+  GenericPointer = 1U << 14,    ///< generic pointer field / 通用指针字段
+  GenericCharacter = 1U << 15,  ///< generic character field / 通用字符字段
+  GenericString = 1U << 16,     ///< generic string field / 通用字符串字段
+  GenericFloatFixed = 1U << 17,  ///< generic float fixed-point / 通用 float 定点格式
+  GenericFloatScientific =
+      1U << 18,                    ///< generic float scientific / 通用 float 科学计数法
+  GenericFloatGeneral = 1U << 19,  ///< generic float general / 通用 float 通用格式
+  GenericDoubleFixed = 1U << 20,   ///< generic double fixed-point / 通用 double 定点格式
+  GenericDoubleScientific =
+      1U << 21,  ///< generic double scientific / 通用 double 科学计数法
+  GenericDoubleGeneral = 1U << 22,  ///< generic double general / 通用 double 通用格式
+  GenericLongDoubleFixed =
+      1U << 23,  ///< generic long double fixed-point / 通用 long double 定点格式
+  GenericLongDoubleScientific =
+      1U << 24,  ///< generic long double scientific / 通用 long double 科学计数法
+  GenericLongDoubleGeneral =
+      1U << 25,           ///< generic long double general / 通用 long double 通用格式
+  Generic = 0x03FFFFFCU,  ///< compatibility mask for every generic field /
+                          ///< 所有通用字段的兼容掩码
 };
 
 /**
@@ -443,7 +490,8 @@ constexpr FormatProfile& operator|=(FormatProfile& left, FormatProfile right)
  * @brief 判断某个 profile 位是否存在 / Test whether one profile bit is present
  * @param profile 待检查的 profile 位集合 / Profile bit set to inspect
  * @param bit 待测试的单个 profile 位 / Single profile bit to test
- * @return `profile` 中存在 `bit` 时返回 `true`，否则返回 `false` / Returns `true` when `bit` is present in `profile`, otherwise `false`
+ * @return `profile` 中存在 `bit` 时返回 `true`，否则返回 `false` / Returns `true` when
+ * `bit` is present in `profile`, otherwise `false`
  */
 [[nodiscard]] constexpr bool HasProfile(FormatProfile profile, FormatProfile bit)
 {
@@ -451,9 +499,11 @@ constexpr FormatProfile& operator|=(FormatProfile& left, FormatProfile right)
 }
 
 /**
- * @brief 返回一个通用字段语义类型对应的精确 profile 位 / Return the precise profile bit for one generic-field semantic type
+ * @brief 返回一个通用字段语义类型对应的精确 profile 位 / Return the precise profile bit
+ * for one generic-field semantic type
  * @param type 通用字段携带的语义类型 / Semantic type carried by the generic field
- * @return 对应的精确 profile 位；非通用值类型返回 `None` / The precise profile bit, or `None` for non-value semantic types
+ * @return 对应的精确 profile 位；非通用值类型返回 `None` / The precise profile bit, or
+ * `None` for non-value semantic types
  */
 [[nodiscard]] constexpr FormatProfile GenericProfileFor(FormatType type)
 {
@@ -467,8 +517,7 @@ constexpr FormatProfile& operator|=(FormatProfile& left, FormatProfile right)
   return static_cast<FormatProfile>(uint32_t{1} << (2U + value - first));
 }
 
-static_assert(GenericProfileFor(FormatType::Signed32) ==
-              FormatProfile::GenericSigned32);
+static_assert(GenericProfileFor(FormatType::Signed32) == FormatProfile::GenericSigned32);
 static_assert(GenericProfileFor(FormatType::LongDoubleGeneral) ==
               FormatProfile::GenericLongDoubleGeneral);
 static_assert(GenericProfileFor(FormatType::TextSpace) == FormatProfile::None);
@@ -476,7 +525,8 @@ static_assert(static_cast<uint32_t>(FormatProfile::Generic) ==
               ((uint32_t{1} << 26U) - (uint32_t{1} << 2U)));
 
 /**
- * @brief Writer 消费的编译格式运行期协议。 / Compiled-format runtime contract consumed by Writer.
+ * @brief Writer 消费的编译格式运行期协议。 / Compiled-format runtime contract consumed by
+ * Writer.
  *
  * A compiled format source always provides Codes(), one contiguous uint8_t byte
  * block terminated in-band by FormatOp::End; ArgumentList(), one field-ordered
@@ -492,7 +542,8 @@ static_assert(static_cast<uint32_t>(FormatProfile::Generic) ==
  */
 
 /**
- * @brief 每个参数对应的元信息，同时用于编译期类型检查和运行期打包。 / Per-argument metadata used both for compile-time type checking and runtime packing.
+ * @brief 每个参数对应的元信息，同时用于编译期类型检查和运行期打包。 / Per-argument
+ * metadata used both for compile-time type checking and runtime packing.
  *
  * `pack` says how the runtime argument blob stores this argument.
  * `rule` says which C++ types are accepted at compile time.
@@ -509,7 +560,8 @@ static_assert(sizeof(FormatArgumentInfo) == 2,
               "LibXR::Print::FormatArgumentInfo must stay tightly packed");
 
 /**
- * @brief 一条已经决定完毕、运行期 writer 知道如何打印的值字段。 / One fully-decided value field that the runtime writer knows how to print.
+ * @brief 一条已经决定完毕、运行期 writer 知道如何打印的值字段。 / One fully-decided value
+ * field that the runtime writer knows how to print.
  *
  * It says:
  * - which printing path to use
@@ -525,17 +577,18 @@ static_assert(sizeof(FormatArgumentInfo) == 2,
 struct FormatField
 {
   FormatType type = FormatType::End;  ///< semantic render category / 语义写出类别
-  FormatPackKind pack{};              ///< packed runtime storage kind / 运行期打包存储类别
+  FormatPackKind pack{};  ///< packed runtime storage kind / 运行期打包存储类别
   FormatArgumentRule rule =
       FormatArgumentRule::None;  ///< compile-time argument rule / 编译期实参匹配规则
   uint8_t flags = 0;             ///< FormatFlag bitset / 字段修饰位集合
   char fill = ' ';               ///< field fill character / 字段填充字符
   uint8_t width = 0;             ///< parsed field width / 已解析的字段宽度
-  uint8_t precision = 0xFF;      ///< parsed precision, or unspecified / 已解析精度，或未指定
+  uint8_t precision = 0xFF;  ///< parsed precision, or unspecified / 已解析精度，或未指定
 };
 
 /**
- * @brief 返回一个运行期已打包参数会占多少字节。 / Returns how many bytes one packed runtime argument occupies.
+ * @brief 返回一个运行期已打包参数会占多少字节。 / Returns how many bytes one packed
+ * runtime argument occupies.
  *
  * This answers "how big is one packed argument", not "how long is one opcode".
  * 这里回答的是“一个参数打包后有多大”，不是“某条操作码记录有多长”。

--- a/src/core/print/format_surface.hpp
+++ b/src/core/print/format_surface.hpp
@@ -22,14 +22,16 @@ class Format
                 "LibXR::Format: index, width, or precision is too large");
   static_assert(source_analysis.error != SourceError::UnexpectedEnd,
                 "LibXR::Format: unexpected end of format string");
-  static_assert(source_analysis.error != SourceError::EmbeddedNul,
-                "LibXR::Format: embedded NUL bytes are not supported in the format literal");
+  static_assert(
+      source_analysis.error != SourceError::EmbeddedNul,
+      "LibXR::Format: embedded NUL bytes are not supported in the format literal");
   static_assert(source_analysis.error != SourceError::UnmatchedBrace,
                 "LibXR::Format: unmatched brace in format string");
   static_assert(source_analysis.error != SourceError::MixedIndexing,
                 "LibXR::Format: automatic and manual argument indexing cannot be mixed");
-  static_assert(source_analysis.error != SourceError::ManualIndexingDisabled,
-                "LibXR::Format: explicit argument indexing is disabled in the current profile");
+  static_assert(
+      source_analysis.error != SourceError::ManualIndexingDisabled,
+      "LibXR::Format: explicit argument indexing is disabled in the current profile");
   static_assert(source_analysis.error != SourceError::DynamicField,
                 "LibXR::Format: dynamic width and precision are not supported");
   static_assert(source_analysis.error != SourceError::InvalidArgumentIndex,
@@ -41,20 +43,25 @@ class Format
 
  public:
   /**
-   * @brief 面向用户的 brace 风格编译期失败类别 / Public brace-style compile-time failure categories
+   * @brief 面向用户的 brace 风格编译期失败类别 / Public brace-style compile-time failure
+   * categories
    */
   using Error = Print::Detail::FormatFrontend::Error;
 
   /**
-   * @brief 绑定到一组具体 C++ 参数类型上的前端适配器 / Frontend adapter bound to one concrete C++ argument list
-   * @tparam Args 这次调用点对应的 C++ 实参类型列表 / Concrete C++ argument types at one call site
+   * @brief 绑定到一组具体 C++ 参数类型上的前端适配器 / Frontend adapter bound to one
+   * concrete C++ argument list
+   * @tparam Args 这次调用点对应的 C++ 实参类型列表 / Concrete C++ argument types at one
+   * call site
    */
   template <typename... Args>
   using Compiler = Print::Detail::FormatFrontend::Compiler<Source, Args...>;
 
   /**
-   * @brief 一条 brace 风格源串绑定到具体调用点参数后的编译结果 / One brace-style source bound to a concrete call-site argument list
-   * @tparam Args 这份编译结果对应的 C++ 实参类型列表 / Concrete C++ argument types bound into this compiled result
+   * @brief 一条 brace 风格源串绑定到具体调用点参数后的编译结果 / One brace-style source
+   * bound to a concrete call-site argument list
+   * @tparam Args 这份编译结果对应的 C++ 实参类型列表 / Concrete C++ argument types bound
+   * into this compiled result
    */
   template <typename... Args>
   struct Compiled
@@ -73,14 +80,17 @@ class Format
                   "LibXR::Format: float precision exceeds the configured print limit");
     static_assert(result.compile_error != Error::UnexpectedEnd,
                   "LibXR::Format: unexpected end of format string");
-    static_assert(result.compile_error != Error::EmbeddedNul,
-                  "LibXR::Format: embedded NUL bytes are not supported in the format literal");
+    static_assert(
+        result.compile_error != Error::EmbeddedNul,
+        "LibXR::Format: embedded NUL bytes are not supported in the format literal");
     static_assert(result.compile_error != Error::UnmatchedBrace,
                   "LibXR::Format: unmatched brace in format string");
-    static_assert(result.compile_error != Error::MixedIndexing,
-                  "LibXR::Format: automatic and manual argument indexing cannot be mixed");
-    static_assert(result.compile_error != Error::ManualIndexingDisabled,
-                  "LibXR::Format: explicit argument indexing is disabled in the current profile");
+    static_assert(
+        result.compile_error != Error::MixedIndexing,
+        "LibXR::Format: automatic and manual argument indexing cannot be mixed");
+    static_assert(
+        result.compile_error != Error::ManualIndexingDisabled,
+        "LibXR::Format: explicit argument indexing is disabled in the current profile");
     static_assert(result.compile_error != Error::DynamicField,
                   "LibXR::Format: dynamic width and precision are not supported");
     static_assert(result.compile_error != Error::InvalidArgumentIndex,
@@ -91,8 +101,9 @@ class Format
                   "LibXR::Format: invalid presentation type");
     static_assert(result.compile_error != Error::MissingArgument,
                   "LibXR::Format: referenced argument index is out of range");
-    static_assert(result.compile_error != Error::ArgumentTypeMismatch,
-                  "LibXR::Format: format options are incompatible with the selected argument type");
+    static_assert(
+        result.compile_error != Error::ArgumentTypeMismatch,
+        "LibXR::Format: format options are incompatible with the selected argument type");
     static_assert(result.compile_error != Error::UnsupportedArgumentType,
                   "LibXR::Format: unsupported C++ argument type");
     static_assert(result.compile_error != Error::TextOffsetOverflow,
@@ -102,24 +113,25 @@ class Format
 
    public:
     /**
-     * @brief 返回运行期 writer 最终会执行的字节流。 / Returns the final byte stream that the runtime writer will execute.
+     * @brief 返回运行期 writer 最终会执行的字节流。 / Returns the final byte stream that
+     * the runtime writer will execute.
      */
     inline static constexpr auto codes = result.codes;
     /**
-     * @brief 返回当前格式需要哪些 writer 分支的编译期摘要。 / Returns the compile-time summary of which writer branches this format needs.
+     * @brief 返回当前格式需要哪些 writer 分支的编译期摘要。 / Returns the compile-time
+     * summary of which writer branches this format needs.
      */
     inline static constexpr Print::FormatProfile profile = result.profile;
 
     /**
-     * @brief 返回运行期参数打包时要按字段顺序读取的参数列表。 / Returns the field-ordered argument list the runtime packer will follow.
+     * @brief 返回运行期参数打包时要按字段顺序读取的参数列表。 / Returns the field-ordered
+     * argument list the runtime packer will follow.
      */
-    [[nodiscard]] static constexpr auto ArgumentList()
-    {
-      return result.arg_info;
-    }
+    [[nodiscard]] static constexpr auto ArgumentList() { return result.arg_info; }
 
     /**
-     * @brief 返回每个字段对应的是第几个源参数。 / Returns, for each field, which source argument index it refers to.
+     * @brief 返回每个字段对应的是第几个源参数。 / Returns, for each field, which source
+     * argument index it refers to.
      */
     [[nodiscard]] static constexpr auto ArgumentOrder()
     {
@@ -127,23 +139,20 @@ class Format
     }
 
     /**
-     * @brief 返回与 `codes` 相同的最终字节流。 / Returns the same final byte stream as `codes`.
+     * @brief 返回与 `codes` 相同的最终字节流。 / Returns the same final byte stream as
+     * `codes`.
      */
-    [[nodiscard]] static constexpr const auto& Codes()
-    {
-      return codes;
-    }
+    [[nodiscard]] static constexpr const auto& Codes() { return codes; }
 
     /**
-     * @brief 返回当前编译格式携带的 writer 分支摘要。 / Returns the writer-branch summary carried by this compiled format.
+     * @brief 返回当前编译格式携带的 writer 分支摘要。 / Returns the writer-branch summary
+     * carried by this compiled format.
      */
-    [[nodiscard]] static constexpr Print::FormatProfile Profile()
-    {
-      return profile;
-    }
+    [[nodiscard]] static constexpr Print::FormatProfile Profile() { return profile; }
 
     /**
-     * @brief 判断另一组 C++ 参数类型是否与当前格式绑定时的参数列表完全一致。 / Returns whether another C++ argument list is exactly the one this format was built for.
+     * @brief 判断另一组 C++ 参数类型是否与当前格式绑定时的参数列表完全一致。 / Returns
+     * whether another C++ argument list is exactly the one this format was built for.
      * @tparam Actual Another C++ argument-type list to compare against. /
      *         待比较的另一组 C++ 实参类型。
      * @return Returns `true` when the type lists match exactly, otherwise
@@ -158,7 +167,8 @@ class Format
   };
 
   /**
-   * @brief 返回当前源串会寻址的调用点参数个数 / Returns the required call-site argument count addressed by this source.
+   * @brief 返回当前源串会寻址的调用点参数个数 / Returns the required call-site argument
+   * count addressed by this source.
    * @return Returns the number of call-site arguments actually referenced by
    *         this source. / 当前源串实际引用到的调用点参数个数。
    */
@@ -168,7 +178,8 @@ class Format
   }
 
   /**
-   * @brief 判断这条源格式串能否和 `Args...` 一起通过编译。 / Returns whether this source string can be compiled with `Args...`.
+   * @brief 判断这条源格式串能否和 `Args...` 一起通过编译。 / Returns whether this source
+   * string can be compiled with `Args...`.
    * @tparam Args C++ argument types to test. / 待检查的 C++ 实参类型列表。
    * @return Returns `true` when the source can compile with `Args...`,
    *         otherwise `false`. / 可编译返回 `true`，否则返回 `false`。
@@ -188,8 +199,10 @@ class Format
   }
 
   /**
-   * @brief 将当前格式写入一个输出端，并且只返回 sink 状态 / Write this format into one sink and return only the sink status
-   * @tparam Sink 输出端类型，需满足 `Print::OutputSink` / Sink type satisfying `Print::OutputSink`
+   * @brief 将当前格式写入一个输出端，并且只返回 sink 状态 / Write this format into one
+   * sink and return only the sink status
+   * @tparam Sink 输出端类型，需满足 `Print::OutputSink` / Sink type satisfying
+   * `Print::OutputSink`
    * @tparam Args 调用点实参类型列表 / Call-site argument types
    * @param sink 输出端 / Destination sink
    * @param args 本次写出使用的实参 / Arguments used by this write
@@ -208,7 +221,9 @@ class Format
 namespace LibXR::Print
 {
 /**
- * @brief 写出一条 brace 格式：先确定它对应的具体参数类型，再交给共享 writer 执行 / Write one brace format by first fixing its concrete argument types, then run the shared writer
+ * @brief 写出一条 brace 格式：先确定它对应的具体参数类型，再交给共享 writer 执行 / Write
+ * one brace format by first fixing its concrete argument types, then run the shared
+ * writer
  * @tparam Source brace 风格格式串字面量 / Brace-style format literal
  * @tparam Sink 输出端类型，需满足 `OutputSink` / Sink type satisfying `OutputSink`
  * @tparam Args 调用点实参类型列表 / Call-site argument types

--- a/src/core/print/print_api.hpp
+++ b/src/core/print/print_api.hpp
@@ -13,7 +13,8 @@
 namespace LibXR::Print
 {
 /**
- * @brief print 便捷接口的公开返回值约定 / Public return-value contract for the print convenience surface
+ * @brief print 便捷接口的公开返回值约定 / Public return-value contract for the print
+ * convenience surface
  *
  * Sink-writing helpers such as Write(), FormatTo(), and PrintfTo() return
  * ErrorCode only and report success or failure without exposing a length.
@@ -37,15 +38,17 @@ namespace LibXR::Print
 /**
  * @brief 将编译后的格式写入输出端 / Write one compiled format into a sink
  * @tparam Sink 输出端类型，需满足 `OutputSink` / Sink type satisfying `OutputSink`
- * @tparam Format 编译格式类型，需满足 `CompiledFormat` / Compiled format type satisfying `CompiledFormat`
+ * @tparam Format 编译格式类型，需满足 `CompiledFormat` / Compiled format type satisfying
+ * `CompiledFormat`
  * @tparam Args 调用点实参类型列表 / Call-site argument types
  * @param sink 输出端 / Destination sink
  * @param format 编译后的格式对象 / Compiled format object
- * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting pass
+ * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting
+ * pass
  * @return 仅返回 sink 写入状态 / Returns only the sink write status
  */
 template <typename Sink, typename Format, typename... Args>
-requires OutputSink<Sink> && CompiledFormat<std::remove_cvref_t<Format>>
+  requires OutputSink<Sink> && CompiledFormat<std::remove_cvref_t<Format>>
 [[nodiscard]] inline ErrorCode Write(Sink& sink, const Format& format, Args&&... args)
 {
   using Built = std::remove_cvref_t<Format>;
@@ -54,13 +57,15 @@ requires OutputSink<Sink> && CompiledFormat<std::remove_cvref_t<Format>>
 }
 
 /**
- * @brief 面向用户的便捷包装：将一份编译格式写入一个输出端 / Public convenience wrapper that writes one compiled format into one sink
+ * @brief 面向用户的便捷包装：将一份编译格式写入一个输出端 / Public convenience wrapper
+ * that writes one compiled format into one sink
  * @tparam Sink 输出端类型，需满足 `OutputSink` / Sink type satisfying `OutputSink`
  * @tparam Format 编译格式类型 / Compiled format type
  * @tparam Args 调用点实参类型列表 / Call-site argument types
  * @param sink 输出端 / Destination sink
  * @param format 编译后的格式对象 / Compiled format object
- * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting pass
+ * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting
+ * pass
  * @return 仅返回 sink 写入状态 / Returns only the sink write status
  */
 template <OutputSink Sink, typename Format, typename... Args>
@@ -70,12 +75,14 @@ template <OutputSink Sink, typename Format, typename... Args>
 }
 
 /**
- * @brief 将一条 brace 风格字面量直接写入一个输出端 / Write one brace-style literal directly into one sink
+ * @brief 将一条 brace 风格字面量直接写入一个输出端 / Write one brace-style literal
+ * directly into one sink
  * @tparam Source brace 风格格式串字面量 / Brace-style format literal
  * @tparam Sink 输出端类型，需满足 `OutputSink` / Sink type satisfying `OutputSink`
  * @tparam Args 调用点实参类型列表 / Call-site argument types
  * @param sink 输出端 / Destination sink
- * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting pass
+ * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting
+ * pass
  * @return 仅返回 sink 写入状态 / Returns only the sink write status
  */
 template <Text Source, OutputSink Sink, typename... Args>
@@ -86,12 +93,14 @@ template <Text Source, OutputSink Sink, typename... Args>
 }
 
 /**
- * @brief 将一条 printf 风格字面量直接写入一个输出端 / Write one printf-style literal directly into one sink
+ * @brief 将一条 printf 风格字面量直接写入一个输出端 / Write one printf-style literal
+ * directly into one sink
  * @tparam Source printf 风格格式串字面量 / Printf-style format literal
  * @tparam Sink 输出端类型，需满足 `OutputSink` / Sink type satisfying `OutputSink`
  * @tparam Args 调用点实参类型列表 / Call-site argument types
  * @param sink 输出端 / Destination sink
- * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting pass
+ * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting
+ * pass
  * @return 仅返回 sink 写入状态 / Returns only the sink write status
  */
 template <Text Source, OutputSink Sink, typename... Args>
@@ -102,11 +111,15 @@ template <Text Source, OutputSink Sink, typename... Args>
 }
 
 /**
- * @brief 将一份编译格式写入一个有界 char 缓冲区；当容量非零时结果始终带结尾零字节 / Format one compiled format into one bounded char buffer and keep the result NUL-terminated when capacity is nonzero
- * @param buffer 目标缓冲区；当 `capacity == 0` 时允许为空 / Destination buffer; may be null when `capacity == 0`
+ * @brief 将一份编译格式写入一个有界 char 缓冲区；当容量非零时结果始终带结尾零字节 /
+ * Format one compiled format into one bounded char buffer and keep the result
+ * NUL-terminated when capacity is nonzero
+ * @param buffer 目标缓冲区；当 `capacity == 0` 时允许为空 / Destination buffer; may be
+ * null when `capacity == 0`
  * @param capacity 目标缓冲区总容量（字节） / Total destination capacity in bytes
  * @param format 编译后的格式对象 / Compiled format object
- * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting pass
+ * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting
+ * pass
  *
  * The returned size follows snprintf semantics: it is the full character count
  * that would have been produced without truncation, excluding the trailing zero
@@ -120,12 +133,18 @@ template <Text Source, OutputSink Sink, typename... Args>
  * NUL-terminated.
  * 当 capacity 非零时，目标缓冲区始终保持 NUL 结尾。
  *
- * @note `buffer` 真正最多保留 `capacity - 1` 个可见字符；最后一个字节保留给结尾零 / The buffer retains at most `capacity - 1` visible characters; the last byte is reserved for the trailing zero
- * @note 当 `capacity == 0` 时不会写入结尾零，返回值仍然表示完整未截断长度 / When `capacity == 0`, no trailing zero is written and the return value still reports the full untruncated size
- * @return 成功时返回完整格式化长度（不含结尾零字节）；运行期错误或长度超出 `int` 可表示范围时返回 `-1` / Returns the full formatted size excluding the trailing zero byte on success, or `-1` on runtime error or `int` overflow
+ * @note `buffer` 真正最多保留 `capacity - 1` 个可见字符；最后一个字节保留给结尾零 / The
+ * buffer retains at most `capacity - 1` visible characters; the last byte is reserved for
+ * the trailing zero
+ * @note 当 `capacity == 0` 时不会写入结尾零，返回值仍然表示完整未截断长度 / When
+ * `capacity == 0`, no trailing zero is written and the return value still reports the
+ * full untruncated size
+ * @return 成功时返回完整格式化长度（不含结尾零字节）；运行期错误或长度超出 `int`
+ * 可表示范围时返回 `-1` / Returns the full formatted size excluding the trailing zero
+ * byte on success, or `-1` on runtime error or `int` overflow
  */
-[[nodiscard]] inline int FormatIntoBuffer(char* buffer, size_t capacity, const auto& format,
-                                          auto&&... args)
+[[nodiscard]] inline int FormatIntoBuffer(char* buffer, size_t capacity,
+                                          const auto& format, auto&&... args)
 {
   struct BufferSink
   {
@@ -182,13 +201,18 @@ template <Text Source, OutputSink Sink, typename... Args>
 }
 
 /**
- * @brief 将一条 brace 风格字面量直接写入一个有界 char 缓冲区 / Format one brace-style literal directly into one bounded char buffer
+ * @brief 将一条 brace 风格字面量直接写入一个有界 char 缓冲区 / Format one brace-style
+ * literal directly into one bounded char buffer
  * @tparam Source brace 风格格式串字面量 / Brace-style format literal
  * @tparam Args 调用点实参类型列表 / Call-site argument types
- * @param buffer 目标缓冲区；当 `capacity == 0` 时允许为空 / Destination buffer; may be null when `capacity == 0`
+ * @param buffer 目标缓冲区；当 `capacity == 0` 时允许为空 / Destination buffer; may be
+ * null when `capacity == 0`
  * @param capacity 目标缓冲区总容量（字节） / Total destination capacity in bytes
- * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting pass
- * @return 返回完整格式化长度，不含结尾零字节；运行期错误（包括尺寸溢出）返回 `-1` / Returns the full formatted size excluding the trailing zero byte, or `-1` on runtime error including size overflow
+ * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting
+ * pass
+ * @return 返回完整格式化长度，不含结尾零字节；运行期错误（包括尺寸溢出）返回 `-1` /
+ * Returns the full formatted size excluding the trailing zero byte, or `-1` on runtime
+ * error including size overflow
  */
 template <Text Source, typename... Args>
 [[nodiscard]] inline int FormatIntoBuffer(char* buffer, size_t capacity, Args&&... args)
@@ -198,13 +222,18 @@ template <Text Source, typename... Args>
 }
 
 /**
- * @brief 将一条 printf 风格字面量直接写入一个有界 char 缓冲区 / Format one printf-style literal directly into one bounded char buffer
+ * @brief 将一条 printf 风格字面量直接写入一个有界 char 缓冲区 / Format one printf-style
+ * literal directly into one bounded char buffer
  * @tparam Source printf 风格格式串字面量 / Printf-style format literal
  * @tparam Args 调用点实参类型列表 / Call-site argument types
- * @param buffer 目标缓冲区；当 `capacity == 0` 时允许为空 / Destination buffer; may be null when `capacity == 0`
+ * @param buffer 目标缓冲区；当 `capacity == 0` 时允许为空 / Destination buffer; may be
+ * null when `capacity == 0`
  * @param capacity 目标缓冲区总容量（字节） / Total destination capacity in bytes
- * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting pass
- * @return 返回完整格式化长度，不含结尾零字节；运行期错误（包括尺寸溢出）返回 `-1` / Returns the full formatted size excluding the trailing zero byte, or `-1` on runtime error including size overflow
+ * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting
+ * pass
+ * @return 返回完整格式化长度，不含结尾零字节；运行期错误（包括尺寸溢出）返回 `-1` /
+ * Returns the full formatted size excluding the trailing zero byte, or `-1` on runtime
+ * error including size overflow
  */
 template <Text Source, typename... Args>
 [[nodiscard]] inline int PrintfIntoBuffer(char* buffer, size_t capacity, Args&&... args)
@@ -214,12 +243,15 @@ template <Text Source, typename... Args>
 }
 
 /**
- * @brief 基于编译格式路径实现的 snprintf 风格包装 / snprintf-style wrapper built on top of the compiled-format path
+ * @brief 基于编译格式路径实现的 snprintf 风格包装 / snprintf-style wrapper built on top
+ * of the compiled-format path
  * @tparam Args 调用点实参类型列表 / Call-site argument types
- * @param buffer 目标缓冲区；当 `capacity == 0` 时允许为空 / Destination buffer; may be null when `capacity == 0`
+ * @param buffer 目标缓冲区；当 `capacity == 0` 时允许为空 / Destination buffer; may be
+ * null when `capacity == 0`
  * @param capacity 目标缓冲区总容量（字节） / Total destination capacity in bytes
  * @param format 编译后的格式对象 / Compiled format object
- * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting pass
+ * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting
+ * pass
  *
  * Returns the full formatted size excluding the trailing zero byte, or -1 on
  * runtime error (including size overflow).
@@ -227,22 +259,29 @@ template <Text Source, typename... Args>
  * Truncation is not an error and still returns the full size.
  * 截断不算错误，返回值仍然是完整长度。
  *
- * @return 成功时返回完整格式化长度；运行期错误或长度超出 `int` 可表示范围时返回 `-1` / Returns the full formatted size on success, or `-1` on runtime error or `int` overflow
+ * @return 成功时返回完整格式化长度；运行期错误或长度超出 `int` 可表示范围时返回 `-1` /
+ * Returns the full formatted size on success, or `-1` on runtime error or `int` overflow
  */
 [[nodiscard]] inline int SNPrintf(char* buffer, size_t capacity, const auto& format,
                                   auto&&... args)
 {
-  return FormatIntoBuffer(buffer, capacity, format, std::forward<decltype(args)>(args)...);
+  return FormatIntoBuffer(buffer, capacity, format,
+                          std::forward<decltype(args)>(args)...);
 }
 
 /**
- * @brief 面向一条 printf 风格字面量的 snprintf 风格包装 / snprintf-style wrapper for one printf-style literal
+ * @brief 面向一条 printf 风格字面量的 snprintf 风格包装 / snprintf-style wrapper for one
+ * printf-style literal
  * @tparam Source printf 风格格式串字面量 / Printf-style format literal
  * @tparam Args 调用点实参类型列表 / Call-site argument types
- * @param buffer 目标缓冲区；当 `capacity == 0` 时允许为空 / Destination buffer; may be null when `capacity == 0`
+ * @param buffer 目标缓冲区；当 `capacity == 0` 时允许为空 / Destination buffer; may be
+ * null when `capacity == 0`
  * @param capacity 目标缓冲区总容量（字节） / Total destination capacity in bytes
- * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting pass
- * @return 返回完整格式化长度，不含结尾零字节；运行期错误（包括尺寸溢出）返回 `-1` / Returns the full formatted size excluding the trailing zero byte, or `-1` on runtime error including size overflow
+ * @param args 参与本次格式化的调用点实参 / Call-site arguments used for this formatting
+ * pass
+ * @return 返回完整格式化长度，不含结尾零字节；运行期错误（包括尺寸溢出）返回 `-1` /
+ * Returns the full formatted size excluding the trailing zero byte, or `-1` on runtime
+ * error including size overflow
  */
 template <Text Source, typename... Args>
 [[nodiscard]] inline int SNPrintf(char* buffer, size_t capacity, Args&&... args)

--- a/src/core/print/print_contract.hpp
+++ b/src/core/print/print_contract.hpp
@@ -6,8 +6,8 @@
 #include <string_view>
 #include <type_traits>
 
-#include "format_protocol.hpp"
 #include "../libxr_def.hpp"
+#include "format_protocol.hpp"
 
 namespace LibXR::Print
 {
@@ -21,28 +21,28 @@ namespace LibXR::Print
  *       `ErrorCode`
  */
 template <typename Sink>
-concept OutputSink = requires(Sink& output, std::string_view text)
-{
+concept OutputSink = requires(Sink& output, std::string_view text) {
   { output.Write(text) } -> std::convertible_to<ErrorCode>;
 };
 
 /**
- * @brief 可由共享后端读取源码信息的格式前端 / Format frontend exposing source metadata to the shared backend
+ * @brief 可由共享后端读取源码信息的格式前端 / Format frontend exposing source metadata to
+ * the shared backend
  * @tparam Frontend 候选前端类型 / Candidate frontend type
  *
  * @note 至少需要暴露 `ErrorType`、`SourceData()` 与 `SourceSize()` /
  *       Must expose at least `ErrorType`, `SourceData()`, and `SourceSize()`
  */
 template <typename Frontend>
-concept SourceFrontend = requires
-{
+concept SourceFrontend = requires {
   typename Frontend::ErrorType;
   { Frontend::SourceData() } -> std::convertible_to<const char*>;
   { Frontend::SourceSize() } -> std::convertible_to<size_t>;
 };
 
 /**
- * @brief 可向指定 visitor 发射格式事件的前端 / Frontend that can emit format events into the supplied visitor
+ * @brief 可向指定 visitor 发射格式事件的前端 / Frontend that can emit format events into
+ * the supplied visitor
  * @tparam Frontend 候选前端类型 / Candidate frontend type
  * @tparam Visitor 候选 visitor 类型 / Candidate visitor type
  *
@@ -50,9 +50,7 @@ concept SourceFrontend = requires
  *       Must support `Walk(visitor)` and return `ErrorType`
  */
 template <typename Frontend, typename Visitor>
-concept WalkableFrontend =
-    SourceFrontend<Frontend> && requires(Visitor& visitor)
-{
+concept WalkableFrontend = SourceFrontend<Frontend> && requires(Visitor& visitor) {
   { Frontend::Walk(visitor) } -> std::same_as<typename Frontend::ErrorType>;
 };
 
@@ -65,17 +63,18 @@ concept WalkableFrontend =
  *       `ArgumentOrder()`, and `Profile()` as its runtime protocol surface
  */
 template <typename Format>
-concept CompiledFormat = requires
-{
-  typename std::remove_cvref_t<decltype(Format::Codes())>::value_type;
-  typename std::remove_cvref_t<decltype(Format::ArgumentList())>::value_type;
-  { Format::Codes().data() } -> std::convertible_to<const uint8_t*>;
-  { Format::Codes().size() } -> std::convertible_to<size_t>;
-  { Format::ArgumentList().size() } -> std::convertible_to<size_t>;
-  { Format::ArgumentOrder().size() } -> std::convertible_to<size_t>;
-  { Format::Profile() } -> std::convertible_to<FormatProfile>;
-} && std::same_as<typename std::remove_cvref_t<decltype(Format::Codes())>::value_type,
-                  uint8_t> &&
+concept CompiledFormat =
+    requires {
+      typename std::remove_cvref_t<decltype(Format::Codes())>::value_type;
+      typename std::remove_cvref_t<decltype(Format::ArgumentList())>::value_type;
+      { Format::Codes().data() } -> std::convertible_to<const uint8_t*>;
+      { Format::Codes().size() } -> std::convertible_to<size_t>;
+      { Format::ArgumentList().size() } -> std::convertible_to<size_t>;
+      { Format::ArgumentOrder().size() } -> std::convertible_to<size_t>;
+      { Format::Profile() } -> std::convertible_to<FormatProfile>;
+    } &&
+    std::same_as<typename std::remove_cvref_t<decltype(Format::Codes())>::value_type,
+                 uint8_t> &&
     std::same_as<
         typename std::remove_cvref_t<decltype(Format::ArgumentList())>::value_type,
         FormatArgumentInfo>;

--- a/src/core/print/printf.hpp
+++ b/src/core/print/printf.hpp
@@ -9,18 +9,21 @@
 namespace LibXR::Print
 {
 /**
- * @brief 作为 printf 格式源的结构化字符串字面量包装 / Structural literal wrapper used as the NTTP source for printf formats
+ * @brief 作为 printf 格式源的结构化字符串字面量包装 / Structural literal wrapper used as
+ * the NTTP source for printf formats
  */
 template <size_t N>
 struct Text
 {
   /**
-   * @brief 含结尾零字节的字面量字节序列 / Literal bytes including the terminating zero byte
+   * @brief 含结尾零字节的字面量字节序列 / Literal bytes including the terminating zero
+   * byte
    */
   char data[N]{};
 
   /**
-   * @brief 将字符串字面量复制到结构化 NTTP 对象中 / Copy the string literal into the structural NTTP object
+   * @brief 将字符串字面量复制到结构化 NTTP 对象中 / Copy the string literal into the
+   * structural NTTP object
    * @param text 原始字符串字面量 / Source string literal
    */
   constexpr Text(const char (&text)[N])
@@ -32,25 +35,31 @@ struct Text
   }
 
   /**
-   * @brief 返回不含结尾零字节的格式串长度 / Return the format length without the terminating zero byte
-   * @return 不含结尾零字节的字面量长度 / Returns the literal size without the trailing zero byte
+   * @brief 返回不含结尾零字节的格式串长度 / Return the format length without the
+   * terminating zero byte
+   * @return 不含结尾零字节的字面量长度 / Returns the literal size without the trailing
+   * zero byte
    */
   [[nodiscard]] constexpr size_t Size() const { return N - 1; }
   /**
-   * @brief 返回含结尾零字节的字面量指针 / Return the literal bytes including the terminating zero byte
-   * @return 指向含结尾零字节的字面量字节序列 / Returns a pointer to the literal bytes including the trailing zero byte
+   * @brief 返回含结尾零字节的字面量指针 / Return the literal bytes including the
+   * terminating zero byte
+   * @return 指向含结尾零字节的字面量字节序列 / Returns a pointer to the literal bytes
+   * including the trailing zero byte
    */
   [[nodiscard]] constexpr const char* Data() const { return data; }
 };
 
 /**
- * @brief printf 风格前端，输出内部格式表示 / Printf-style frontend that emits the internal format representation
+ * @brief printf 风格前端，输出内部格式表示 / Printf-style frontend that emits the
+ * internal format representation
  */
 class Printf
 {
  public:
   /**
-   * @brief 归一化后的 printf 长度修饰符 / Supported printf length modifiers after normalization
+   * @brief 归一化后的 printf 长度修饰符 / Supported printf length modifiers after
+   * normalization
    */
   enum class Length : uint8_t
   {
@@ -66,24 +75,36 @@ class Printf
   };
 
   /**
-   * @brief 通过 static_assert 暴露的编译期解析或构建失败类别 / Compile-time parse or build failure categories surfaced through static_assert
+   * @brief 通过 static_assert 暴露的编译期解析或构建失败类别 / Compile-time parse or
+   * build failure categories surfaced through static_assert
    */
   enum class Error : uint8_t
   {
-    None,                ///< success / 成功
-    NumberOverflow,      ///< width / precision literal does not fit in its field / 宽度或精度字面量超出字段范围
-    FloatPrecisionLimitExceeded,  ///< float precision exceeds the configured frontend limit / 浮点精度超出当前配置的前端上限
-    UnexpectedEnd,       ///< format string ended in the middle of one conversion / 格式串在转换项中途结束
-    EmbeddedNul,         ///< format literal contains an embedded NUL byte / 格式串字面量内部包含嵌入式 NUL 字节
-    MixedIndexing,       ///< positional and sequential arguments were mixed / 混用了位置参数与顺序参数
-    PositionalArgumentDisabled,  ///< positional n$ indexing is disabled by configuration / 位置参数 n$ 索引已被配置关闭
-    DynamicField,        ///< * width / precision is not supported / 不支持 * 宽度或精度
+    None,            ///< success / 成功
+    NumberOverflow,  ///< width / precision literal does not fit in its field /
+                     ///< 宽度或精度字面量超出字段范围
+    FloatPrecisionLimitExceeded,  ///< float precision exceeds the configured frontend
+                                  ///< limit / 浮点精度超出当前配置的前端上限
+    UnexpectedEnd,  ///< format string ended in the middle of one conversion /
+                    ///< 格式串在转换项中途结束
+    EmbeddedNul,    ///< format literal contains an embedded NUL byte /
+                    ///< 格式串字面量内部包含嵌入式 NUL 字节
+    MixedIndexing,  ///< positional and sequential arguments were mixed /
+                    ///< 混用了位置参数与顺序参数
+    PositionalArgumentDisabled,  ///< positional n$ indexing is disabled by configuration
+                                 ///< / 位置参数 n$ 索引已被配置关闭
+    DynamicField,          ///< * width / precision is not supported / 不支持 * 宽度或精度
     InvalidArgumentIndex,  ///< positional argument index is invalid / 位置参数索引非法
-    InvalidSpecifier,    ///< unsupported or disabled conversion specifier / 转换说明符无效或被禁用
-    InvalidLength,       ///< length modifier is incompatible with the conversion / 长度修饰符与转换说明不兼容
-    ConflictingArgument,  ///< one positional argument was reused with incompatible rules / 同一位置参数被不兼容的规则重复使用
-    TextOffsetOverflow,  ///< referenced text offset no longer fits in uint16_t / 文本池偏移超出 uint16_t
-    TextSizeOverflow,    ///< referenced text size no longer fits in uint16_t / 文本长度超出 uint16_t
+    InvalidSpecifier,      ///< unsupported or disabled conversion specifier /
+                           ///< 转换说明符无效或被禁用
+    InvalidLength,         ///< length modifier is incompatible with the conversion /
+                           ///< 长度修饰符与转换说明不兼容
+    ConflictingArgument,   ///< one positional argument was reused with incompatible rules
+                           ///< / 同一位置参数被不兼容的规则重复使用
+    TextOffsetOverflow,    ///< referenced text offset no longer fits in uint16_t /
+                           ///< 文本池偏移超出 uint16_t
+    TextSizeOverflow,  ///< referenced text size no longer fits in uint16_t / 文本长度超出
+                       ///< uint16_t
   };
 
   template <Text Source>
@@ -93,7 +114,8 @@ class Printf
   struct Compiled;
 
   /**
-   * @brief 在编译期解析并校验 printf 格式串 / Parse and validate a printf format at compile time
+   * @brief 在编译期解析并校验 printf 格式串 / Parse and validate a printf format at
+   * compile time
    * @tparam Source printf 风格格式串字面量 / Printf-style format literal
    * @return 编译后的 printf 格式对象 / Returns the compiled printf format object
    */
@@ -104,10 +126,12 @@ class Printf
   }
 
   /**
-   * @brief 判断 `Args...` 是否与启用的转换项精确匹配 / Return whether `Args...` exactly match the enabled conversions
+   * @brief 判断 `Args...` 是否与启用的转换项精确匹配 / Return whether `Args...` exactly
+   * match the enabled conversions
    * @tparam Source printf 风格格式串字面量 / Printf-style format literal
    * @tparam Args 待检查的 C++ 实参类型列表 / C++ argument types to test
-   * @return 完全匹配返回 `true`，否则返回 `false` / Returns `true` when the enabled conversions match `Args...` exactly, otherwise `false`
+   * @return 完全匹配返回 `true`，否则返回 `false` / Returns `true` when the enabled
+   * conversions match `Args...` exactly, otherwise `false`
    */
   template <Text Source, typename... Args>
   [[nodiscard]] static consteval bool Matches()
@@ -130,16 +154,20 @@ struct Printf::Compiled
 
   static_assert(result.compile_error != Printf::Error::NumberOverflow,
                 "LibXR::Print::Printf: numeric field is too large");
-  static_assert(result.compile_error != Printf::Error::FloatPrecisionLimitExceeded,
-                "LibXR::Print::Printf: float precision exceeds the configured print limit");
+  static_assert(
+      result.compile_error != Printf::Error::FloatPrecisionLimitExceeded,
+      "LibXR::Print::Printf: float precision exceeds the configured print limit");
   static_assert(result.compile_error != Printf::Error::UnexpectedEnd,
                 "LibXR::Print::Printf: unexpected end of format string");
-  static_assert(result.compile_error != Printf::Error::EmbeddedNul,
-                "LibXR::Print::Printf: embedded NUL bytes are not supported in the format literal");
-  static_assert(result.compile_error != Printf::Error::MixedIndexing,
-                "LibXR::Print::Printf: positional and sequential arguments cannot be mixed");
+  static_assert(
+      result.compile_error != Printf::Error::EmbeddedNul,
+      "LibXR::Print::Printf: embedded NUL bytes are not supported in the format literal");
+  static_assert(
+      result.compile_error != Printf::Error::MixedIndexing,
+      "LibXR::Print::Printf: positional and sequential arguments cannot be mixed");
   static_assert(result.compile_error != Printf::Error::PositionalArgumentDisabled,
-                "LibXR::Print::Printf: positional argument indexing is disabled in the current profile");
+                "LibXR::Print::Printf: positional argument indexing is disabled in the "
+                "current profile");
   static_assert(result.compile_error != Printf::Error::DynamicField,
                 "LibXR::Print::Printf: dynamic width and precision are not supported");
   static_assert(result.compile_error != Printf::Error::InvalidArgumentIndex,
@@ -149,42 +177,43 @@ struct Printf::Compiled
   static_assert(result.compile_error != Printf::Error::InvalidLength,
                 "LibXR::Print::Printf: invalid length modifier");
   static_assert(result.compile_error != Printf::Error::ConflictingArgument,
-                "LibXR::Print::Printf: one positional argument is reused with incompatible conversions");
+                "LibXR::Print::Printf: one positional argument is reused with "
+                "incompatible conversions");
   static_assert(result.compile_error != Printf::Error::TextOffsetOverflow,
                 "LibXR::Print::Printf: text pool offset is too large");
   static_assert(result.compile_error != Printf::Error::TextSizeOverflow,
                 "LibXR::Print::Printf: text span is too large");
   static_assert(source_analysis.error != Printf::Error::ConflictingArgument,
-                "LibXR::Print::Printf: one positional argument is reused with incompatible conversions");
+                "LibXR::Print::Printf: one positional argument is reused with "
+                "incompatible conversions");
 
  public:
   /**
-   * @brief 返回运行期 writer 最终会执行的字节流。 / Returns the final byte stream that the runtime writer will execute.
+   * @brief 返回运行期 writer 最终会执行的字节流。 / Returns the final byte stream that
+   * the runtime writer will execute.
    */
   inline static constexpr auto codes = result.codes;
   /**
-   * @brief 返回当前格式需要哪些 writer 分支的编译期摘要。 / Returns the compile-time summary of which writer branches this format needs.
+   * @brief 返回当前格式需要哪些 writer 分支的编译期摘要。 / Returns the compile-time
+   * summary of which writer branches this format needs.
    */
   inline static constexpr FormatProfile profile = result.profile;
 
   /**
-   * @brief 返回运行期参数打包时要按字段顺序读取的参数列表。 / Returns the field-ordered argument list the runtime packer will follow.
+   * @brief 返回运行期参数打包时要按字段顺序读取的参数列表。 / Returns the field-ordered
+   * argument list the runtime packer will follow.
    */
-  [[nodiscard]] static constexpr auto ArgumentList()
-  {
-    return result.arg_info;
-  }
+  [[nodiscard]] static constexpr auto ArgumentList() { return result.arg_info; }
 
   /**
-   * @brief 返回每个字段对应的是第几个源参数。 / Returns, for each field, which source argument index it refers to.
+   * @brief 返回每个字段对应的是第几个源参数。 / Returns, for each field, which source
+   * argument index it refers to.
    */
-  [[nodiscard]] static constexpr auto ArgumentOrder()
-  {
-    return source_analysis.order;
-  }
+  [[nodiscard]] static constexpr auto ArgumentOrder() { return source_analysis.order; }
 
   /**
-   * @brief 返回仅供编译期类型匹配使用的源参数列表。 / Returns the source-argument list used only for compile-time type matching.
+   * @brief 返回仅供编译期类型匹配使用的源参数列表。 / Returns the source-argument list
+   * used only for compile-time type matching.
    */
   [[nodiscard]] static constexpr auto SourceArgumentList()
   {
@@ -192,23 +221,20 @@ struct Printf::Compiled
   }
 
   /**
-   * @brief 返回与 `codes` 相同的最终字节流。 / Returns the same final byte stream as `codes`.
+   * @brief 返回与 `codes` 相同的最终字节流。 / Returns the same final byte stream as
+   * `codes`.
    */
-  [[nodiscard]] static constexpr const auto& Codes()
-  {
-    return codes;
-  }
+  [[nodiscard]] static constexpr const auto& Codes() { return codes; }
 
   /**
-   * @brief 返回当前编译格式携带的 writer 分支摘要。 / Returns the writer-branch summary carried by this compiled format.
+   * @brief 返回当前编译格式携带的 writer 分支摘要。 / Returns the writer-branch summary
+   * carried by this compiled format.
    */
-  [[nodiscard]] static constexpr FormatProfile Profile()
-  {
-    return profile;
-  }
+  [[nodiscard]] static constexpr FormatProfile Profile() { return profile; }
 
   /**
-   * @brief 判断 `Args...` 是否就是当前编译格式期望的那组 C++ 参数类型。 / Returns whether `Args...` are exactly the C++ argument types this compiled format expects.
+   * @brief 判断 `Args...` 是否就是当前编译格式期望的那组 C++ 参数类型。 / Returns whether
+   * `Args...` are exactly the C++ argument types this compiled format expects.
    * @tparam Args C++ argument types to compare. / 待比较的 C++ 实参类型列表。
    * @return Returns `true` when the type list matches exactly, otherwise
    *         `false`. / 完全匹配返回 `true`，否则返回 `false`。

--- a/src/core/print/printf/printf_frontend_binding_base.hpp
+++ b/src/core/print/printf/printf_frontend_binding_base.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 /**
- * @brief printf 降级阶段共享的描述表与策略辅助函数 / Shared descriptor-table and policy helpers for printf lowering
+ * @brief printf 降级阶段共享的描述表与策略辅助函数 / Shared descriptor-table and policy
+ * helpers for printf lowering
  */
 namespace SourceSyntax
 {
@@ -9,7 +10,8 @@ namespace FieldSelection
 {
 
 /**
- * @brief 将一个归一化长度标签转换为描述表索引 / Converts one normalized length tag to its descriptor-table index.
+ * @brief 将一个归一化长度标签转换为描述表索引 / Converts one normalized length tag to its
+ * descriptor-table index.
  * @param length Normalized printf length tag. / 归一化后的 printf 长度标签。
  * @return Returns the descriptor-table index for that length. /
  *         返回该长度标签对应的描述表索引。
@@ -20,7 +22,8 @@ namespace FieldSelection
 }
 
 /**
- * @brief 判断某个前端语义族是否应使用无符号存储与匹配规则 / Returns whether one frontend semantic family should use unsigned storage/rules.
+ * @brief 判断某个前端语义族是否应使用无符号存储与匹配规则 / Returns whether one frontend
+ * semantic family should use unsigned storage/rules.
  * @param type Frontend semantic family. / 前端语义族。
  * @return Returns `true` when unsigned storage/rules should be used, otherwise
  *         `false`. / 应使用无符号存储与匹配规则时返回 `true`，否则返回 `false`。
@@ -41,7 +44,8 @@ namespace FieldSelection
 }
 
 /**
- * @brief 在描述表中查找一个源级转换字符 / Looks up one source conversion character in the descriptor table.
+ * @brief 在描述表中查找一个源级转换字符 / Looks up one source conversion character in the
+ * descriptor table.
  * @param token Source conversion character. / 源级转换字符。
  * @return Returns the matching descriptor, or an empty one when not found. /
  *         返回匹配的描述项；找不到时返回空描述项。
@@ -60,10 +64,12 @@ namespace FieldSelection
 }
 
 /**
- * @brief 判断某个说明符家族在当前功能开关下是否启用 / Return whether one specifier family is enabled under the current feature gates
+ * @brief 判断某个说明符家族在当前功能开关下是否启用 / Return whether one specifier family
+ * is enabled under the current feature gates
  * @param gate 待检查的功能开关类别 / Feature-switch family to test
  * @param length 已解析的归一化长度修饰符 / Parsed normalized length modifier
- * @return 该说明符家族在当前配置下启用时返回 `true`，否则返回 `false` / Returns `true` when the selected family is enabled, otherwise `false`
+ * @return 该说明符家族在当前配置下启用时返回 `true`，否则返回 `false` / Returns `true`
+ * when the selected family is enabled, otherwise `false`
  */
 [[nodiscard]] constexpr bool TypeEnabled(FeatureGate gate, Length length)
 {
@@ -92,7 +98,8 @@ namespace FieldSelection
 }
 
 /**
- * @brief 判断某个长度修饰符对当前说明符家族是否合法 / Returns whether one parsed length modifier is legal for the selected specifier family.
+ * @brief 判断某个长度修饰符对当前说明符家族是否合法 / Returns whether one parsed length
+ * modifier is legal for the selected specifier family.
  * @param policy Length-policy family selected by the descriptor. /
  *        描述项选中的长度策略族。
  * @param length Parsed normalized length modifier. / 已解析的归一化长度修饰符。
@@ -115,7 +122,8 @@ namespace FieldSelection
 }
 
 /**
- * @brief 返回某个归一化长度索引选中的参数匹配规则 / Return the argument rule selected by one normalized length index
+ * @brief 返回某个归一化长度索引选中的参数匹配规则 / Return the argument rule selected by
+ * one normalized length index
  * @param rules 按长度索引的规则表 / Length-indexed rule table
  * @param length 已解析的归一化长度修饰符 / Parsed normalized length modifier
  * @return 返回选中的编译期参数匹配规则 / Returns the selected compile-time argument rule
@@ -127,7 +135,8 @@ namespace FieldSelection
 }
 
 /**
- * @brief 判断某个参数规则在当前目标上是否需要 64 位打包存储 / Returns whether one argument rule requires 64-bit packed storage on this target.
+ * @brief 判断某个参数规则在当前目标上是否需要 64 位打包存储 / Returns whether one
+ * argument rule requires 64-bit packed storage on this target.
  * @param rule Compile-time argument rule. / 编译期参数匹配规则。
  * @return Returns `true` when this rule requires 64-bit packed storage on the
  *         current target, otherwise `false`. / 该规则在当前目标上需要 64 位打包
@@ -163,7 +172,8 @@ namespace FieldSelection
 }
 
 /**
- * @brief 判断普通 printf 浮点转换是否降为 double 存储 / Returns whether ordinary printf float conversions lower to double storage.
+ * @brief 判断普通 printf 浮点转换是否降为 double 存储 / Returns whether ordinary printf
+ * float conversions lower to double storage.
  * @return Returns `true` when ordinary printf float conversions lower to
  *         double-backed storage, otherwise `false`. / 普通 printf 浮点转换降为
  *         double 存储时返回 `true`，否则返回 `false`。

--- a/src/core/print/printf/printf_frontend_binding_field.hpp
+++ b/src/core/print/printf/printf_frontend_binding_field.hpp
@@ -1,17 +1,21 @@
 #pragma once
 
 /**
- * @brief 为一个已解析 printf 转换选择运行期语义类型 / Choose the runtime semantic type for one parsed printf conversion
+ * @brief 为一个已解析 printf 转换选择运行期语义类型 / Choose the runtime semantic type
+ * for one parsed printf conversion
  */
 namespace SourceSyntax
 {
 namespace FieldSelection
 {
 /**
- * @brief 在已知参数匹配规则后，为一个已解析转换选择运行期语义类型 / Choose the runtime semantic type for one parsed conversion after its argument rule is known
+ * @brief 在已知参数匹配规则后，为一个已解析转换选择运行期语义类型 / Choose the runtime
+ * semantic type for one parsed conversion after its argument rule is known
  * @param conversion 已解析的 printf 转换项 / Parsed printf conversion
- * @param rule 该转换项对应的编译期参数匹配规则 / Compile-time argument rule selected for that conversion
- * @return 返回该转换项最终选中的运行期语义类型 / Returns the runtime semantic type selected for this conversion
+ * @param rule 该转换项对应的编译期参数匹配规则 / Compile-time argument rule selected for
+ * that conversion
+ * @return 返回该转换项最终选中的运行期语义类型 / Returns the runtime semantic type
+ * selected for this conversion
  */
 [[nodiscard]] consteval FormatType SelectFormatType(const Conversion& conversion,
                                                     FormatArgumentRule rule)
@@ -38,8 +42,7 @@ namespace FieldSelection
   }
   if (conversion.type == ValueKind::Unsigned)
   {
-    return RuleUses64BitStorage(rule) ? FormatType::Unsigned64
-                                      : FormatType::Unsigned32;
+    return RuleUses64BitStorage(rule) ? FormatType::Unsigned64 : FormatType::Unsigned32;
   }
   if (conversion.type == ValueKind::Binary)
   {
@@ -51,13 +54,11 @@ namespace FieldSelection
   }
   if (conversion.type == ValueKind::HexLower)
   {
-    return RuleUses64BitStorage(rule) ? FormatType::HexLower64
-                                      : FormatType::HexLower32;
+    return RuleUses64BitStorage(rule) ? FormatType::HexLower64 : FormatType::HexLower32;
   }
   if (conversion.type == ValueKind::HexUpper)
   {
-    return RuleUses64BitStorage(rule) ? FormatType::HexUpper64
-                                      : FormatType::HexUpper32;
+    return RuleUses64BitStorage(rule) ? FormatType::HexUpper64 : FormatType::HexUpper32;
   }
 
   switch (conversion.type)
@@ -69,8 +70,7 @@ namespace FieldSelection
     case ValueKind::String:
       return FormatType::String;
     case ValueKind::FloatFixed:
-      return UsesDoubleFloatStorage() ? FormatType::DoubleFixed
-                                      : FormatType::FloatFixed;
+      return UsesDoubleFloatStorage() ? FormatType::DoubleFixed : FormatType::FloatFixed;
     case ValueKind::FloatScientific:
       return UsesDoubleFloatStorage() ? FormatType::DoubleScientific
                                       : FormatType::FloatScientific;
@@ -91,7 +91,8 @@ namespace FieldSelection
 }
 
 /**
- * @brief 为一个运行期语义类型选择参数打包存储类别。 / Chooses the packed storage kind for one runtime semantic type.
+ * @brief 为一个运行期语义类型选择参数打包存储类别。 / Chooses the packed storage kind for
+ * one runtime semantic type.
  * @param type Runtime semantic type. / 运行期语义类型。
  * @return Returns the packed storage kind used by that runtime type. /
  *         返回该运行期类型使用的参数打包存储类别。
@@ -147,12 +148,14 @@ namespace FieldSelection
 }
 
 /**
- * @brief 为一个已解析转换选择它消耗的编译期参数匹配规则。 / Chooses which compile-time argument rule one parsed conversion consumes.
+ * @brief 为一个已解析转换选择它消耗的编译期参数匹配规则。 / Chooses which compile-time
+ * argument rule one parsed conversion consumes.
  * @param conversion Parsed printf conversion. / 已解析的 printf 转换项。
  * @return Returns the compile-time argument rule consumed by this conversion. /
  *         返回该转换项消耗的编译期参数匹配规则。
  */
-[[nodiscard]] consteval FormatArgumentRule SelectArgumentRule(const Conversion& conversion)
+[[nodiscard]] consteval FormatArgumentRule SelectArgumentRule(
+    const Conversion& conversion)
 {
   if (conversion.type == ValueKind::Signed)
   {
@@ -175,9 +178,8 @@ namespace FieldSelection
     case ValueKind::FloatFixed:
     case ValueKind::FloatScientific:
     case ValueKind::FloatGeneral:
-      return (conversion.length == Length::LongDouble)
-                 ? FormatArgumentRule::LongDouble
-                 : FormatArgumentRule::Float;
+      return (conversion.length == Length::LongDouble) ? FormatArgumentRule::LongDouble
+                                                       : FormatArgumentRule::Float;
     case ValueKind::None:
     case ValueKind::Signed:
     case ValueKind::Unsigned:
@@ -192,7 +194,8 @@ namespace FieldSelection
 }
 
 /**
- * @brief 在解析后校验与目标相关的格式选择约束。 / Validates target-dependent format-selection constraints after parsing.
+ * @brief 在解析后校验与目标相关的格式选择约束。 / Validates target-dependent
+ * format-selection constraints after parsing.
  * @param conversion Parsed printf conversion. / 已解析的 printf 转换项。
  * @return Returns `Error::None` when the conversion is legal on the current
  *         target/profile, otherwise the first target-dependent error. /
@@ -203,8 +206,7 @@ namespace FieldSelection
   if ((conversion.type == ValueKind::FloatFixed ||
        conversion.type == ValueKind::FloatScientific ||
        conversion.type == ValueKind::FloatGeneral) &&
-      conversion.has_precision &&
-      conversion.precision > Config::max_float_precision)
+      conversion.has_precision && conversion.precision > Config::max_float_precision)
   {
     return Error::FloatPrecisionLimitExceeded;
   }
@@ -220,7 +222,8 @@ namespace FieldSelection
 }
 
 /**
- * @brief 为一个已解析 printf 转换构造共享 FormatField 记录。 / Builds the shared FormatField record for one parsed printf conversion.
+ * @brief 为一个已解析 printf 转换构造共享 FormatField 记录。 / Builds the shared
+ * FormatField record for one parsed printf conversion.
  * @param conversion Parsed printf conversion. / 已解析的 printf 转换项。
  * @return Returns the shared `FormatField` record consumed by the compile-time
  *         backend. / 返回共享编译后端要消费的 `FormatField` 记录。

--- a/src/core/print/printf/printf_frontend_detail.hpp
+++ b/src/core/print/printf/printf_frontend_detail.hpp
@@ -9,21 +9,28 @@
 namespace LibXR::Print::Detail::PrintfCompile
 {
 /**
- * @brief 把一条 printf 字面量转换成共享打印字段的编译期入口层 / Compile-time entry layer that turns one printf literal into shared print fields
+ * @brief 把一条 printf 字面量转换成共享打印字段的编译期入口层 / Compile-time entry layer
+ * that turns one printf literal into shared print fields
  */
 using Error = Printf::Error;
 using Length = Printf::Length;
 
+// These implementation headers form an ordered dependency chain.
+// clang-format off
 #include "printf_frontend_spec.hpp"
 
 #include "printf_frontend_source.hpp"
+// clang-format on
 
 namespace FieldSelection = SourceSyntax::FieldSelection;
 
 /**
- * @brief 对单条 printf 字面量执行仅源串分析 / Run source-only analysis for one printf literal
+ * @brief 对单条 printf 字面量执行仅源串分析 / Run source-only analysis for one printf
+ * literal
  * @tparam Source printf 风格格式串字面量 / Printf-style format literal
- * @return 源串分析结果，包含字段顺序、参数引用摘要与首个源级错误 / Returns the source analysis result, including field order, argument reference summary, and the first source-level error
+ * @return 源串分析结果，包含字段顺序、参数引用摘要与首个源级错误 / Returns the source
+ * analysis result, including field order, argument reference summary, and the first
+ * source-level error
  */
 template <Text Source>
 [[nodiscard]] consteval auto Analyze()
@@ -32,10 +39,13 @@ template <Text Source>
 }
 
 /**
- * @brief 遍历一条 printf 字面量，并为每个已解析转换产出共享 `FormatField` 记录 / Walk one printf literal and emit shared `FormatField` records for each parsed conversion
+ * @brief 遍历一条 printf 字面量，并为每个已解析转换产出共享 `FormatField` 记录 / Walk one
+ * printf literal and emit shared `FormatField` records for each parsed conversion
  * @tparam Source printf 风格格式串字面量 / Printf-style format literal
- * @param visitor 接收文本片段与最终 `FormatField` 记录的 visitor / Visitor receiving text spans and final `FormatField` records
- * @return 首个源级解析错误或字段选择错误；成功时返回 `Error::None` / Returns the first source-level parse or field-selection error; returns `Error::None` on success
+ * @param visitor 接收文本片段与最终 `FormatField` 记录的 visitor / Visitor receiving text
+ * spans and final `FormatField` records
+ * @return 首个源级解析错误或字段选择错误；成功时返回 `Error::None` / Returns the first
+ * source-level parse or field-selection error; returns `Error::None` on success
  */
 template <Text Source>
 [[nodiscard]] consteval Error WalkSourceAsFormatFields(auto& visitor)
@@ -64,7 +74,8 @@ template <Text Source>
 namespace LibXR::Print
 {
 /**
- * @brief 单个 printf 源字符串的编译期前端，负责解析并降为共享格式语义 / Compile-time printf frontend that parses and lowers one source string
+ * @brief 单个 printf 源字符串的编译期前端，负责解析并降为共享格式语义 / Compile-time
+ * printf frontend that parses and lowers one source string
  * @tparam Source printf 风格格式串字面量 / Printf-style format literal
  */
 template <Text Source>
@@ -74,20 +85,25 @@ class Printf::Compiler
   using ErrorType = Printf::Error;
 
   /**
-   * @brief 返回去掉结尾零字节后的源字符串数据 / Return the underlying source bytes without the terminating zero byte
+   * @brief 返回去掉结尾零字节后的源字符串数据 / Return the underlying source bytes
+   * without the terminating zero byte
    * @return 指向当前格式字面量正文的指针 / Returns a pointer to the literal body
    */
   [[nodiscard]] static constexpr const char* SourceData() { return Source.Data(); }
   /**
-   * @brief 返回去掉结尾零字节后的源字符串长度 / Return the source length without the terminating zero byte
+   * @brief 返回去掉结尾零字节后的源字符串长度 / Return the source length without the
+   * terminating zero byte
    * @return 当前格式字面量正文长度 / Returns the literal-body size
    */
   [[nodiscard]] static constexpr size_t SourceSize() { return Source.Size(); }
 
   /**
-   * @brief 按源串顺序遍历这条字面量，并产出文本片段和最终字段记录 / Walk the literal in source order and emit text spans plus final field records
-   * @param visitor 接收文本片段与最终字段记录的 visitor / Visitor receiving text spans and final field records
-   * @return 首个源级解析错误或字段选择错误；成功时返回 `Error::None` / Returns the first source-level parse or field-selection error; returns `Error::None` on success
+   * @brief 按源串顺序遍历这条字面量，并产出文本片段和最终字段记录 / Walk the literal in
+   * source order and emit text spans plus final field records
+   * @param visitor 接收文本片段与最终字段记录的 visitor / Visitor receiving text spans
+   * and final field records
+   * @return 首个源级解析错误或字段选择错误；成功时返回 `Error::None` / Returns the first
+   * source-level parse or field-selection error; returns `Error::None` on success
    */
   [[nodiscard]] static consteval ErrorType Walk(auto& visitor)
   {

--- a/src/core/print/printf/printf_frontend_parse_util.hpp
+++ b/src/core/print/printf/printf_frontend_parse_util.hpp
@@ -1,29 +1,33 @@
 #pragma once
 
 /**
- * @brief 源级位置参数或顺序参数索引状态 / Source-level positional or sequential indexing state
+ * @brief 源级位置参数或顺序参数索引状态 / Source-level positional or sequential indexing
+ * state
  */
 struct IndexingState
 {
-  bool uses_positional = false;  ///< at least one conversion used n$ syntax / 至少有一个转换使用了 n$ 语法
-  bool uses_sequential = false;  ///< at least one conversion used implicit sequential order / 至少有一个转换使用了隐式顺序参数
+  bool uses_positional =
+      false;  ///< at least one conversion used n$ syntax / 至少有一个转换使用了 n$ 语法
+  bool uses_sequential = false;  ///< at least one conversion used implicit sequential
+                                 ///< order / 至少有一个转换使用了隐式顺序参数
   size_t next_index = 0;         ///< next sequential argument index / 下一个顺序参数索引
 };
 
 /**
- * @brief 判断一个源字节是否为 ASCII 十进制数字 / Return whether one source byte is an ASCII decimal digit
+ * @brief 判断一个源字节是否为 ASCII 十进制数字 / Return whether one source byte is an
+ * ASCII decimal digit
  * @param ch 待检查的源字节 / Source byte to test
- * @return 若是 ASCII 十进制数字则返回 `true`，否则返回 `false` / Returns `true` for an ASCII decimal digit, otherwise `false`
+ * @return 若是 ASCII 十进制数字则返回 `true`，否则返回 `false` / Returns `true` for an
+ * ASCII decimal digit, otherwise `false`
  */
-[[nodiscard]] constexpr bool IsDigit(char ch)
-{
-  return ch >= '0' && ch <= '9';
-}
+[[nodiscard]] constexpr bool IsDigit(char ch) { return ch >= '0' && ch <= '9'; }
 
 /**
- * @brief 判断源字符串在结尾终止字节之前是否包含嵌入式 NUL / Return whether the source contains an embedded NUL byte before the terminator
+ * @brief 判断源字符串在结尾终止字节之前是否包含嵌入式 NUL / Return whether the source
+ * contains an embedded NUL byte before the terminator
  * @param source 待检查的源字符串 / Source string to inspect
- * @return 若终止前包含嵌入式 NUL 则返回 `true`，否则返回 `false` / Returns `true` when an embedded NUL exists before the terminator, otherwise `false`
+ * @return 若终止前包含嵌入式 NUL 则返回 `true`，否则返回 `false` / Returns `true` when an
+ * embedded NUL exists before the terminator, otherwise `false`
  */
 [[nodiscard]] constexpr bool HasEmbeddedNul(std::string_view source)
 {
@@ -38,17 +42,21 @@ struct IndexingState
 }
 
 /**
- * @brief 解析可选的前导 n$ 位置参数选择器 / Parse the optional leading n$ positional argument selector
+ * @brief 解析可选的前导 n$ 位置参数选择器 / Parse the optional leading n$ positional
+ * argument selector
  *
  * This probe only consumes digits when they are immediately followed by '$'.
  * Plain width digits such as %05d stay untouched for the later width parser.
  * 只有当数字后面紧跟 '$' 时，这个探测才会真正消费它们；像 %05d 这样的普通宽度
  * 数字会完整保留给后续宽度解析阶段。
  * @param source 完整 printf 源字符串 / Full printf source string
- * @param pos 当前解析位置，成功时推进到 `n$` 之后 / Current parse position; advanced past `n$` on success
+ * @param pos 当前解析位置，成功时推进到 `n$` 之后 / Current parse position; advanced past
+ * `n$` on success
  * @param indexing 源级索引模式跟踪状态 / Source-level indexing mode tracker
  * @param conversion 当前正在填充的转换项 / Conversion being filled
- * @return 解析成功或本段没有位置参数选择器时返回 `Error::None`；出错时返回首个解析错误 / Returns the first parse error, or `Error::None` when no positional selector is present or parsing succeeds
+ * @return 解析成功或本段没有位置参数选择器时返回 `Error::None`；出错时返回首个解析错误 /
+ * Returns the first parse error, or `Error::None` when no positional selector is present
+ * or parsing succeeds
  */
 [[nodiscard]] consteval Error ParseArgumentIndex(std::string_view source, size_t& pos,
                                                  IndexingState& indexing,
@@ -100,12 +108,15 @@ struct IndexingState
 }
 
 /**
- * @brief 解析一个目标为字节宽度的十进制整数字段片段，并检查是否溢出 / Parse one decimal byte-sized integer fragment with overflow checking
+ * @brief 解析一个目标为字节宽度的十进制整数字段片段，并检查是否溢出 / Parse one decimal
+ * byte-sized integer fragment with overflow checking
  * @param source 含该十进制片段的源字符串 / Source string holding the decimal fragment
- * @param pos 当前解析位置，成功时推进到片段之后 / Current parse position; advanced past the fragment on success
+ * @param pos 当前解析位置，成功时推进到片段之后 / Current parse position; advanced past
+ * the fragment on success
  * @param limit 该字段允许的最大值 / Inclusive upper bound accepted by this field
  * @param value 输出解析结果 / Parsed result output
- * @return 成功返回 `Error::None`；溢出或语法非法时返回对应错误 / Returns `Error::None` on success, or the first overflow or syntax failure
+ * @return 成功返回 `Error::None`；溢出或语法非法时返回对应错误 / Returns `Error::None` on
+ * success, or the first overflow or syntax failure
  */
 [[nodiscard]] consteval Error ParseByte(std::string_view source, size_t& pos,
                                         uint8_t limit, uint8_t& value)

--- a/src/core/print/printf/printf_frontend_parser.hpp
+++ b/src/core/print/printf/printf_frontend_parser.hpp
@@ -9,9 +9,11 @@
 /**
  * @brief 解析单个转换项前导的标志位簇 / Parse the leading flag cluster of one conversion
  * @param source 完整 printf 源字符串 / Full printf source string
- * @param pos 当前解析位置，成功时推进到已解析标志之后 / Current parse position; advanced past parsed flags
+ * @param pos 当前解析位置，成功时推进到已解析标志之后 / Current parse position; advanced
+ * past parsed flags
  * @param conversion 当前正在填充的转换项 / Conversion being filled
- * @return 成功返回 `Error::None`；遇到非法标志时返回对应错误 / Returns `Error::None` on success, or the first invalid flag error
+ * @return 成功返回 `Error::None`；遇到非法标志时返回对应错误 / Returns `Error::None` on
+ * success, or the first invalid flag error
  */
 [[nodiscard]] consteval Error ParseFlags(std::string_view source, size_t& pos,
                                          Conversion& conversion)
@@ -51,9 +53,11 @@
 /**
  * @brief 解析一个可选的常量宽度字段 / Parse one optional constant width field
  * @param source 完整 printf 源字符串 / Full printf source string
- * @param pos 当前解析位置，成功时推进到宽度片段之后 / Current parse position; advanced past the width fragment on success
+ * @param pos 当前解析位置，成功时推进到宽度片段之后 / Current parse position; advanced
+ * past the width fragment on success
  * @param conversion 当前正在填充的转换项 / Conversion being filled
- * @return 成功返回 `Error::None`；动态宽度或非法宽度时返回对应错误 / Returns `Error::None` on success, or the first dynamic-field or invalid-width error
+ * @return 成功返回 `Error::None`；动态宽度或非法宽度时返回对应错误 / Returns
+ * `Error::None` on success, or the first dynamic-field or invalid-width error
  */
 [[nodiscard]] consteval Error ParseWidth(std::string_view source, size_t& pos,
                                          Conversion& conversion)
@@ -68,16 +72,17 @@
     return Error::InvalidSpecifier;
   }
 
-  return ParseByte(source, pos, std::numeric_limits<uint8_t>::max(),
-                   conversion.width);
+  return ParseByte(source, pos, std::numeric_limits<uint8_t>::max(), conversion.width);
 }
 
 /**
  * @brief 解析一个可选的常量精度字段 / Parse one optional constant precision field
  * @param source 完整 printf 源字符串 / Full printf source string
- * @param pos 当前解析位置，成功时推进到精度片段之后 / Current parse position; advanced past the precision fragment on success
+ * @param pos 当前解析位置，成功时推进到精度片段之后 / Current parse position; advanced
+ * past the precision fragment on success
  * @param conversion 当前正在填充的转换项 / Conversion being filled
- * @return 成功返回 `Error::None`；精度相关错误时返回对应错误 / Returns `Error::None` on success, or the first precision-related error
+ * @return 成功返回 `Error::None`；精度相关错误时返回对应错误 / Returns `Error::None` on
+ * success, or the first precision-related error
  */
 [[nodiscard]] consteval Error ParsePrecision(std::string_view source, size_t& pos,
                                              Conversion& conversion)
@@ -101,9 +106,9 @@
   if (pos < source.size() && IsDigit(source[pos]))
   {
     conversion.has_precision = true;
-    return ParseByte(
-        source, pos, static_cast<uint8_t>(std::numeric_limits<uint8_t>::max() - 1),
-        conversion.precision);
+    return ParseByte(source, pos,
+                     static_cast<uint8_t>(std::numeric_limits<uint8_t>::max() - 1),
+                     conversion.precision);
   }
 
   conversion.has_precision = true;
@@ -114,11 +119,11 @@
 /**
  * @brief 解析一个可选的长度修饰符序列 / Parse one optional length modifier sequence
  * @param source 完整 printf 源字符串 / Full printf source string
- * @param pos 当前解析位置；若存在长度修饰符则推进到其后 / Current parse position; advanced past the length modifier when present
+ * @param pos 当前解析位置；若存在长度修饰符则推进到其后 / Current parse position;
+ * advanced past the length modifier when present
  * @param conversion 当前正在填充的转换项 / Conversion being filled
  */
-consteval void ParseLength(std::string_view source, size_t& pos,
-                           Conversion& conversion)
+consteval void ParseLength(std::string_view source, size_t& pos, Conversion& conversion)
 {
   if (pos >= source.size())
   {
@@ -162,11 +167,14 @@ consteval void ParseLength(std::string_view source, size_t& pos,
 }
 
 /**
- * @brief 解析并校验最终的转换说明符字符 / Parse and validate the final conversion specifier token
+ * @brief 解析并校验最终的转换说明符字符 / Parse and validate the final conversion
+ * specifier token
  * @param source 完整 printf 源字符串 / Full printf source string
- * @param pos 当前解析位置，成功时推进到说明符之后 / Current parse position; advanced past the specifier on success
+ * @param pos 当前解析位置，成功时推进到说明符之后 / Current parse position; advanced past
+ * the specifier on success
  * @param conversion 当前正在填充的转换项 / Conversion being filled
- * @return 成功返回 `Error::None`；说明符、长度或功能开关不合法时返回对应错误 / Returns `Error::None` on success, or the first specifier, length, or gate error
+ * @return 成功返回 `Error::None`；说明符、长度或功能开关不合法时返回对应错误 / Returns
+ * `Error::None` on success, or the first specifier, length, or gate error
  */
 [[nodiscard]] consteval Error ParseSpecifier(std::string_view source, size_t& pos,
                                              Conversion& conversion)
@@ -197,16 +205,18 @@ consteval void ParseLength(std::string_view source, size_t& pos,
 }
 
 /**
- * @brief 在前导 `%` 之后解析一个完整 printf 转换项 / Parse one complete printf conversion after the leading `%`
+ * @brief 在前导 `%` 之后解析一个完整 printf 转换项 / Parse one complete printf conversion
+ * after the leading `%`
  * @param source 完整 printf 源字符串 / Full printf source string
- * @param pos 当前解析位置，进入时应指向 `%`，成功时推进到该转换项之后 / Current parse position; must point at `%` on entry and lands after the conversion on success
+ * @param pos 当前解析位置，进入时应指向 `%`，成功时推进到该转换项之后 / Current parse
+ * position; must point at `%` on entry and lands after the conversion on success
  * @param indexing 源级索引模式跟踪状态 / Source-level indexing mode tracker
  * @param conversion 输出转换项结果 / Conversion result output
- * @return 成功返回 `Error::None`；解析或校验失败时返回对应错误 / Returns `Error::None` on success, or the first parse or validation failure
+ * @return 成功返回 `Error::None`；解析或校验失败时返回对应错误 / Returns `Error::None` on
+ * success, or the first parse or validation failure
  */
 [[nodiscard]] consteval Error Parse(std::string_view source, size_t& pos,
-                                    IndexingState& indexing,
-                                    Conversion& conversion)
+                                    IndexingState& indexing, Conversion& conversion)
 {
   ++pos;
   if (pos >= source.size())

--- a/src/core/print/printf/printf_frontend_source.hpp
+++ b/src/core/print/printf/printf_frontend_source.hpp
@@ -6,16 +6,20 @@
 namespace SourceSyntax
 {
 /**
- * @brief 供位置参数分析使用的仅源串临时摘要 / Source-only scratch summary for positional argument analysis
- * @tparam MaxFieldCount 已解析转换项数量的保守上界 / Conservative upper bound for parsed conversion count
+ * @brief 供位置参数分析使用的仅源串临时摘要 / Source-only scratch summary for positional
+ * argument analysis
+ * @tparam MaxFieldCount 已解析转换项数量的保守上界 / Conservative upper bound for parsed
+ * conversion count
  */
 template <size_t MaxFieldCount>
 struct SourceAnalysisScratch
 {
-  std::array<size_t, MaxFieldCount> order{};  ///< field-ordered source argument indexes / 按字段顺序排列的源参数索引
-  size_t field_count = 0;                     ///< parsed conversion count / 已解析的转换项数量
-  size_t argument_count = 0;                  ///< highest referenced argument count / 最高引用到的参数个数
-  Error error = Error::None;                  ///< first parse/analysis error / 首个解析或分析错误
+  std::array<size_t, MaxFieldCount>
+      order{};  ///< field-ordered source argument indexes / 按字段顺序排列的源参数索引
+  size_t field_count = 0;  ///< parsed conversion count / 已解析的转换项数量
+  size_t argument_count =
+      0;  ///< highest referenced argument count / 最高引用到的参数个数
+  Error error = Error::None;  ///< first parse/analysis error / 首个解析或分析错误
 
   [[nodiscard]] consteval Error Text(size_t, size_t) const { return Error::None; }
 
@@ -32,20 +36,24 @@ struct SourceAnalysisScratch
 };
 
 /**
- * @brief 最终的源级位置参数或顺序参数摘要 / Final source-level positional or sequential argument summary
+ * @brief 最终的源级位置参数或顺序参数摘要 / Final source-level positional or sequential
+ * argument summary
  * @tparam FieldCount 最终解析出的转换项数量 / Final parsed conversion count
  * @tparam ArgCount 最终引用到的参数个数 / Final referenced argument count
  */
 template <size_t FieldCount, size_t ArgCount>
 struct SourceAnalysis
 {
-  std::array<size_t, FieldCount> order{};          ///< field-ordered source argument indexes / 按字段顺序排列的源参数索引
-  std::array<FormatArgumentInfo, ArgCount> args{};  ///< source-ordered argument metadata / 按源参数顺序排列的参数元信息
-  Error error = Error::None;                       ///< first parse/analysis error / 首个解析或分析错误
+  std::array<size_t, FieldCount>
+      order{};  ///< field-ordered source argument indexes / 按字段顺序排列的源参数索引
+  std::array<FormatArgumentInfo, ArgCount>
+      args{};  ///< source-ordered argument metadata / 按源参数顺序排列的参数元信息
+  Error error = Error::None;  ///< first parse/analysis error / 首个解析或分析错误
 };
 
 /**
- * @brief 将已解析转换解析成最终源顺序参数元信息摘要的 visitor / Visitor that resolves parsed conversions into the final source-ordered argument metadata summary
+ * @brief 将已解析转换解析成最终源顺序参数元信息摘要的 visitor / Visitor that resolves
+ * parsed conversions into the final source-ordered argument metadata summary
  * @tparam FieldCount 最终解析出的转换项数量 / Final parsed conversion count
  * @tparam ArgCount 最终引用到的参数个数 / Final referenced argument count
  */
@@ -78,10 +86,13 @@ struct ResolvedArgumentVisitor
 #include "printf_frontend_parser.hpp"
 
 /**
- * @brief 遍历一个 printf 源字符串，并发射字面文本片段与已解析转换项 / Walk one printf source string and emit literal-text spans plus parsed conversions
+ * @brief 遍历一个 printf 源字符串，并发射字面文本片段与已解析转换项 / Walk one printf
+ * source string and emit literal-text spans plus parsed conversions
  * @param source 当前待解析的 printf 源字符串 / Printf source string to walk
- * @param visitor 接收文本片段与已解析转换项的 visitor / Visitor receiving text spans and parsed conversions
- * @return 首个源级解析错误；成功时返回 `Error::None` / Returns the first source-level parse error, or `Error::None` on success
+ * @param visitor 接收文本片段与已解析转换项的 visitor / Visitor receiving text spans and
+ * parsed conversions
+ * @return 首个源级解析错误；成功时返回 `Error::None` / Returns the first source-level
+ * parse error, or `Error::None` on success
  */
 [[nodiscard]] consteval Error WalkSource(std::string_view source, auto& visitor)
 {
@@ -143,17 +154,21 @@ struct ResolvedArgumentVisitor
 }
 
 /**
- * @brief 对一个 printf 字面量执行仅源串分析，并返回按顺序整理的参数引用摘要 / Run source-only analysis for one printf literal and return the ordered argument-reference summary
+ * @brief 对一个 printf 字面量执行仅源串分析，并返回按顺序整理的参数引用摘要 / Run
+ * source-only analysis for one printf literal and return the ordered argument-reference
+ * summary
  * @tparam Source printf 风格格式串字面量 / Printf-style format literal
- * @return 源串分析结果，包含字段顺序、参数引用摘要与首个源级错误 / Returns the source analysis result, including field order, argument reference summary, and the first source-level error
+ * @return 源串分析结果，包含字段顺序、参数引用摘要与首个源级错误 / Returns the source
+ * analysis result, including field order, argument reference summary, and the first
+ * source-level error
  */
 template <Text Source>
 [[nodiscard]] consteval auto Analyze()
 {
-  constexpr auto scratch = []() consteval {
+  constexpr auto scratch = []() consteval
+  {
     SourceAnalysisScratch<Source.Size()> visitor{};
-    visitor.error =
-        WalkSource(std::string_view(Source.Data(), Source.Size()), visitor);
+    visitor.error = WalkSource(std::string_view(Source.Data(), Source.Size()), visitor);
     return visitor;
   }();
 
@@ -170,8 +185,7 @@ template <Text Source>
   }
   else
   {
-    ResolvedArgumentVisitor<scratch.field_count, scratch.argument_count> visitor{
-        result};
+    ResolvedArgumentVisitor<scratch.field_count, scratch.argument_count> visitor{result};
     result.error = WalkSource(std::string_view(Source.Data(), Source.Size()), visitor);
     return result;
   }

--- a/src/core/print/printf/printf_frontend_spec.hpp
+++ b/src/core/print/printf/printf_frontend_spec.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 /**
- * @brief 降为运行时类型之前，仅供前端使用的语义转换族 / Frontend-only semantic conversion families before runtime lowering
+ * @brief 降为运行时类型之前，仅供前端使用的语义转换族 / Frontend-only semantic conversion
+ * families before runtime lowering
  *
  * This layer is intentionally narrower than FormatType. It only describes what
  * the source-level printf token means before target-dependent width selection,
@@ -11,43 +12,50 @@
  */
 enum class ValueKind : uint8_t
 {
-  None,               ///< invalid or unresolved specifier / 无效或尚未解析的说明符
-  Signed,             ///< %d / %i family / %d / %i 族
-  Unsigned,           ///< %u family / %u 族
-  Binary,             ///< %b / %B family / %b / %B 族
-  Octal,              ///< %o family / %o 族
-  HexLower,           ///< %x family / %x 族
-  HexUpper,           ///< %X family / %X 族
-  Pointer,            ///< %p / %p
-  Character,          ///< %c / %c
-  String,             ///< %s / %s
-  FloatFixed,         ///< %f / %F / %f / %F
-  FloatScientific,    ///< %e / %E / %e / %E
-  FloatGeneral,       ///< %g / %G / %g / %G
+  None,             ///< invalid or unresolved specifier / 无效或尚未解析的说明符
+  Signed,           ///< %d / %i family / %d / %i 族
+  Unsigned,         ///< %u family / %u 族
+  Binary,           ///< %b / %B family / %b / %B 族
+  Octal,            ///< %o family / %o 族
+  HexLower,         ///< %x family / %x 族
+  HexUpper,         ///< %X family / %X 族
+  Pointer,          ///< %p / %p
+  Character,        ///< %c / %c
+  String,           ///< %s / %s
+  FloatFixed,       ///< %f / %F / %f / %F
+  FloatScientific,  ///< %e / %E / %e / %E
+  FloatGeneral,     ///< %g / %G / %g / %G
 };
 
 /**
- * @brief 单个 printf 转换在降为共享格式前的解析结果 / One parsed printf conversion before lowering into the shared format
+ * @brief 单个 printf 转换在降为共享格式前的解析结果 / One parsed printf conversion before
+ * lowering into the shared format
  */
 struct Conversion
 {
-  size_t arg_index = 0;            ///< source argument index consumed by this field / 当前字段消耗的源参数索引
-  ValueKind type = ValueKind::None;   ///< semantic conversion category / 转换项归一化后的语义类别
-  Length length = Length::Default;    ///< parsed length modifier / 已解析的长度修饰符
-  bool left_align = false;            ///< parsed - flag / 已解析的 - 标志
-  bool force_sign = false;            ///< parsed + flag / 已解析的 + 标志
-  bool space_sign = false;            ///< parsed space-sign flag / 已解析的空格正号标志
-  bool alternate = false;             ///< parsed # flag / 已解析的 # 标志
-  bool zero_pad = false;              ///< parsed 0 flag / 已解析的 0 标志
-  bool upper_case = false;            ///< implied uppercase output / 隐含的大写输出标志
-  bool positional = false;            ///< whether arg_index came from n$ syntax / arg_index 是否来自 n$ 语法
-  uint8_t width = 0;                  ///< parsed field width / 已解析的字段宽度
-  bool has_precision = false;         ///< whether precision was explicitly provided / 是否显式提供了精度
-  uint8_t precision = 0;              ///< parsed precision value / 已解析的精度值
+  size_t arg_index =
+      0;  ///< source argument index consumed by this field / 当前字段消耗的源参数索引
+  ValueKind type =
+      ValueKind::None;  ///< semantic conversion category / 转换项归一化后的语义类别
+  Length length = Length::Default;  ///< parsed length modifier / 已解析的长度修饰符
+  bool left_align = false;          ///< parsed - flag / 已解析的 - 标志
+  bool force_sign = false;          ///< parsed + flag / 已解析的 + 标志
+  bool space_sign = false;          ///< parsed space-sign flag / 已解析的空格正号标志
+  bool alternate = false;           ///< parsed # flag / 已解析的 # 标志
+  bool zero_pad = false;            ///< parsed 0 flag / 已解析的 0 标志
+  bool upper_case = false;          ///< implied uppercase output / 隐含的大写输出标志
+  bool positional =
+      false;  ///< whether arg_index came from n$ syntax / arg_index 是否来自 n$ 语法
+  uint8_t width = 0;  ///< parsed field width / 已解析的字段宽度
+  bool has_precision =
+      false;  ///< whether precision was explicitly provided / 是否显式提供了精度
+  uint8_t precision = 0;  ///< parsed precision value / 已解析的精度值
 
   /**
-   * @brief 将前端解析出的标志位打包成共享的 `FormatFlag` 字节 / Pack the parsed frontend flags into the shared `FormatFlag` byte
-   * @return 返回打包后的共享 `FormatFlag` 字节 / Returns the packed shared `FormatFlag` byte
+   * @brief 将前端解析出的标志位打包成共享的 `FormatFlag` 字节 / Pack the parsed frontend
+   * flags into the shared `FormatFlag` byte
+   * @return 返回打包后的共享 `FormatFlag` 字节 / Returns the packed shared `FormatFlag`
+   * byte
    */
   [[nodiscard]] constexpr uint8_t FlagsByte() const
   {
@@ -80,8 +88,10 @@ struct Conversion
   }
 
   /**
-   * @brief 返回共享精度字节；若未显式指定精度则为 `0xFF` / Return the shared precision byte, or `0xFF` when precision is absent
-   * @return 返回运行期协议期望的共享精度字节 / Returns the shared precision byte expected by the runtime protocol
+   * @brief 返回共享精度字节；若未显式指定精度则为 `0xFF` / Return the shared precision
+   * byte, or `0xFF` when precision is absent
+   * @return 返回运行期协议期望的共享精度字节 / Returns the shared precision byte expected
+   * by the runtime protocol
    */
   [[nodiscard]] constexpr uint8_t PrecisionByte() const
   {
@@ -90,7 +100,8 @@ struct Conversion
 };
 
 /**
- * @brief printf 转换说明符描述表使用的功能开关类别 / Feature-switch families referenced by printf conversion descriptors
+ * @brief printf 转换说明符描述表使用的功能开关类别 / Feature-switch families referenced
+ * by printf conversion descriptors
  */
 enum class FeatureGate : uint8_t
 {
@@ -104,7 +115,8 @@ enum class FeatureGate : uint8_t
 };
 
 /**
- * @brief 单个 printf 转换说明符允许的长度修饰类别 / Length families accepted by one printf conversion descriptor
+ * @brief 单个 printf 转换说明符允许的长度修饰类别 / Length families accepted by one
+ * printf conversion descriptor
  */
 enum class LengthPolicy : uint8_t
 {
@@ -119,37 +131,35 @@ enum class LengthPolicy : uint8_t
 struct SpecifierDescriptor
 {
   char token = 0;  ///< source conversion character / 源格式转换字符
-  ValueKind type = ValueKind::None;   ///< normalized semantic category / 归一化后的语义类别
-  FeatureGate gate =
-      FeatureGate::Integer;  ///< feature gate controlling this specifier / 控制该说明符的功能开关
+  ValueKind type =
+      ValueKind::None;  ///< normalized semantic category / 归一化后的语义类别
+  FeatureGate gate = FeatureGate::Integer;  ///< feature gate controlling this specifier /
+                                            ///< 控制该说明符的功能开关
   LengthPolicy length_policy =
       LengthPolicy::NoneOnly;  ///< accepted length family / 允许的长度修饰类别
-  bool upper_case = false;  ///< whether the specifier implies uppercase output / 说明符是否隐含大写输出
+  bool upper_case =
+      false;  ///< whether the specifier implies uppercase output / 说明符是否隐含大写输出
 };
 
 /**
  * @brief 归一化 printf 长度表的宽度 / Normalized printf length-table width
  */
-inline constexpr size_t length_rule_count =
-    static_cast<size_t>(Length::LongDouble) + 1;
+inline constexpr size_t length_rule_count = static_cast<size_t>(Length::LongDouble) + 1;
 
 /**
  * @brief 按长度索引的有符号参数规则表 / Per-length signed argument-rule table
  */
 inline constexpr std::array<FormatArgumentRule, length_rule_count> signed_rules{
-    FormatArgumentRule::SignedAny,
-    FormatArgumentRule::SignedChar,
-    FormatArgumentRule::SignedShort,
-    FormatArgumentRule::SignedLong,
-    FormatArgumentRule::SignedLongLong,
-    FormatArgumentRule::SignedIntMax,
-    FormatArgumentRule::SignedSize,
-    FormatArgumentRule::SignedPtrDiff,
+    FormatArgumentRule::SignedAny,      FormatArgumentRule::SignedChar,
+    FormatArgumentRule::SignedShort,    FormatArgumentRule::SignedLong,
+    FormatArgumentRule::SignedLongLong, FormatArgumentRule::SignedIntMax,
+    FormatArgumentRule::SignedSize,     FormatArgumentRule::SignedPtrDiff,
     FormatArgumentRule::None,
 };
 
 /**
- * @brief 按归一化 printf 长度索引的无符号参数规则表 / Per-length unsigned argument-rule table indexed by normalized printf length
+ * @brief 按归一化 printf 长度索引的无符号参数规则表 / Per-length unsigned argument-rule
+ * table indexed by normalized printf length
  */
 inline constexpr std::array<FormatArgumentRule, length_rule_count> unsigned_rules{
     FormatArgumentRule::UnsignedAny,
@@ -182,12 +192,10 @@ inline constexpr std::array<SpecifierDescriptor, 17> specifiers{{
     {'s', ValueKind::String, FeatureGate::Text, LengthPolicy::NoneOnly, false},
     {'f', ValueKind::FloatFixed, FeatureGate::FloatFixed, LengthPolicy::Float, false},
     {'F', ValueKind::FloatFixed, FeatureGate::FloatFixed, LengthPolicy::Float, true},
-    {'e', ValueKind::FloatScientific, FeatureGate::FloatScientific,
-     LengthPolicy::Float, false},
-    {'E', ValueKind::FloatScientific, FeatureGate::FloatScientific,
-     LengthPolicy::Float, true},
-    {'g', ValueKind::FloatGeneral, FeatureGate::FloatGeneral, LengthPolicy::Float,
+    {'e', ValueKind::FloatScientific, FeatureGate::FloatScientific, LengthPolicy::Float,
      false},
-    {'G', ValueKind::FloatGeneral, FeatureGate::FloatGeneral, LengthPolicy::Float,
+    {'E', ValueKind::FloatScientific, FeatureGate::FloatScientific, LengthPolicy::Float,
      true},
+    {'g', ValueKind::FloatGeneral, FeatureGate::FloatGeneral, LengthPolicy::Float, false},
+    {'G', ValueKind::FloatGeneral, FeatureGate::FloatGeneral, LengthPolicy::Float, true},
 }};

--- a/src/core/print/writer.hpp
+++ b/src/core/print/writer.hpp
@@ -14,9 +14,9 @@
 #include <type_traits>
 #include <utility>
 
+#include "../libxr_def.hpp"
 #include "format_argument.hpp"
 #include "format_protocol.hpp"
-#include "../libxr_def.hpp"
 #include "print_contract.hpp"
 
 namespace LibXR::Print
@@ -24,7 +24,8 @@ namespace LibXR::Print
 namespace Detail::WriterFloatLimit
 {
 /**
- * @brief 返回一个正整数的十进制位数 / Return the base-10 digit count of one positive integer value
+ * @brief 返回一个正整数的十进制位数 / Return the base-10 digit count of one positive
+ * integer value
  * @param value 正整数值 / Positive integer value
  * @return 十进制位数 / Returns the decimal digit count
  */
@@ -40,7 +41,8 @@ namespace Detail::WriterFloatLimit
 }
 
 /**
- * @brief 返回某个浮点类型在定点格式下的有界文本长度 / Return the bounded fixed-format text length for one float family
+ * @brief 返回某个浮点类型在定点格式下的有界文本长度 / Return the bounded fixed-format
+ * text length for one float family
  * @tparam Float 浮点类型 / Float type
  * @return 有界定点文本长度 / Returns the bounded fixed-format text length
  */
@@ -54,7 +56,8 @@ template <typename Float>
 }
 
 /**
- * @brief 返回某个浮点类型在科学计数法下的有界文本长度 / Return the bounded scientific-format text length for one float family
+ * @brief 返回某个浮点类型在科学计数法下的有界文本长度 / Return the bounded
+ * scientific-format text length for one float family
  * @tparam Float 浮点类型 / Float type
  * @return 有界科学计数法文本长度 / Returns the bounded scientific-format text length
  */
@@ -63,14 +66,15 @@ template <typename Float>
 {
   constexpr size_t decimal_point =
       (Config::max_float_precision != 0 || Config::enable_alternate) ? 1U : 0U;
-  constexpr size_t exponent_digits = DecimalDigitCount(
-      static_cast<size_t>(std::numeric_limits<Float>::max_exponent10));
-  return 1U + decimal_point + static_cast<size_t>(Config::max_float_precision) +
-         2U + exponent_digits;
+  constexpr size_t exponent_digits =
+      DecimalDigitCount(static_cast<size_t>(std::numeric_limits<Float>::max_exponent10));
+  return 1U + decimal_point + static_cast<size_t>(Config::max_float_precision) + 2U +
+         exponent_digits;
 }
 
 /**
- * @brief 返回定点与科学计数法文本长度上界中的较大者 / Return the larger bound between fixed and scientific text lengths
+ * @brief 返回定点与科学计数法文本长度上界中的较大者 / Return the larger bound between
+ * fixed and scientific text lengths
  * @tparam Float 浮点类型 / Float type
  * @return 两种有界文本长度中的较大值 / Returns the larger of the two bounded text lengths
  */
@@ -83,7 +87,8 @@ template <typename Float>
 }
 
 /**
- * @brief 计算当前启用的浮点格式族共用的本地文本缓冲区容量 / Compute the shared local float text-buffer capacity required by the enabled float families
+ * @brief 计算当前启用的浮点格式族共用的本地文本缓冲区容量 / Compute the shared local
+ * float text-buffer capacity required by the enabled float families
  * @return 所需的共享浮点缓冲区容量 / Returns the required shared float buffer capacity
  */
 [[nodiscard]] constexpr size_t ComputeBufferCapacity()
@@ -109,19 +114,23 @@ template <typename Float>
 }  // namespace Detail::WriterFloatLimit
 
 /**
- * @brief 运行期 writer，负责打包调用点参数并执行编译好的字节流 / Runtime writer that packs call-site arguments and executes the compiled byte stream
+ * @brief 运行期 writer，负责打包调用点参数并执行编译好的字节流 / Runtime writer that
+ * packs call-site arguments and executes the compiled byte stream
  */
 class Writer
 {
  public:
   /**
-   * @brief 执行一份编译格式；它的字段顺序与源参数顺序可以不同 / Run one compiled format whose field order and source argument order may differ
+   * @brief 执行一份编译格式；它的字段顺序与源参数顺序可以不同 / Run one compiled format
+   * whose field order and source argument order may differ
    * @tparam Sink 输出端类型，需满足 `OutputSink` / Sink type satisfying `OutputSink`
    * @tparam Format 编译格式类型 / Compiled format type
-   * @tparam ArgumentOrder 按字段顺序排列的源参数索引表 / Source-argument index list ordered by emitted fields
+   * @tparam ArgumentOrder 按字段顺序排列的源参数索引表 / Source-argument index list
+   * ordered by emitted fields
    * @tparam Args 调用点实参类型列表 / Call-site argument types
    * @param sink 输出端 / Destination sink
-   * @param format 编译格式对象，仅用于约束与类型推导 / Compiled format object, used only for constraints and type deduction
+   * @param format 编译格式对象，仅用于约束与类型推导 / Compiled format object, used only
+   * for constraints and type deduction
    * @param args 调用点实参 / Call-site arguments
    *
    * This path is used by formats such as `{1} {0}`: fields are still executed
@@ -129,28 +138,32 @@ class Writer
    * 这条路径用于 `{1} {0}` 这种格式：字段仍然按源串顺序执行，
    * 但运行期参数包要按另一种顺序构造。
    *
-   * @note 这条接口不重新解析源格式串；它直接执行编译好的字节流 / This function does not re-parse the source format string; it executes the compiled byte stream directly
+   * @note 这条接口不重新解析源格式串；它直接执行编译好的字节流 / This function does not
+   * re-parse the source format string; it executes the compiled byte stream directly
    * @return 运行期 writer 执行状态 / Returns the runtime writer status
    */
   template <typename Sink, typename Format, auto ArgumentOrder, typename... Args>
-  requires OutputSink<Sink> && CompiledFormat<std::remove_cvref_t<Format>>
-  [[nodiscard]] static ErrorCode RunArgumentOrder(Sink& sink, const Format&, Args&&... args)
+    requires OutputSink<Sink> && CompiledFormat<std::remove_cvref_t<Format>>
+  [[nodiscard]] static ErrorCode RunArgumentOrder(Sink& sink, const Format&,
+                                                  Args&&... args)
   {
     using Built = std::remove_cvref_t<Format>;
     static_assert(ArgumentOrder.size() == Built::ArgumentList().size(),
                   "LibXR::Print::Writer: argument reorder list must match the "
                   "compiled field count");
-    static_assert(Built::template Matches<Args...>(),
-                  "LibXR::Print::Writer::RunArgumentOrder: format arguments do not match");
+    static_assert(
+        Built::template Matches<Args...>(),
+        "LibXR::Print::Writer::RunArgumentOrder: format arguments do not match");
 
     return RunTaggedArgumentOrder<Sink, Built::ArgumentList(), ArgumentOrder,
-                                  Built::Profile()>(
-        sink, Built::Codes().data(), std::forward<Args>(args)...);
+                                  Built::Profile()>(sink, Built::Codes().data(),
+                                                    std::forward<Args>(args)...);
   }
 
  private:
   /**
-   * @brief 为某个已编译参数列表生成栈上参数字节块 / Emit the stack argument byte blob for one compiled argument list
+   * @brief 为某个已编译参数列表生成栈上参数字节块 / Emit the stack argument byte blob for
+   * one compiled argument list
    */
   static constexpr uint8_t unspecified_precision = 0xFF;
   template <FormatPackKind K>
@@ -159,7 +172,8 @@ class Writer
       Detail::WriterFloatLimit::ComputeBufferCapacity();
 
   /**
-   * @brief 判断某个已解码字段修饰位是否被设置 / Test whether one decoded field-spec bit is set
+   * @brief 判断某个已解码字段修饰位是否被设置 / Test whether one decoded field-spec bit
+   * is set
    */
   [[nodiscard]] static constexpr bool HasFlag(uint8_t flags, uint8_t bit)
   {
@@ -167,19 +181,21 @@ class Writer
   }
 
   /**
-   * @brief 运行期对单个字段描述字节组的解码视图 / Runtime view of one decoded field specification byte group
+   * @brief 运行期对单个字段描述字节组的解码视图 / Runtime view of one decoded field
+   * specification byte group
    */
   struct Spec
   {
     uint8_t flags = 0;  ///< FormatFlag bitset / 字段修饰位集合
     char fill = ' ';    ///< field fill character / 字段填充字符
     uint8_t width = 0;  ///< field width, or zero when absent / 字段宽度，未指定时为 0
-    uint8_t precision =
-        unspecified_precision;  ///< precision, or unspecified_precision / 字段精度，未指定时为哨兵值
+    uint8_t precision = unspecified_precision;  ///< precision, or unspecified_precision /
+                                                ///< 字段精度，未指定时为哨兵值
 
     /**
      * @brief 判断是否请求了左对齐 / Return whether left alignment is requested
-     * @return 开启左对齐时返回 `true`，否则返回 `false` / Returns `true` when left alignment is enabled, otherwise `false`
+     * @return 开启左对齐时返回 `true`，否则返回 `false` / Returns `true` when left
+     * alignment is enabled, otherwise `false`
      */
     [[nodiscard]] constexpr bool LeftAlign() const
     {
@@ -187,8 +203,10 @@ class Writer
     }
 
     /**
-     * @brief 判断是否请求了显式正号输出 / Return whether explicit plus-sign output is requested
-     * @return 开启显式正号输出时返回 `true`，否则返回 `false` / Returns `true` when explicit plus-sign output is enabled, otherwise `false`
+     * @brief 判断是否请求了显式正号输出 / Return whether explicit plus-sign output is
+     * requested
+     * @return 开启显式正号输出时返回 `true`，否则返回 `false` / Returns `true` when
+     * explicit plus-sign output is enabled, otherwise `false`
      */
     [[nodiscard]] constexpr bool ForceSign() const
     {
@@ -197,7 +215,8 @@ class Writer
 
     /**
      * @brief 判断是否请求了居中对齐 / Return whether center alignment is requested
-     * @return 开启居中对齐时返回 `true`，否则返回 `false` / Returns `true` when center alignment is enabled, otherwise `false`
+     * @return 开启居中对齐时返回 `true`，否则返回 `false` / Returns `true` when center
+     * alignment is enabled, otherwise `false`
      */
     [[nodiscard]] constexpr bool CenterAlign() const
     {
@@ -205,8 +224,10 @@ class Writer
     }
 
     /**
-     * @brief 判断是否请求了正值前补空格的符号策略 / Return whether space-sign output for positive values is requested
-     * @return 开启空格符号策略时返回 `true`，否则返回 `false` / Returns `true` when the space-sign policy is enabled, otherwise `false`
+     * @brief 判断是否请求了正值前补空格的符号策略 / Return whether space-sign output for
+     * positive values is requested
+     * @return 开启空格符号策略时返回 `true`，否则返回 `false` / Returns `true` when the
+     * space-sign policy is enabled, otherwise `false`
      */
     [[nodiscard]] constexpr bool SpaceSign() const
     {
@@ -215,7 +236,8 @@ class Writer
 
     /**
      * @brief 判断是否请求了备用格式 / Return whether alternate form is requested
-     * @return 开启备用格式时返回 `true`，否则返回 `false` / Returns `true` when alternate form is enabled, otherwise `false`
+     * @return 开启备用格式时返回 `true`，否则返回 `false` / Returns `true` when alternate
+     * form is enabled, otherwise `false`
      */
     [[nodiscard]] constexpr bool Alternate() const
     {
@@ -224,7 +246,8 @@ class Writer
 
     /**
      * @brief 判断是否请求了零填充 / Return whether zero-padding is requested
-     * @return 开启零填充时返回 `true`，否则返回 `false` / Returns `true` when zero-padding is enabled, otherwise `false`
+     * @return 开启零填充时返回 `true`，否则返回 `false` / Returns `true` when
+     * zero-padding is enabled, otherwise `false`
      */
     [[nodiscard]] constexpr bool ZeroPad() const
     {
@@ -233,7 +256,8 @@ class Writer
 
     /**
      * @brief 判断是否请求了大写输出 / Return whether uppercase output is requested
-     * @return 开启大写输出时返回 `true`，否则返回 `false` / Returns `true` when uppercase output is enabled, otherwise `false`
+     * @return 开启大写输出时返回 `true`，否则返回 `false` / Returns `true` when uppercase
+     * output is enabled, otherwise `false`
      */
     [[nodiscard]] constexpr bool UpperCase() const
     {
@@ -242,7 +266,8 @@ class Writer
 
     /**
      * @brief 判断是否显式指定了精度 / Return whether precision was explicitly specified
-     * @return 显式给出精度时返回 `true`，否则返回 `false` / Returns `true` when precision is present, otherwise `false`
+     * @return 显式给出精度时返回 `true`，否则返回 `false` / Returns `true` when precision
+     * is present, otherwise `false`
      */
     [[nodiscard]] constexpr bool HasPrecision() const
     {
@@ -251,7 +276,8 @@ class Writer
   };
 
   /**
-   * @brief 返回一个 char 数组参数在边界内的 C 字符串长度 / Return the bounded C-string length stored inside one char array argument
+   * @brief 返回一个 char 数组参数在边界内的 C 字符串长度 / Return the bounded C-string
+   * length stored inside one char array argument
    * @tparam N 数组长度 / Array extent
    * @param text char 数组参数 / Char array argument
    * @return 返回边界内首个 NUL 的位置 / Returns the first in-range NUL position
@@ -260,7 +286,8 @@ class Writer
   [[nodiscard]] static constexpr size_t BoundedTextLength(const char (&text)[N]) noexcept;
 
   /**
-   * @brief 将一个字符串类运行期参数归一化为 `std::string_view` / Normalize one string-like runtime argument into `std::string_view`
+   * @brief 将一个字符串类运行期参数归一化为 `std::string_view` / Normalize one
+   * string-like runtime argument into `std::string_view`
    * @tparam T 运行期实参类型 / Runtime argument type
    * @param text 运行期实参值 / Runtime argument value
    * @return 返回归一化后的文本视图 / Returns the normalized text view
@@ -269,7 +296,8 @@ class Writer
   [[nodiscard]] static constexpr std::string_view ToStringView(const T& text);
 
   /**
-   * @brief 将一个运行期实参转换为某个编译参数槽要求的打包存储形态 / Convert one runtime argument into the packed storage shape required by one compiled argument slot
+   * @brief 将一个运行期实参转换为某个编译参数槽要求的打包存储形态 / Convert one runtime
+   * argument into the packed storage shape required by one compiled argument slot
    * @tparam pack 目标打包存储类型 / Target packed storage kind
    * @tparam T 运行期实参类型 / Runtime argument type
    * @param value 运行期实参值 / Runtime argument value
@@ -279,7 +307,8 @@ class Writer
   [[nodiscard]] static constexpr auto PackValue(T&& value);
 
   /**
-   * @brief 把一个已打包值复制进参数字节块，并推进写指针 / Copy one packed value into the argument byte blob and advance the cursor
+   * @brief 把一个已打包值复制进参数字节块，并推进写指针 / Copy one packed value into the
+   * argument byte blob and advance the cursor
    * @tparam T 已打包值类型 / Packed value type
    * @param out 当前写指针 / Current write cursor
    * @param value 待写入的已打包值 / Packed value to store
@@ -288,7 +317,8 @@ class Writer
   static void StoreArgument(uint8_t*& out, const T& value);
 
   /**
-   * @brief 返回一组编译参数元信息在运行期需要的打包字节数 / Return the runtime packed-byte size required by one compiled argument metadata list
+   * @brief 返回一组编译参数元信息在运行期需要的打包字节数 / Return the runtime
+   * packed-byte size required by one compiled argument metadata list
    * @tparam ArgumentInfoList 编译期参数元信息列表 / Compile-time argument metadata list
    * @return 返回运行期打包总字节数 / Returns the packed runtime byte size
    */
@@ -296,10 +326,13 @@ class Writer
   [[nodiscard]] static consteval size_t PackedArgumentBytes();
 
   /**
-   * @brief 按字段执行顺序把运行期参数打包成最终字节块 / Pack runtime arguments into the final byte blob in field execution order
+   * @brief 按字段执行顺序把运行期参数打包成最终字节块 / Pack runtime arguments into the
+   * final byte blob in field execution order
    * @tparam ArgumentInfoList 编译期参数元信息列表 / Compile-time argument metadata list
-   * @tparam ArgumentOrder 按字段顺序排列的源参数索引表 / Source-argument index list ordered by emitted fields
-   * @tparam Tuple 保存转发后运行期实参的 tuple 类型 / Tuple type holding forwarded runtime arguments
+   * @tparam ArgumentOrder 按字段顺序排列的源参数索引表 / Source-argument index list
+   * ordered by emitted fields
+   * @tparam Tuple 保存转发后运行期实参的 tuple 类型 / Tuple type holding forwarded
+   * runtime arguments
    * @param out 当前写指针 / Current write cursor
    * @param tuple 转发后的运行期实参集合 / Forwarded runtime arguments
    */
@@ -307,7 +340,8 @@ class Writer
   static void StoreArgumentsOrdered(uint8_t*& out, Tuple& tuple);
 
   /**
-   * @brief 返回某个无符号整数在指定进制下所需的最大数字个数 / Return the maximum digit count required for one unsigned integer under the selected radix
+   * @brief 返回某个无符号整数在指定进制下所需的最大数字个数 / Return the maximum digit
+   * count required for one unsigned integer under the selected radix
    *
    * This helper intentionally uses a short exact integer division loop instead
    * of a floating-point approximation. It is `consteval`, so it can only be
@@ -318,15 +352,18 @@ class Writer
    * 场景，因此不会引入任何运行期开销。
    * @tparam UInt 无符号整数类型 / Unsigned integer type
    * @tparam Base 整数进制 / Integer radix
-   * @return 返回该整型在所选进制下的最大数字个数 / Returns the maximum digit count under the selected radix
+   * @return 返回该整型在所选进制下的最大数字个数 / Returns the maximum digit count under
+   * the selected radix
    */
   template <std::unsigned_integral UInt, uint8_t Base>
   [[nodiscard]] static consteval size_t UnsignedDigitCapacity();
 
   /**
-   * @brief 把一个无符号整数写进调用方提供的定长数字缓冲区 / Append one unsigned integer into a caller-provided fixed-size digit buffer
+   * @brief 把一个无符号整数写进调用方提供的定长数字缓冲区 / Append one unsigned integer
+   * into a caller-provided fixed-size digit buffer
    * @tparam Base 整数进制 / Integer radix
-   * @tparam UpperCase 十六进制数字是否使用大写字母 / Whether hexadecimal digits should use uppercase letters
+   * @tparam UpperCase 十六进制数字是否使用大写字母 / Whether hexadecimal digits should
+   * use uppercase letters
    * @tparam N 目标缓冲区长度 / Destination buffer size
    * @tparam UInt 无符号整数类型 / Unsigned integer type
    * @param out 目标数字缓冲区 / Destination digit buffer
@@ -337,7 +374,8 @@ class Writer
   [[nodiscard]] static size_t AppendUnsigned(char (&out)[N], UInt value);
 
   /**
-   * @brief 以十进制形式追加一个较小的无符号整数 / Append one small unsigned integer in base 10
+   * @brief 以十进制形式追加一个较小的无符号整数 / Append one small unsigned integer in
+   * base 10
    * @param out 目标数字缓冲区 / Destination digit buffer
    * @param value 待编码的无符号值 / Unsigned value to encode
    * @return 返回输出的数字个数 / Returns the emitted digit count
@@ -346,7 +384,8 @@ class Writer
   [[nodiscard]] static size_t AppendSmallUnsigned(char (&out)[N], uint8_t value);
 
   /**
-   * @brief 返回把某段载荷扩展到目标字段宽度所需的填充长度 / Return the padding width needed to expand one payload to the requested field width
+   * @brief 返回把某段载荷扩展到目标字段宽度所需的填充长度 / Return the padding width
+   * needed to expand one payload to the requested field width
    * @param width 请求的字段宽度 / Requested field width
    * @param payload_size 填充前的可见载荷长度 / Visible payload size before padding
    * @return 返回需要补上的填充个数 / Returns the required padding count
@@ -354,7 +393,8 @@ class Writer
   [[nodiscard]] static constexpr size_t FieldPadding(uint8_t width, size_t payload_size);
 
   /**
-   * @brief 返回整数精度引入的额外前导零个数 / Return the extra leading-zero count introduced by integer precision
+   * @brief 返回整数精度引入的额外前导零个数 / Return the extra leading-zero count
+   * introduced by integer precision
    * @param spec 解码后的字段规格 / Decoded field spec
    * @param digit_count 当前已有的数字个数 / Existing digit count
    * @return 返回额外前导零个数 / Returns the extra leading-zero count
@@ -363,7 +403,8 @@ class Writer
                                                               size_t digit_count);
 
   /**
-   * @brief 返回放在数字载荷之外的备用格式前缀 / Return the alternate-form prefix carried outside the digit payload
+   * @brief 返回放在数字载荷之外的备用格式前缀 / Return the alternate-form prefix carried
+   * outside the digit payload
    * @tparam UInt 无符号整数类型 / Unsigned integer type
    * @param type 运行期字段类型 / Runtime field type
    * @param spec 解码后的字段规格 / Decoded field spec
@@ -376,7 +417,8 @@ class Writer
                                                                 UInt value);
 
   /**
-   * @brief 直接在已生成的数字载荷上应用 `%#o` 的特殊规则 / Apply `%#o` special rules directly onto the generated digit payload
+   * @brief 直接在已生成的数字载荷上应用 `%#o` 的特殊规则 / Apply `%#o` special rules
+   * directly onto the generated digit payload
    *
    * Octal alternate form differs from hex: it is represented by a leading zero
    * in the digit payload itself, not by a detached prefix string. This helper
@@ -396,84 +438,102 @@ class Writer
                                                   const Spec& spec, UInt value);
 
   /**
-   * @brief 判断这个字段类型是否走共享的浮点文本输出路径 / Return whether this field type is printed by the shared float-text path
+   * @brief 判断这个字段类型是否走共享的浮点文本输出路径 / Return whether this field type
+   * is printed by the shared float-text path
    * @param type 运行期字段类型 / Runtime field type
-   * @return 该类型走共享浮点文本后端时返回 `true`，否则返回 `false` / Returns `true` when this type uses the shared float-text backend, otherwise `false`
+   * @return 该类型走共享浮点文本后端时返回 `true`，否则返回 `false` / Returns `true` when
+   * this type uses the shared float-text backend, otherwise `false`
    */
   [[nodiscard]] static constexpr bool UsesFloatTextBackend(FormatType type);
 
   /**
-   * @brief 判断这个浮点字段类型是否被当前功能开关启用 / Return whether this float field type is enabled by current feature switches
+   * @brief 判断这个浮点字段类型是否被当前功能开关启用 / Return whether this float field
+   * type is enabled by current feature switches
    * @param type 运行期浮点字段类型 / Runtime float field type
-   * @return 当前功能开关允许该浮点字段类型时返回 `true`，否则返回 `false` / Returns `true` when this float field type is enabled, otherwise `false`
+   * @return 当前功能开关允许该浮点字段类型时返回 `true`，否则返回 `false` / Returns
+   * `true` when this float field type is enabled, otherwise `false`
    */
   [[nodiscard]] static constexpr bool FloatEnabled(FormatType type);
   /**
-   * @brief 返回格式串没有显式写精度时使用的默认浮点精度 / Return the default float precision used when the format string did not specify one
+   * @brief 返回格式串没有显式写精度时使用的默认浮点精度 / Return the default float
+   * precision used when the format string did not specify one
    * @return 返回默认浮点精度 / Returns the default float precision
    */
   [[nodiscard]] static constexpr uint8_t DefaultFloatPrecision();
   /**
-   * @brief 判断定点形态的浮点输出是否会超出当前配置的整数位数上限 / Return whether fixed-shape float output would exceed the configured integer-digit limit
+   * @brief 判断定点形态的浮点输出是否会超出当前配置的整数位数上限 / Return whether
+   * fixed-shape float output would exceed the configured integer-digit limit
    * @tparam Float 浮点类型 / Float type
    * @param value 待检查的浮点绝对值 / Float magnitude to test
    * @param precision 请求的小数精度 / Requested fractional precision
-   * @return 若定点输出的整数部分会超出配置上限则返回 `true`，否则返回 `false` / Returns `true` when the fixed-form integer part would exceed the configured limit, otherwise `false`
+   * @return 若定点输出的整数部分会超出配置上限则返回 `true`，否则返回 `false` / Returns
+   * `true` when the fixed-form integer part would exceed the configured limit, otherwise
+   * `false`
    */
   template <typename Float>
   [[nodiscard]] static bool ExceedsFixedIntegerDigits(Float value, uint8_t precision);
 
   /**
-   * @brief 向有界本地格式化缓冲区追加一个字符 / Append one character to a bounded local formatting buffer
+   * @brief 向有界本地格式化缓冲区追加一个字符 / Append one character to a bounded local
+   * formatting buffer
    * @param buffer 目标缓冲区 / Destination buffer
    * @param capacity 缓冲区总容量 / Total buffer capacity
    * @param size 当前已保留长度；成功时会推进 / Current retained size; advanced on success
    * @param ch 待追加字符 / Character to append
-   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise `false`
+   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise
+   * `false`
    */
   [[nodiscard]] static bool AppendBufferChar(char* buffer, size_t capacity, size_t& size,
                                              char ch);
 
   /**
-   * @brief 向有界本地格式化缓冲区追加一段文本 / Append one text span to a bounded local formatting buffer
+   * @brief 向有界本地格式化缓冲区追加一段文本 / Append one text span to a bounded local
+   * formatting buffer
    * @param buffer 目标缓冲区 / Destination buffer
    * @param capacity 缓冲区总容量 / Total buffer capacity
    * @param size 当前已保留长度；成功时会推进 / Current retained size; advanced on success
    * @param text 待追加文本片段 / Text span to append
-   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise `false`
+   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise
+   * `false`
    */
   [[nodiscard]] static bool AppendBufferText(char* buffer, size_t capacity, size_t& size,
                                              std::string_view text);
 
   /**
-   * @brief 追加一个 `uint32_t` 十进制值，并在前面补零到目标宽度 / Append one `uint32_t` decimal value and pad leading zeros up to the target width
+   * @brief 追加一个 `uint32_t` 十进制值，并在前面补零到目标宽度 / Append one `uint32_t`
+   * decimal value and pad leading zeros up to the target width
    * @param buffer 目标缓冲区 / Destination buffer
    * @param capacity 缓冲区总容量 / Total buffer capacity
    * @param size 当前已保留长度；成功时会推进 / Current retained size; advanced on success
    * @param value 待追加的无符号值 / Unsigned value to append
    * @param width 目标零填充宽度 / Target zero-padded width
-   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise `false`
+   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise
+   * `false`
    */
   [[nodiscard]] static bool AppendBufferU32ZeroPad(char* buffer, size_t capacity,
-                                                   size_t& size, uint32_t value, uint8_t width);
+                                                   size_t& size, uint32_t value,
+                                                   uint8_t width);
 
 #if LIBXR_PRINT_ENABLE_FLOAT
   /**
-   * @brief 科学计数法与通用浮点格式化使用的十进制规范化结果 / Decimal normalization result used by scientific and general float formatting
+   * @brief 科学计数法与通用浮点格式化使用的十进制规范化结果 / Decimal normalization
+   * result used by scientific and general float formatting
    * @tparam Float 浮点类型 / Float type
    */
   template <typename Float>
   struct DecimalScale;
 
   /**
-   * @brief 科学计数法舍入后的十进制数字块 / Rounded decimal digit block for scientific notation
+   * @brief 科学计数法舍入后的十进制数字块 / Rounded decimal digit block for scientific
+   * notation
    * @tparam Float 浮点类型 / Float type
    */
   template <typename Float>
   struct ScientificDigits;
 
   /**
-   * @brief 以指定浮点类型返回 `10^exponent` / Return `10^exponent` in the selected float type
+   * @brief 以指定浮点类型返回 `10^exponent` / Return `10^exponent` in the selected float
+   * type
    * @tparam Float 浮点类型 / Float type
    * @param exponent 十进制指数 / Base-10 exponent
    * @return 对应的十进制幂 / Returns the corresponding power of ten
@@ -482,28 +542,32 @@ class Writer
   [[nodiscard]] static Float Power10(int exponent);
 
   /**
-   * @brief 把有限非负值舍入到指定小数位 / Round one finite non-negative value to a decimal precision
+   * @brief 把有限非负值舍入到指定小数位 / Round one finite non-negative value to a
+   * decimal precision
    * @tparam Float 浮点类型 / Float type
    * @param value 有限非负值 / Finite non-negative value
    * @param precision 保留的小数位数 / Decimal places to retain
-   * @return 舍入后的值；若内部缩放溢出则返回原值 / Rounded value, or the original value if internal scaling overflows
+   * @return 舍入后的值；若内部缩放溢出则返回原值 / Rounded value, or the original value
+   * if internal scaling overflows
    */
   template <typename Float>
   [[nodiscard]] static Float RoundDecimal(Float value, uint8_t precision);
 
   /**
-   * @brief 计算科学计数法舍入后的数字块与指数 / Build the rounded digit block and exponent for scientific notation
+   * @brief 计算科学计数法舍入后的数字块与指数 / Build the rounded digit block and
+   * exponent for scientific notation
    * @tparam Float 浮点类型 / Float type
    * @param value 有限非负值 / Finite non-negative value
    * @param precision 小数点后的位数 / Digits after the decimal point
    * @return 舍入后的数字块、数字块权重和指数 / Rounded digits, digit scale, and exponent
    */
   template <typename Float>
-  [[nodiscard]] static ScientificDigits<Float> RoundScientificDigits(
-      Float value, uint8_t precision);
+  [[nodiscard]] static ScientificDigits<Float> RoundScientificDigits(Float value,
+                                                                     uint8_t precision);
 
   /**
-   * @brief 将一个有限正值规范化，使 `value / scale` 落在 `[1, 10)` / Normalize one finite positive value so that `value / scale` stays in `[1, 10)`
+   * @brief 将一个有限正值规范化，使 `value / scale` 落在 `[1, 10)` / Normalize one finite
+   * positive value so that `value / scale` stays in `[1, 10)`
    * @tparam Float 浮点类型 / Float type
    * @param value 有限正数绝对值 / Finite positive magnitude
    * @return 规范化后的十进制缩放描述 / Returns the normalized decimal scale description
@@ -512,7 +576,8 @@ class Writer
   [[nodiscard]] static DecimalScale<Float> NormalizeDecimal(Float value);
 
   /**
-   * @brief 在当前十进制权重下提取一位数字，并容忍微小浮点残差 / Extract one base-10 digit at the current scale while tolerating tiny floating-point residue
+   * @brief 在当前十进制权重下提取一位数字，并容忍微小浮点残差 / Extract one base-10 digit
+   * at the current scale while tolerating tiny floating-point residue
    * @tparam Float 浮点类型 / Float type
    * @param value 剩余规范化值；会原地减少 / Remaining normalized value; reduced in place
    * @param scale 当前十进制权重 / Current decimal scale
@@ -522,7 +587,9 @@ class Writer
   [[nodiscard]] static uint8_t ExtractDigit(Float& value, Float scale);
 
   /**
-   * @brief 在未启用备用格式时修剪通用浮点输出的尾随零，并去掉孤立小数点 / Trim trailing zeros for general float output and remove a dangling decimal point when alternate form is absent
+   * @brief 在未启用备用格式时修剪通用浮点输出的尾随零，并去掉孤立小数点 / Trim trailing
+   * zeros for general float output and remove a dangling decimal point when alternate
+   * form is absent
    * @param text 可修改的浮点文本缓冲区 / Mutable float text buffer
    * @param size 当前文本长度 / Current text size
    * @return 修剪后的文本长度 / Returns the trimmed text size
@@ -537,11 +604,12 @@ class Writer
    * @param alternate 是否启用备用格式 / Whether alternate form is enabled
    * @param out 目标文本缓冲区 / Destination text buffer
    * @param out_size 输出文本长度 / Output text size
-   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise `false`
+   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise
+   * `false`
    */
   template <typename Float>
-  [[nodiscard]] static bool FormatFixedText(Float value, uint8_t precision, bool alternate,
-                                            char* out, size_t& out_size);
+  [[nodiscard]] static bool FormatFixedText(Float value, uint8_t precision,
+                                            bool alternate, char* out, size_t& out_size);
 
   /**
    * @brief 追加一个科学计数法指数后缀 / Append one scientific-notation exponent suffix
@@ -549,7 +617,8 @@ class Writer
    * @param out_size 当前输出长度；成功时会推进 / Current output size; advanced on success
    * @param exponent 十进制指数 / Decimal exponent
    * @param upper_case 指数标记是否使用 `E` / Whether the exponent marker should use `E`
-   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise `false`
+   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise
+   * `false`
    */
   [[nodiscard]] static bool AppendExponentText(char* out, size_t& out_size, int exponent,
                                                bool upper_case);
@@ -563,7 +632,8 @@ class Writer
    * @param upper_case 指数标记是否使用 `E` / Whether the exponent marker should use `E`
    * @param out 目标文本缓冲区 / Destination text buffer
    * @param out_size 输出文本长度 / Output text size
-   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise `false`
+   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise
+   * `false`
    */
   template <typename Float>
   [[nodiscard]] static bool FormatScientificText(Float value, uint8_t precision,
@@ -571,18 +641,20 @@ class Writer
                                                  char* out, size_t& out_size);
 
   /**
-   * @brief 按运行期字段类型选择的顶层浮点文本格式化器 / Top-level float text formatter selected by runtime field type
+   * @brief 按运行期字段类型选择的顶层浮点文本格式化器 / Top-level float text formatter
+   * selected by runtime field type
    * @tparam Float 浮点类型 / Float type
    * @param type 运行期浮点字段类型 / Runtime float field type
    * @param spec 解码后的字段规格 / Decoded field spec
    * @param value 浮点绝对值 / Float magnitude
    * @param out 目标文本缓冲区 / Destination text buffer
    * @param out_size 输出文本长度 / Output text size
-   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise `false`
+   * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise
+   * `false`
    */
   template <typename Float>
-  [[nodiscard]] static bool FormatFloatText(FormatType type, const Spec& spec, Float value,
-                                            char* out, size_t& out_size);
+  [[nodiscard]] static bool FormatFloatText(FormatType type, const Spec& spec,
+                                            Float value, char* out, size_t& out_size);
 #endif
 
   class CodeReader;
@@ -592,14 +664,16 @@ class Writer
   class Executor;
 
   /**
-   * @brief 使用一份已打包参数字节块执行一段编译字节流 / Execute one compiled byte stream against one already packed argument blob
+   * @brief 使用一份已打包参数字节块执行一段编译字节流 / Execute one compiled byte stream
+   * against one already packed argument blob
    * @tparam Sink 输出端类型，需满足 `OutputSink` / Sink type satisfying `OutputSink`
    * @tparam Profile 编译期 writer 摘要 / Compile-time writer profile
    * @param sink 输出端 / Destination sink
    * @param codes 指向编译字节流的指针 / Pointer to the compiled byte stream
-   * @param args 指向已打包参数字节块的指针；无参数时可为空 / Pointer to the packed argument blob, or null when no arguments exist
+   * @param args 指向已打包参数字节块的指针；无参数时可为空 / Pointer to the packed
+   * argument blob, or null when no arguments exist
    * @return 执行器运行结果 / Returns the executor result
-  */
+   */
   template <OutputSink Sink, FormatProfile Profile>
   [[nodiscard]] static LIBXR_NOINLINE ErrorCode Execute(Sink& sink, const uint8_t* codes,
                                                         const uint8_t* args)
@@ -608,21 +682,23 @@ class Writer
   }
 
   /**
-   * @brief 先打包转发后的运行期参数，再执行编译字节流 / Pack forwarded runtime arguments, then execute the compiled byte stream
+   * @brief 先打包转发后的运行期参数，再执行编译字节流 / Pack forwarded runtime arguments,
+   * then execute the compiled byte stream
    * @tparam Sink 输出端类型，需满足 `OutputSink` / Sink type satisfying `OutputSink`
    * @tparam ArgumentInfoList 编译期参数元信息列表 / Compile-time argument metadata list
-   * @tparam ArgumentOrder 按字段顺序排列的源参数索引表 / Source-argument index list ordered by emitted fields
+   * @tparam ArgumentOrder 按字段顺序排列的源参数索引表 / Source-argument index list
+   * ordered by emitted fields
    * @tparam Profile 编译期 writer 摘要 / Compile-time writer profile
    * @tparam Args 转发后的运行期实参类型列表 / Forwarded runtime argument types
    * @param sink 输出端 / Destination sink
    * @param codes 指向编译字节流的指针 / Pointer to the compiled byte stream
    * @param args 转发后的运行期实参 / Forwarded runtime arguments
    * @return 执行器运行结果 / Returns the executor result
-  */
+   */
   template <OutputSink Sink, auto ArgumentInfoList, auto ArgumentOrder,
             FormatProfile Profile, typename... Args>
-  [[nodiscard]] static LIBXR_NOINLINE ErrorCode RunTaggedArgumentOrder(
-      Sink& sink, const uint8_t* codes, Args&&... args)
+  [[nodiscard]] static LIBXR_NOINLINE ErrorCode
+  RunTaggedArgumentOrder(Sink& sink, const uint8_t* codes, Args&&... args)
   {
     if constexpr (ArgumentInfoList.size() == 0)
     {
@@ -640,6 +716,8 @@ class Writer
   }
 };
 
+// These implementation headers form an ordered dependency chain.
+// clang-format off
 #include "writer/writer_argument.hpp"
 #include "writer/writer_integer.hpp"
 #if LIBXR_PRINT_ENABLE_FLOAT
@@ -650,4 +728,5 @@ class Writer
 #endif
 #include "writer/writer_reader.hpp"
 #include "writer/writer_executor.hpp"
+// clang-format on
 }  // namespace LibXR::Print

--- a/src/core/print/writer/writer_argument.hpp
+++ b/src/core/print/writer/writer_argument.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
 /**
- * @brief Writer 的运行期参数归一化与打包辅助函数 / Runtime argument normalization and packing helpers for Writer
+ * @brief Writer 的运行期参数归一化与打包辅助函数 / Runtime argument normalization and
+ * packing helpers for Writer
  */
 
 /**
- * @brief 返回一个 char 数组参数在边界内的 C 字符串长度 / Return the bounded C-string length inside one char array argument
+ * @brief 返回一个 char 数组参数在边界内的 C 字符串长度 / Return the bounded C-string
+ * length inside one char array argument
  * @tparam N 数组长度 / Array extent
  * @param text char 数组参数 / Char array argument
  * @return 返回边界内首个 NUL 的位置 / Returns the first in-range NUL position
@@ -16,7 +18,8 @@
 template <size_t N>
 constexpr size_t Writer::BoundedTextLength(const char (&text)[N]) noexcept
 {
-  static_assert(N > 0, "LibXR::Print::Writer::BoundedTextLength: char array must be non-empty");
+  static_assert(N > 0,
+                "LibXR::Print::Writer::BoundedTextLength: char array must be non-empty");
   size_t size = 0;
   while (size < N && text[size] != '\0')
   {
@@ -30,7 +33,8 @@ constexpr size_t Writer::BoundedTextLength(const char (&text)[N]) noexcept
 }
 
 /**
- * @brief 将一个字符串类运行期参数归一化为 `std::string_view` / Normalize one string-like runtime argument into `std::string_view`
+ * @brief 将一个字符串类运行期参数归一化为 `std::string_view` / Normalize one string-like
+ * runtime argument into `std::string_view`
  * @tparam T 运行期实参类型 / Runtime argument type
  * @param text 运行期实参值 / Runtime argument value
  * @return 返回归一化后的文本视图 / Returns the normalized text view
@@ -70,11 +74,14 @@ constexpr std::string_view Writer::ToStringView(const T& text)
 }
 
 /**
- * @brief 将一个已匹配的 C++ 实参归一化为某个编译参数槽要求的运行期打包存储类型 / Normalize one matched C++ argument into the packed runtime storage kind required by one compiled argument slot
+ * @brief 将一个已匹配的 C++ 实参归一化为某个编译参数槽要求的运行期打包存储类型 /
+ * Normalize one matched C++ argument into the packed runtime storage kind required by one
+ * compiled argument slot
  * @tparam pack 目标打包存储类型 / Target packed storage kind
  * @tparam T 运行期实参类型 / Runtime argument type
  * @param value 运行期实参值 / Runtime argument value
- * @return 返回该参数槽需要的归一化打包值 / Returns the normalized packed value for this slot
+ * @return 返回该参数槽需要的归一化打包值 / Returns the normalized packed value for this
+ * slot
  */
 template <FormatPackKind pack, typename T>
 constexpr auto Writer::PackValue(T&& value)
@@ -104,8 +111,8 @@ constexpr auto Writer::PackValue(T&& value)
     }
     else if constexpr (std::is_integral_v<Normalized>)
     {
-      return static_cast<uint32_t>(static_cast<std::make_unsigned_t<Normalized>>(
-          static_cast<Normalized>(value)));
+      return static_cast<uint32_t>(
+          static_cast<std::make_unsigned_t<Normalized>>(static_cast<Normalized>(value)));
     }
   }
   else if constexpr (pack == FormatPackKind::U64)
@@ -116,8 +123,8 @@ constexpr auto Writer::PackValue(T&& value)
     }
     else if constexpr (std::is_integral_v<Normalized>)
     {
-      return static_cast<uint64_t>(static_cast<std::make_unsigned_t<Normalized>>(
-          static_cast<Normalized>(value)));
+      return static_cast<uint64_t>(
+          static_cast<std::make_unsigned_t<Normalized>>(static_cast<Normalized>(value)));
     }
   }
   else if constexpr (pack == FormatPackKind::Pointer)
@@ -172,16 +179,17 @@ constexpr auto Writer::PackValue(T&& value)
   }
   else
   {
-    static_assert(
-        dependent_false_v<pack>,
-        "LibXR::Print::Writer::PackValue: unsupported packed argument kind");
+    static_assert(dependent_false_v<pack>,
+                  "LibXR::Print::Writer::PackValue: unsupported packed argument kind");
   }
 }
 
 /**
- * @brief 把一个已打包参数值复制进字节块，并推进写指针 / Copy one packed argument value into the byte blob and advance the cursor
+ * @brief 把一个已打包参数值复制进字节块，并推进写指针 / Copy one packed argument value
+ * into the byte blob and advance the cursor
  * @tparam T 已打包值类型 / Packed value type
- * @param out 当前写指针；会前进 `sizeof(T)` / Current write cursor; advanced by `sizeof(T)`
+ * @param out 当前写指针；会前进 `sizeof(T)` / Current write cursor; advanced by
+ * `sizeof(T)`
  * @param value 待写入的已打包值 / Packed value to store
  */
 template <typename T>
@@ -192,9 +200,11 @@ void Writer::StoreArgument(uint8_t*& out, const T& value)
 }
 
 /**
- * @brief 返回一个编译期参数列表所需的参数打包字节数 / Return the packed-byte size required by one compiled argument list
+ * @brief 返回一个编译期参数列表所需的参数打包字节数 / Return the packed-byte size
+ * required by one compiled argument list
  * @tparam ArgumentInfoList 编译期参数元信息列表 / Compile-time argument metadata list
- * @return 返回该参数列表在运行期打包后需要的总字节数 / Returns the packed runtime byte size for this argument list
+ * @return 返回该参数列表在运行期打包后需要的总字节数 / Returns the packed runtime byte
+ * size for this argument list
  */
 template <auto ArgumentInfoList>
 consteval size_t Writer::PackedArgumentBytes()
@@ -208,19 +218,24 @@ consteval size_t Writer::PackedArgumentBytes()
 }
 
 /**
- * @brief 按字段执行顺序把运行期参数打包成最终字节块 / Pack runtime arguments into the final byte blob in field execution order
+ * @brief 按字段执行顺序把运行期参数打包成最终字节块 / Pack runtime arguments into the
+ * final byte blob in field execution order
  * @tparam ArgumentInfoList 编译期参数元信息列表 / Compile-time argument metadata list
- * @tparam ArgumentOrder 每个输出字段对应的源参数索引表 / Source-argument index per emitted field
- * @tparam Tuple 持有转发后运行期实参的 tuple 类型 / Tuple type holding forwarded runtime arguments
- * @param out 当前写指针；会随着写入推进 / Current write cursor; advanced as values are stored
+ * @tparam ArgumentOrder 每个输出字段对应的源参数索引表 / Source-argument index per
+ * emitted field
+ * @tparam Tuple 持有转发后运行期实参的 tuple 类型 / Tuple type holding forwarded runtime
+ * arguments
+ * @param out 当前写指针；会随着写入推进 / Current write cursor; advanced as values are
+ * stored
  * @param tuple 转发后的运行期实参集合 / Forwarded runtime arguments
  */
 template <auto ArgumentInfoList, auto ArgumentOrder, typename Tuple>
 void Writer::StoreArgumentsOrdered(uint8_t*& out, Tuple& tuple)
 {
-  [&]<size_t... I>(std::index_sequence<I...>) {
-    (StoreArgument(out, PackValue<ArgumentInfoList[I].pack>(
-                            std::get<ArgumentOrder[I]>(tuple))),
+  [&]<size_t... I>(std::index_sequence<I...>)
+  {
+    (StoreArgument(
+         out, PackValue<ArgumentInfoList[I].pack>(std::get<ArgumentOrder[I]>(tuple))),
      ...);
   }(std::make_index_sequence<ArgumentInfoList.size()>{});
 }

--- a/src/core/print/writer/writer_executor.hpp
+++ b/src/core/print/writer/writer_executor.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
 /**
- * @brief 按输出端共享重后端、按调用点 profile 裁剪操作码分发的字节码执行器 / Per-sink bytecode executor with shared heavy backends and per-call profile-pruned opcode dispatch
+ * @brief 按输出端共享重后端、按调用点 profile 裁剪操作码分发的字节码执行器 / Per-sink
+ * bytecode executor with shared heavy backends and per-call profile-pruned opcode
+ * dispatch
  * @tparam Sink 输出端类型，需满足 `OutputSink` / Sink type satisfying `OutputSink`
  */
 template <OutputSink Sink>
@@ -9,17 +11,23 @@ class Writer::Executor
 {
  public:
   /**
-   * @brief 将一个输出端、一份编译字节块和一份参数字节块绑定起来 / Bind one sink with one compiled byte blob and one packed argument blob
+   * @brief 将一个输出端、一份编译字节块和一份参数字节块绑定起来 / Bind one sink with one
+   * compiled byte blob and one packed argument blob
    * @param sink 输出端 / Destination sink
    * @param codes 指向编译字节块的指针 / Pointer to the compiled byte blob
-   * @param args 指向运行期参数打包字节块的指针；无参数时可为空 / Pointer to the packed runtime argument blob, or null when no arguments exist
+   * @param args 指向运行期参数打包字节块的指针；无参数时可为空 / Pointer to the packed
+   * runtime argument blob, or null when no arguments exist
    */
   Executor(Sink& sink, const uint8_t* codes, const uint8_t* args);
 
   /**
-   * @brief 持续执行记录流，直到遇到 `FormatOp::End` / Run until the compiled record stream reaches `FormatOp::End`
-   * @tparam Profile 当前编译格式需要的操作码配置 / Opcode profile required by the current compiled format
-   * @return 返回首个 sink 或运行期错误；正常执行到记录流结束时返回 `ErrorCode::OK` / Returns the first sink or runtime error, or `ErrorCode::OK` when the record stream finishes normally
+   * @brief 持续执行记录流，直到遇到 `FormatOp::End` / Run until the compiled record
+   * stream reaches `FormatOp::End`
+   * @tparam Profile 当前编译格式需要的操作码配置 / Opcode profile required by the current
+   * compiled format
+   * @return 返回首个 sink 或运行期错误；正常执行到记录流结束时返回 `ErrorCode::OK` /
+   * Returns the first sink or runtime error, or `ErrorCode::OK` when the record stream
+   * finishes normally
    */
   template <FormatProfile Profile>
   [[nodiscard]] ErrorCode Run();
@@ -31,8 +39,7 @@ class Writer::Executor
   [[nodiscard]] ErrorCode WritePadding(char fill, size_t count);
   [[nodiscard]] ErrorCode WriteTextField(std::string_view text, const Spec& spec);
   [[nodiscard]] ErrorCode WriteIntegerField(char sign_char, std::string_view prefix,
-                                            std::string_view digits,
-                                            const Spec& spec);
+                                            std::string_view digits, const Spec& spec);
   [[nodiscard]] ErrorCode WriteFloatField(char sign_char, std::string_view text,
                                           const Spec& spec);
 
@@ -51,18 +58,23 @@ class Writer::Executor
   [[nodiscard]] ErrorCode DispatchUnsigned(const Spec& spec, UInt value);
 
   /**
-   * @brief 按编译期进制/大小写/八进制备用格式参数复用无符号数字载荷写出逻辑 / Reuse the unsigned-digit payload writer with compile-time radix, case, and octal-alternate parameters
+   * @brief 按编译期进制/大小写/八进制备用格式参数复用无符号数字载荷写出逻辑 / Reuse the
+   * unsigned-digit payload writer with compile-time radix, case, and octal-alternate
+   * parameters
    * @tparam Base 整数进制 / Integer radix
-   * @tparam UpperCase 十六进制数字是否使用大写字符 / Whether hexadecimal digits should use uppercase characters
-   * @tparam PrependOctalZero 是否把 `%#o` 的前导 `0` 直接并入数字载荷 / Whether `%#o` should inline its leading `0` into the digit payload
+   * @tparam UpperCase 十六进制数字是否使用大写字符 / Whether hexadecimal digits should
+   * use uppercase characters
+   * @tparam PrependOctalZero 是否把 `%#o` 的前导 `0` 直接并入数字载荷 / Whether `%#o`
+   * should inline its leading `0` into the digit payload
    * @tparam UInt 无符号整数类型 / Unsigned integer type
    * @param prefix 脱离数字载荷输出的前缀 / Prefix emitted outside the digit payload
    * @param spec 解码后的字段规格 / Decoded field spec
    * @param value 待写出的整数值 / Integer value to write
-   * @return 返回共享无符号数字写出路径的结果 / Returns the shared unsigned-digit write result
+   * @return 返回共享无符号数字写出路径的结果 / Returns the shared unsigned-digit write
+   * result
    */
-  template <uint8_t Base, bool UpperCase = false,
-            bool PrependOctalZero = false, std::unsigned_integral UInt>
+  template <uint8_t Base, bool UpperCase = false, bool PrependOctalZero = false,
+            std::unsigned_integral UInt>
   [[nodiscard]] ErrorCode WriteUnsignedDigits(std::string_view prefix, const Spec& spec,
                                               UInt value);
   [[nodiscard]] ErrorCode WritePointer(const Spec& spec, uintptr_t value);
@@ -75,23 +87,27 @@ class Writer::Executor
 #endif
 
   /**
-   * @brief 单个原始 uint32_t 十进制字段的快路径。 / Fast path for one raw uint32_t decimal field.
+   * @brief 单个原始 uint32_t 十进制字段的快路径。 / Fast path for one raw uint32_t
+   * decimal field.
    */
   [[nodiscard]] ErrorCode WriteU32Dec(uint32_t value);
 
   /**
-   * @brief 单个原始 int32_t 十进制字段的快路径。 / Fast path for one raw int32_t decimal field.
+   * @brief 单个原始 int32_t 十进制字段的快路径。 / Fast path for one raw int32_t decimal
+   * field.
    */
   [[nodiscard]] ErrorCode WriteI32Dec(int32_t value);
 
   /**
-   * @brief 单个原始 uint32_t 非十进制字段的快路径。 / Fast path for one raw uint32_t non-decimal field.
+   * @brief 单个原始 uint32_t 非十进制字段的快路径。 / Fast path for one raw uint32_t
+   * non-decimal field.
    */
   template <uint8_t Base, bool UpperCase = false>
   [[nodiscard]] ErrorCode WriteU32Base(uint32_t value);
 
   /**
-   * @brief 单个零填充 uint32_t 十进制字段的快路径。 / Fast path for one zero-padded uint32_t decimal field.
+   * @brief 单个零填充 uint32_t 十进制字段的快路径。 / Fast path for one zero-padded
+   * uint32_t decimal field.
    */
   [[nodiscard]] ErrorCode WriteU32ZeroPadWidth(uint8_t width, uint32_t value);
 
@@ -128,19 +144,25 @@ class Writer::Executor
   [[nodiscard]] ErrorCode DispatchStringField();
 
   /**
-   * @brief 将一个 `GenericField` 载荷分发到对应的宽回退路径 / Dispatch one `GenericField` payload to the corresponding wide fallback
-   * @tparam Profile 当前编译格式使用的精确通用字段类型集合 / Exact generic-field type set used by the current compiled format
-   * @param type `GenericField` 记录携带的语义字段类型 / Semantic field type carried by the `GenericField` record
+   * @brief 将一个 `GenericField` 载荷分发到对应的宽回退路径 / Dispatch one `GenericField`
+   * payload to the corresponding wide fallback
+   * @tparam Profile 当前编译格式使用的精确通用字段类型集合 / Exact generic-field type set
+   * used by the current compiled format
+   * @param type `GenericField` 记录携带的语义字段类型 / Semantic field type carried by
+   * the `GenericField` record
    * @return 返回该字段的具体写出结果 / Returns the concrete writer result for that field
    */
   template <FormatProfile Profile>
   [[nodiscard]] ErrorCode DispatchGenericField(FormatType type);
 
   /**
-   * @brief 将一个运行期操作码分发到选中的特化路径 / Dispatch one runtime opcode to the selected specialized path
-   * @tparam Profile 当前编译格式需要的操作码配置 / Opcode profile required by the current compiled format
+   * @brief 将一个运行期操作码分发到选中的特化路径 / Dispatch one runtime opcode to the
+   * selected specialized path
+   * @tparam Profile 当前编译格式需要的操作码配置 / Opcode profile required by the current
+   * compiled format
    * @param op 解码后的运行期操作码 / Decoded runtime opcode
-   * @return 返回该操作码对应特化路径的运行结果 / Returns the specialized runtime result for that opcode
+   * @return 返回该操作码对应特化路径的运行结果 / Returns the specialized runtime result
+   * for that opcode
    */
   template <FormatProfile Profile>
   [[nodiscard]] ErrorCode DispatchOp(FormatOp op);
@@ -150,7 +172,10 @@ class Writer::Executor
   ArgumentReader args_;
 };
 
+// These implementation headers form an ordered dependency chain.
+// clang-format off
 #include "writer_executor_field.hpp"
 #include "writer_executor_value.hpp"
 #include "writer_executor_generic.hpp"
 #include "writer_executor_opcode.hpp"
+// clang-format on

--- a/src/core/print/writer/writer_executor_field.hpp
+++ b/src/core/print/writer/writer_executor_field.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 /**
- * @brief 运行期执行器共享的字段写出原语，供所有操作码路径复用 / Executor-side field-writing primitives shared by all runtime opcodes
+ * @brief 运行期执行器共享的字段写出原语，供所有操作码路径复用 / Executor-side
+ * field-writing primitives shared by all runtime opcodes
  */
 
 /**
@@ -19,7 +20,8 @@ ErrorCode Writer::Executor<Sink>::WriteRaw(std::string_view text)
  * @brief 向输出端写入重复填充字符 / Write repeated fill characters into the sink
  * @param fill 填充字符 / Fill character
  * @param count 重复次数 / Repeat count
- * @return 返回首个 sink 错误；全部填充字节写出后返回 `ErrorCode::OK` / Returns the first sink error, or `ErrorCode::OK` when all fill bytes are written
+ * @return 返回首个 sink 错误；全部填充字节写出后返回 `ErrorCode::OK` / Returns the first
+ * sink error, or `ErrorCode::OK` when all fill bytes are written
  */
 template <OutputSink Sink>
 ErrorCode Writer::Executor<Sink>::WritePadding(char fill, size_t count)
@@ -42,14 +44,15 @@ ErrorCode Writer::Executor<Sink>::WritePadding(char fill, size_t count)
 }
 
 /**
- * @brief 按宽度与对齐策略写出一个文本字段 / Write one text field with width/alignment policy applied
+ * @brief 按宽度与对齐策略写出一个文本字段 / Write one text field with width/alignment
+ * policy applied
  * @param text 上层归一化后的文本载荷 / Text payload after higher-level normalization
  * @param spec 解码后的字段规格 / Decoded field spec
- * @return 返回首个 sink 错误；成功时返回 `ErrorCode::OK` / Returns the first sink error, or `ErrorCode::OK` on success
+ * @return 返回首个 sink 错误；成功时返回 `ErrorCode::OK` / Returns the first sink error,
+ * or `ErrorCode::OK` on success
  */
 template <OutputSink Sink>
-ErrorCode Writer::Executor<Sink>::WriteTextField(std::string_view text,
-                                                          const Spec& spec)
+ErrorCode Writer::Executor<Sink>::WriteTextField(std::string_view text, const Spec& spec)
 {
   size_t pad = FieldPadding(spec.width, text.size());
   size_t left_pad = 0;
@@ -80,25 +83,33 @@ ErrorCode Writer::Executor<Sink>::WriteTextField(std::string_view text,
 }
 
 /**
- * @brief 按符号、前缀、精度与填充策略写出一个整数载荷 / Write one integer payload with sign, prefix, precision, and padding policy applied
- * @param sign_char 最终可见的符号字符；无符号时为 `'\0'` / Visible sign character, or `'\0'` when absent
+ * @brief 按符号、前缀、精度与填充策略写出一个整数载荷 / Write one integer payload with
+ * sign, prefix, precision, and padding policy applied
+ * @param sign_char 最终可见的符号字符；无符号时为 `'\0'` / Visible sign character, or
+ * `'\0'` when absent
  * @param prefix 输出在数字前面的前缀 / Prefix emitted ahead of the digits
- * @param digits 十进制、二进制、八进制或十六进制数字载荷 / Decimal, binary, octal, or hex digit payload
+ * @param digits 十进制、二进制、八进制或十六进制数字载荷 / Decimal, binary, octal, or hex
+ * digit payload
  * @param spec 解码后的字段规格 / Decoded field spec
- * @return 返回首个 sink 错误；成功时返回 `ErrorCode::OK` / Returns the first sink error, or `ErrorCode::OK` on success
+ * @return 返回首个 sink 错误；成功时返回 `ErrorCode::OK` / Returns the first sink error,
+ * or `ErrorCode::OK` on success
  */
 template <OutputSink Sink>
-ErrorCode Writer::Executor<Sink>::WriteIntegerField(
-    char sign_char, std::string_view prefix, std::string_view digits, const Spec& spec)
+ErrorCode Writer::Executor<Sink>::WriteIntegerField(char sign_char,
+                                                    std::string_view prefix,
+                                                    std::string_view digits,
+                                                    const Spec& spec)
 {
-  auto write_char = [this](char ch) -> ErrorCode {
+  auto write_char = [this](char ch) -> ErrorCode
+  {
     if (ch == '\0')
     {
       return ErrorCode::OK;
     }
     return WriteRaw(std::string_view(&ch, 1));
   };
-  auto write_text = [this](std::string_view text) -> ErrorCode {
+  auto write_text = [this](std::string_view text) -> ErrorCode
+  {
     if (text.empty())
     {
       return ErrorCode::OK;
@@ -107,11 +118,11 @@ ErrorCode Writer::Executor<Sink>::WriteIntegerField(
   };
 
   size_t zeros = IntegerPrecisionZeros(spec, digits.size());
-  size_t total = digits.size() + zeros + prefix.size() +
-                 static_cast<size_t>(sign_char != '\0');
+  size_t total =
+      digits.size() + zeros + prefix.size() + static_cast<size_t>(sign_char != '\0');
   size_t pad = FieldPadding(spec.width, total);
-  bool zero_fill = spec.ZeroPad() && !spec.LeftAlign() && !spec.CenterAlign() &&
-                   !spec.HasPrecision();
+  bool zero_fill =
+      spec.ZeroPad() && !spec.LeftAlign() && !spec.CenterAlign() && !spec.HasPrecision();
   size_t left_pad = 0;
   size_t middle_zeros = zero_fill ? pad : 0;
   size_t right_pad = 0;
@@ -160,18 +171,21 @@ ErrorCode Writer::Executor<Sink>::WriteIntegerField(
 }
 
 /**
- * @brief 按符号与字段填充策略写出一个浮点文本载荷 / Write one float text payload with sign and field padding applied
- * @param sign_char 最终可见的符号字符；无符号时为 `'\0'` / Visible sign character, or `'\0'` when absent
+ * @brief 按符号与字段填充策略写出一个浮点文本载荷 / Write one float text payload with
+ * sign and field padding applied
+ * @param sign_char 最终可见的符号字符；无符号时为 `'\0'` / Visible sign character, or
+ * `'\0'` when absent
  * @param text 已完成格式化的浮点文本载荷 / Already formatted float text payload
  * @param spec 解码后的字段规格 / Decoded field spec
- * @return 返回首个 sink 错误；成功时返回 `ErrorCode::OK` / Returns the first sink error, or `ErrorCode::OK` on success
+ * @return 返回首个 sink 错误；成功时返回 `ErrorCode::OK` / Returns the first sink error,
+ * or `ErrorCode::OK` on success
  */
 template <OutputSink Sink>
-ErrorCode Writer::Executor<Sink>::WriteFloatField(char sign_char,
-                                                           std::string_view text,
-                                                           const Spec& spec)
+ErrorCode Writer::Executor<Sink>::WriteFloatField(char sign_char, std::string_view text,
+                                                  const Spec& spec)
 {
-  auto write_char = [this](char ch) -> ErrorCode {
+  auto write_char = [this](char ch) -> ErrorCode
+  {
     if (ch == '\0')
     {
       return ErrorCode::OK;

--- a/src/core/print/writer/writer_executor_generic.hpp
+++ b/src/core/print/writer/writer_executor_generic.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
 /**
- * @brief 运行期执行器中 `GenericField` 的分发桥接函数 / `GenericField` dispatch bridges for the runtime executor
+ * @brief 运行期执行器中 `GenericField` 的分发桥接函数 / `GenericField` dispatch bridges
+ * for the runtime executor
  */
 
 /**
- * @brief 读取一个有符号载荷并转发给具体有符号写出路径 / Read one signed payload and forward it to the concrete signed writer
+ * @brief 读取一个有符号载荷并转发给具体有符号写出路径 / Read one signed payload and
+ * forward it to the concrete signed writer
  * @tparam Int 有符号打包存储类型 / Signed packed-storage type
  * @return 返回具体有符号字段写出结果 / Returns the concrete signed-field write result
  */
@@ -17,10 +19,12 @@ ErrorCode Writer::Executor<Sink>::DispatchSignedField()
 }
 
 /**
- * @brief 读取一个无符号载荷并转发给选定的整数语义写出路径 / Read one unsigned payload and forward it to the selected integer semantic writer
+ * @brief 读取一个无符号载荷并转发给选定的整数语义写出路径 / Read one unsigned payload and
+ * forward it to the selected integer semantic writer
  * @tparam Type 运行期整数语义类型 / Runtime integer semantic type
  * @tparam UInt 无符号打包存储类型 / Unsigned packed-storage type
- * @return 返回选定整数语义路径的写出结果 / Returns the selected integer-field write result
+ * @return 返回选定整数语义路径的写出结果 / Returns the selected integer-field write
+ * result
  */
 template <OutputSink Sink>
 template <FormatType Type, std::unsigned_integral UInt>
@@ -31,7 +35,8 @@ ErrorCode Writer::Executor<Sink>::DispatchUnsignedField()
 
 #if LIBXR_PRINT_ENABLE_FLOAT
 /**
- * @brief 读取一个浮点载荷并转发给选定的浮点语义写出路径 / Read one float payload and forward it to the selected float semantic writer
+ * @brief 读取一个浮点载荷并转发给选定的浮点语义写出路径 / Read one float payload and
+ * forward it to the selected float semantic writer
  * @tparam Type 运行期浮点语义类型 / Runtime float semantic type
  * @tparam Float 打包浮点存储类型 / Packed float storage type
  * @return 返回选定浮点语义路径的写出结果 / Returns the selected float-field write result
@@ -45,7 +50,8 @@ ErrorCode Writer::Executor<Sink>::DispatchFloatField()
 #endif
 
 /**
- * @brief 读取一个指针载荷并走指针字段写出路径 / Read one pointer payload and write it through the pointer field path
+ * @brief 读取一个指针载荷并走指针字段写出路径 / Read one pointer payload and write it
+ * through the pointer field path
  * @return 返回指针字段写出结果 / Returns the pointer-field write result
  */
 template <OutputSink Sink>
@@ -55,7 +61,8 @@ ErrorCode Writer::Executor<Sink>::DispatchPointerField()
 }
 
 /**
- * @brief 读取一个字符载荷并走字符字段写出路径 / Read one character payload and write it through the character field path
+ * @brief 读取一个字符载荷并走字符字段写出路径 / Read one character payload and write it
+ * through the character field path
  * @return 返回字符字段写出结果 / Returns the character-field write result
  */
 template <OutputSink Sink>
@@ -65,7 +72,8 @@ ErrorCode Writer::Executor<Sink>::DispatchCharacterField()
 }
 
 /**
- * @brief 读取一个字符串载荷并走字符串字段写出路径 / Read one string payload and write it through the string field path
+ * @brief 读取一个字符串载荷并走字符串字段写出路径 / Read one string payload and write it
+ * through the string field path
  * @return 返回字符串字段写出结果 / Returns the string-field write result
  */
 template <OutputSink Sink>
@@ -75,8 +83,10 @@ ErrorCode Writer::Executor<Sink>::DispatchStringField()
 }
 
 /**
- * @brief 将一个 `GenericField` 语义类型分发到具体宽回退写出路径 / Dispatch one `GenericField` semantic type to the concrete wide fallback writer
- * @param type 当前 `GenericField` 携带的运行期语义类型 / Runtime semantic type carried by this `GenericField`
+ * @brief 将一个 `GenericField` 语义类型分发到具体宽回退写出路径 / Dispatch one
+ * `GenericField` semantic type to the concrete wide fallback writer
+ * @param type 当前 `GenericField` 携带的运行期语义类型 / Runtime semantic type carried by
+ * this `GenericField`
  * @return 返回具体宽回退路径的写出结果 / Returns the concrete wide-path write result
  */
 template <OutputSink Sink>

--- a/src/core/print/writer/writer_executor_opcode.hpp
+++ b/src/core/print/writer/writer_executor_opcode.hpp
@@ -1,27 +1,29 @@
 #pragma once
 
 /**
- * @brief writer 执行器的顶层运行期操作码循环。 / Top-level runtime opcode loop for the writer executor.
+ * @brief writer 执行器的顶层运行期操作码循环。 / Top-level runtime opcode loop for the
+ * writer executor.
  */
 
 /**
- * @brief 将一个输出端、码流和参数字节块绑定到当前执行器 / Bind one sink, code stream, and packed-argument blob to this executor
+ * @brief 将一个输出端、码流和参数字节块绑定到当前执行器 / Bind one sink, code stream, and
+ * packed-argument blob to this executor
  * @param sink 输出端 / Destination sink
  * @param codes 指向编译字节流的指针 / Pointer to the compiled byte stream
- * @param args 指向已打包参数字节块的指针；无参数时可为空 / Pointer to the packed argument blob, or null when no arguments exist
+ * @param args 指向已打包参数字节块的指针；无参数时可为空 / Pointer to the packed argument
+ * blob, or null when no arguments exist
  */
 template <OutputSink Sink>
-Writer::Executor<Sink>::Executor(Sink& sink, const uint8_t* codes,
-                                 const uint8_t* args)
-    : sink_(sink),
-      codes_(codes),
-      args_(args)
+Writer::Executor<Sink>::Executor(Sink& sink, const uint8_t* codes, const uint8_t* args)
+    : sink_(sink), codes_(codes), args_(args)
 {
 }
 
 /**
- * @brief 运行操作码循环，直到遇到 End 或首个 sink/运行期错误 / Runs the opcode loop until End or the first sink/runtime error.
- * @tparam Profile 当前编译格式需要的操作码配置 / Opcode profile required by the current compiled format
+ * @brief 运行操作码循环，直到遇到 End 或首个 sink/运行期错误 / Runs the opcode loop until
+ * End or the first sink/runtime error.
+ * @tparam Profile 当前编译格式需要的操作码配置 / Opcode profile required by the current
+ * compiled format
  * @return Returns `ErrorCode::OK` on normal completion, or the first sink /
  *         runtime error. / 正常结束返回 `ErrorCode::OK`；否则返回首个
  *         sink/运行期错误。
@@ -47,8 +49,10 @@ ErrorCode Writer::Executor<Sink>::Run()
 }
 
 /**
- * @brief 将一个顶层操作码分发到其特化运行期路径 / Dispatches one top-level opcode to its specialized runtime path.
- * @tparam Profile 当前编译格式需要的操作码配置 / Opcode profile required by the current compiled format
+ * @brief 将一个顶层操作码分发到其特化运行期路径 / Dispatches one top-level opcode to its
+ * specialized runtime path.
+ * @tparam Profile 当前编译格式需要的操作码配置 / Opcode profile required by the current
+ * compiled format
  * @param op Decoded runtime opcode. / 解码后的运行期操作码。
  * @return Returns the specialized runtime result for that opcode. /
  *         返回该操作码对应特化路径的运行结果。
@@ -115,15 +119,13 @@ ErrorCode Writer::Executor<Sink>::DispatchOp(FormatOp op)
       }
       return WriteU32Base<16, true>(args_.Read<uint32_t>());
     case FormatOp::StringRaw:
-      if constexpr (!HasProfile(Profile, FormatProfile::TextArg) ||
-                    !Config::enable_text)
+      if constexpr (!HasProfile(Profile, FormatProfile::TextArg) || !Config::enable_text)
       {
         return ErrorCode::STATE_ERR;
       }
       return WriteStringRaw(args_.Read<std::string_view>());
     case FormatOp::CharacterRaw:
-      if constexpr (!HasProfile(Profile, FormatProfile::TextArg) ||
-                    !Config::enable_text)
+      if constexpr (!HasProfile(Profile, FormatProfile::TextArg) || !Config::enable_text)
       {
         return ErrorCode::STATE_ERR;
       }

--- a/src/core/print/writer/writer_executor_value.hpp
+++ b/src/core/print/writer/writer_executor_value.hpp
@@ -5,7 +5,8 @@
  */
 
 /**
- * @brief 为一个有符号整数载荷确定最终可见的符号字符 / Resolve the visible sign character for one signed integer payload
+ * @brief 为一个有符号整数载荷确定最终可见的符号字符 / Resolve the visible sign character
+ * for one signed integer payload
  * @tparam Int 有符号整数类型 / Signed integer type
  * @param value 当前要输出的整数值 / Integer value being emitted
  * @param spec 解码后的字段规格 / Decoded field spec
@@ -32,7 +33,8 @@ char Writer::Executor<Sink>::ResolveSignChar(Int value, const Spec& spec)
 
 #if LIBXR_PRINT_ENABLE_FLOAT
 /**
- * @brief 为一个浮点载荷确定最终可见的符号字符 / Resolve the visible sign character for one float payload
+ * @brief 为一个浮点载荷确定最终可见的符号字符 / Resolve the visible sign character for
+ * one float payload
  * @tparam T 浮点类型 / Float type
  * @param value 当前要输出的浮点值 / Float value being emitted
  * @param spec 解码后的字段规格 / Decoded field spec
@@ -67,7 +69,8 @@ char Writer::Executor<Sink>::ResolveFloatSignChar(T value, const Spec& spec)
 #endif
 
 /**
- * @brief 通过共享整数字段路径写出一个有符号整数值 / Write one signed integer value through the shared integer-field path
+ * @brief 通过共享整数字段路径写出一个有符号整数值 / Write one signed integer value
+ * through the shared integer-field path
  * @tparam Int 有符号整数类型 / Signed integer type
  * @param spec 解码后的字段规格 / Decoded field spec
  * @param value 待写出的整数值 / Integer value to write
@@ -93,10 +96,13 @@ ErrorCode Writer::Executor<Sink>::WriteSigned(const Spec& spec, Int value)
 }
 
 /**
- * @brief 通过共享整数字段路径写出一个无符号整数语义值 / Write one unsigned integer semantic value through the shared integer-field path
+ * @brief 通过共享整数字段路径写出一个无符号整数语义值 / Write one unsigned integer
+ * semantic value through the shared integer-field path
  * @tparam Base 整数进制 / Integer radix
- * @tparam UpperCase 十六进制数字是否使用大写字符 / Whether hexadecimal digits should use uppercase characters
- * @tparam PrependOctalZero 是否把 `%#o` 的前导 `0` 直接并入数字载荷 / Whether `%#o` should inline its leading `0` into the digit payload
+ * @tparam UpperCase 十六进制数字是否使用大写字符 / Whether hexadecimal digits should use
+ * uppercase characters
+ * @tparam PrependOctalZero 是否把 `%#o` 的前导 `0` 直接并入数字载荷 / Whether `%#o`
+ * should inline its leading `0` into the digit payload
  * @tparam UInt 无符号整数类型 / Unsigned integer type
  * @param prefix 脱离数字载荷输出的前缀 / Prefix emitted outside the digit payload
  * @param spec 解码后的字段规格 / Decoded field spec
@@ -107,11 +113,9 @@ template <OutputSink Sink>
 template <uint8_t Base, bool UpperCase, bool PrependOctalZero,
           std::unsigned_integral UInt>
 ErrorCode Writer::Executor<Sink>::WriteUnsignedDigits(std::string_view prefix,
-                                                               const Spec& spec,
-                                                               UInt value)
+                                                      const Spec& spec, UInt value)
 {
-  char digit_buffer[UnsignedDigitCapacity<UInt, Base>() +
-                    (PrependOctalZero ? 1U : 0U)];
+  char digit_buffer[UnsignedDigitCapacity<UInt, Base>() + (PrependOctalZero ? 1U : 0U)];
   size_t digit_count = AppendUnsigned<Base, UpperCase>(digit_buffer, value);
 
   if constexpr (PrependOctalZero)
@@ -128,7 +132,8 @@ ErrorCode Writer::Executor<Sink>::WriteUnsignedDigits(std::string_view prefix,
 }
 
 /**
- * @brief 通过共享整数字段路径写出一个无符号整数语义值 / Write one unsigned integer semantic value through the shared integer-field path
+ * @brief 通过共享整数字段路径写出一个无符号整数语义值 / Write one unsigned integer
+ * semantic value through the shared integer-field path
  * @tparam Type 运行期整数语义类型 / Runtime integer semantic type
  * @tparam UInt 无符号整数类型 / Unsigned integer type
  * @param spec 解码后的字段规格 / Decoded field spec
@@ -171,14 +176,14 @@ ErrorCode Writer::Executor<Sink>::DispatchUnsigned(const Spec& spec, UInt value)
 }
 
 /**
- * @brief 按规范指针字段策略写出一个指针值 / Write one pointer value using the canonical pointer field policy
+ * @brief 按规范指针字段策略写出一个指针值 / Write one pointer value using the canonical
+ * pointer field policy
  * @param spec 解码后的字段规格 / Decoded field spec
  * @param value 以 `uintptr_t` 编码的指针值 / Pointer value encoded as `uintptr_t`
  * @return 返回指针字段写出结果 / Returns the pointer-field write result
  */
 template <OutputSink Sink>
-ErrorCode Writer::Executor<Sink>::WritePointer(const Spec& spec,
-                                                        uintptr_t value)
+ErrorCode Writer::Executor<Sink>::WritePointer(const Spec& spec, uintptr_t value)
 {
   char digit_buffer[UnsignedDigitCapacity<uintptr_t, 16>()];
   size_t digit_count = AppendUnsigned<16>(digit_buffer, value);
@@ -206,14 +211,14 @@ ErrorCode Writer::Executor<Sink>::WriteCharacter(const Spec& spec, char ch)
 }
 
 /**
- * @brief 写出一个字符串字段值，并在需要时应用精度截断 / Write one string field value, including precision truncation when present
+ * @brief 写出一个字符串字段值，并在需要时应用精度截断 / Write one string field value,
+ * including precision truncation when present
  * @param spec 解码后的字段规格 / Decoded field spec
  * @param text 待写出的字符串载荷 / String payload to write
  * @return 返回字符串字段写出结果 / Returns the string-field write result
  */
 template <OutputSink Sink>
-ErrorCode Writer::Executor<Sink>::WriteString(const Spec& spec,
-                                                       std::string_view text)
+ErrorCode Writer::Executor<Sink>::WriteString(const Spec& spec, std::string_view text)
 {
   auto view = text;
   if (spec.HasPrecision() && spec.precision < view.size())
@@ -225,7 +230,8 @@ ErrorCode Writer::Executor<Sink>::WriteString(const Spec& spec,
 }
 
 /**
- * @brief 通过共享浮点文本后端写出一个浮点语义值 / Write one float semantic value through the shared float-text backend
+ * @brief 通过共享浮点文本后端写出一个浮点语义值 / Write one float semantic value through
+ * the shared float-text backend
  * @tparam T 浮点类型 / Float type
  * @param type 运行期浮点语义类型 / Runtime float semantic type
  * @param spec 解码后的字段规格 / Decoded field spec
@@ -235,8 +241,7 @@ ErrorCode Writer::Executor<Sink>::WriteString(const Spec& spec,
 #if LIBXR_PRINT_ENABLE_FLOAT
 template <OutputSink Sink>
 template <typename T>
-ErrorCode Writer::Executor<Sink>::WriteFloat(FormatType type,
-                                                      const Spec& spec, T value)
+ErrorCode Writer::Executor<Sink>::WriteFloat(FormatType type, const Spec& spec, T value)
 {
   if (!UsesFloatTextBackend(type))
   {
@@ -292,7 +297,8 @@ ErrorCode Writer::Executor<Sink>::WriteFloat(FormatType type,
 #endif
 
 /**
- * @brief 写出一个原始 uint32 十进制快路径字段 / Writes one raw uint32 decimal fast-path field.
+ * @brief 写出一个原始 uint32 十进制快路径字段 / Writes one raw uint32 decimal fast-path
+ * field.
  * @param value Unsigned value to write. / 待写出的无符号值。
  * @return Returns the sink write result. / 返回 sink 写出结果。
  */
@@ -305,7 +311,8 @@ ErrorCode Writer::Executor<Sink>::WriteU32Dec(uint32_t value)
 }
 
 /**
- * @brief 写出一个原始 int32 十进制快路径字段 / Writes one raw int32 decimal fast-path field.
+ * @brief 写出一个原始 int32 十进制快路径字段 / Writes one raw int32 decimal fast-path
+ * field.
  * @param value Signed value to write. / 待写出的有符号值。
  * @return Returns the sink write result. / 返回 sink 写出结果。
  */
@@ -330,7 +337,8 @@ ErrorCode Writer::Executor<Sink>::WriteI32Dec(int32_t value)
 }
 
 /**
- * @brief 写出一个原始 uint32 多进制快路径字段 / Writes one raw uint32 base-specific fast-path field.
+ * @brief 写出一个原始 uint32 多进制快路径字段 / Writes one raw uint32 base-specific
+ * fast-path field.
  * @tparam Base Integer radix. / 整数进制。
  * @tparam UpperCase Whether hexadecimal digits are uppercase. / 十六进制数字是否大写。
  * @param value Unsigned value to write. / 待写出的无符号值。
@@ -346,14 +354,14 @@ ErrorCode Writer::Executor<Sink>::WriteU32Base(uint32_t value)
 }
 
 /**
- * @brief 写出一个带零填充宽度的 `uint32_t` 十进制快路径字段 / Write one zero-padded `uint32_t` decimal fast-path field
+ * @brief 写出一个带零填充宽度的 `uint32_t` 十进制快路径字段 / Write one zero-padded
+ * `uint32_t` decimal fast-path field
  * @param width 目标零填充宽度 / Target zero-padded width
  * @param value 待写出的无符号值 / Unsigned value to write
  * @return 返回该快路径的写出结果 / Returns the fast-path write result
  */
 template <OutputSink Sink>
-ErrorCode Writer::Executor<Sink>::WriteU32ZeroPadWidth(uint8_t width,
-                                                                uint32_t value)
+ErrorCode Writer::Executor<Sink>::WriteU32ZeroPadWidth(uint8_t width, uint32_t value)
 {
   char digit_buffer[UnsignedDigitCapacity<uint32_t, 10>()];
   size_t digit_count = AppendUnsigned<10>(digit_buffer, value);

--- a/src/core/print/writer/writer_float_fixed.hpp
+++ b/src/core/print/writer/writer_float_fixed.hpp
@@ -5,14 +5,16 @@
  */
 
 /**
- * @brief 将一个通用定点浮点结果写入局部文本缓冲区 / Formats one generic fixed-point float payload into the local text buffer.
+ * @brief 将一个通用定点浮点结果写入局部文本缓冲区 / Formats one generic fixed-point float
+ * payload into the local text buffer.
  * @tparam Float 浮点类型 / Float type
  * @param value 浮点绝对值 / Float magnitude
  * @param precision 请求的小数精度 / Requested fractional precision
  * @param alternate 是否启用备用格式 / Whether alternate form is enabled
  * @param out 目标文本缓冲区 / Destination text buffer
  * @param out_size 输出文本长度 / Output text size
- * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise `false`
+ * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise
+ * `false`
  */
 template <typename Float>
 bool Writer::FormatFixedText(Float value, uint8_t precision, bool alternate, char* out,

--- a/src/core/print/writer/writer_float_general.hpp
+++ b/src/core/print/writer/writer_float_general.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
 /**
- * @brief 通用的浮点定点、科学计数法与通用格式文本辅助函数 / Generic float, scientific, and general text formatting helpers
+ * @brief 通用的浮点定点、科学计数法与通用格式文本辅助函数 / Generic float, scientific,
+ * and general text formatting helpers
  */
 
 /**
- * @brief 将一个浮点值按科学计数法写入局部文本缓冲区 / Format one float in scientific notation into the local text buffer
+ * @brief 将一个浮点值按科学计数法写入局部文本缓冲区 / Format one float in scientific
+ * notation into the local text buffer
  * @tparam Float 浮点类型 / Float type
  * @param value 浮点绝对值 / Float magnitude
  * @param precision 请求的小数精度 / Requested fractional precision
@@ -13,7 +15,8 @@
  * @param upper_case 指数标记是否使用 `E` / Whether the exponent marker should use `E`
  * @param out 目标文本缓冲区 / Destination text buffer
  * @param out_size 输出文本长度 / Output text size
- * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise `false`
+ * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise
+ * `false`
  */
 template <typename Float>
 bool Writer::FormatScientificText(Float value, uint8_t precision, bool alternate,
@@ -24,8 +27,9 @@ bool Writer::FormatScientificText(Float value, uint8_t precision, bool alternate
   Float digit_scale = rounded.scale;
 
   out_size = 0;
-  if (!AppendBufferChar(out, float_buffer_capacity, out_size,
-                        static_cast<char>('0' + ExtractDigit(rounded_digits, digit_scale))))
+  if (!AppendBufferChar(
+          out, float_buffer_capacity, out_size,
+          static_cast<char>('0' + ExtractDigit(rounded_digits, digit_scale))))
   {
     return false;
   }
@@ -41,8 +45,9 @@ bool Writer::FormatScientificText(Float value, uint8_t precision, bool alternate
   digit_scale /= 10;
   for (uint8_t i = 0; i < precision; ++i)
   {
-    if (!AppendBufferChar(out, float_buffer_capacity, out_size,
-                          static_cast<char>('0' + ExtractDigit(rounded_digits, digit_scale))))
+    if (!AppendBufferChar(
+            out, float_buffer_capacity, out_size,
+            static_cast<char>('0' + ExtractDigit(rounded_digits, digit_scale))))
     {
       return false;
     }
@@ -53,14 +58,16 @@ bool Writer::FormatScientificText(Float value, uint8_t precision, bool alternate
 }
 
 /**
- * @brief 将一个运行期浮点语义格式化到局部文本缓冲区 / Format one runtime float semantic into the local text buffer
+ * @brief 将一个运行期浮点语义格式化到局部文本缓冲区 / Format one runtime float semantic
+ * into the local text buffer
  * @tparam Float 浮点类型 / Float type
  * @param type 运行期浮点字段类型 / Runtime float field type
  * @param spec 解码后的字段规格 / Decoded field spec
  * @param value 浮点绝对值 / Float magnitude
  * @param out 目标文本缓冲区 / Destination text buffer
  * @param out_size 输出文本长度 / Output text size
- * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise `false`
+ * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise
+ * `false`
  */
 template <typename Float>
 bool Writer::FormatFloatText(FormatType type, const Spec& spec, Float value, char* out,
@@ -121,8 +128,7 @@ bool Writer::FormatFloatText(FormatType type, const Spec& spec, Float value, cha
         {
           fractional_precision = 0;
         }
-        if (ExceedsFixedIntegerDigits(
-                value, static_cast<uint8_t>(fractional_precision)))
+        if (ExceedsFixedIntegerDigits(value, static_cast<uint8_t>(fractional_precision)))
         {
           return false;
         }

--- a/src/core/print/writer/writer_float_math.hpp
+++ b/src/core/print/writer/writer_float_math.hpp
@@ -1,11 +1,13 @@
 #pragma once
 
 /**
- * @brief 通用浮点文本格式化器使用的数学辅助函数。 / Math helpers used by the generic float text formatter.
+ * @brief 通用浮点文本格式化器使用的数学辅助函数。 / Math helpers used by the generic
+ * float text formatter.
  */
 
 /**
- * @brief 浮点文本输出归一化过程中使用的十进制缩放对 / Decimal-scale pair used while normalizing one float for text output.
+ * @brief 浮点文本输出归一化过程中使用的十进制缩放对 / Decimal-scale pair used while
+ * normalizing one float for text output.
  * @tparam Float Float type. / 浮点类型。
  */
 template <typename Float>
@@ -16,15 +18,18 @@ struct Writer::DecimalScale
 };
 
 /**
- * @brief 科学计数法归一化后的尾数数字、缩放因子与十进制指数 / Rounded mantissa digits, scale factor, and decimal exponent after scientific normalization.
+ * @brief 科学计数法归一化后的尾数数字、缩放因子与十进制指数 / Rounded mantissa digits,
+ * scale factor, and decimal exponent after scientific normalization.
  * @tparam Float Float type. / 浮点类型。
  */
 template <typename Float>
 struct Writer::ScientificDigits
 {
-  Float digits = 0;   ///< rounded mantissa scaled to integer digits / 舍入后按整数位缩放的尾数
-  Float scale = 1;    ///< 10 ^ precision applied to the mantissa / 施加到尾数上的 10 的 precision 次幂
-  int exponent = 0;   ///< decimal exponent / 十进制指数
+  Float digits =
+      0;  ///< rounded mantissa scaled to integer digits / 舍入后按整数位缩放的尾数
+  Float scale = 1;   ///< 10 ^ precision applied to the mantissa / 施加到尾数上的 10 的
+                     ///< precision 次幂
+  int exponent = 0;  ///< decimal exponent / 十进制指数
 };
 
 /**
@@ -38,8 +43,7 @@ Float Writer::Power10(int exponent)
 {
   Float result = 1;
   Float base = 10;
-  unsigned int remaining =
-      static_cast<unsigned int>(exponent < 0 ? -exponent : exponent);
+  unsigned int remaining = static_cast<unsigned int>(exponent < 0 ? -exponent : exponent);
 
   while (remaining != 0)
   {
@@ -92,10 +96,12 @@ Float Writer::RoundDecimal(Float value, uint8_t precision)
 }
 
 /**
- * @brief 把一个值归一化为科学计数法的尾数数字与十进制指数 / Normalize one value into scientific-notation mantissa digits and a decimal exponent.
+ * @brief 把一个值归一化为科学计数法的尾数数字与十进制指数 / Normalize one value into
+ * scientific-notation mantissa digits and a decimal exponent.
  * @tparam Float Float type. / 浮点类型。
  * @param value Finite non-negative value. / 有限非负值。
- * @param precision Significant fractional digits to retain in the mantissa. / 尾数中保留的有效小数位数。
+ * @param precision Significant fractional digits to retain in the mantissa. /
+ * 尾数中保留的有效小数位数。
  * @return Rounded mantissa, its scale, and the decimal exponent (carry-out
  *         adjusts the exponent when rounding overflows one digit). /
  *         返回舍入后的尾数、缩放因子与十进制指数；若舍入进位溢出一位，会相应调整指数。
@@ -121,7 +127,8 @@ Writer::ScientificDigits<Float> Writer::RoundScientificDigits(Float value,
 }
 
 /**
- * @brief 将一个浮点值归一化为十进制指数与缩放因子 / Normalizes one float into a decimal exponent plus scale pair.
+ * @brief 将一个浮点值归一化为十进制指数与缩放因子 / Normalizes one float into a decimal
+ * exponent plus scale pair.
  * @tparam Float Float type. / 浮点类型。
  * @param value Finite positive magnitude. / 有限正数绝对值。
  * @return Returns the normalized decimal scale description. /
@@ -138,8 +145,7 @@ Writer::DecimalScale<Float> Writer::NormalizeDecimal(Float value)
 
   int binary_exponent = 0;
   std::frexp(value, &binary_exponent);
-  constexpr Float log10_of_2 =
-      static_cast<Float>(0.30102999566398119521373889472449L);
+  constexpr Float log10_of_2 = static_cast<Float>(0.30102999566398119521373889472449L);
   normalized.exponent =
       static_cast<int>(static_cast<Float>(binary_exponent - 1) * log10_of_2);
   normalized.scale = Power10<Float>(normalized.exponent);
@@ -162,7 +168,8 @@ Writer::DecimalScale<Float> Writer::NormalizeDecimal(Float value)
 }
 
 /**
- * @brief 在当前缩放位提取一个十进制数字并推进剩余值 / Extracts one decimal digit at the current scale and advances the remainder.
+ * @brief 在当前缩放位提取一个十进制数字并推进剩余值 / Extracts one decimal digit at the
+ * current scale and advances the remainder.
  * @tparam Float Float type. / 浮点类型。
  * @param value Remaining normalized value; reduced in place. / 剩余规范化值；
  *        会原地减少。

--- a/src/core/print/writer/writer_float_runtime.hpp
+++ b/src/core/print/writer/writer_float_runtime.hpp
@@ -1,13 +1,16 @@
 #pragma once
 
 /**
- * @brief 浮点运行期后端的功能开关判断与有界文本缓冲辅助函数 / Runtime float-backend feature gates and bounded text-buffer helpers
+ * @brief 浮点运行期后端的功能开关判断与有界文本缓冲辅助函数 / Runtime float-backend
+ * feature gates and bounded text-buffer helpers
  */
 
 /**
- * @brief 判断某个运行期浮点语义是否走共享文本后端 / Return whether one runtime float semantic uses the shared text backend
+ * @brief 判断某个运行期浮点语义是否走共享文本后端 / Return whether one runtime float
+ * semantic uses the shared text backend
  * @param type 运行期浮点字段类型 / Runtime float field type
- * @return 该字段类型走共享浮点文本后端时返回 `true`，否则返回 `false` / Returns `true` when this field type uses the shared float-text backend, otherwise `false`
+ * @return 该字段类型走共享浮点文本后端时返回 `true`，否则返回 `false` / Returns `true`
+ * when this field type uses the shared float-text backend, otherwise `false`
  */
 constexpr bool Writer::UsesFloatTextBackend(FormatType type)
 {
@@ -29,9 +32,11 @@ constexpr bool Writer::UsesFloatTextBackend(FormatType type)
 }
 
 /**
- * @brief 判断某个运行期浮点语义是否在当前配置下启用 / Return whether one runtime float semantic is enabled under current config
+ * @brief 判断某个运行期浮点语义是否在当前配置下启用 / Return whether one runtime float
+ * semantic is enabled under current config
  * @param type 运行期浮点字段类型 / Runtime float field type
- * @return 当前配置启用了该字段类型时返回 `true`，否则返回 `false` / Returns `true` when this field type is enabled, otherwise `false`
+ * @return 当前配置启用了该字段类型时返回 `true`，否则返回 `false` / Returns `true` when
+ * this field type is enabled, otherwise `false`
  */
 constexpr bool Writer::FloatEnabled(FormatType type)
 {
@@ -61,7 +66,8 @@ constexpr bool Writer::FloatEnabled(FormatType type)
 }
 
 /**
- * @brief 返回格式串没有显式指定精度时使用的默认浮点精度 / Return the default float precision used when the format string did not specify one
+ * @brief 返回格式串没有显式指定精度时使用的默认浮点精度 / Return the default float
+ * precision used when the format string did not specify one
  * @return 返回默认浮点精度 / Returns the default float precision
  */
 constexpr uint8_t Writer::DefaultFloatPrecision()
@@ -70,11 +76,14 @@ constexpr uint8_t Writer::DefaultFloatPrecision()
 }
 
 /**
- * @brief 判断定点形态的浮点输出是否会超出当前配置的整数位数上限 / Return whether fixed-form float output would exceed the configured integer-digit limit
+ * @brief 判断定点形态的浮点输出是否会超出当前配置的整数位数上限 / Return whether
+ * fixed-form float output would exceed the configured integer-digit limit
  * @tparam Float 浮点类型 / Float type
  * @param value 待检查的浮点绝对值 / Float magnitude to test
  * @param precision 请求的小数精度 / Requested fractional precision
- * @return 若定点输出的整数部分会超出配置上限则返回 `true`，否则返回 `false` / Returns `true` when the fixed-form integer part would exceed the configured limit, otherwise `false`
+ * @return 若定点输出的整数部分会超出配置上限则返回 `true`，否则返回 `false` / Returns
+ * `true` when the fixed-form integer part would exceed the configured limit, otherwise
+ * `false`
  */
 template <typename Float>
 bool Writer::ExceedsFixedIntegerDigits(Float value, uint8_t precision)
@@ -103,10 +112,12 @@ bool Writer::ExceedsFixedIntegerDigits(Float value, uint8_t precision)
 }
 
 /**
- * @brief 向局部有界浮点格式缓冲区追加一个字符 / Append one character into a bounded local float-format buffer
+ * @brief 向局部有界浮点格式缓冲区追加一个字符 / Append one character into a bounded local
+ * float-format buffer
  * @param buffer 目标缓冲区 / Destination buffer
  * @param capacity 缓冲区总容量 / Total buffer capacity
  * @param size 当前已保留长度；成功时会推进 / Current retained size; advanced on success
  * @param ch 待追加字符 / Character to append
- * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise `false`
+ * @return 成功返回 `true`，否则返回 `false` / Returns `true` on success, otherwise
+ * `false`
  */

--- a/src/core/print/writer/writer_integer.hpp
+++ b/src/core/print/writer/writer_integer.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
 /**
- * @brief 运行期 writer 后端共享的整数文本辅助函数 / Shared integer-text helpers for the runtime writer backend
+ * @brief 运行期 writer 后端共享的整数文本辅助函数 / Shared integer-text helpers for the
+ * runtime writer backend
  */
 
 template <std::unsigned_integral UInt, uint8_t Base>
@@ -21,9 +22,11 @@ consteval size_t Writer::UnsignedDigitCapacity()
 }
 
 /**
- * @brief 将一个无符号整数写入调用方提供的定长数字缓冲区 / Append one unsigned integer into a caller-provided fixed-size digit buffer
+ * @brief 将一个无符号整数写入调用方提供的定长数字缓冲区 / Append one unsigned integer
+ * into a caller-provided fixed-size digit buffer
  * @tparam Base 整数进制 / Integer radix
- * @tparam UpperCase 十六进制数字是否使用大写字母 / Whether hexadecimal digits should use uppercase letters
+ * @tparam UpperCase 十六进制数字是否使用大写字母 / Whether hexadecimal digits should use
+ * uppercase letters
  * @tparam N 目标缓冲区长度 / Destination buffer size
  * @tparam UInt 无符号整数类型 / Unsigned integer type
  * @param out 目标数字缓冲区 / Destination digit buffer
@@ -35,8 +38,9 @@ size_t Writer::AppendUnsigned(char (&out)[N], UInt value)
 {
   constexpr char lower_digits[] = "0123456789abcdef";
   constexpr char upper_digits[] = "0123456789ABCDEF";
-  static_assert(N >= UnsignedDigitCapacity<UInt, Base>(),
-                "LibXR::Print::Writer digit buffer is too small for the selected integer type");
+  static_assert(
+      N >= UnsignedDigitCapacity<UInt, Base>(),
+      "LibXR::Print::Writer digit buffer is too small for the selected integer type");
 
   const char* digits = UpperCase ? upper_digits : lower_digits;
   char reverse[UnsignedDigitCapacity<UInt, Base>()];
@@ -75,7 +79,8 @@ inline size_t Writer::AppendSmallUnsigned(char (&out)[N], uint8_t value)
 }
 
 /**
- * @brief 返回某个载荷尺寸对应的字段宽度填充量 / Return the field-width padding needed for one payload size
+ * @brief 返回某个载荷尺寸对应的字段宽度填充量 / Return the field-width padding needed for
+ * one payload size
  * @param width 请求的字段宽度 / Requested field width
  * @param payload_size 填充前的可见载荷长度 / Visible payload size before padding
  * @return 返回需要补上的填充个数 / Returns the required padding count
@@ -86,7 +91,8 @@ constexpr size_t Writer::FieldPadding(uint8_t width, size_t payload_size)
 }
 
 /**
- * @brief 返回整数精度要求引入的额外前导零个数 / Return the extra leading zeros introduced by integer precision
+ * @brief 返回整数精度要求引入的额外前导零个数 / Return the extra leading zeros introduced
+ * by integer precision
  * @param spec 解码后的字段规格 / Decoded field spec
  * @param digit_count 当前已有的数字个数 / Existing digit count
  * @return 返回额外前导零个数 / Returns the extra leading-zero count
@@ -99,7 +105,8 @@ constexpr size_t Writer::IntegerPrecisionZeros(const Spec& spec, size_t digit_co
 }
 
 /**
- * @brief 返回备用格式下脱离数字主体输出的整数前缀 / Return the detached integer prefix emitted by alternate formatting
+ * @brief 返回备用格式下脱离数字主体输出的整数前缀 / Return the detached integer prefix
+ * emitted by alternate formatting
  * @tparam UInt 无符号整数类型 / Unsigned integer type
  * @param type 运行期字段类型 / Runtime field type
  * @param spec 解码后的字段规格 / Decoded field spec
@@ -130,7 +137,8 @@ constexpr std::string_view Writer::IntegerPrefix(FormatType type, const Spec& sp
 }
 
 /**
- * @brief 直接在已生成数字上应用 `%#o` 的特殊规则 / Apply the special `%#o` payload rules directly onto the generated digits
+ * @brief 直接在已生成数字上应用 `%#o` 的特殊规则 / Apply the special `%#o` payload rules
+ * directly onto the generated digits
  * @tparam UInt 无符号整数类型 / Unsigned integer type
  * @param digits 可修改的数字缓冲区 / Mutable digit buffer
  * @param digit_count 当前数字个数 / Current digit count

--- a/src/core/print/writer/writer_reader.hpp
+++ b/src/core/print/writer/writer_reader.hpp
@@ -11,8 +11,10 @@ class Writer::CodeReader
 {
  public:
   /**
-   * @brief 从单个编译字节块起点构造读取器 / Create a reader over the beginning of one compiled byte blob
-   * @param codes 指向单个编译字节块起点的指针 / Pointer to the beginning of one compiled byte blob
+   * @brief 从单个编译字节块起点构造读取器 / Create a reader over the beginning of one
+   * compiled byte blob
+   * @param codes 指向单个编译字节块起点的指针 / Pointer to the beginning of one compiled
+   * byte blob
    */
   explicit CodeReader(const uint8_t* codes);
 
@@ -23,7 +25,8 @@ class Writer::CodeReader
   [[nodiscard]] FormatOp ReadOp();
 
   /**
-   * @brief 读取编译期发射器按本机字节序写入的 POD 值 / Read a native-endian POD value emitted by the compile-time emitter
+   * @brief 读取编译期发射器按本机字节序写入的 POD 值 / Read a native-endian POD value
+   * emitted by the compile-time emitter
    * @tparam T 待读取的 POD 类型 / POD type to read
    * @return 返回解码后的 POD 值 / Returns the decoded POD value
    */
@@ -37,13 +40,15 @@ class Writer::CodeReader
   }
 
   /**
-   * @brief 读取 `GenericField` 载荷中的语义类型字节 / Read the semantic type byte carried by one `GenericField` payload
+   * @brief 读取 `GenericField` 载荷中的语义类型字节 / Read the semantic type byte carried
+   * by one `GenericField` payload
    * @return 返回解码后的字段语义类型 / Returns the decoded field semantic type
    */
   [[nodiscard]] FormatType ReadFormatType();
 
   /**
-   * @brief 读取紧跟在 `GenericField` 类型字节后的 4 字节字段载荷 / Read the 4-byte field payload that follows one `GenericField` type byte
+   * @brief 读取紧跟在 `GenericField` 类型字节后的 4 字节字段载荷 / Read the 4-byte field
+   * payload that follows one `GenericField` type byte
    *
    * The opcode and semantic type bytes are read separately. This call only
    * consumes flags, fill, width, and precision, in that order.
@@ -54,17 +59,20 @@ class Writer::CodeReader
   [[nodiscard]] Spec ReadSpec();
 
   /**
-   * @brief 读取内嵌在记录流中的短文本 / Read a null-terminated short text payload embedded in the record stream
+   * @brief 读取内嵌在记录流中的短文本 / Read a null-terminated short text payload
+   * embedded in the record stream
    * @return 返回该内嵌文本片段的视图 / Returns a view of the embedded text span
    */
   [[nodiscard]] std::string_view ReadInlineText();
 
   /**
-   * @brief 读取指向尾部文本池的偏移和长度 / Read an offset-size pair pointing into the trailing text pool
+   * @brief 读取指向尾部文本池的偏移和长度 / Read an offset-size pair pointing into the
+   * trailing text pool
    *
    * The offset is already rebased against the final code blob base.
    * 该偏移已经按最终代码块起点完成重定位。
-   * @return 返回尾部文本池中被引用的文本片段 / Returns the referenced text span inside the trailing text pool
+   * @return 返回尾部文本池中被引用的文本片段 / Returns the referenced text span inside
+   * the trailing text pool
    */
   [[nodiscard]] std::string_view ReadTextRef();
 
@@ -74,19 +82,23 @@ class Writer::CodeReader
 };
 
 /**
- * @brief 运行期参数字节块的顺序读取器 / Sequential reader for the packed runtime argument byte blob
+ * @brief 运行期参数字节块的顺序读取器 / Sequential reader for the packed runtime argument
+ * byte blob
  */
 class Writer::ArgumentReader
 {
  public:
   /**
-   * @brief 从单个运行期参数打包字节块构造读取器 / Create a reader over one packed runtime argument blob
-   * @param data 指向运行期参数打包字节块的指针 / Pointer to the packed runtime argument blob
+   * @brief 从单个运行期参数打包字节块构造读取器 / Create a reader over one packed runtime
+   * argument blob
+   * @param data 指向运行期参数打包字节块的指针 / Pointer to the packed runtime argument
+   * blob
    */
   explicit ArgumentReader(const uint8_t* data);
 
   /**
-   * @brief 以无对齐要求的方式读取一个已打包参数值 / Read one packed argument value without requiring alignment
+   * @brief 以无对齐要求的方式读取一个已打包参数值 / Read one packed argument value
+   * without requiring alignment
    * @tparam T 待读取的已打包参数类型 / Packed argument type to read
    * @return 返回解码后的已打包参数值 / Returns the decoded packed argument value
    */

--- a/src/core/rw/libxr_rw.hpp
+++ b/src/core/rw/libxr_rw.hpp
@@ -2,5 +2,5 @@
 
 #include "operation.hpp"
 #include "read_port.hpp"
-#include "write_port.hpp"
 #include "stdio.hpp"
+#include "write_port.hpp"

--- a/src/core/rw/operation.hpp
+++ b/src/core/rw/operation.hpp
@@ -62,7 +62,8 @@ class Operation
    */
   Operation(Semaphore& sem, uint32_t timeout = UINT32_MAX)
       : data{.sem_info = {&sem, timeout}}, type(OperationType::BLOCK)
-  {}
+  {
+  }
 
   /**
    * @brief Constructs a callback-based operation.
@@ -71,7 +72,8 @@ class Operation
    */
   Operation(Callback& callback)
       : data{.callback = &callback}, type(OperationType::CALLBACK)
-  {}
+  {
+  }
 
   /**
    * @brief Constructs a polling operation.
@@ -80,7 +82,8 @@ class Operation
    */
   Operation(OperationPollingStatus& status)
       : data{.status = &status}, type(OperationType::POLLING)
-  {}
+  {
+  }
 
   Operation(const Operation& op) : data{nullptr}, type(OperationType::NONE)
   {
@@ -303,9 +306,8 @@ class AsyncBlockWait
       if (expected == State::DETACHED)
       {
         expected = State::DETACHED;
-        (void)state_.compare_exchange_strong(expected, State::IDLE,
-                                             std::memory_order_acq_rel,
-                                             std::memory_order_acquire);
+        (void)state_.compare_exchange_strong(
+            expected, State::IDLE, std::memory_order_acq_rel, std::memory_order_acquire);
       }
       return false;
     }
@@ -352,7 +354,8 @@ typedef ErrorCode (*WriteFun)(WritePort& port, bool in_isr);
 /// ProcessPendingReads(). Any non-negative return means accepted/armed; negative values
 /// mean failure.
 /// 成功返回只表示已通知或挂起底层接收，不得直接完成本次读；producer 必须先把字节写入
-/// queue_data_，再调用 ProcessPendingReads() 完成读取。返回值非负表示已接受/已挂起，负值表示失败。
+/// queue_data_，再调用 ProcessPendingReads()
+/// 完成读取。返回值非负表示已接受/已挂起，负值表示失败。
 typedef ErrorCode (*ReadFun)(ReadPort& port, bool in_isr);
 
 /**

--- a/src/core/rw/read_port.hpp
+++ b/src/core/rw/read_port.hpp
@@ -4,8 +4,8 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "queue.hpp"
 #include "operation.hpp"
+#include "queue.hpp"
 
 namespace LibXR
 {
@@ -37,9 +37,9 @@ class ReadPort
   // 同一个信号量只能在上一次 BLOCK 调用返回、端口回到 IDLE 后复用。
   enum class BusyState : uint32_t
   {
-    IDLE = 0,     ///< No active waiter and no pending completion. 无等待者、无挂起完成。
-    PENDING = 1,  ///< Driver accepted the request; completion still owns progress.
-                  ///< 请求已交给底层推进。
+    IDLE = 0,      ///< No active waiter and no pending completion. 无等待者、无挂起完成。
+    PENDING = 1,   ///< Driver accepted the request; completion still owns progress.
+                   ///< 请求已交给底层推进。
     CLEARING = 2,  ///< ClearQueuedData() owns software dequeue progress.
                    ///< ClearQueuedData() 占有软件出队进度。
     BLOCK_CLAIMED = 3,   ///< BLOCK wakeup already belongs to the current waiter. 当前
@@ -50,10 +50,12 @@ class ReadPort
                          ///< re-check queue. 数据先到，后续调用者要重查队列。
   };
 
-  ReadFun read_fun_ = nullptr;  ///< Driver/backend read notification entry. 底层驱动或后端读取通知入口。
+  ReadFun read_fun_ =
+      nullptr;  ///< Driver/backend read notification entry. 底层驱动或后端读取通知入口。
   SPSCQueue<uint8_t>* queue_data_ = nullptr;  ///< RX payload queue. 接收数据字节队列。
   ReadInfoBlock info_{};  ///< In-flight read request metadata. 当前在途读取请求的元数据。
-  std::atomic<BusyState> busy_{BusyState::IDLE};  ///< Shared read-progress handoff state. 共享的读进度交接状态。
+  std::atomic<BusyState> busy_{
+      BusyState::IDLE};  ///< Shared read-progress handoff state. 共享的读进度交接状态。
   ErrorCode block_result_ = ErrorCode::OK;  ///< Final status for the current BLOCK read.
 
   /**

--- a/src/core/rw/stdio.hpp
+++ b/src/core/rw/stdio.hpp
@@ -14,7 +14,8 @@ namespace LibXR
 {
 
 /**
- * @brief 提供静态全局的输入输出接口绑定与写会话管理 / STDIO interface for read and write ports
+ * @brief 提供静态全局的输入输出接口绑定与写会话管理 / STDIO interface for read and write
+ * ports
  */
 class STDIO
 {
@@ -28,41 +29,49 @@ class STDIO
       nullptr;  ///< Write port mutex. 写入端口互斥锁。
   static inline LibXR::WritePort::Stream* write_stream_ =
       nullptr;  ///< Optional externally owned write stream. 可选的外部托管写流。
-  // NOLINTEND
+                // NOLINTEND
 
  private:
   // Compiled-format bridge shared by the brace and printf frontends.
   // brace 与 printf 两个前端共用的编译格式桥接层。
 
   /**
-   * @brief STDIO 编译格式会话使用的流式截断输出端 / Stream-backed truncating sink used by one STDIO compiled-format session
+   * @brief STDIO 编译格式会话使用的流式截断输出端 / Stream-backed truncating sink used by
+   * one STDIO compiled-format session
    */
   class CompiledSink
   {
    public:
     /**
-     * @brief 构造一个绑定到指定流的编译格式输出端 / Construct one compiled-format sink bound to the given stream
+     * @brief 构造一个绑定到指定流的编译格式输出端 / Construct one compiled-format sink
+     * bound to the given stream
      * @param stream 当前会话绑定的写入流 / Write stream bound to the current session
      */
     explicit CompiledSink(WritePort::Stream& stream);
 
     /**
-     * @brief 追加一个文本片段；必要时按会话剩余空间直接截断 / Append one text chunk and truncate directly to the remaining session capacity when needed
+     * @brief 追加一个文本片段；必要时按会话剩余空间直接截断 / Append one text chunk and
+     * truncate directly to the remaining session capacity when needed
      * @param chunk 待写出的文本片段 / Text chunk to write
-     * @return 写出状态；若会话写流失败则返回对应错误 / Write status; returns the underlying stream error on failure
+     * @return 写出状态；若会话写流失败则返回对应错误 / Write status; returns the
+     * underlying stream error on failure
      */
     [[nodiscard]] ErrorCode Write(std::string_view chunk);
 
     /**
-     * @brief 返回当前会话最终保留下来的字节数 / Return the retained byte count of the current session
-     * @return 当前会话最终保留下来的字节数 / Returns the retained byte count of the current session
+     * @brief 返回当前会话最终保留下来的字节数 / Return the retained byte count of the
+     * current session
+     * @return 当前会话最终保留下来的字节数 / Returns the retained byte count of the
+     * current session
      */
     [[nodiscard]] size_t RetainedSize() const { return retained_size_; }
 
    private:
-    WritePort::Stream& stream_;  ///< Active stream session receiving retained bytes. 接收保留字节的活动流会话。
-    size_t retained_size_ = 0;  ///< Bytes retained so far. 当前已保留的字节数。
-    bool saturated_ = false;  ///< No more bytes should be retained in this session. 当前会话不再继续保留输出。
+    WritePort::Stream& stream_;  ///< Active stream session receiving retained bytes.
+                                 ///< 接收保留字节的活动流会话。
+    size_t retained_size_ = 0;   ///< Bytes retained so far. 当前已保留的字节数。
+    bool saturated_ = false;     ///< No more bytes should be retained in this session.
+                                 ///< 当前会话不再继续保留输出。
   };
 
   // Type-erased bridge for one compiled STDIO call.
@@ -70,20 +79,25 @@ class STDIO
   using CompiledWriteFun = ErrorCode (*)(void* context, CompiledSink& sink);
 
   /**
-   * @brief 一次编译格式 STDIO 调用的模板上下文 / Template context for one compiled-format STDIO call
+   * @brief 一次编译格式 STDIO 调用的模板上下文 / Template context for one compiled-format
+   * STDIO call
    * @tparam CompiledFormat 编译后的格式类型 / Compiled format type
    * @tparam Args 转发保存的运行时参数类型列表 / Forwarded runtime argument types
    */
   template <typename CompiledFormat, typename... Args>
   struct CompiledCall
   {
-    const CompiledFormat& format;  ///< Compile-time compiled format object. 编译期已编译的格式对象。
+    const CompiledFormat&
+        format;  ///< Compile-time compiled format object. 编译期已编译的格式对象。
     std::tuple<Args&&...> args;  ///< Forwarded runtime arguments. 转发保存的运行时参数。
 
     /**
-     * @brief 将当前模板上下文桥接到编译格式前端写入入口 / Bridge the current template context into the compiled-format write entry
-     * @param context 指向当前类型化调用上下文的指针 / Pointer to the current typed call context
-     * @param sink 当前会话使用的编译格式输出端 / Compiled-format sink used by the current session
+     * @brief 将当前模板上下文桥接到编译格式前端写入入口 / Bridge the current template
+     * context into the compiled-format write entry
+     * @param context 指向当前类型化调用上下文的指针 / Pointer to the current typed call
+     * context
+     * @param sink 当前会话使用的编译格式输出端 / Compiled-format sink used by the current
+     * session
      * @return 编译格式写出状态 / Compiled-format write status
      */
     [[nodiscard]] static ErrorCode Write(void* context, CompiledSink& sink)
@@ -100,36 +114,43 @@ class STDIO
   };
 
   /**
-   * @brief 在指定 `Stream` 上执行一次完整的 STDIO 编译格式写入与收尾 / Run one complete STDIO compiled-format write and finalize pass on the given `Stream`
+   * @brief 在指定 `Stream` 上执行一次完整的 STDIO 编译格式写入与收尾 / Run one complete
+   * STDIO compiled-format write and finalize pass on the given `Stream`
    *
    * 该 helper 统一负责：构造 CompiledSink、调用前端桥接函数、再用
    * FinishWriteSession() 做最终提交或丢弃。
    * This helper centralizes: constructing CompiledSink, invoking the frontend bridge,
    * then finalizing through FinishWriteSession().
    * @param stream 本次会话绑定的写入流 / Write stream bound to the current session
-   * @param context 前端桥接函数对应的类型擦除上下文 / Type-erased context consumed by the frontend bridge
+   * @param context 前端桥接函数对应的类型擦除上下文 / Type-erased context consumed by the
+   * frontend bridge
    * @param write_fun 前端桥接写入函数 / Frontend bridge write function
-   * @return 当前 STDIO 会话最终提交的字节数；失败返回 `-1` / Byte count finally committed by the current STDIO session; returns `-1` on failure
+   * @return 当前 STDIO 会话最终提交的字节数；失败返回 `-1` / Byte count finally committed
+   * by the current STDIO session; returns `-1` on failure
    */
-  [[nodiscard]] static int WriteCompiledToStream(WritePort::Stream& stream,
-                                                 void* context,
+  [[nodiscard]] static int WriteCompiledToStream(WritePort::Stream& stream, void* context,
                                                  CompiledWriteFun write_fun);
 
   /**
-   * @brief 执行一次完整的 STDIO 编译格式流会话选择、写入与收尾 / Run one complete STDIO compiled-format stream session: stream selection, write, and finalization
+   * @brief 执行一次完整的 STDIO 编译格式流会话选择、写入与收尾 / Run one complete STDIO
+   * compiled-format stream session: stream selection, write, and finalization
    *
    * 若当前已存在外部绑定的 write_stream_，则复用它；否则创建一个临时的
    * WritePort::Stream 供本次会话使用。
    * Reuses the externally bound write_stream_ when available; otherwise creates one
    * temporary WritePort::Stream for the current session.
-   * @param context 前端桥接函数对应的类型擦除上下文 / Type-erased context consumed by the frontend bridge
+   * @param context 前端桥接函数对应的类型擦除上下文 / Type-erased context consumed by the
+   * frontend bridge
    * @param write_fun 前端桥接写入函数 / Frontend bridge write function
-   * @return 当前 STDIO 会话最终提交的字节数；失败返回 `-1` / Byte count finally committed by the current STDIO session; returns `-1` on failure
+   * @return 当前 STDIO 会话最终提交的字节数；失败返回 `-1` / Byte count finally committed
+   * by the current STDIO session; returns `-1` on failure
    */
-  [[nodiscard]] static int WriteCompiledSession(void* context, CompiledWriteFun write_fun);
+  [[nodiscard]] static int WriteCompiledSession(void* context,
+                                                CompiledWriteFun write_fun);
 
   /**
-   * @brief 执行一次模板已知的 STDIO 编译格式会话 / Run one STDIO compiled-format session whose format and argument types are already known at compile time
+   * @brief 执行一次模板已知的 STDIO 编译格式会话 / Run one STDIO compiled-format session
+   * whose format and argument types are already known at compile time
    *
    * 该 helper 只保留模板相关的最薄一层：拿共享会话，再把类型化调用对象交给
    * WriteCompiledSession()。
@@ -137,7 +158,8 @@ class STDIO
    * pass the typed call object into WriteCompiledSession().
    * @tparam Call 类型化编译格式调用对象 / Typed compiled-format call object
    * @param call 当前会话的类型化调用对象 / Typed call object for the current session
-   * @return 当前 STDIO 会话最终提交的字节数；失败返回 `-1` / Byte count finally committed by the current STDIO session; returns `-1` on failure
+   * @return 当前 STDIO 会话最终提交的字节数；失败返回 `-1` / Byte count finally committed
+   * by the current STDIO session; returns `-1` on failure
    */
   template <typename Call>
   [[nodiscard]] static int RunCompiledSession(Call& call)
@@ -151,12 +173,15 @@ class STDIO
   }
 
   /**
-   * @brief 用一份已编译格式和一组运行时参数执行一次完整的 STDIO 写会话 / Run one complete STDIO write session with one compiled format and one runtime argument pack
+   * @brief 用一份已编译格式和一组运行时参数执行一次完整的 STDIO 写会话 / Run one complete
+   * STDIO write session with one compiled format and one runtime argument pack
    * @tparam CompiledFormat 编译后的格式类型 / Compiled format type
    * @tparam Args 运行时参数类型列表 / Runtime argument types
    * @param format 编译后的格式对象 / Compiled format object
-   * @param args 参与本次写会话的运行时参数 / Runtime arguments used by the current write session
-   * @return 当前 STDIO 会话最终提交的字节数；失败返回 `-1` / Byte count finally committed by the current STDIO session; returns `-1` on failure
+   * @param args 参与本次写会话的运行时参数 / Runtime arguments used by the current write
+   * session
+   * @return 当前 STDIO 会话最终提交的字节数；失败返回 `-1` / Byte count finally committed
+   * by the current STDIO session; returns `-1` on failure
    */
   template <typename CompiledFormat, typename... Args>
   [[nodiscard]] static int RunCompiled(const CompiledFormat& format, Args&&... args)
@@ -168,29 +193,36 @@ class STDIO
 
   /**
    * @brief 获取一个共享的 STDIO 写入会话 / Acquire one shared STDIO write session
-   * @return 成功获取共享写会话返回 `true`，否则返回 `false` / Returns `true` on success, otherwise `false`
+   * @return 成功获取共享写会话返回 `true`，否则返回 `false` / Returns `true` on success,
+   * otherwise `false`
    */
   [[nodiscard]] static bool BeginWriteSession();
 
   /**
-   * @brief 提交当前编译格式会话的写入流并释放共享会话 / Commit the current compiled-format session stream and release the shared session
+   * @brief 提交当前编译格式会话的写入流并释放共享会话 / Commit the current
+   * compiled-format session stream and release the shared session
    * @param stream 当前会话使用的写入流 / Write stream used by the current session
-   * @param retained_size 当前会话真正保留下来的字节数 / Byte count actually retained by the current session
-   * @param format_result 本次格式化写出阶段的状态 / Status returned by the formatting write phase
-   * @return 当前 STDIO 会话最终提交的字节数；失败返回 `-1` / Byte count finally committed by the current STDIO session; returns `-1` on failure
+   * @param retained_size 当前会话真正保留下来的字节数 / Byte count actually retained by
+   * the current session
+   * @param format_result 本次格式化写出阶段的状态 / Status returned by the formatting
+   * write phase
+   * @return 当前 STDIO 会话最终提交的字节数；失败返回 `-1` / Byte count finally committed
+   * by the current STDIO session; returns `-1` on failure
    */
   [[nodiscard]] static int FinishWriteSession(WritePort::Stream& stream,
                                               size_t retained_size,
                                               ErrorCode format_result);
 
  public:
-
   /**
-   * @brief 将一个编译期 brace 字面量打印到当前 STDIO 输出 / Print one compile-time brace literal to the active STDIO output
+   * @brief 将一个编译期 brace 字面量打印到当前 STDIO 输出 / Print one compile-time brace
+   * literal to the active STDIO output
    * @tparam Source 编译期 brace 格式字面量 / Compile-time brace format literal
    * @tparam Args 调用点运行时参数类型列表 / Call-site runtime argument types
    * @param args 参与本次打印的运行时参数 / Runtime arguments used by the current print
-   * @return 返回当前 STDIO 流实际保留并提交的字节数；若会话建立或提交失败则返回 `-1` / Returns the byte count actually retained and committed to the current STDIO stream; returns `-1` on session or commit failure
+   * @return 返回当前 STDIO 流实际保留并提交的字节数；若会话建立或提交失败则返回 `-1` /
+   * Returns the byte count actually retained and committed to the current STDIO stream;
+   * returns `-1` on session or commit failure
    */
   template <Print::Text Source, typename... Args>
   static int Print(Args&&... args)
@@ -200,11 +232,14 @@ class STDIO
   }
 
   /**
-   * @brief 将一个编译期 printf 字面量打印到当前 STDIO 输出 / Print one compile-time printf literal to the active STDIO output
+   * @brief 将一个编译期 printf 字面量打印到当前 STDIO 输出 / Print one compile-time
+   * printf literal to the active STDIO output
    * @tparam Source 编译期 printf 格式字面量 / Compile-time printf format literal
    * @tparam Args 调用点运行时参数类型列表 / Call-site runtime argument types
    * @param args 参与本次打印的运行时参数 / Runtime arguments used by the current print
-   * @return 返回当前 STDIO 流实际保留并提交的字节数；若会话建立或提交失败则返回 `-1` / Returns the byte count actually retained and committed to the current STDIO stream; returns `-1` on session or commit failure
+   * @return 返回当前 STDIO 流实际保留并提交的字节数；若会话建立或提交失败则返回 `-1` /
+   * Returns the byte count actually retained and committed to the current STDIO stream;
+   * returns `-1` on session or commit failure
    */
   template <Print::Text Source, typename... Args>
   static int Printf(Args&&... args)

--- a/src/core/rw/write_port.hpp
+++ b/src/core/rw/write_port.hpp
@@ -5,8 +5,8 @@
 #include <cstdint>
 #include <string_view>
 
-#include "queue.hpp"
 #include "operation.hpp"
+#include "queue.hpp"
 
 namespace LibXR
 {
@@ -54,19 +54,22 @@ class WritePort
         3,  ///< Final wakeup belongs to the current waiter. 最终唤醒已归当前等待者所有。
     BLOCK_DETACHED = 4,  ///< Waiter already timed out/detached; completion must not post.
                          ///< 等待者已超时/被分离，完成侧不能再 Post。
-    RESETTING = 5,        ///< Fail-and-clear owns queue mutation.
-                          ///< Fail-and-clear 路径占有写队列/元数据修改权。
+    RESETTING = 5,       ///< Fail-and-clear owns queue mutation.
+                         ///< Fail-and-clear 路径占有写队列/元数据修改权。
     IDLE = UINT32_MAX    ///< No active submitter and no armed BLOCK waiter.
                          ///< 没有活动提交者，也没有挂起中的 BLOCK 等待者。
   };
 
-  WriteFun write_fun_ = nullptr;  ///< Driver/backend write entry. 底层驱动或后端写入入口。
+  WriteFun write_fun_ =
+      nullptr;  ///< Driver/backend write entry. 底层驱动或后端写入入口。
   SPSCQueue<WriteInfoBlock>* queue_info_ =
       nullptr;  ///< Metadata queue for pending write batches. 挂起写批次的元数据队列。
   SPSCQueue<uint8_t>* queue_data_ =
       nullptr;  ///< Payload queue for pending write bytes. 挂起写入字节的数据队列。
-  std::atomic<BusyState> busy_{BusyState::IDLE};  ///< Shared submit/wait handoff state. 共享的提交/等待交接状态。
-  ErrorCode block_result_ = ErrorCode::OK;  ///< Final status for the current BLOCK write. 当前 BLOCK 写入的最终结果。
+  std::atomic<BusyState> busy_{
+      BusyState::IDLE};  ///< Shared submit/wait handoff state. 共享的提交/等待交接状态。
+  ErrorCode block_result_ = ErrorCode::OK;  ///< Final status for the current BLOCK write.
+                                            ///< 当前 BLOCK 写入的最终结果。
 
   // Stream batch facade.
   // Stream 负责一次批次的累积写入与提交。
@@ -179,11 +182,16 @@ class WritePort
      */
     void Release();
 
-    LibXR::WritePort* port_;  ///< 写端口指针 Pointer to the WritePort
+    LibXR::WritePort* port_;    ///< 写端口指针 Pointer to the WritePort
     LibXR::WriteOperation op_;  ///< 写操作对象 Write operation object
-    size_t batch_capacity_ = 0;  ///< 当前批次可用的总容量 Total capacity reserved for the current batch
-    size_t buffered_size_ = 0;  ///< 当前批次已追加到共享 data queue、但尚未发布对应元数据的字节数 Bytes already appended into the shared data queue for the current batch, but whose metadata has not yet been published
-    bool owns_port_ = false;  ///< 当前 Stream 是否持有该批次的端口所有权 Whether this Stream currently owns the batch
+    size_t batch_capacity_ =
+        0;  ///< 当前批次可用的总容量 Total capacity reserved for the current batch
+    size_t buffered_size_ =
+        0;  ///< 当前批次已追加到共享 data queue、但尚未发布对应元数据的字节数 Bytes
+            ///< already appended into the shared data queue for the current batch, but
+            ///< whose metadata has not yet been published
+    bool owns_port_ = false;  ///< 当前 Stream 是否持有该批次的端口所有权 Whether this
+                              ///< Stream currently owns the batch
   };
 
   /**

--- a/src/driver/can.hpp
+++ b/src/driver/can.hpp
@@ -120,7 +120,7 @@ class CAN
    */
   virtual ~CAN() = default;
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @struct ClassicPack
    * @brief 经典 CAN 帧数据结构。Classic CAN frame structure.
@@ -132,7 +132,7 @@ LIBXR_PACKED_BEGIN
     uint8_t dlc;      ///< 有效数据长度（0~8）。Data length code (0–8).
     uint8_t data[8];  ///< 数据载荷。Data payload (up to 8 bytes).
   };
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   /// 错误 ID 前缀 Error ID prefix.
   static constexpr uint32_t CAN_ERROR_ID_PREFIX = 0xFFFF0000u;
@@ -256,7 +256,7 @@ class FDCAN : public CAN
    */
   virtual ~FDCAN() = default;
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @struct FDPack
    * @brief CAN FD 帧数据结构。CAN FD frame structure.
@@ -268,7 +268,7 @@ LIBXR_PACKED_BEGIN
     uint8_t len;       ///< 数据长度（0~64）。Data length (0–64 bytes).
     uint8_t data[64];  ///< 数据载荷。Data payload.
   };
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   using CAN::AddMessage;
   using CAN::FilterMode;

--- a/src/driver/debug/jtag_dp.hpp
+++ b/src/driver/debug/jtag_dp.hpp
@@ -33,8 +33,7 @@ class JtagDp final
   ErrorCode DpRead(uint8_t addr2b, uint32_t& val, JtagProtocol::Ack& ack)
   {
     JtagProtocol::Response resp;
-    const ErrorCode EC =
-        Transfer(JtagProtocol::make_dp_req(true, addr2b, 0u), resp);
+    const ErrorCode EC = Transfer(JtagProtocol::make_dp_req(true, addr2b, 0u), resp);
     ack = resp.ack;
     val = resp.rdata;
     return EC;
@@ -43,8 +42,7 @@ class JtagDp final
   ErrorCode DpWrite(uint8_t addr2b, uint32_t val, JtagProtocol::Ack& ack)
   {
     JtagProtocol::Response resp;
-    const ErrorCode EC =
-        Transfer(JtagProtocol::make_dp_req(false, addr2b, val), resp);
+    const ErrorCode EC = Transfer(JtagProtocol::make_dp_req(false, addr2b, val), resp);
     ack = resp.ack;
     return EC;
   }
@@ -121,8 +119,7 @@ class JtagDp final
   ErrorCode ApWriteTxn(uint8_t addr2b, uint32_t val, JtagProtocol::Ack& ack)
   {
     JtagProtocol::Response resp;
-    const ErrorCode EC =
-        Transfer(JtagProtocol::make_ap_req(false, addr2b, val), resp);
+    const ErrorCode EC = Transfer(JtagProtocol::make_ap_req(false, addr2b, val), resp);
     ack = resp.ack;
     return EC;
   }
@@ -178,9 +175,9 @@ class JtagDp final
 
   ErrorCode Transfer(const JtagProtocol::Request& req, JtagProtocol::Response& resp)
   {
-    const ErrorCode EC = SelectIr(req.port == JtagProtocol::Port::AP
-                                      ? JtagProtocol::JTAG_IR_APACC
-                                      : JtagProtocol::JTAG_IR_DPACC);
+    const ErrorCode EC =
+        SelectIr(req.port == JtagProtocol::Port::AP ? JtagProtocol::JTAG_IR_APACC
+                                                    : JtagProtocol::JTAG_IR_DPACC);
     if (EC != ErrorCode::OK)
     {
       resp.ack = JtagProtocol::Ack::PROTOCOL;
@@ -188,9 +185,8 @@ class JtagDp final
     }
 
     uint64_t out_dr = 0u;
-    const ErrorCode EC2 =
-        ShiftValueThroughChain(JtagProtocol::PackDpDr(req),
-                               JtagProtocol::JTAG_DP_DR_LEN, out_dr);
+    const ErrorCode EC2 = ShiftValueThroughChain(JtagProtocol::PackDpDr(req),
+                                                 JtagProtocol::JTAG_DP_DR_LEN, out_dr);
     if (EC2 != ErrorCode::OK)
     {
       resp.ack = JtagProtocol::Ack::PROTOCOL;

--- a/src/driver/debug/jtag_general_gpio.hpp
+++ b/src/driver/debug/jtag_general_gpio.hpp
@@ -117,8 +117,8 @@ class JtagGeneralGPIO final : public Jtag
     else
     {
       const uint64_t LOOPS_CEIL = (LOOPS_SCALED + CEIL_BIAS) / LOOPS_SCALE;
-      half_period_loops_ = (LOOPS_CEIL > UINT32_MAX) ? UINT32_MAX
-                                                     : static_cast<uint32_t>(LOOPS_CEIL);
+      half_period_loops_ =
+          (LOOPS_CEIL > UINT32_MAX) ? UINT32_MAX : static_cast<uint32_t>(LOOPS_CEIL);
     }
 
     return ErrorCode::OK;
@@ -347,7 +347,6 @@ class JtagGeneralGPIO final : public Jtag
       }
       tck_.Write(false);
     }
-
   }
 
   inline void DelayHalf() { BusyLoop(half_period_loops_); }

--- a/src/driver/debug/jtag_protocol.hpp
+++ b/src/driver/debug/jtag_protocol.hpp
@@ -103,11 +103,11 @@ constexpr Ack map_jtag_ack(uint8_t raw_ack)
  */
 struct ChainConfig
 {
-  uint8_t count = 0;        ///< 设备数（TDO 端为 index=0）/ Device count (TDO side index=0)
-  uint8_t index = 0;        ///< 当前设备索引 / Current device index
-  const uint8_t* ir_length = nullptr;  ///< 各设备 IR 长度数组 / IR length array
-  const uint16_t* ir_before = nullptr; ///< 当前设备前的 bypass 位数 / Bypass bits before
-  const uint16_t* ir_after = nullptr;  ///< 当前设备后的 bypass 位数 / Bypass bits after
+  uint8_t count = 0;  ///< 设备数（TDO 端为 index=0）/ Device count (TDO side index=0)
+  uint8_t index = 0;  ///< 当前设备索引 / Current device index
+  const uint8_t* ir_length = nullptr;   ///< 各设备 IR 长度数组 / IR length array
+  const uint16_t* ir_before = nullptr;  ///< 当前设备前的 bypass 位数 / Bypass bits before
+  const uint16_t* ir_after = nullptr;   ///< 当前设备后的 bypass 位数 / Bypass bits after
 
   // 运行期缓存（可选）：用于减少每次 Shift 计算
   uint32_t ir_before_bits_len = 0;  ///< 前面设备 IR 总位数 / IR bits before

--- a/src/driver/debug/swd_general_gpio.hpp
+++ b/src/driver/debug/swd_general_gpio.hpp
@@ -128,9 +128,8 @@ class SwdGeneralGPIO final : public Swd
     }
     else
     {
-      const uint64_t loops_ceil =
-          (loops_num + static_cast<uint64_t>(LOOPS_SCALE) - 1u) /
-          static_cast<uint64_t>(LOOPS_SCALE);
+      const uint64_t loops_ceil = (loops_num + static_cast<uint64_t>(LOOPS_SCALE) - 1u) /
+                                  static_cast<uint64_t>(LOOPS_SCALE);
       half_period_loops_ = (loops_ceil >= static_cast<uint64_t>(UINT32_MAX))
                                ? UINT32_MAX
                                : static_cast<uint32_t>(loops_ceil);

--- a/src/driver/usb/core/core.hpp
+++ b/src/driver/usb/core/core.hpp
@@ -1,6 +1,7 @@
 #pragma once
-#include "libxr_def.hpp"
 #include <cstdint>
+
+#include "libxr_def.hpp"
 
 namespace LibXR::USB
 {

--- a/src/driver/usb/core/desc_cfg.hpp
+++ b/src/driver/usb/core/desc_cfg.hpp
@@ -37,7 +37,7 @@ class ConfigDescriptorItem : public BosCapabilityProvider
  public:
   virtual ~ConfigDescriptorItem() = default;
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @brief 配置描述符头（9 字节）/ Configuration descriptor header (9 bytes)
    */
@@ -96,7 +96,7 @@ LIBXR_PACKED_BEGIN
     uint16_t wMaxPacketSize;         ///< 最大包长 / Maximum packet size
     uint8_t bInterval;               ///< 轮询间隔 / Polling interval
   };
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   /**
    * @brief 绑定端点资源 / Bind endpoint resources

--- a/src/driver/usb/core/desc_dev.hpp
+++ b/src/driver/usb/core/desc_dev.hpp
@@ -82,7 +82,7 @@ class DeviceDescriptor
   static constexpr uint8_t DEVICE_DESC_LENGTH =
       18;  ///< 设备描述符长度（固定18字节）/ Device descriptor length (18 bytes)
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   struct Data
   {
     uint8_t bLength;  ///< 描述符长度（固定18）/ Descriptor length (always 18)
@@ -101,7 +101,7 @@ LIBXR_PACKED_BEGIN
     uint8_t iSerialNumber;        ///< 序列号字符串索引 / Index of serial number string
     uint8_t bNumConfigurations;   ///< 支持的配置数 / Number of possible configurations
   };
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   static_assert(sizeof(Data) == 18, "DeviceDescriptor must be 18 bytes");
 

--- a/src/driver/usb/device/cdc/cdc_base.hpp
+++ b/src/driver/usb/device/cdc/cdc_base.hpp
@@ -81,7 +81,7 @@ class CDCBase : public DeviceClass
                           ///< (required for CDC-ACM)
   };
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @brief CDC线路编码参数结构体
    *        CDC line coding parameters structure
@@ -108,14 +108,14 @@ LIBXR_PACKED_BEGIN
   struct SerialStateNotification
   {
     uint8_t bmRequestType;  ///< 请求类型（固定为 0xA1） / Request type (fixed to 0xA1)
-    uint8_t bNotification;  ///< 通知类型（固定为 SERIAL_STATE） / Notification type (fixed
-                            ///< to SERIAL_STATE)
+    uint8_t bNotification;  ///< 通知类型（固定为 SERIAL_STATE） / Notification type
+                            ///< (fixed to SERIAL_STATE)
     uint16_t wValue;        ///< 值（固定为 0） / Value (fixed to 0)
     uint16_t wIndex;        ///< 接口号 / Interface number
     uint16_t wLength;       ///< 数据长度（固定为2）| Data length (fixed to 2)
     uint16_t serialState;   ///< 串行状态位图 / Serial state bitmap
   };
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   // 确保 CDCLineCoding 结构体大小为 7 字节。
   // Ensure CDCLineCoding is exactly 7 bytes.
@@ -602,7 +602,7 @@ LIBXR_PACKED_END
     }
   }
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @brief CDC描述符块结构
    *        CDC descriptor block structure
@@ -658,7 +658,7 @@ LIBXR_PACKED_BEGIN
     EndpointDescriptor data_ep_out;  ///< 数据OUT端点描述符 / Data OUT endpoint descriptor
     EndpointDescriptor data_ep_in;   ///< 数据IN端点描述符 / Data IN endpoint descriptor
   } desc_block_;
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
  protected:
   CDCLineCoding& GetLineCoding() { return line_coding_; }
@@ -706,7 +706,7 @@ LIBXR_PACKED_END
 
   // 状态标志。
   // State flags.
-  bool inited_ = false;                 ///< 初始化标志 / Initialization flag
+  bool inited_ = false;                     ///< 初始化标志 / Initialization flag
   bool has_control_line_state_cb_ = false;  ///< Control-line callback registered
   bool has_line_coding_cb_ = false;         ///< Line-coding callback registered
 

--- a/src/driver/usb/device/cdc/cdc_to_uart.hpp
+++ b/src/driver/usb/device/cdc/cdc_to_uart.hpp
@@ -41,8 +41,9 @@ class CDCToUart : public CDCUart
    * allocation
    */
   CDCToUart(Endpoint::EPNumber data_in_ep_num, Endpoint::EPNumber data_out_ep_num,
-            Endpoint::EPNumber comm_ep_num, LibXR::UART& uart, size_t rx_buffer_size = 128,
-            size_t tx_buffer_size = 128, size_t tx_queue_size = 5)
+            Endpoint::EPNumber comm_ep_num, LibXR::UART& uart,
+            size_t rx_buffer_size = 128, size_t tx_buffer_size = 128,
+            size_t tx_queue_size = 5)
       : CDCUart(data_in_ep_num, data_out_ep_num, comm_ep_num, rx_buffer_size,
                 tx_buffer_size, tx_queue_size),
         rx_buffer_(new uint8_t[rx_buffer_size], rx_buffer_size),

--- a/src/driver/usb/device/cdc/cdc_uart.hpp
+++ b/src/driver/usb/device/cdc/cdc_uart.hpp
@@ -587,7 +587,8 @@ class CDCUart : public CDCBase, public LibXR::UART
           cdc->need_write_zlp_ = true;
         }
 
-        return ErrorCode::OK;  // 非 PENDING -> 上层完成一次 / Non-PENDING triggers one upstream finish
+        return ErrorCode::OK;  // 非 PENDING -> 上层完成一次 / Non-PENDING triggers one
+                               // upstream finish
       }
 
       // 预写下一段。

--- a/src/driver/usb/device/dap/daplink_v1.hpp
+++ b/src/driver/usb/device/dap/daplink_v1.hpp
@@ -82,7 +82,8 @@ class DapLinkV1Class
   ErrorCode WriteDeviceDescriptor(DeviceDescriptor& header) override;
   ConstRawData GetReportDesc() override;
 
-  void BindEndpoints(EndpointPool& endpoint_pool, uint8_t start_itf_num, bool in_isr) override;
+  void BindEndpoints(EndpointPool& endpoint_pool, uint8_t start_itf_num,
+                     bool in_isr) override;
   void UnbindEndpoints(EndpointPool& endpoint_pool, bool in_isr) override;
 
   void OnDataOutComplete(bool in_isr, LibXR::ConstRawData& data) override;
@@ -162,7 +163,7 @@ class DapLinkV1Class
                                  uint8_t* resp, uint16_t resp_cap, uint16_t& out_len);
   void SetTransferAbortFlag(bool on);
 
- void DriveReset(bool release);
+  void DriveReset(bool release);
   void DelayUsIfAllowed(bool in_isr, uint32_t us);
 
  private:
@@ -237,8 +238,8 @@ class DapLinkV1Class
 
 template <typename SwdPort>
 DapLinkV1Class<SwdPort>::DapLinkV1Class(Endpoint::EPNumber in_ep_num,
-                               Endpoint::EPNumber out_ep_num, SwdPort& swd_link,
-                               LibXR::GPIO* nreset_gpio)
+                                        Endpoint::EPNumber out_ep_num, SwdPort& swd_link,
+                                        LibXR::GPIO* nreset_gpio)
     : HID(in_ep_num, out_ep_num, true, 1, 1, DEFAULT_INTERFACE_STRING),
       swd_(swd_link),
       nreset_gpio_(nreset_gpio)
@@ -253,7 +254,10 @@ DapLinkV1Class<SwdPort>::DapLinkV1Class(Endpoint::EPNumber in_ep_num,
 }
 
 template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::SetInfoStrings(const InfoStrings& info) { info_ = info; }
+void DapLinkV1Class<SwdPort>::SetInfoStrings(const InfoStrings& info)
+{
+  info_ = info;
+}
 
 template <typename SwdPort>
 void DapLinkV1Class<SwdPort>::SetJtag(LibXR::Debug::Jtag* jtag)
@@ -275,7 +279,10 @@ const LibXR::USB::DapLinkV1Def::State& DapLinkV1Class<SwdPort>::GetState() const
 }
 
 template <typename SwdPort>
-bool DapLinkV1Class<SwdPort>::IsInited() const { return inited_; }
+bool DapLinkV1Class<SwdPort>::IsInited() const
+{
+  return inited_;
+}
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::WriteDeviceDescriptor(DeviceDescriptor& header)
@@ -293,8 +300,8 @@ ConstRawData DapLinkV1Class<SwdPort>::GetReportDesc()
 }
 
 template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::BindEndpoints(EndpointPool& endpoint_pool, uint8_t start_itf_num,
-                                            bool in_isr)
+void DapLinkV1Class<SwdPort>::BindEndpoints(EndpointPool& endpoint_pool,
+                                            uint8_t start_itf_num, bool in_isr)
 {
   HID::BindEndpoints(endpoint_pool, start_itf_num, in_isr);
 
@@ -380,8 +387,7 @@ void DapLinkV1Class<SwdPort>::UnbindEndpoints(EndpointPool& endpoint_pool, bool 
 }
 
 template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::OnDataOutCompleteStatic(bool in_isr,
-                                                      DapLinkV1Class* self,
+void DapLinkV1Class<SwdPort>::OnDataOutCompleteStatic(bool in_isr, DapLinkV1Class* self,
                                                       LibXR::ConstRawData& data)
 {
   if (self && self->inited_)
@@ -391,8 +397,7 @@ void DapLinkV1Class<SwdPort>::OnDataOutCompleteStatic(bool in_isr,
 }
 
 template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::OnDataInCompleteStatic(bool in_isr,
-                                                     DapLinkV1Class* self,
+void DapLinkV1Class<SwdPort>::OnDataInCompleteStatic(bool in_isr, DapLinkV1Class* self,
                                                      LibXR::ConstRawData& data)
 {
   if (self && self->inited_)
@@ -423,9 +428,8 @@ void DapLinkV1Class<SwdPort>::OnDataOutComplete(bool in_isr, LibXR::ConstRawData
 
   Memory::FastSet(tx_buff.addr_, 0, RESP_CAP);
   uint16_t out_len = 0u;
-  auto ans = ProcessOneCommand(in_isr, REQ, REQ_LEN,
-                               reinterpret_cast<uint8_t*>(tx_buff.addr_), RESP_CAP,
-                               out_len);
+  auto ans = ProcessOneCommand(
+      in_isr, REQ, REQ_LEN, reinterpret_cast<uint8_t*>(tx_buff.addr_), RESP_CAP, out_len);
   UNUSED(ans);
   UNUSED(out_len);
 
@@ -474,8 +478,8 @@ void DapLinkV1Class<SwdPort>::ArmOutTransferIfIdle()
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::ProcessOneCommand(bool in_isr, const uint8_t* req,
-                                            uint16_t req_len, uint8_t* resp,
-                                            uint16_t resp_cap, uint16_t& out_len)
+                                                     uint16_t req_len, uint8_t* resp,
+                                                     uint16_t resp_cap, uint16_t& out_len)
 {
   out_len = 0u;
 
@@ -557,7 +561,7 @@ ErrorCode DapLinkV1Class<SwdPort>::ProcessOneCommand(bool in_isr, const uint8_t*
 
 template <typename SwdPort>
 void DapLinkV1Class<SwdPort>::BuildNotSupportResponse(uint8_t* resp, uint16_t resp_cap,
-                                             uint16_t& out_len)
+                                                      uint16_t& out_len)
 {
   if (!resp || resp_cap < 1u)
   {
@@ -570,8 +574,8 @@ void DapLinkV1Class<SwdPort>::BuildNotSupportResponse(uint8_t* resp, uint16_t re
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleInfo(bool /*in_isr*/, const uint8_t* req,
-                                     uint16_t req_len, uint8_t* resp, uint16_t resp_cap,
-                                     uint16_t& out_len)
+                                              uint16_t req_len, uint8_t* resp,
+                                              uint16_t resp_cap, uint16_t& out_len)
 {
   if (req_len < 2u)
   {
@@ -636,8 +640,9 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleInfo(bool /*in_isr*/, const uint8_t* re
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::BuildInfoStringResponse(uint8_t cmd, const char* str,
-                                                  uint8_t* resp, uint16_t resp_cap,
-                                                  uint16_t& out_len)
+                                                           uint8_t* resp,
+                                                           uint16_t resp_cap,
+                                                           uint16_t& out_len)
 {
   resp[0] = cmd;
   resp[1] = 0u;
@@ -664,8 +669,9 @@ ErrorCode DapLinkV1Class<SwdPort>::BuildInfoStringResponse(uint8_t cmd, const ch
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU8Response(uint8_t cmd, uint8_t val, uint8_t* resp,
-                                              uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU8Response(uint8_t cmd, uint8_t val,
+                                                       uint8_t* resp, uint16_t resp_cap,
+                                                       uint16_t& out_len)
 {
   if (resp_cap < 3u)
   {
@@ -680,8 +686,9 @@ ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU8Response(uint8_t cmd, uint8_t val,
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU16Response(uint8_t cmd, uint16_t val, uint8_t* resp,
-                                               uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU16Response(uint8_t cmd, uint16_t val,
+                                                        uint8_t* resp, uint16_t resp_cap,
+                                                        uint16_t& out_len)
 {
   if (resp_cap < 4u)
   {
@@ -696,8 +703,9 @@ ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU16Response(uint8_t cmd, uint16_t va
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU32Response(uint8_t cmd, uint32_t val, uint8_t* resp,
-                                               uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU32Response(uint8_t cmd, uint32_t val,
+                                                        uint8_t* resp, uint16_t resp_cap,
+                                                        uint16_t& out_len)
 {
   if (resp_cap < 6u)
   {
@@ -712,9 +720,10 @@ ErrorCode DapLinkV1Class<SwdPort>::BuildInfoU32Response(uint8_t cmd, uint32_t va
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleHostStatus(bool /*in_isr*/, const uint8_t* /*req*/,
-                                           uint16_t /*req_len*/, uint8_t* resp,
-                                           uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleHostStatus(bool /*in_isr*/,
+                                                    const uint8_t* /*req*/,
+                                                    uint16_t /*req_len*/, uint8_t* resp,
+                                                    uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -729,8 +738,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleHostStatus(bool /*in_isr*/, const uint8
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleConnect(bool /*in_isr*/, const uint8_t* req,
-                                        uint16_t req_len, uint8_t* resp,
-                                        uint16_t resp_cap, uint16_t& out_len)
+                                                 uint16_t req_len, uint8_t* resp,
+                                                 uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -792,9 +801,10 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleConnect(bool /*in_isr*/, const uint8_t*
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleDisconnect(bool /*in_isr*/, const uint8_t* /*req*/,
-                                           uint16_t /*req_len*/, uint8_t* resp,
-                                           uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleDisconnect(bool /*in_isr*/,
+                                                    const uint8_t* /*req*/,
+                                                    uint16_t /*req_len*/, uint8_t* resp,
+                                                    uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -813,9 +823,9 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleDisconnect(bool /*in_isr*/, const uint8
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleTransferConfigure(bool /*in_isr*/, const uint8_t* req,
-                                                  uint16_t req_len, uint8_t* resp,
-                                                  uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleTransferConfigure(
+    bool /*in_isr*/, const uint8_t* req, uint16_t req_len, uint8_t* resp,
+    uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -854,9 +864,11 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferConfigure(bool /*in_isr*/, cons
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleTransferAbort(bool /*in_isr*/, const uint8_t* /*req*/,
-                                              uint16_t /*req_len*/, uint8_t* resp,
-                                              uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleTransferAbort(bool /*in_isr*/,
+                                                       const uint8_t* /*req*/,
+                                                       uint16_t /*req_len*/,
+                                                       uint8_t* resp, uint16_t resp_cap,
+                                                       uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -874,8 +886,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferAbort(bool /*in_isr*/, const ui
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleWriteABORT(bool /*in_isr*/, const uint8_t* req,
-                                           uint16_t req_len, uint8_t* resp,
-                                           uint16_t resp_cap, uint16_t& out_len)
+                                                    uint16_t req_len, uint8_t* resp,
+                                                    uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -915,8 +927,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleWriteABORT(bool /*in_isr*/, const uint8
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleDelay(bool /*in_isr*/, const uint8_t* req,
-                                      uint16_t req_len, uint8_t* resp, uint16_t resp_cap,
-                                      uint16_t& out_len)
+                                               uint16_t req_len, uint8_t* resp,
+                                               uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -945,8 +957,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleDelay(bool /*in_isr*/, const uint8_t* r
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleResetTarget(bool in_isr, const uint8_t* /*req*/,
-                                            uint16_t /*req_len*/, uint8_t* resp,
-                                            uint16_t resp_cap, uint16_t& out_len)
+                                                     uint16_t /*req_len*/, uint8_t* resp,
+                                                     uint16_t resp_cap, uint16_t& out_len)
 {
   if (!resp || resp_cap < 3u)
   {
@@ -974,8 +986,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleResetTarget(bool in_isr, const uint8_t*
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleSWJPins(bool /*in_isr*/, const uint8_t* req,
-                                        uint16_t req_len, uint8_t* resp,
-                                        uint16_t resp_cap, uint16_t& out_len)
+                                                 uint16_t req_len, uint8_t* resp,
+                                                 uint16_t resp_cap, uint16_t& out_len)
 {
   if (!resp || resp_cap < 2u)
   {
@@ -1003,8 +1015,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWJPins(bool /*in_isr*/, const uint8_t*
 
   if ((PIN_SEL & LibXR::USB::DapLinkV1Def::DAP_SWJ_NRESET) != 0u)
   {
-    const bool LEVEL_HIGH =
-        ((PIN_OUT & LibXR::USB::DapLinkV1Def::DAP_SWJ_NRESET) != 0u);
+    const bool LEVEL_HIGH = ((PIN_OUT & LibXR::USB::DapLinkV1Def::DAP_SWJ_NRESET) != 0u);
     DriveReset(LEVEL_HIGH);
   }
 
@@ -1056,8 +1067,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWJPins(bool /*in_isr*/, const uint8_t*
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleSWJClock(bool /*in_isr*/, const uint8_t* req,
-                                         uint16_t req_len, uint8_t* resp,
-                                         uint16_t resp_cap, uint16_t& out_len)
+                                                  uint16_t req_len, uint8_t* resp,
+                                                  uint16_t resp_cap, uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -1094,8 +1105,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWJClock(bool /*in_isr*/, const uint8_t
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleSWJSequence(bool /*in_isr*/, const uint8_t* req,
-                                            uint16_t req_len, uint8_t* resp,
-                                            uint16_t resp_cap, uint16_t& out_len)
+                                                     uint16_t req_len, uint8_t* resp,
+                                                     uint16_t resp_cap, uint16_t& out_len)
 {
   if (!resp || resp_cap < 2u)
   {
@@ -1158,9 +1169,11 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWJSequence(bool /*in_isr*/, const uint
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleSWDConfigure(bool /*in_isr*/, const uint8_t* /*req*/,
-                                             uint16_t /*req_len*/, uint8_t* resp,
-                                             uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleSWDConfigure(bool /*in_isr*/,
+                                                      const uint8_t* /*req*/,
+                                                      uint16_t /*req_len*/, uint8_t* resp,
+                                                      uint16_t resp_cap,
+                                                      uint16_t& out_len)
 {
   if (resp_cap < 2u)
   {
@@ -1176,8 +1189,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWDConfigure(bool /*in_isr*/, const uin
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleSWDSequence(bool /*in_isr*/, const uint8_t* req,
-                                            uint16_t req_len, uint8_t* resp,
-                                            uint16_t resp_cap, uint16_t& out_len)
+                                                     uint16_t req_len, uint8_t* resp,
+                                                     uint16_t resp_cap, uint16_t& out_len)
 {
   if (!req || !resp || resp_cap < 2u)
   {
@@ -1267,8 +1280,9 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleSWDSequence(bool /*in_isr*/, const uint
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGSequence(bool /*in_isr*/, const uint8_t* req,
-                                             uint16_t req_len, uint8_t* resp,
-                                             uint16_t resp_cap, uint16_t& out_len)
+                                                      uint16_t req_len, uint8_t* resp,
+                                                      uint16_t resp_cap,
+                                                      uint16_t& out_len)
 {
   if (!req || !resp || resp_cap < 2u)
   {
@@ -1313,8 +1327,7 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGSequence(bool /*in_isr*/, const uin
     }
 
     const bool TMS = ((INFO & LibXR::Debug::JtagProtocol::JTAG_SEQUENCE_TMS) != 0u);
-    const bool CAPTURE =
-        ((INFO & LibXR::Debug::JtagProtocol::JTAG_SEQUENCE_TDO) != 0u);
+    const bool CAPTURE = ((INFO & LibXR::Debug::JtagProtocol::JTAG_SEQUENCE_TDO) != 0u);
     const uint16_t BYTES = static_cast<uint16_t>((cycles + 7u) / 8u);
 
     if (req_off + BYTES > req_len)
@@ -1358,9 +1371,11 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGSequence(bool /*in_isr*/, const uin
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGConfigure(bool /*in_isr*/, const uint8_t* req,
-                                              uint16_t req_len, uint8_t* resp,
-                                              uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGConfigure(bool /*in_isr*/,
+                                                       const uint8_t* req,
+                                                       uint16_t req_len, uint8_t* resp,
+                                                       uint16_t resp_cap,
+                                                       uint16_t& out_len)
 {
   if (!req || !resp || resp_cap < 2u)
   {
@@ -1416,8 +1431,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGConfigure(bool /*in_isr*/, const ui
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGIdCode(bool /*in_isr*/, const uint8_t* req,
-                                           uint16_t req_len, uint8_t* resp,
-                                           uint16_t resp_cap, uint16_t& out_len)
+                                                    uint16_t req_len, uint8_t* resp,
+                                                    uint16_t resp_cap, uint16_t& out_len)
 {
   if (!req || !resp || resp_cap < 2u)
   {
@@ -1435,7 +1450,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGIdCode(bool /*in_isr*/, const uint8
   resp[1] = DAP_ERROR;
   out_len = 2u;
 
-  if (jtag_ == nullptr || dap_state_.debug_port != LibXR::USB::DapLinkV1Def::DebugPort::JTAG)
+  if (jtag_ == nullptr ||
+      dap_state_.debug_port != LibXR::USB::DapLinkV1Def::DebugPort::JTAG)
   {
     return ErrorCode::OK;
   }
@@ -1457,8 +1473,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGIdCode(bool /*in_isr*/, const uint8
   LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
   uint32_t idcode = 0u;
   ErrorCode EC = dp.ReadIdCode(idcode);
-  if (EC == ErrorCode::OK && (idcode == 0u || idcode == 0xFFFF'FFFFu ||
-                              ((idcode & 0x1u) == 0u)) &&
+  if (EC == ErrorCode::OK &&
+      (idcode == 0u || idcode == 0xFFFF'FFFFu || ((idcode & 0x1u) == 0u)) &&
       jtag_ir_len_[INDEX] != 4u)
   {
     uint32_t fallback_idcode = 0u;
@@ -1488,9 +1504,11 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJTAGIdCode(bool /*in_isr*/, const uint8
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleQueueCommands(bool /*in_isr*/, const uint8_t* /*req*/,
-                                              uint16_t /*req_len*/, uint8_t* resp,
-                                              uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleQueueCommands(bool /*in_isr*/,
+                                                       const uint8_t* /*req*/,
+                                                       uint16_t /*req_len*/,
+                                                       uint8_t* resp, uint16_t resp_cap,
+                                                       uint16_t& out_len)
 {
   return build_cmd_status_response(
       to_u8(LibXR::USB::DapLinkV1Def::CommandId::QUEUE_COMMANDS), DAP_ERROR, resp,
@@ -1498,9 +1516,11 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleQueueCommands(bool /*in_isr*/, const ui
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleExecuteCommands(bool /*in_isr*/, const uint8_t* /*req*/,
-                                                uint16_t /*req_len*/, uint8_t* resp,
-                                                uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleExecuteCommands(bool /*in_isr*/,
+                                                         const uint8_t* /*req*/,
+                                                         uint16_t /*req_len*/,
+                                                         uint8_t* resp, uint16_t resp_cap,
+                                                         uint16_t& out_len)
 {
   return build_cmd_status_response(
       to_u8(LibXR::USB::DapLinkV1Def::CommandId::EXECUTE_COMMANDS), DAP_ERROR, resp,
@@ -1545,12 +1565,15 @@ uint8_t DapLinkV1Class<SwdPort>::MapAckToDapResp(
 }
 
 template <typename SwdPort>
-void DapLinkV1Class<SwdPort>::SetTransferAbortFlag(bool on) { dap_state_.transfer_abort = on; }
+void DapLinkV1Class<SwdPort>::SetTransferAbortFlag(bool on)
+{
+  dap_state_.transfer_abort = on;
+}
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t* req,
-                                         uint16_t req_len, uint8_t* resp,
-                                         uint16_t resp_cap, uint16_t& out_len)
+                                                  uint16_t req_len, uint8_t* resp,
+                                                  uint16_t resp_cap, uint16_t& out_len)
 {
   out_len = 0u;
   if (!req || !resp || resp_cap < 3u)
@@ -1939,10 +1962,9 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t
         const uint8_t CUR_V = ack_to_dap(ack);
         if (CUR_V != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK || EC != ErrorCode::OK)
         {
-          const uint8_t PRIOR_FAIL =
-              (CUR_V != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
-                  ? CUR_V
-                  : LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
+          const uint8_t PRIOR_FAIL = (CUR_V != LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK)
+                                         ? CUR_V
+                                         : LibXR::USB::DapLinkV1Def::DAP_TRANSFER_ERROR;
 
           if (!complete_pending_by_rdbuff())
           {
@@ -2012,9 +2034,11 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransfer(bool /*in_isr*/, const uint8_t
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/, const uint8_t* req,
-                                              uint16_t req_len, uint8_t* resp,
-                                              uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/,
+                                                       const uint8_t* req,
+                                                       uint16_t req_len, uint8_t* resp,
+                                                       uint16_t resp_cap,
+                                                       uint16_t& out_len)
 {
   if constexpr (JTAG_ENABLED)
   {
@@ -2304,8 +2328,9 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleTransferBlock(bool /*in_isr*/, const ui
 
 template <typename SwdPort>
 ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransfer(bool /*in_isr*/, const uint8_t* req,
-                                             uint16_t req_len, uint8_t* resp,
-                                             uint16_t resp_cap, uint16_t& out_len)
+                                                      uint16_t req_len, uint8_t* resp,
+                                                      uint16_t resp_cap,
+                                                      uint16_t& out_len)
 {
   out_len = 0u;
   if (!req || !resp || resp_cap < 3u)
@@ -2372,7 +2397,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransfer(bool /*in_isr*/, const uin
   auto bytes_for_read = [&](bool need_ts) -> uint16_t
   { return static_cast<uint16_t>(need_ts ? 8u : 4u); };
 
-  auto idle_after_attempt = [&]() {
+  auto idle_after_attempt = [&]()
+  {
     if (dap_state_.transfer_cfg.idle_cycles != 0u)
     {
       jtag_->IdleClocks(dap_state_.transfer_cfg.idle_cycles);
@@ -2450,8 +2476,9 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransfer(bool /*in_isr*/, const uin
   auto check_posted_ap_write_jtag = [&](LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
   {
     uint32_t ctrl_stat = 0u;
-    return dp_read_retry(static_cast<uint8_t>(LibXR::Debug::SwdProtocol::DpReadReg::CTRL_STAT),
-                         ctrl_stat, ack);
+    return dp_read_retry(
+        static_cast<uint8_t>(LibXR::Debug::SwdProtocol::DpReadReg::CTRL_STAT), ctrl_stat,
+        ack);
   };
 
   uint8_t response_count = 0u;
@@ -2487,8 +2514,9 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransfer(bool /*in_isr*/, const uin
   auto should_check_pending_ap_write_at_tail = [&]() -> bool
   {
     return response_value == LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK ||
-           response_value == static_cast<uint8_t>(LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK |
-                                                  LibXR::USB::DapLinkV1Def::DAP_TRANSFER_MISMATCH);
+           response_value ==
+               static_cast<uint8_t>(LibXR::USB::DapLinkV1Def::DAP_TRANSFER_OK |
+                                    LibXR::USB::DapLinkV1Def::DAP_TRANSFER_MISMATCH);
   };
 
   auto emit_read_with_ts = [&](bool need_ts, uint32_t data) -> bool
@@ -2731,10 +2759,9 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransfer(bool /*in_isr*/, const uin
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransferBlock(bool /*in_isr*/,
-                                                  const uint8_t* req, uint16_t req_len,
-                                                  uint8_t* resp, uint16_t resp_cap,
-                                                  uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransferBlock(
+    bool /*in_isr*/, const uint8_t* req, uint16_t req_len, uint8_t* resp,
+    uint16_t resp_cap, uint16_t& out_len)
 {
   if (!resp || resp_cap < 4u)
   {
@@ -2799,7 +2826,8 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransferBlock(bool /*in_isr*/,
 
   LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
 
-  auto idle_after_attempt = [&]() {
+  auto idle_after_attempt = [&]()
+  {
     if (dap_state_.transfer_cfg.idle_cycles != 0u)
     {
       jtag_->IdleClocks(dap_state_.transfer_cfg.idle_cycles);
@@ -2877,8 +2905,9 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransferBlock(bool /*in_isr*/,
   auto check_posted_ap_write_jtag = [&](LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
   {
     uint32_t ctrl_stat = 0u;
-    return dp_read_retry(static_cast<uint8_t>(LibXR::Debug::SwdProtocol::DpReadReg::CTRL_STAT),
-                         ctrl_stat, ack);
+    return dp_read_retry(
+        static_cast<uint8_t>(LibXR::Debug::SwdProtocol::DpReadReg::CTRL_STAT), ctrl_stat,
+        ack);
   };
 
   const bool AP = LibXR::USB::DapLinkV1Def::req_is_ap(DAP_RQ);
@@ -3010,9 +3039,11 @@ ErrorCode DapLinkV1Class<SwdPort>::HandleJtagTransferBlock(bool /*in_isr*/,
 }
 
 template <typename SwdPort>
-ErrorCode DapLinkV1Class<SwdPort>::HandleJtagWriteAbort(bool /*in_isr*/, const uint8_t* req,
-                                               uint16_t req_len, uint8_t* resp,
-                                               uint16_t resp_cap, uint16_t& out_len)
+ErrorCode DapLinkV1Class<SwdPort>::HandleJtagWriteAbort(bool /*in_isr*/,
+                                                        const uint8_t* req,
+                                                        uint16_t req_len, uint8_t* resp,
+                                                        uint16_t resp_cap,
+                                                        uint16_t& out_len)
 {
   if (!resp || resp_cap < 2u)
   {

--- a/src/driver/usb/device/dap/daplink_v2.hpp
+++ b/src/driver/usb/device/dap/daplink_v2.hpp
@@ -68,10 +68,10 @@ class DapLinkV2Class : public DeviceClass
    * @param nreset_gpio     Optional nRESET GPIO
    *
    */
-  explicit DapLinkV2Class(
-      Endpoint::EPNumber data_in_ep_num, Endpoint::EPNumber data_out_ep_num,
-      SwdPort& swd_link, LibXR::GPIO* nreset_gpio = nullptr,
-      const char* interface_string = DEFAULT_INTERFACE_STRING)
+  explicit DapLinkV2Class(Endpoint::EPNumber data_in_ep_num,
+                          Endpoint::EPNumber data_out_ep_num, SwdPort& swd_link,
+                          LibXR::GPIO* nreset_gpio = nullptr,
+                          const char* interface_string = DEFAULT_INTERFACE_STRING)
       : DeviceClass(),
         swd_(swd_link),
         nreset_gpio_(nreset_gpio),
@@ -2183,8 +2183,8 @@ class DapLinkV2Class : public DeviceClass
     LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
     uint32_t idcode = 0u;
     ErrorCode ec = dp.ReadIdCode(idcode);
-    if (ec == ErrorCode::OK && (idcode == 0u || idcode == 0xFFFF'FFFFu ||
-                                ((idcode & 0x1u) == 0u)) &&
+    if (ec == ErrorCode::OK &&
+        (idcode == 0u || idcode == 0xFFFF'FFFFu || ((idcode & 0x1u) == 0u)) &&
         jtag_ir_len_[index] != 4u)
     {
       uint32_t fallback_idcode = 0u;
@@ -2608,8 +2608,7 @@ class DapLinkV2Class : public DeviceClass
       {
         return true;
       }
-      LibXR::Debug::SwdProtocol::Ack check_ack =
-          LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
+      LibXR::Debug::SwdProtocol::Ack check_ack = LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
       const ErrorCode check_ec = CheckPostedApWriteFast(check_ack);
       response_value = MapAckToDapResp(check_ack);
       if (response_value != LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK)
@@ -3093,7 +3092,8 @@ class DapLinkV2Class : public DeviceClass
               LibXR::Debug::SwdProtocol::Ack::PROTOCOL;
           const ErrorCode check_ec = CheckPostedApWriteFast(check_ack);
           xresp = MapAckToDapResp(check_ack);
-          if (check_ack == LibXR::Debug::SwdProtocol::Ack::OK && check_ec != ErrorCode::OK)
+          if (check_ack == LibXR::Debug::SwdProtocol::Ack::OK &&
+              check_ec != ErrorCode::OK)
           {
             xresp |= LibXR::USB::DapLinkV2Def::DAP_TRANSFER_ERROR;
           }
@@ -3340,16 +3340,13 @@ class DapLinkV2Class : public DeviceClass
     };
 
     auto ensure_space = [&](uint16_t bytes) -> bool
-    {
-      return (resp_off + bytes) <= resp_cap;
-    };
+    { return (resp_off + bytes) <= resp_cap; };
 
     auto bytes_for_read = [&](bool need_ts) -> uint16_t
-    {
-      return static_cast<uint16_t>(need_ts ? 8u : 4u);
-    };
+    { return static_cast<uint16_t>(need_ts ? 8u : 4u); };
 
-    auto idle_after_attempt = [&]() {
+    auto idle_after_attempt = [&]()
+    {
       if (dap_state_.transfer_cfg.idle_cycles != 0u)
       {
         jtag_->IdleClocks(dap_state_.transfer_cfg.idle_cycles);
@@ -3424,11 +3421,13 @@ class DapLinkV2Class : public DeviceClass
       }
     };
 
-    auto check_posted_ap_write_jtag = [&](LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+    auto check_posted_ap_write_jtag =
+        [&](LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
     {
       uint32_t ctrl_stat = 0u;
-      return dp_read_retry(static_cast<uint8_t>(LibXR::Debug::SwdProtocol::DpReadReg::CTRL_STAT),
-                           ctrl_stat, ack);
+      return dp_read_retry(
+          static_cast<uint8_t>(LibXR::Debug::SwdProtocol::DpReadReg::CTRL_STAT),
+          ctrl_stat, ack);
     };
 
     uint8_t response_count = 0u;
@@ -3481,8 +3480,9 @@ class DapLinkV2Class : public DeviceClass
     auto should_check_pending_ap_write_at_tail = [&]() -> bool
     {
       return response_value == LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK ||
-             response_value == static_cast<uint8_t>(LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK |
-                                                    LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MISMATCH);
+             response_value ==
+                 static_cast<uint8_t>(LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK |
+                                      LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MISMATCH);
     };
 
     for (uint32_t i = 0; i < COUNT; ++i)
@@ -3498,8 +3498,10 @@ class DapLinkV2Class : public DeviceClass
       const bool RNW = LibXR::USB::DapLinkV2Def::req_is_read(RQ);
       const uint8_t ADDR2B = LibXR::USB::DapLinkV2Def::req_addr2b(RQ);
       const bool TS = LibXR::USB::DapLinkV2Def::req_need_timestamp(RQ);
-      const bool MATCH_VALUE = ((RQ & LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MATCH_VALUE) != 0u);
-      const bool MATCH_MASK = ((RQ & LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MATCH_MASK) != 0u);
+      const bool MATCH_VALUE =
+          ((RQ & LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MATCH_VALUE) != 0u);
+      const bool MATCH_MASK =
+          ((RQ & LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MATCH_MASK) != 0u);
 
       if (TS && (MATCH_VALUE || MATCH_MASK))
       {
@@ -3630,9 +3632,9 @@ class DapLinkV2Class : public DeviceClass
 
           if (!matched)
           {
-            response_value = static_cast<uint8_t>(
-                LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK |
-                LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MISMATCH);
+            response_value =
+                static_cast<uint8_t>(LibXR::USB::DapLinkV2Def::DAP_TRANSFER_OK |
+                                     LibXR::USB::DapLinkV2Def::DAP_TRANSFER_MISMATCH);
             break;
           }
 
@@ -3797,7 +3799,8 @@ class DapLinkV2Class : public DeviceClass
     }
 
     LibXR::Debug::JtagDp dp(*jtag_, &jtag_chain_);
-    auto idle_after_attempt = [&]() {
+    auto idle_after_attempt = [&]()
+    {
       if (dap_state_.transfer_cfg.idle_cycles != 0u)
       {
         jtag_->IdleClocks(dap_state_.transfer_cfg.idle_cycles);
@@ -3872,11 +3875,13 @@ class DapLinkV2Class : public DeviceClass
       }
     };
 
-    auto check_posted_ap_write_jtag = [&](LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
+    auto check_posted_ap_write_jtag =
+        [&](LibXR::Debug::JtagProtocol::Ack& ack) -> ErrorCode
     {
       uint32_t ctrl_stat = 0u;
-      return dp_read_retry(static_cast<uint8_t>(LibXR::Debug::SwdProtocol::DpReadReg::CTRL_STAT),
-                           ctrl_stat, ack);
+      return dp_read_retry(
+          static_cast<uint8_t>(LibXR::Debug::SwdProtocol::DpReadReg::CTRL_STAT),
+          ctrl_stat, ack);
     };
 
     const bool AP = LibXR::USB::DapLinkV2Def::req_is_ap(DAP_RQ);
@@ -3903,8 +3908,8 @@ class DapLinkV2Class : public DeviceClass
         req_off = static_cast<uint16_t>(req_off + 4u);
 
         LibXR::Debug::JtagProtocol::Ack ack = LibXR::Debug::JtagProtocol::Ack::PROTOCOL;
-        ErrorCode ec = AP ? ap_write_retry(ADDR2B, wdata, ack)
-                          : dp_write_retry(ADDR2B, wdata, ack);
+        ErrorCode ec =
+            AP ? ap_write_retry(ADDR2B, wdata, ack) : dp_write_retry(ADDR2B, wdata, ack);
 
         xresp = MapAckToDapResp(ack);
         if (xresp == 0u)
@@ -4150,7 +4155,7 @@ class DapLinkV2Class : public DeviceClass
   uint8_t in_tx_multi_storage_[MAX_DAP_PACKET_SIZE] = {};
   LibXR::RawData in_tx_multi_buf_{in_tx_multi_storage_, DEFAULT_DAP_PACKET_SIZE};
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @brief MS OS 2.0 descriptor set layout
    */
@@ -4174,19 +4179,18 @@ LIBXR_PACKED_BEGIN
       uint8_t name[LibXR::USB::WinUsbMsOs20::
                        PROP_NAME_DEVICE_INTERFACE_GUIDS_BYTES];  ///< Property name /
                                                                  ///< Property name
-      uint16_t wPropertyDataLength;  ///< UTF-16 byte length
-      uint8_t
-          data[GUID_MULTI_SZ_UTF_16_BYTES];  ///< REG_MULTI_SZ data
+      uint16_t wPropertyDataLength;                              ///< UTF-16 byte length
+      uint8_t data[GUID_MULTI_SZ_UTF_16_BYTES];                  ///< REG_MULTI_SZ data
     } prop;
   } winusb_msos20_{};
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
  private:
   SwdPort& swd_;  ///< SWD link
 
-  LibXR::Debug::Jtag* jtag_ = nullptr;  ///< JTAG link
+  LibXR::Debug::Jtag* jtag_ = nullptr;                    ///< JTAG link
   LibXR::Debug::JtagProtocol::ChainConfig jtag_chain_{};  ///< JTAG chain state
-  uint8_t jtag_ir_len_[JTAG_MAX_DEVICES] = {};  ///< JTAG IR lengths
+  uint8_t jtag_ir_len_[JTAG_MAX_DEVICES] = {};            ///< JTAG IR lengths
 
   LibXR::GPIO* nreset_gpio_ = nullptr;  ///< Optional nRESET GPIO
 
@@ -4213,7 +4217,7 @@ LIBXR_PACKED_END
   bool inited_ = false;        ///< Initialized flag
   uint8_t interface_num_ = 0;  ///< Interface number
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @brief Descriptor block (Interface + 2x Endpoint)
    *
@@ -4224,7 +4228,7 @@ LIBXR_PACKED_BEGIN
     EndpointDescriptor ep_out;  ///< OUT endpoint descriptor / OUT endpoint descriptor
     EndpointDescriptor ep_in;   ///< IN endpoint descriptor / IN endpoint descriptor
   } desc_block_{};
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
  private:
   LibXR::USB::WinUsbMsOs20::MsOs20BosCapability winusb_msos20_cap_{

--- a/src/driver/usb/device/device_composition.hpp
+++ b/src/driver/usb/device/device_composition.hpp
@@ -170,7 +170,8 @@ class DeviceComposition
    */
   ErrorCode GenerateInterfaceString(uint8_t string_index, ConstRawData& data);
 
-  bool configured_ = false;   ///< 是否已进入非 0 配置态 / Whether a non-zero config is active
+  bool configured_ =
+      false;  ///< 是否已进入非 0 配置态 / Whether a non-zero config is active
   bool ep_assigned_ = false;  ///< 端点是否已绑定 / Whether endpoints are assigned
 
   EndpointPool& endpoint_pool_;  ///< 端点池引用 / Endpoint pool reference

--- a/src/driver/usb/device/dfu/dfu_bootloader.hpp
+++ b/src/driver/usb/device/dfu/dfu_bootloader.hpp
@@ -16,7 +16,7 @@ class DfuBootloaderBackend
   using JumpCallback = void (*)(void*);
   static constexpr uint32_t SEAL_MAGIC = 0x4C414553u;  // "SEAL"
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @brief seal 区固定记录 / Fixed record stored in the seal region
    */
@@ -27,7 +27,7 @@ LIBXR_PACKED_BEGIN
     uint32_t crc32 = 0u;
     uint32_t crc32_inv = 0u;
   };
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   // Backend 负责：
   // - 管理 download/upload/manifest 状态
@@ -754,7 +754,7 @@ class DFUClass : public DfuInterfaceClassBase
   static constexpr uint8_t ATTR_WILL_DETACH = 0x08u;
 
  public:
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @brief DFU Functional Descriptor（固件模式）
    *        DFU Functional Descriptor for firmware mode.
@@ -804,7 +804,7 @@ LIBXR_PACKED_BEGIN
         0};
     FunctionalDescriptor func_desc = {};
   };
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   static_assert(sizeof(FunctionalDescriptor) == 9,
                 "DFU functional descriptor size mismatch.");

--- a/src/driver/usb/device/dfu/dfu_runtime.hpp
+++ b/src/driver/usb/device/dfu/dfu_runtime.hpp
@@ -58,7 +58,7 @@ class DfuRuntimeClass : public DfuInterfaceClassBase
   }
 
  protected:
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @brief DFU Functional Descriptor（Runtime 变体）
    *        DFU Functional Descriptor for the runtime variant.
@@ -102,7 +102,7 @@ LIBXR_PACKED_BEGIN
         0};
     FunctionalDescriptor func_desc = {};
   };
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   void BindEndpoints(EndpointPool&, uint8_t start_itf_num, bool) override
   {

--- a/src/driver/usb/device/gsusb/gs_usb.hpp
+++ b/src/driver/usb/device/gsusb/gs_usb.hpp
@@ -39,7 +39,7 @@ class GsUsbClass : public DeviceClass
  private:
   // ===== Linux gs_usb 线缆格式（固定 12 字节头） / Linux gs_usb wire format
   // (fixed 12-byte header) =====
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
 
   /**
    * @brief gs_usb 线缆格式头（12 字节） / gs_usb wire-format header (12 bytes)
@@ -53,7 +53,7 @@ LIBXR_PACKED_BEGIN
     uint8_t flags;     ///< 帧标志（GS_CAN_FLAG_*） / Frame flags (GS_CAN_FLAG_*)
     uint8_t reserved;  ///< 保留 / Reserved
   };
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   static constexpr uint32_t ECHO_ID_RX =
       0xFFFFFFFFu;  ///< RX 帧 echo_id 固定值 / Fixed echo_id for RX frames
@@ -94,9 +94,8 @@ LIBXR_PACKED_END
    * @param interface_string 接口字符串 / Interface string
    */
   GsUsbClass(Endpoint::EPNumber data_in_ep_num, Endpoint::EPNumber data_out_ep_num,
-             std::initializer_list<LibXR::CAN*> cans,
-             size_t rx_queue_size = 32, size_t echo_queue_size = 32,
-             LibXR::GPIO* identify_gpio = nullptr,
+             std::initializer_list<LibXR::CAN*> cans, size_t rx_queue_size = 32,
+             size_t echo_queue_size = 32, LibXR::GPIO* identify_gpio = nullptr,
              std::initializer_list<LibXR::GPIO*> termination_gpios = {},
              LibXR::Database* database = nullptr,
              const char* interface_string = DEFAULT_INTERFACE_STRING)
@@ -155,9 +154,8 @@ LIBXR_PACKED_END
    * @param interface_string 接口字符串 / Interface string
    */
   GsUsbClass(Endpoint::EPNumber data_in_ep_num, Endpoint::EPNumber data_out_ep_num,
-             std::initializer_list<LibXR::FDCAN*> fd_cans,
-             size_t rx_queue_size = 32, size_t echo_queue_size = 32,
-             LibXR::GPIO* identify_gpio = nullptr,
+             std::initializer_list<LibXR::FDCAN*> fd_cans, size_t rx_queue_size = 32,
+             size_t echo_queue_size = 32, LibXR::GPIO* identify_gpio = nullptr,
              std::initializer_list<LibXR::GPIO*> termination_gpios = {},
              LibXR::Database* database = nullptr,
              const char* interface_string = DEFAULT_INTERFACE_STRING)
@@ -222,7 +220,8 @@ LIBXR_PACKED_END
     ASSERT(ans == ErrorCode::OK);
 
     // UINT16_MAX 只是上限，底层会选不超过该值的可用最大长度。
-    // UINT16_MAX is only an upper bound; the backend still chooses the largest valid length.
+    // UINT16_MAX is only an upper bound; the backend still chooses the largest valid
+    // length.
     ep_data_in_->Configure(
         {Endpoint::Direction::IN, Endpoint::Type::BULK, UINT16_MAX, true});
     ep_data_out_->Configure(
@@ -859,7 +858,8 @@ LIBXR_PACKED_END
     }
 
     // TX echo：host 通过 echo_id 跟踪 TX buffer；设备需回送 echo_id。
-    // TX echo: the host tracks TX buffers via echo_id, and the device should echo it back.
+    // TX echo: the host tracks TX buffers via echo_id, and the device should echo it
+    // back.
     if (wh.echo_id != ECHO_ID_RX)
     {
       QueueItem qi;
@@ -962,7 +962,7 @@ LIBXR_PACKED_END
   uint8_t ctrl_target_channel_ =
       0;  ///< 控制请求目标通道 / Control request target channel
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @brief 本类的接口与端点描述符块 / Descriptor block for interface and endpoints
    */
@@ -972,7 +972,7 @@ LIBXR_PACKED_BEGIN
     EndpointDescriptor ep_out;  ///< OUT 端点描述符 / OUT endpoint descriptor
     EndpointDescriptor ep_in;   ///< IN 端点描述符 / IN endpoint descriptor
   } desc_block_{};
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   uint8_t rx_buf_[WIRE_MAX_SIZE]{};  ///< OUT 接收缓冲区 / OUT receive buffer
   std::array<uint8_t, WIRE_MAX_SIZE>
@@ -1740,7 +1740,8 @@ LIBXR_PACKED_END
     }
 
     // 与 Linux can/error.h 对齐（沿用之前版本的映射）。
-    // Keep these definitions aligned with Linux can/error.h, matching the previous mapping.
+    // Keep these definitions aligned with Linux can/error.h, matching the previous
+    // mapping.
     constexpr uint8_t LNX_CAN_ERR_CRTL_UNSPEC = 0x00;
     constexpr uint8_t LNX_CAN_ERR_CRTL_RX_WARNING = 0x04;
     constexpr uint8_t LNX_CAN_ERR_CRTL_TX_WARNING = 0x08;

--- a/src/driver/usb/device/hid/hid.hpp
+++ b/src/driver/usb/device/hid/hid.hpp
@@ -61,7 +61,7 @@ class HID : public DeviceClass
     FEATURE = 3  ///< 特征报告 / Feature report
   };
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @brief HID描述符结构体
    *        HID descriptor structure
@@ -100,7 +100,7 @@ LIBXR_PACKED_BEGIN
     EndpointDescriptor ep_in;   ///< IN 端点描述符 / IN endpoint descriptor
     EndpointDescriptor ep_out;  ///< OUT 端点描述符 / OUT endpoint descriptor
   };
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   /**
    * @brief HID 构造函数

--- a/src/driver/usb/device/hid/hid_gamepad.hpp
+++ b/src/driver/usb/device/hid/hid_gamepad.hpp
@@ -71,7 +71,7 @@ class HIDGamepadT
     BTN8 = 0x80,
   };
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @brief 输入报告结构（9 字节） / Input report structure (9 bytes)
    * @details 4 个 16 位轴（LOG_MIN..LOG_MAX）+ 8 位按钮 / Four 16-bit axes
@@ -85,7 +85,7 @@ LIBXR_PACKED_BEGIN
     int16_t rx;       ///< Rx 轴 / Rx axis (LOG_MIN..LOG_MAX)
     uint8_t buttons;  ///< 按钮位 / Button bits (8)
   };
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   static_assert(sizeof(Report) == 9, "Report size must be 9 bytes");
 

--- a/src/driver/usb/device/uac/uac_mic.hpp
+++ b/src/driver/usb/device/uac/uac_mic.hpp
@@ -181,7 +181,7 @@ class UAC1MicrophoneQ : public DeviceClass
     ID_OT_USB = 3
   };
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @brief AC 头描述符
    *        AC header descriptor
@@ -307,7 +307,7 @@ LIBXR_PACKED_BEGIN
     EndpointDescriptorIso9 ep_in;  ///< 标准 IN 端点（9B）/ Std IN EP (9B)
     CSEndpointGeneral ep_cs;       ///< 类特定端点 / CS EP
   };
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   // ===== DeviceClass 接口实现 / DeviceClass implementation =====
   /**
@@ -539,7 +539,8 @@ LIBXR_PACKED_END
 
     // ===== Feature Unit（收件人：Interface / AC 接口） / Feature Unit =====
     const uint8_t CS = static_cast<uint8_t>((wValue >> 8) & 0xFF);  // FU_MUTE / FU_VOLUME
-    const uint8_t CH = static_cast<uint8_t>(wValue & 0xFF);         // 0=主控, 1..N / 0=master, 1..N
+    const uint8_t CH =
+        static_cast<uint8_t>(wValue & 0xFF);  // 0=主控, 1..N / 0=master, 1..N
     const uint8_t ENT =
         static_cast<uint8_t>((wIndex >> 8) & 0xFF);           // 实体 ID / entity ID
     const uint8_t ITF = static_cast<uint8_t>(wIndex & 0xFF);  // 接口号 / interface num
@@ -816,12 +817,14 @@ LIBXR_PACKED_END
       {
         eff = 16;
       }
-      const uint32_t MICROFRAMES = 1u << (eff - 1u);  // 2^(bInterval-1) 个微帧 / microframes
-      service_hz_ = 8000u / MICROFRAMES;              // 8000 微帧/秒 / microframes per second
+      const uint32_t MICROFRAMES = 1u
+                                   << (eff - 1u);  // 2^(bInterval-1) 个微帧 / microframes
+      service_hz_ = 8000u / MICROFRAMES;  // 8000 微帧/秒 / microframes per second
     }
     else
     {
-      service_hz_ = 1000u;  // FS 等时：规范上 bInterval 必须为 1 帧 / FS isochronous requires bInterval=1
+      service_hz_ = 1000u;  // FS 等时：规范上 bInterval 必须为 1 帧 / FS isochronous
+                            // requires bInterval=1
     }
 
     // 2) 计算每服务周期应送字节。
@@ -842,7 +845,8 @@ LIBXR_PACKED_END
     w_max_packet_size_ = static_cast<uint16_t>(ceil_bpt);
 
     // 4) 若已构建过描述符，则运行时能力不得超过宣告值。
-    // 4) Once descriptors are built, runtime capability must not exceed the advertised value.
+    // 4) Once descriptors are built, runtime capability must not exceed the advertised
+    // value.
     if (desc_block_.ep_in.wMaxPacketSize != 0 &&
         w_max_packet_size_ > desc_block_.ep_in.wMaxPacketSize)
     {

--- a/src/libxr.hpp
+++ b/src/libxr.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "app_framework.hpp"
-#include "libxr_assert.hpp"
 #include "async.hpp"
 #include "database.hpp"
 #include "double_buffer.hpp"
@@ -9,11 +8,11 @@
 #include "flag.hpp"
 #include "inertia.hpp"
 #include "kinematic.hpp"
+#include "libxr_assert.hpp"
 #include "libxr_cb.hpp"
 #include "libxr_color.hpp"
 #include "libxr_def.hpp"
 #include "libxr_pipe.hpp"
-#include "print.hpp"
 #include "libxr_rw.hpp"
 #include "libxr_string.hpp"
 #include "libxr_system.hpp"
@@ -21,9 +20,10 @@
 #include "libxr_type.hpp"
 #include "list.hpp"
 #include "lockfree_list.hpp"
-#include "object_pool.hpp"
 #include "logger.hpp"
 #include "message.hpp"
+#include "object_pool.hpp"
+#include "print.hpp"
 #if defined(LIBXR_SYSTEM_POSIX_HOST)
 #include "linux_shared_topic.hpp"
 #endif

--- a/src/middleware/app_framework/application.hpp
+++ b/src/middleware/app_framework/application.hpp
@@ -42,7 +42,8 @@ class Application
 class ApplicationManager
 {
  public:
-  LibXR::LockFreeList app_list_;  ///< 当前已注册模块链表 / List of currently registered modules.
+  LibXR::LockFreeList
+      app_list_;  ///< 当前已注册模块链表 / List of currently registered modules.
 
   /**
    * @brief 注册一个应用模块

--- a/src/middleware/app_framework/hardware.hpp
+++ b/src/middleware/app_framework/hardware.hpp
@@ -144,7 +144,8 @@ class HardwareContainer
     TypeID::ID id;     ///< 设备对象类型 ID / Device object type ID.
   };
 
-  mutable LibXR::LockFreeList alias_list_;  ///< 当前已注册的全部别名链表 / List of all currently registered aliases.
+  mutable LibXR::LockFreeList alias_list_;  ///< 当前已注册的全部别名链表 / List of all
+                                            ///< currently registered aliases.
 };
 
 }  // namespace LibXR

--- a/src/middleware/database/database.hpp
+++ b/src/middleware/database/database.hpp
@@ -11,5 +11,5 @@
  */
 
 #include "interface.hpp"
-#include "raw_sequential.hpp"
 #include "raw/raw.hpp"
+#include "raw_sequential.hpp"

--- a/src/middleware/database/interface.hpp
+++ b/src/middleware/database/interface.hpp
@@ -81,7 +81,8 @@ class Database
 
     /**
      * @brief 构造函数，初始化键，并在数据库不存在时赋默认值
-     *        (Constructor to initialize key, assigning default value if not found in the database).
+     *        (Constructor to initialize key, assigning default value if not found in the
+     * database).
      *
      * If the key does not exist in the database, it is initialized with zero.
      * 如果键在数据库中不存在，则初始化为零。

--- a/src/middleware/database/raw/block_ops.hpp
+++ b/src/middleware/database/raw/block_ops.hpp
@@ -1,234 +1,231 @@
-  /**
-   * @brief `DatabaseRaw` 的块级操作片段 / Block-operation fragment of `DatabaseRaw`
-   *
-   * @note 这一组函数只负责整块语义：块头、尾校验、空块初始化、损坏判断、已用空间计算、
-   *       以及块间前缀复制。
-   *       This group owns only block-level semantics: block headers, trailing
-   *       checksums, empty-block initialization, corruption checks, used-space
-   *       accounting, and block-prefix copying.
-   */
+/**
+ * @brief `DatabaseRaw` 的块级操作片段 / Block-operation fragment of `DatabaseRaw`
+ *
+ * @note 这一组函数只负责整块语义：块头、尾校验、空块初始化、损坏判断、已用空间计算、
+ *       以及块间前缀复制。
+ *       This group owns only block-level semantics: block headers, trailing
+ *       checksums, empty-block initialization, corruption checks, used-space
+ *       accounting, and block-prefix copying.
+ */
 
-  /**
-   * @brief 计算可用的存储空间大小
-   *        (Calculate the available storage size).
-   * @return 剩余的可用字节数 (Remaining available bytes).
-   * @note 这里统计的是主块当前已用前缀到块尾校验区之间还剩多少可写空间。
-   *       This counts how much writable space remains between the current live
-   *       prefix of the main block and its trailing checksum area.
-   */
-  size_t AvailableSize()
+/**
+ * @brief 计算可用的存储空间大小
+ *        (Calculate the available storage size).
+ * @return 剩余的可用字节数 (Remaining available bytes).
+ * @note 这里统计的是主块当前已用前缀到块尾校验区之间还剩多少可写空间。
+ *       This counts how much writable space remains between the current live
+ *       prefix of the main block and its trailing checksum area.
+ */
+size_t AvailableSize() { return GetChecksumOffset() - GetUsedBlockSize(BlockType::MAIN); }
+
+/**
+ * @brief 计算指定块的起始偏移 (Compute the starting offset of one block).
+ * @param block 目标块类型 (Target block type).
+ * @return 块起始偏移 (Starting offset of the block).
+ */
+size_t GetBlockOffset(BlockType block)
+{
+  return block == BlockType::BACKUP ? block_size_ : 0;
+}
+
+/**
+ * @brief 计算块尾校验区起始偏移 (Compute the starting offset of the checksum area).
+ * @return 块尾校验区起始偏移 (Starting offset of the checksum area).
+ */
+size_t GetChecksumOffset() { return block_size_ - GetChecksumSize(); }
+
+/**
+ * @brief 计算块尾校验区字节数 (Compute the byte size of the checksum area).
+ * @return 块尾校验区字节数 (Byte size of the checksum area).
+ */
+size_t GetChecksumSize() { return AlignSize(sizeof(CHECKSUM_BYTE)); }
+
+/**
+ * @brief 把指定块初始化为空数据库块 (Initialize one block as an empty database block).
+ * @param block 目标块类型 (Target block type).
+ * @note 初始化后的块是“结构合法但没有任何用户键”的空块：块头有效、首个哨兵键有效、
+ *       尾校验有效。
+ *       After initialization, the block is a structurally valid empty block:
+ *       valid header, valid sentinel key, and valid trailing checksum.
+ */
+void InitBlock(BlockType block)
+{
+  const size_t offset = GetBlockOffset(block);
+  EraseFlashOrExit(offset, block_size_);
+
+  FlashInfo info;  // padding filled with 0xFF by constructor
+  info.header = FLASH_HEADER;
+  KeyInfo& tmp_key = info.key;
+  BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.no_next_key, true);
+  BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.available_flag, true);
+  BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.uninit, false);
+  tmp_key.SetNameLength(0);
+  tmp_key.SetDataSize(0);
+  WriteFlashOrExit(offset, {reinterpret_cast<uint8_t*>(&info), sizeof(FlashInfo)});
+  WriteFlashOrExit(offset + GetChecksumOffset(), {&CHECKSUM_BYTE, sizeof(CHECKSUM_BYTE)});
+}
+
+/**
+ * @brief 判断块头是否已初始化 (Check whether the block header is initialized).
+ * @param block 目标块类型 (Target block type).
+ * @return 若块头有效则返回 `true` (Returns `true` when the block header is valid).
+ */
+bool IsBlockInited(BlockType block)
+{
+  const size_t offset = GetBlockOffset(block);
+  FlashInfo flash_data;
+  ReadFlashOrExit(offset, flash_data);
+  return flash_data.header == FLASH_HEADER;
+}
+
+/**
+ * @brief 判断块当前是否为空 (Check whether the block is currently empty).
+ * @param block 目标块类型 (Target block type).
+ * @return 若块内没有有效键则返回 `true`
+ *         (Returns `true` when the block contains no valid key).
+ * @note 这里的“空”指只有初始化哨兵，没有任何可发布的用户键。
+ *       Here, "empty" means the block contains only the initialized sentinel
+ *       and no publishable user key.
+ */
+bool IsBlockEmpty(BlockType block)
+{
+  const size_t offset = GetBlockOffset(block);
+  FlashInfo flash_data;
+  ReadFlashOrExit(offset, flash_data);
+  return BlockBoolUtil<MinWriteSize>::ReadFlag(flash_data.key.available_flag) == true;
+}
+
+/**
+ * @brief 判断块尾校验是否损坏 (Check whether the block checksum is corrupted).
+ * @param block 目标块类型 (Target block type).
+ * @return 若块尾校验不符则返回 `true`
+ *         (Returns `true` when the trailing checksum is invalid).
+ */
+bool IsBlockError(BlockType block)
+{
+  const size_t offset = GetBlockOffset(block);
+  uint32_t checksum = 0;
+  ReadFlashOrExit(offset + GetChecksumOffset(), checksum);
+  return checksum != CHECKSUM_BYTE;
+}
+
+/**
+ * @brief 判断块整体是否处于可用状态
+ *        (Check whether the block as a whole is currently usable).
+ * @param block 目标块类型 (Target block type).
+ * @return 若块头和校验都有效则返回 `true`
+ *         (Returns `true` when both header and checksum are valid).
+ */
+bool IsBlockValid(BlockType block)
+{
+  return IsBlockInited(block) && !IsBlockError(block);
+}
+
+/**
+ * @brief 使指定块尾校验失效 (Invalidate the checksum of one block).
+ * @param block 目标块类型 (Target block type).
+ */
+void InvalidateBlock(BlockType block)
+{
+  const uint32_t invalid_checksum = 0;
+  // Keep startup cleanup erase-free so same-bank MCUs only pay a single program op.
+  WriteFlashOrExit(GetBlockOffset(block) + GetChecksumOffset(),
+                   {&invalid_checksum, sizeof(invalid_checksum)});
+}
+
+/**
+ * @brief 试算一个块里已用空间，并在发现布局损坏时提前失败
+ *        (Try to compute used block size and fail early on invalid layout).
+ * @param block 目标块类型 (Target block type).
+ * @param used_size 输出已用字节数 (Receives the used byte size).
+ * @return 若成功计算则返回 `true`
+ *         (Returns `true` when the used size is computed successfully).
+ * @note 这个版本给恢复路径用；它不会假设块内键布局一定合法，而是逐步验证每个键头的
+ *       位图编码和边界。
+ *       This variant is used by recovery paths; it does not assume the key
+ *       layout is valid and instead verifies each key header's bitmap
+ *       encoding and bounds incrementally.
+ */
+bool TryGetUsedBlockSize(BlockType block, size_t& used_size)
+{
+  const size_t block_offset = GetBlockOffset(block);
+  const size_t checksum_offset = block_offset + GetChecksumOffset();
+  size_t key_offset = block_offset + LibXR::OffsetOf(&FlashInfo::key);
+
+  while (true)
   {
-    return GetChecksumOffset() - GetUsedBlockSize(BlockType::MAIN);
-  }
-
-  /**
-   * @brief 计算指定块的起始偏移 (Compute the starting offset of one block).
-   * @param block 目标块类型 (Target block type).
-   * @return 块起始偏移 (Starting offset of the block).
-   */
-  size_t GetBlockOffset(BlockType block)
-  {
-    return block == BlockType::BACKUP ? block_size_ : 0;
-  }
-
-  /**
-   * @brief 计算块尾校验区起始偏移 (Compute the starting offset of the checksum area).
-   * @return 块尾校验区起始偏移 (Starting offset of the checksum area).
-   */
-  size_t GetChecksumOffset() { return block_size_ - GetChecksumSize(); }
-
-  /**
-   * @brief 计算块尾校验区字节数 (Compute the byte size of the checksum area).
-   * @return 块尾校验区字节数 (Byte size of the checksum area).
-   */
-  size_t GetChecksumSize() { return AlignSize(sizeof(CHECKSUM_BYTE)); }
-
-  /**
-   * @brief 把指定块初始化为空数据库块 (Initialize one block as an empty database block).
-   * @param block 目标块类型 (Target block type).
-   * @note 初始化后的块是“结构合法但没有任何用户键”的空块：块头有效、首个哨兵键有效、
-   *       尾校验有效。
-   *       After initialization, the block is a structurally valid empty block:
-   *       valid header, valid sentinel key, and valid trailing checksum.
-   */
-  void InitBlock(BlockType block)
-  {
-    const size_t offset = GetBlockOffset(block);
-    EraseFlashOrExit(offset, block_size_);
-
-    FlashInfo info;  // padding filled with 0xFF by constructor
-    info.header = FLASH_HEADER;
-    KeyInfo& tmp_key = info.key;
-    BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.no_next_key, true);
-    BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.available_flag, true);
-    BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.uninit, false);
-    tmp_key.SetNameLength(0);
-    tmp_key.SetDataSize(0);
-    WriteFlashOrExit(offset, {reinterpret_cast<uint8_t*>(&info), sizeof(FlashInfo)});
-    WriteFlashOrExit(offset + GetChecksumOffset(),
-                     {&CHECKSUM_BYTE, sizeof(CHECKSUM_BYTE)});
-  }
-
-  /**
-   * @brief 判断块头是否已初始化 (Check whether the block header is initialized).
-   * @param block 目标块类型 (Target block type).
-   * @return 若块头有效则返回 `true` (Returns `true` when the block header is valid).
-   */
-  bool IsBlockInited(BlockType block)
-  {
-    const size_t offset = GetBlockOffset(block);
-    FlashInfo flash_data;
-    ReadFlashOrExit(offset, flash_data);
-    return flash_data.header == FLASH_HEADER;
-  }
-
-  /**
-   * @brief 判断块当前是否为空 (Check whether the block is currently empty).
-   * @param block 目标块类型 (Target block type).
-   * @return 若块内没有有效键则返回 `true`
-   *         (Returns `true` when the block contains no valid key).
-   * @note 这里的“空”指只有初始化哨兵，没有任何可发布的用户键。
-   *       Here, "empty" means the block contains only the initialized sentinel
-   *       and no publishable user key.
-   */
-  bool IsBlockEmpty(BlockType block)
-  {
-    const size_t offset = GetBlockOffset(block);
-    FlashInfo flash_data;
-    ReadFlashOrExit(offset, flash_data);
-    return BlockBoolUtil<MinWriteSize>::ReadFlag(flash_data.key.available_flag) == true;
-  }
-
-  /**
-   * @brief 判断块尾校验是否损坏 (Check whether the block checksum is corrupted).
-   * @param block 目标块类型 (Target block type).
-   * @return 若块尾校验不符则返回 `true`
-   *         (Returns `true` when the trailing checksum is invalid).
-   */
-  bool IsBlockError(BlockType block)
-  {
-    const size_t offset = GetBlockOffset(block);
-    uint32_t checksum = 0;
-    ReadFlashOrExit(offset + GetChecksumOffset(), checksum);
-    return checksum != CHECKSUM_BYTE;
-  }
-
-  /**
-   * @brief 判断块整体是否处于可用状态
-   *        (Check whether the block as a whole is currently usable).
-   * @param block 目标块类型 (Target block type).
-   * @return 若块头和校验都有效则返回 `true`
-   *         (Returns `true` when both header and checksum are valid).
-   */
-  bool IsBlockValid(BlockType block)
-  {
-    return IsBlockInited(block) && !IsBlockError(block);
-  }
-
-  /**
-   * @brief 使指定块尾校验失效 (Invalidate the checksum of one block).
-   * @param block 目标块类型 (Target block type).
-   */
-  void InvalidateBlock(BlockType block)
-  {
-    const uint32_t invalid_checksum = 0;
-    // Keep startup cleanup erase-free so same-bank MCUs only pay a single program op.
-    WriteFlashOrExit(GetBlockOffset(block) + GetChecksumOffset(),
-                     {&invalid_checksum, sizeof(invalid_checksum)});
-  }
-
-  /**
-   * @brief 试算一个块里已用空间，并在发现布局损坏时提前失败
-   *        (Try to compute used block size and fail early on invalid layout).
-   * @param block 目标块类型 (Target block type).
-   * @param used_size 输出已用字节数 (Receives the used byte size).
-   * @return 若成功计算则返回 `true`
-   *         (Returns `true` when the used size is computed successfully).
-   * @note 这个版本给恢复路径用；它不会假设块内键布局一定合法，而是逐步验证每个键头的
-   *       位图编码和边界。
-   *       This variant is used by recovery paths; it does not assume the key
-   *       layout is valid and instead verifies each key header's bitmap
-   *       encoding and bounds incrementally.
-   */
-  bool TryGetUsedBlockSize(BlockType block, size_t& used_size)
-  {
-    const size_t block_offset = GetBlockOffset(block);
-    const size_t checksum_offset = block_offset + GetChecksumOffset();
-    size_t key_offset = block_offset + LibXR::OffsetOf(&FlashInfo::key);
-
-    while (true)
+    if (key_offset + AlignSize(sizeof(KeyInfo)) > checksum_offset)
     {
-      if (key_offset + AlignSize(sizeof(KeyInfo)) > checksum_offset)
-      {
-        return false;
-      }
-
-      KeyInfo key;
-      ReadFlashOrExit(key_offset, key);
-
-      // Recovery cannot trust erased or half-written key metadata to bound copies.
-      if (!BlockBoolUtil<MinWriteSize>::Valid(key.no_next_key) ||
-          !BlockBoolUtil<MinWriteSize>::Valid(key.available_flag) ||
-          !BlockBoolUtil<MinWriteSize>::Valid(key.uninit))
-      {
-        return false;
-      }
-
-      const size_t next_key_offset =
-          key_offset + AlignSize(sizeof(KeyInfo)) + AlignSize(key.GetNameLength()) +
-          AlignSize(key.GetDataSize());
-      if (next_key_offset > checksum_offset)
-      {
-        return false;
-      }
-
-      if (BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key))
-      {
-        used_size = next_key_offset - block_offset;
-        return true;
-      }
-
-      key_offset = next_key_offset;
-    }
-  }
-
-  /**
-   * @brief 计算一个块当前已用的总字节数 (Compute the currently used byte span of one block).
-   * @param block 目标块类型 (Target block type).
-   * @return 当前已用的总字节数 (Currently used byte span of the block).
-   */
-  size_t GetUsedBlockSize(BlockType block)
-  {
-    const size_t block_offset = GetBlockOffset(block);
-    const size_t first_key_offset = block_offset + LibXR::OffsetOf(&FlashInfo::key);
-
-    if (IsBlockEmpty(block))
-    {
-      return GetNextKey(first_key_offset) - block_offset;
+      return false;
     }
 
-    return GetNextKey(GetLastKey(block)) - block_offset;
-  }
+    KeyInfo key;
+    ReadFlashOrExit(key_offset, key);
 
-  /**
-   * @brief 复制活跃键前缀和块尾校验 (Copy the live key prefix and trailing checksum).
-   * @param dst_block 目标块类型 (Destination block type).
-   * @param src_block 源块类型 (Source block type).
-   * @param used_size 活跃前缀总字节数 (Byte size of the live prefix).
-   * @note 已擦除尾部不参与复制；只要活跃前缀和块尾校验能重建块语义就够了。
-   *       The erased tail is not copied; reproducing the live prefix plus the
-   *       trailing checksum is sufficient to rebuild the block semantics.
-   */
-  void CopyBlockPrefixAndChecksum(BlockType dst_block, BlockType src_block,
-                                  size_t used_size)
+    // Recovery cannot trust erased or half-written key metadata to bound copies.
+    if (!BlockBoolUtil<MinWriteSize>::Valid(key.no_next_key) ||
+        !BlockBoolUtil<MinWriteSize>::Valid(key.available_flag) ||
+        !BlockBoolUtil<MinWriteSize>::Valid(key.uninit))
+    {
+      return false;
+    }
+
+    const size_t next_key_offset = key_offset + AlignSize(sizeof(KeyInfo)) +
+                                   AlignSize(key.GetNameLength()) +
+                                   AlignSize(key.GetDataSize());
+    if (next_key_offset > checksum_offset)
+    {
+      return false;
+    }
+
+    if (BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key))
+    {
+      used_size = next_key_offset - block_offset;
+      return true;
+    }
+
+    key_offset = next_key_offset;
+  }
+}
+
+/**
+ * @brief 计算一个块当前已用的总字节数 (Compute the currently used byte span of one
+ * block).
+ * @param block 目标块类型 (Target block type).
+ * @return 当前已用的总字节数 (Currently used byte span of the block).
+ */
+size_t GetUsedBlockSize(BlockType block)
+{
+  const size_t block_offset = GetBlockOffset(block);
+  const size_t first_key_offset = block_offset + LibXR::OffsetOf(&FlashInfo::key);
+
+  if (IsBlockEmpty(block))
   {
-    const size_t dst_offset = GetBlockOffset(dst_block);
-    const size_t src_offset = GetBlockOffset(src_block);
-    const size_t checksum_offset = GetChecksumOffset();
-
-    ASSERT(used_size <= checksum_offset);
-    // Only the live key prefix and checksum are needed; erased tail bytes are irrelevant.
-    CopyFlashData(dst_offset, src_offset, used_size);
-    CopyFlashData(dst_offset + checksum_offset, src_offset + checksum_offset,
-                  GetChecksumSize());
+    return GetNextKey(first_key_offset) - block_offset;
   }
+
+  return GetNextKey(GetLastKey(block)) - block_offset;
+}
+
+/**
+ * @brief 复制活跃键前缀和块尾校验 (Copy the live key prefix and trailing checksum).
+ * @param dst_block 目标块类型 (Destination block type).
+ * @param src_block 源块类型 (Source block type).
+ * @param used_size 活跃前缀总字节数 (Byte size of the live prefix).
+ * @note 已擦除尾部不参与复制；只要活跃前缀和块尾校验能重建块语义就够了。
+ *       The erased tail is not copied; reproducing the live prefix plus the
+ *       trailing checksum is sufficient to rebuild the block semantics.
+ */
+void CopyBlockPrefixAndChecksum(BlockType dst_block, BlockType src_block,
+                                size_t used_size)
+{
+  const size_t dst_offset = GetBlockOffset(dst_block);
+  const size_t src_offset = GetBlockOffset(src_block);
+  const size_t checksum_offset = GetChecksumOffset();
+
+  ASSERT(used_size <= checksum_offset);
+  // Only the live key prefix and checksum are needed; erased tail bytes are irrelevant.
+  CopyFlashData(dst_offset, src_offset, used_size);
+  CopyFlashData(dst_offset + checksum_offset, src_offset + checksum_offset,
+                GetChecksumSize());
+}

--- a/src/middleware/database/raw/flash_io.hpp
+++ b/src/middleware/database/raw/flash_io.hpp
@@ -1,136 +1,136 @@
-  /**
-   * @brief `DatabaseRaw` 的底层 Flash IO 片段 / Low-level Flash-I/O fragment of
-   *        `DatabaseRaw`
-   *
-   * @note 这一组函数只处理“怎么按最小写入单元安全读写 Flash”，不负责数据库条目或
-   *       块级语义。
-   *       This group handles only "how to read and write Flash safely under
-   *       the minimum write-unit rule"; it does not own database-entry or
-   *       block-level semantics.
-   */
+/**
+ * @brief `DatabaseRaw` 的底层 Flash IO 片段 / Low-level Flash-I/O fragment of
+ *        `DatabaseRaw`
+ *
+ * @note 这一组函数只处理“怎么按最小写入单元安全读写 Flash”，不负责数据库条目或
+ *       块级语义。
+ *       This group handles only "how to read and write Flash safely under
+ *       the minimum write-unit rule"; it does not own database-entry or
+ *       block-level semantics.
+ */
 
-  /**
-   * @brief 读取 Flash 数据，失败则直接触发强约束
-   *        (Read flash data and fail fast on error).
-   * @param offset 读取偏移 (Read offset).
-   * @param data 接收数据的缓冲区 (Destination buffer receiving the data).
-   */
-  void ReadFlashOrExit(size_t offset, RawData data)
+/**
+ * @brief 读取 Flash 数据，失败则直接触发强约束
+ *        (Read flash data and fail fast on error).
+ * @param offset 读取偏移 (Read offset).
+ * @param data 接收数据的缓冲区 (Destination buffer receiving the data).
+ */
+void ReadFlashOrExit(size_t offset, RawData data)
+{
+  REQUIRE(flash_.Read(offset, data) == ErrorCode::OK);
+}
+
+/**
+ * @brief 读取 Flash 数据到对象里，失败则直接触发强约束
+ *        (Read flash data into one object and fail fast on error).
+ * @tparam Data 接收对象类型 (Destination object type).
+ * @param offset 读取偏移 (Read offset).
+ * @param data 接收数据的对象 (Destination object receiving the data).
+ */
+template <typename Data>
+void ReadFlashOrExit(size_t offset, Data& data)
+{
+  ReadFlashOrExit(offset, RawData(data));
+}
+
+/**
+ * @brief 写入 Flash 数据，失败则直接触发强约束
+ *        (Write flash data and fail fast on error).
+ * @param offset 写入偏移 (Write offset).
+ * @param data 待写入数据 (Data to write).
+ */
+void WriteFlashOrExit(size_t offset, ConstRawData data)
+{
+  REQUIRE(Write(offset, data) == ErrorCode::OK);
+}
+
+/**
+ * @brief 写入一个对象到 Flash，失败则直接触发强约束
+ *        (Write one object to flash and fail fast on error).
+ * @tparam Data 待写入对象类型 (Object type to write).
+ * @param offset 写入偏移 (Write offset).
+ * @param data 待写入对象 (Object to write).
+ */
+template <typename Data>
+void WriteFlashOrExit(size_t offset, const Data& data)
+{
+  WriteFlashOrExit(offset, ConstRawData(data));
+}
+
+/**
+ * @brief 擦除 Flash 区域，失败则直接触发强约束
+ *        (Erase a flash range and fail fast on error).
+ * @param offset 擦除偏移 (Erase offset).
+ * @param size 擦除字节数 (Erase size in bytes).
+ */
+void EraseFlashOrExit(size_t offset, size_t size)
+{
+  REQUIRE(flash_.Erase(offset, size) == ErrorCode::OK);
+}
+
+/**
+ * @brief 在两个块之间按最小写入单元复制数据
+ *        (Copy data between blocks in minimum-write-size chunks).
+ * @param dst_offset 目标偏移 (Destination offset).
+ * @param src_offset 源偏移 (Source offset).
+ * @param size 待复制字节数 (Byte count to copy).
+ */
+void CopyFlashData(size_t dst_offset, size_t src_offset, size_t size)
+{
+  for (size_t i = 0; i < size; i += MinWriteSize)
   {
-    REQUIRE(flash_.Read(offset, data) == ErrorCode::OK);
+    ReadFlashOrExit(src_offset + i, {write_buffer_, MinWriteSize});
+    WriteFlashOrExit(dst_offset + i, {write_buffer_, MinWriteSize});
+  }
+}
+
+/**
+ * @brief 计算对齐后的大小
+ *        (Calculate the aligned size).
+ * @param size 需要对齐的大小 (Size to align).
+ * @return 对齐后的大小 (Aligned size).
+ */
+size_t AlignSize(size_t size)
+{
+  return static_cast<size_t>((size + MinWriteSize - 1) / MinWriteSize) * MinWriteSize;
+}
+
+/**
+ * @brief 以最小写入单元对齐的方式写入数据
+ *        (Write data aligned to the minimum write unit).
+ * @param offset 写入偏移量 (Write offset).
+ * @param data 要写入的数据 (Data to write).
+ * @return 操作结果 (Operation result).
+ * @note 当末尾不足一个最小写入单元时，当前实现会用 `0xFF` 补齐尾块后再写入。
+ *       When the tail is shorter than one minimum write unit, the current
+ *       implementation pads that final unit with `0xFF` before writing it.
+ */
+ErrorCode Write(size_t offset, ConstRawData data)
+{
+  if (data.size_ == 0)
+  {
+    return ErrorCode::OK;
   }
 
-  /**
-   * @brief 读取 Flash 数据到对象里，失败则直接触发强约束
-   *        (Read flash data into one object and fail fast on error).
-   * @tparam Data 接收对象类型 (Destination object type).
-   * @param offset 读取偏移 (Read offset).
-   * @param data 接收数据的对象 (Destination object receiving the data).
-   */
-  template <typename Data>
-  void ReadFlashOrExit(size_t offset, Data& data)
+  if (data.size_ % MinWriteSize == 0)
   {
-    ReadFlashOrExit(offset, RawData(data));
+    return flash_.Write(offset, data);
   }
-
-  /**
-   * @brief 写入 Flash 数据，失败则直接触发强约束
-   *        (Write flash data and fail fast on error).
-   * @param offset 写入偏移 (Write offset).
-   * @param data 待写入数据 (Data to write).
-   */
-  void WriteFlashOrExit(size_t offset, ConstRawData data)
+  else
   {
-    REQUIRE(Write(offset, data) == ErrorCode::OK);
-  }
-
-  /**
-   * @brief 写入一个对象到 Flash，失败则直接触发强约束
-   *        (Write one object to flash and fail fast on error).
-   * @tparam Data 待写入对象类型 (Object type to write).
-   * @param offset 写入偏移 (Write offset).
-   * @param data 待写入对象 (Object to write).
-   */
-  template <typename Data>
-  void WriteFlashOrExit(size_t offset, const Data& data)
-  {
-    WriteFlashOrExit(offset, ConstRawData(data));
-  }
-
-  /**
-   * @brief 擦除 Flash 区域，失败则直接触发强约束
-   *        (Erase a flash range and fail fast on error).
-   * @param offset 擦除偏移 (Erase offset).
-   * @param size 擦除字节数 (Erase size in bytes).
-   */
-  void EraseFlashOrExit(size_t offset, size_t size)
-  {
-    REQUIRE(flash_.Erase(offset, size) == ErrorCode::OK);
-  }
-
-  /**
-   * @brief 在两个块之间按最小写入单元复制数据
-   *        (Copy data between blocks in minimum-write-size chunks).
-   * @param dst_offset 目标偏移 (Destination offset).
-   * @param src_offset 源偏移 (Source offset).
-   * @param size 待复制字节数 (Byte count to copy).
-   */
-  void CopyFlashData(size_t dst_offset, size_t src_offset, size_t size)
-  {
-    for (size_t i = 0; i < size; i += MinWriteSize)
+    auto final_block_index = data.size_ - data.size_ % MinWriteSize;
+    if (final_block_index != 0)
     {
-      ReadFlashOrExit(src_offset + i, {write_buffer_, MinWriteSize});
-      WriteFlashOrExit(dst_offset + i, {write_buffer_, MinWriteSize});
-    }
-  }
-
-  /**
-   * @brief 计算对齐后的大小
-   *        (Calculate the aligned size).
-   * @param size 需要对齐的大小 (Size to align).
-   * @return 对齐后的大小 (Aligned size).
-   */
-  size_t AlignSize(size_t size)
-  {
-    return static_cast<size_t>((size + MinWriteSize - 1) / MinWriteSize) * MinWriteSize;
-  }
-
-  /**
-   * @brief 以最小写入单元对齐的方式写入数据
-   *        (Write data aligned to the minimum write unit).
-   * @param offset 写入偏移量 (Write offset).
-   * @param data 要写入的数据 (Data to write).
-   * @return 操作结果 (Operation result).
-   * @note 当末尾不足一个最小写入单元时，当前实现会用 `0xFF` 补齐尾块后再写入。
-   *       When the tail is shorter than one minimum write unit, the current
-   *       implementation pads that final unit with `0xFF` before writing it.
-   */
-  ErrorCode Write(size_t offset, ConstRawData data)
-  {
-    if (data.size_ == 0)
-    {
-      return ErrorCode::OK;
-    }
-
-    if (data.size_ % MinWriteSize == 0)
-    {
-      return flash_.Write(offset, data);
-    }
-    else
-    {
-      auto final_block_index = data.size_ - data.size_ % MinWriteSize;
-      if (final_block_index != 0)
+      auto ec = flash_.Write(offset, {data.addr_, final_block_index});
+      if (ec != ErrorCode::OK)
       {
-        auto ec = flash_.Write(offset, {data.addr_, final_block_index});
-        if (ec != ErrorCode::OK)
-        {
-          return ec;
-        }
+        return ec;
       }
-      Memory::FastSet(write_buffer_, 0xff, MinWriteSize);
-      LibXR::Memory::FastCopy(
-          write_buffer_, reinterpret_cast<const uint8_t*>(data.addr_) + final_block_index,
-          data.size_ % MinWriteSize);
-      return flash_.Write(offset + final_block_index, {write_buffer_, MinWriteSize});
     }
+    Memory::FastSet(write_buffer_, 0xff, MinWriteSize);
+    LibXR::Memory::FastCopy(
+        write_buffer_, reinterpret_cast<const uint8_t*>(data.addr_) + final_block_index,
+        data.size_ % MinWriteSize);
+    return flash_.Write(offset + final_block_index, {write_buffer_, MinWriteSize});
   }
+}

--- a/src/middleware/database/raw/key_ops.hpp
+++ b/src/middleware/database/raw/key_ops.hpp
@@ -1,389 +1,388 @@
-  /**
-   * @brief `DatabaseRaw` 的键级操作片段 / Key-operation fragment of `DatabaseRaw`
-   *
-   * @note 这一组函数只负责单个键条目的语义：地址计算、名称比较、数据比较、逻辑追加、
-   *       以及按名称查找。
-   *       This group owns only per-entry semantics: address calculations, name
-   *       comparisons, data comparisons, logical appends, and name-based
-   *       lookup.
-   */
+/**
+ * @brief `DatabaseRaw` 的键级操作片段 / Key-operation fragment of `DatabaseRaw`
+ *
+ * @note 这一组函数只负责单个键条目的语义：地址计算、名称比较、数据比较、逻辑追加、
+ *       以及按名称查找。
+ *       This group owns only per-entry semantics: address calculations, name
+ *       comparisons, data comparisons, logical appends, and name-based
+ *       lookup.
+ */
 
-  /**
-   * @brief 为新增键预留空间并写入元数据头
-   *        (Reserve space for one new key and write its metadata header).
-   * @param name_len 键名长度 (Key name length).
-   * @param size 数据字节数 (Payload size in bytes).
-   * @param key_buf_offset 返回新键头偏移 (Receives the new key-header offset).
-   * @return 操作结果 (Operation result).
-   * @note 这个阶段只负责把新键头放到主块尾部，并在必要时把上一键改成“后面还有下一键”；
-   *       名字区和数据区由调用方随后写入。
-   *       This stage only places the new key header at the tail of the main
-   *       block and, when needed, rewrites the previous key into "has next
-   *       key"; the name bytes and payload bytes are written by the caller
-   *       afterwards.
-   */
-  ErrorCode AddKeyBody(size_t name_len, size_t size, size_t& key_buf_offset)
+/**
+ * @brief 为新增键预留空间并写入元数据头
+ *        (Reserve space for one new key and write its metadata header).
+ * @param name_len 键名长度 (Key name length).
+ * @param size 数据字节数 (Payload size in bytes).
+ * @param key_buf_offset 返回新键头偏移 (Receives the new key-header offset).
+ * @return 操作结果 (Operation result).
+ * @note 这个阶段只负责把新键头放到主块尾部，并在必要时把上一键改成“后面还有下一键”；
+ *       名字区和数据区由调用方随后写入。
+ *       This stage only places the new key header at the tail of the main
+ *       block and, when needed, rewrites the previous key into "has next
+ *       key"; the name bytes and payload bytes are written by the caller
+ *       afterwards.
+ */
+ErrorCode AddKeyBody(size_t name_len, size_t size, size_t& key_buf_offset)
+{
+  bool recycle = false;
+add_again:
+  size_t last_key_offset = GetLastKey(BlockType::MAIN);
+  key_buf_offset = 0;
+
+  if (AvailableSize() <
+      AlignSize(sizeof(KeyInfo)) + AlignSize(name_len) + AlignSize(size))
   {
-    bool recycle = false;
-  add_again:
-    size_t last_key_offset = GetLastKey(BlockType::MAIN);
-    key_buf_offset = 0;
-
-    if (AvailableSize() <
-        AlignSize(sizeof(KeyInfo)) + AlignSize(name_len) + AlignSize(size))
+    if (!recycle)
     {
-      if (!recycle)
-      {
-        Recycle();
-        recycle = true;
-        // NOLINTNEXTLINE
-        goto add_again;
-      }
-      else
-      {
-        ASSERT(false);
-        return ErrorCode::FULL;
-      }
-    }
-
-    if (last_key_offset == 0)
-    {
-      FlashInfo flash_info;
-      flash_info.header = FLASH_HEADER;
-      KeyInfo& tmp_key = flash_info.key;
-      BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.no_next_key, false);
-      BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.available_flag, false);
-      BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.uninit, false);
-      tmp_key.SetNameLength(0);
-      tmp_key.SetDataSize(0);
-      WriteFlashOrExit(0, flash_info);
-      key_buf_offset = GetNextKey(LibXR::OffsetOf(&FlashInfo::key));
+      Recycle();
+      recycle = true;
+      // NOLINTNEXTLINE
+      goto add_again;
     }
     else
     {
-      key_buf_offset = GetNextKey(last_key_offset);
+      ASSERT(false);
+      return ErrorCode::FULL;
     }
-
-    KeyInfo new_key = {};
-    BlockBoolUtil<MinWriteSize>::SetFlag(new_key.no_next_key, true);
-    BlockBoolUtil<MinWriteSize>::SetFlag(new_key.available_flag, true);
-    BlockBoolUtil<MinWriteSize>::SetFlag(new_key.uninit, true);
-    new_key.SetNameLength(name_len);
-    new_key.SetDataSize(size);
-
-    WriteFlashOrExit(key_buf_offset, new_key);
-    BlockBoolUtil<MinWriteSize>::SetFlag(new_key.uninit, false);
-
-    if (last_key_offset != 0)
-    {
-      KeyInfo last_key;
-      ReadFlashOrExit(last_key_offset, last_key);
-      KeyInfo new_last_key = {};
-      BlockBoolUtil<MinWriteSize>::SetFlag(new_last_key.no_next_key, false);
-      BlockBoolUtil<MinWriteSize>::SetFlag(
-          new_last_key.available_flag,
-          BlockBoolUtil<MinWriteSize>::ReadFlag(last_key.available_flag));
-      BlockBoolUtil<MinWriteSize>::SetFlag(
-          new_last_key.uninit, BlockBoolUtil<MinWriteSize>::ReadFlag(last_key.uninit));
-      new_last_key.SetNameLength(last_key.GetNameLength());
-      new_last_key.SetDataSize(last_key.GetDataSize());
-
-      WriteFlashOrExit(last_key_offset, new_last_key);
-    }
-
-    WriteFlashOrExit(key_buf_offset, new_key);
-
-    return ErrorCode::OK;
   }
 
-  /**
-   * @brief 使用现有名字数据新增一个键
-   *        (Add one key using an existing name already stored in flash).
-   * @param name_offset 已存键名在 Flash 中的偏移 (Flash offset of the already stored name).
-   * @param name_len 键名长度 (Key name length).
-   * @param data 键数据地址 (Address of the key payload).
-   * @param size 键数据字节数 (Payload size in bytes).
-   * @return 操作结果 (Operation result).
-   * @note 这个重载给“逻辑更新旧键、但复用旧名字字节”那条路径使用。
-   *       This overload is used by the logical-update path that reuses the
-   *       existing key-name bytes already stored in Flash.
-   */
-  ErrorCode AddKey(size_t name_offset, size_t name_len, const void* data, size_t size)
+  if (last_key_offset == 0)
   {
-    size_t key_buf_offset = 0;
-    ErrorCode ec = AddKeyBody(name_len, size, key_buf_offset);
-    if (ec != ErrorCode::OK)
-    {
-      return ec;
-    }
-    CopyFlashData(GetKeyName(key_buf_offset), name_offset, name_len);
-    WriteFlashOrExit(GetKeyData(key_buf_offset),
-                     {reinterpret_cast<const uint8_t*>(data), size});
-    return ErrorCode::OK;
+    FlashInfo flash_info;
+    flash_info.header = FLASH_HEADER;
+    KeyInfo& tmp_key = flash_info.key;
+    BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.no_next_key, false);
+    BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.available_flag, false);
+    BlockBoolUtil<MinWriteSize>::SetFlag(tmp_key.uninit, false);
+    tmp_key.SetNameLength(0);
+    tmp_key.SetDataSize(0);
+    WriteFlashOrExit(0, flash_info);
+    key_buf_offset = GetNextKey(LibXR::OffsetOf(&FlashInfo::key));
+  }
+  else
+  {
+    key_buf_offset = GetNextKey(last_key_offset);
   }
 
-  /**
-   * @brief 按名称新增一个键 (Add one key by name).
-   * @param name 键名 (Key name).
-   * @param data 键数据地址 (Address of the key payload).
-   * @param size 键数据字节数 (Payload size in bytes).
-   * @return 操作结果 (Operation result).
-   */
-  ErrorCode AddKey(const char* name, const void* data, size_t size)
+  KeyInfo new_key = {};
+  BlockBoolUtil<MinWriteSize>::SetFlag(new_key.no_next_key, true);
+  BlockBoolUtil<MinWriteSize>::SetFlag(new_key.available_flag, true);
+  BlockBoolUtil<MinWriteSize>::SetFlag(new_key.uninit, true);
+  new_key.SetNameLength(name_len);
+  new_key.SetDataSize(size);
+
+  WriteFlashOrExit(key_buf_offset, new_key);
+  BlockBoolUtil<MinWriteSize>::SetFlag(new_key.uninit, false);
+
+  if (last_key_offset != 0)
   {
-    size_t name_len = strlen(name) + 1;
-    if (auto ans = SearchKey(name))
-    {
-      return SetKey(name, data, size);
-    }
-    size_t key_buf_offset = 0;
-    ErrorCode ec = AddKeyBody(name_len, size, key_buf_offset);
-    if (ec != ErrorCode::OK)
-    {
-      return ec;
-    }
-    WriteFlashOrExit(GetKeyName(key_buf_offset),
-                     {reinterpret_cast<const uint8_t*>(name), name_len});
-    WriteFlashOrExit(GetKeyData(key_buf_offset),
-                     {reinterpret_cast<const uint8_t*>(data), size});
-    return ErrorCode::OK;
+    KeyInfo last_key;
+    ReadFlashOrExit(last_key_offset, last_key);
+    KeyInfo new_last_key = {};
+    BlockBoolUtil<MinWriteSize>::SetFlag(new_last_key.no_next_key, false);
+    BlockBoolUtil<MinWriteSize>::SetFlag(
+        new_last_key.available_flag,
+        BlockBoolUtil<MinWriteSize>::ReadFlag(last_key.available_flag));
+    BlockBoolUtil<MinWriteSize>::SetFlag(
+        new_last_key.uninit, BlockBoolUtil<MinWriteSize>::ReadFlag(last_key.uninit));
+    new_last_key.SetNameLength(last_key.GetNameLength());
+    new_last_key.SetDataSize(last_key.GetDataSize());
+
+    WriteFlashOrExit(last_key_offset, new_last_key);
   }
 
-  /**
-   * @brief 按名称更新一个键，并在需要时触发回收
-   *        (Update one key by name and recycle storage when needed).
-   * @param name 键名 (Key name).
-   * @param data 新数据地址 (Address of the new payload).
-   * @param size 新数据字节数 (Payload size in bytes).
-   * @param recycle 是否允许本次调用触发回收
-   *                (Whether this call may trigger recycle).
-   * @return 操作结果 (Operation result).
-   * @note 当前实现只支持“同名且同尺寸”的逻辑更新；尺寸不一致时直接返回
-   *       `ErrorCode::FAILED`，不会自动改写布局。
-   *       The current implementation supports only logical replacement of the
-   *       same named key with the same payload size; when the size differs, it
-   *       returns `ErrorCode::FAILED` directly and does not rewrite the
-   *       on-flash layout automatically.
-   */
-  ErrorCode SetKey(const char* name, const void* data, size_t size, bool recycle = true)
+  WriteFlashOrExit(key_buf_offset, new_key);
+
+  return ErrorCode::OK;
+}
+
+/**
+ * @brief 使用现有名字数据新增一个键
+ *        (Add one key using an existing name already stored in flash).
+ * @param name_offset 已存键名在 Flash 中的偏移 (Flash offset of the already stored name).
+ * @param name_len 键名长度 (Key name length).
+ * @param data 键数据地址 (Address of the key payload).
+ * @param size 键数据字节数 (Payload size in bytes).
+ * @return 操作结果 (Operation result).
+ * @note 这个重载给“逻辑更新旧键、但复用旧名字字节”那条路径使用。
+ *       This overload is used by the logical-update path that reuses the
+ *       existing key-name bytes already stored in Flash.
+ */
+ErrorCode AddKey(size_t name_offset, size_t name_len, const void* data, size_t size)
+{
+  size_t key_buf_offset = 0;
+  ErrorCode ec = AddKeyBody(name_len, size, key_buf_offset);
+  if (ec != ErrorCode::OK)
   {
-    size_t key_offset = SearchKey(name);
-    if (key_offset)
+    return ec;
+  }
+  CopyFlashData(GetKeyName(key_buf_offset), name_offset, name_len);
+  WriteFlashOrExit(GetKeyData(key_buf_offset),
+                   {reinterpret_cast<const uint8_t*>(data), size});
+  return ErrorCode::OK;
+}
+
+/**
+ * @brief 按名称新增一个键 (Add one key by name).
+ * @param name 键名 (Key name).
+ * @param data 键数据地址 (Address of the key payload).
+ * @param size 键数据字节数 (Payload size in bytes).
+ * @return 操作结果 (Operation result).
+ */
+ErrorCode AddKey(const char* name, const void* data, size_t size)
+{
+  size_t name_len = strlen(name) + 1;
+  if (auto ans = SearchKey(name))
+  {
+    return SetKey(name, data, size);
+  }
+  size_t key_buf_offset = 0;
+  ErrorCode ec = AddKeyBody(name_len, size, key_buf_offset);
+  if (ec != ErrorCode::OK)
+  {
+    return ec;
+  }
+  WriteFlashOrExit(GetKeyName(key_buf_offset),
+                   {reinterpret_cast<const uint8_t*>(name), name_len});
+  WriteFlashOrExit(GetKeyData(key_buf_offset),
+                   {reinterpret_cast<const uint8_t*>(data), size});
+  return ErrorCode::OK;
+}
+
+/**
+ * @brief 按名称更新一个键，并在需要时触发回收
+ *        (Update one key by name and recycle storage when needed).
+ * @param name 键名 (Key name).
+ * @param data 新数据地址 (Address of the new payload).
+ * @param size 新数据字节数 (Payload size in bytes).
+ * @param recycle 是否允许本次调用触发回收
+ *                (Whether this call may trigger recycle).
+ * @return 操作结果 (Operation result).
+ * @note 当前实现只支持“同名且同尺寸”的逻辑更新；尺寸不一致时直接返回
+ *       `ErrorCode::FAILED`，不会自动改写布局。
+ *       The current implementation supports only logical replacement of the
+ *       same named key with the same payload size; when the size differs, it
+ *       returns `ErrorCode::FAILED` directly and does not rewrite the
+ *       on-flash layout automatically.
+ */
+ErrorCode SetKey(const char* name, const void* data, size_t size, bool recycle = true)
+{
+  size_t key_offset = SearchKey(name);
+  if (key_offset)
+  {
+    KeyInfo key;
+    ReadFlashOrExit(key_offset, key);
+    if (key.GetDataSize() == size)
     {
-      KeyInfo key;
-      ReadFlashOrExit(key_offset, key);
-      if (key.GetDataSize() == size)
+      if (KeyDataCompare(key_offset, data, size))
       {
-        if (KeyDataCompare(key_offset, data, size))
+        if (AvailableSize() <
+            AlignSize(size) + AlignSize(sizeof(KeyInfo)) + AlignSize(key.GetNameLength()))
         {
-          if (AvailableSize() < AlignSize(size) + AlignSize(sizeof(KeyInfo)) +
-                                    AlignSize(key.GetNameLength()))
+          if (recycle)
           {
-            if (recycle)
-            {
-              Recycle();
-              return SetKey(name, data, size, false);
-            }
-            else
-            {
-              ASSERT(false);
-              return ErrorCode::FULL;
-            }
+            Recycle();
+            return SetKey(name, data, size, false);
           }
-          KeyInfo new_key = {};
-          BlockBoolUtil<MinWriteSize>::SetFlag(
-              new_key.no_next_key,
-              BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key));
-          BlockBoolUtil<MinWriteSize>::SetFlag(new_key.available_flag, false);
-          BlockBoolUtil<MinWriteSize>::SetFlag(
-              new_key.uninit, BlockBoolUtil<MinWriteSize>::ReadFlag(key.uninit));
-          new_key.SetNameLength(key.GetNameLength());
-          new_key.SetDataSize(size);
-          WriteFlashOrExit(key_offset, new_key);
-          return AddKey(GetKeyName(key_offset), key.GetNameLength(), data, size);
+          else
+          {
+            ASSERT(false);
+            return ErrorCode::FULL;
+          }
         }
-        return ErrorCode::OK;
+        KeyInfo new_key = {};
+        BlockBoolUtil<MinWriteSize>::SetFlag(
+            new_key.no_next_key, BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key));
+        BlockBoolUtil<MinWriteSize>::SetFlag(new_key.available_flag, false);
+        BlockBoolUtil<MinWriteSize>::SetFlag(
+            new_key.uninit, BlockBoolUtil<MinWriteSize>::ReadFlag(key.uninit));
+        new_key.SetNameLength(key.GetNameLength());
+        new_key.SetDataSize(size);
+        WriteFlashOrExit(key_offset, new_key);
+        return AddKey(GetKeyName(key_offset), key.GetNameLength(), data, size);
       }
+      return ErrorCode::OK;
     }
-    return ErrorCode::FAILED;
+  }
+  return ErrorCode::FAILED;
+}
+
+/**
+ * @brief 计算某个键的数据区起始偏移
+ *        (Compute the starting offset of one key payload).
+ * @param offset 键头偏移 (Key-header offset).
+ * @return 数据区起始偏移 (Starting offset of the payload).
+ */
+size_t GetKeyData(size_t offset)
+{
+  KeyInfo key;
+  ReadFlashOrExit(offset, key);
+  return offset + AlignSize(sizeof(KeyInfo)) + AlignSize(key.GetNameLength());
+}
+
+/**
+ * @brief 计算某个键名字区起始偏移
+ *        (Compute the starting offset of one key name).
+ * @param offset 键头偏移 (Key-header offset).
+ * @return 名字区起始偏移 (Starting offset of the key name).
+ */
+size_t GetKeyName(size_t offset) { return offset + AlignSize(sizeof(KeyInfo)); }
+
+/**
+ * @brief 计算一个键总共占用的字节数 (Compute the total byte span of one key).
+ * @param offset 键头偏移 (Key-header offset).
+ * @return 该键占用的总字节数 (Total byte size occupied by the key).
+ */
+size_t GetKeySize(size_t offset)
+{
+  KeyInfo key;
+  ReadFlashOrExit(offset, key);
+  return AlignSize(sizeof(KeyInfo)) + AlignSize(key.GetNameLength()) +
+         AlignSize(key.GetDataSize());
+}
+
+/**
+ * @brief 计算下一键的起始偏移 (Compute the starting offset of the next key).
+ * @param offset 当前键头偏移 (Current key-header offset).
+ * @return 下一键的起始偏移 (Starting offset of the next key).
+ */
+size_t GetNextKey(size_t offset)
+{
+  KeyInfo key;
+  ReadFlashOrExit(offset, key);
+  return offset + GetKeySize(offset);
+}
+
+/**
+ * @brief 计算当前块里最后一个键的偏移 (Locate the last key in the current block).
+ * @param block 目标块类型 (Target block type).
+ * @return 最后一个键的偏移；若块为空则返回 `0`
+ *         (Offset of the last key, or `0` when the block is empty).
+ */
+size_t GetLastKey(BlockType block)
+{
+  if (IsBlockEmpty(block))
+  {
+    return 0;
   }
 
-  /**
-   * @brief 计算某个键的数据区起始偏移
-   *        (Compute the starting offset of one key payload).
-   * @param offset 键头偏移 (Key-header offset).
-   * @return 数据区起始偏移 (Starting offset of the payload).
-   */
-  size_t GetKeyData(size_t offset)
+  KeyInfo key;
+  size_t key_offset = GetBlockOffset(block) + LibXR::OffsetOf(&FlashInfo::key);
+  ReadFlashOrExit(key_offset, key);
+  while (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key))
   {
-    KeyInfo key;
-    ReadFlashOrExit(offset, key);
-    return offset + AlignSize(sizeof(KeyInfo)) + AlignSize(key.GetNameLength());
-  }
-
-  /**
-   * @brief 计算某个键名字区起始偏移
-   *        (Compute the starting offset of one key name).
-   * @param offset 键头偏移 (Key-header offset).
-   * @return 名字区起始偏移 (Starting offset of the key name).
-   */
-  size_t GetKeyName(size_t offset) { return offset + AlignSize(sizeof(KeyInfo)); }
-
-  /**
-   * @brief 计算一个键总共占用的字节数 (Compute the total byte span of one key).
-   * @param offset 键头偏移 (Key-header offset).
-   * @return 该键占用的总字节数 (Total byte size occupied by the key).
-   */
-  size_t GetKeySize(size_t offset)
-  {
-    KeyInfo key;
-    ReadFlashOrExit(offset, key);
-    return AlignSize(sizeof(KeyInfo)) + AlignSize(key.GetNameLength()) +
-           AlignSize(key.GetDataSize());
-  }
-
-  /**
-   * @brief 计算下一键的起始偏移 (Compute the starting offset of the next key).
-   * @param offset 当前键头偏移 (Current key-header offset).
-   * @return 下一键的起始偏移 (Starting offset of the next key).
-   */
-  size_t GetNextKey(size_t offset)
-  {
-    KeyInfo key;
-    ReadFlashOrExit(offset, key);
-    return offset + GetKeySize(offset);
-  }
-
-  /**
-   * @brief 计算当前块里最后一个键的偏移 (Locate the last key in the current block).
-   * @param block 目标块类型 (Target block type).
-   * @return 最后一个键的偏移；若块为空则返回 `0`
-   *         (Offset of the last key, or `0` when the block is empty).
-   */
-  size_t GetLastKey(BlockType block)
-  {
-    if (IsBlockEmpty(block))
-    {
-      return 0;
-    }
-
-    KeyInfo key;
-    size_t key_offset = GetBlockOffset(block) + LibXR::OffsetOf(&FlashInfo::key);
+    key_offset = GetNextKey(key_offset);
     ReadFlashOrExit(key_offset, key);
-    while (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key))
-    {
-      key_offset = GetNextKey(key_offset);
-      ReadFlashOrExit(key_offset, key);
-    }
-    return key_offset;
   }
+  return key_offset;
+}
 
-  /**
-   * @brief 比较存储中的键数据和给定数据是否不同
-   *        (Compare whether the stored payload differs from the given payload).
-   * @param offset 键头偏移 (Key-header offset).
-   * @param data 待比较数据地址 (Address of the candidate payload).
-   * @param size 待比较数据字节数 (Payload size in bytes).
-   * @return 若内容不同则返回 `true`
-   *         (Returns `true` when the payloads differ).
-   */
-  bool KeyDataCompare(size_t offset, const void* data, size_t size)
+/**
+ * @brief 比较存储中的键数据和给定数据是否不同
+ *        (Compare whether the stored payload differs from the given payload).
+ * @param offset 键头偏移 (Key-header offset).
+ * @param data 待比较数据地址 (Address of the candidate payload).
+ * @param size 待比较数据字节数 (Payload size in bytes).
+ * @return 若内容不同则返回 `true`
+ *         (Returns `true` when the payloads differ).
+ */
+bool KeyDataCompare(size_t offset, const void* data, size_t size)
+{
+  KeyInfo key;
+  ReadFlashOrExit(offset, key);
+  size_t key_data_offset = GetKeyData(offset);
+  uint8_t data_buffer = 0;
+  for (size_t i = 0; i < size; i++)
   {
-    KeyInfo key;
-    ReadFlashOrExit(offset, key);
-    size_t key_data_offset = GetKeyData(offset);
+    ReadFlashOrExit(key_data_offset + i, data_buffer);
+    if (data_buffer != (reinterpret_cast<const uint8_t*>(data))[i])
+    {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @brief 比较存储中的键名和给定名称是否不同
+ *        (Compare whether the stored key name differs from the given name).
+ * @param offset 键头偏移 (Key-header offset).
+ * @param name 待比较键名 (Key name to compare against).
+ * @return 若名称不同则返回 `true`
+ *         (Returns `true` when the names differ).
+ */
+bool KeyNameCompare(size_t offset, const char* name)
+{
+  KeyInfo key;
+  ReadFlashOrExit(offset, key);
+  for (size_t i = 0; i < key.GetNameLength(); i++)
+  {
     uint8_t data_buffer = 0;
-    for (size_t i = 0; i < size; i++)
+    ReadFlashOrExit(offset + AlignSize(sizeof(KeyInfo)) + i, data_buffer);
+    if (data_buffer != name[i])
     {
-      ReadFlashOrExit(key_data_offset + i, data_buffer);
-      if (data_buffer != (reinterpret_cast<const uint8_t*>(data))[i])
-      {
-        return true;
-      }
+      return true;
     }
-    return false;
+  }
+  return false;
+}
+
+/**
+ * @brief 在主块里按名称查找键，并在删除项过多时触发回收
+ *        (Search one key by name in the main block and trigger recycle when
+ *        too many tombstones are observed).
+ * @param name 待查找键名 (Key name to search for).
+ * @return 找到时返回键头偏移，找不到返回 `0`
+ *         (Returns the key-header offset when found, otherwise `0`).
+ * @note 这里会顺手统计沿途遇到的失效键数量；超过阈值时，查找结束后会先做一次回收，
+ *       再重新查一遍。
+ *       This also counts invalidated keys seen along the scan; when that
+ *       count exceeds the threshold, it recycles first and then retries the
+ *       lookup once.
+ */
+size_t SearchKey(const char* name)
+{
+  if (IsBlockEmpty(BlockType::MAIN))
+  {
+    return 0;
   }
 
-  /**
-   * @brief 比较存储中的键名和给定名称是否不同
-   *        (Compare whether the stored key name differs from the given name).
-   * @param offset 键头偏移 (Key-header offset).
-   * @param name 待比较键名 (Key name to compare against).
-   * @return 若名称不同则返回 `true`
-   *         (Returns `true` when the names differ).
-   */
-  bool KeyNameCompare(size_t offset, const char* name)
+  KeyInfo key;
+  size_t key_offset = LibXR::OffsetOf(&FlashInfo::key);
+  ReadFlashOrExit(key_offset, key);
+
+  size_t ans = 0, need_cycle = 0;
+
+  while (true)
   {
-    KeyInfo key;
-    ReadFlashOrExit(offset, key);
-    for (size_t i = 0; i < key.GetNameLength(); i++)
+    if (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.available_flag))
     {
-      uint8_t data_buffer = 0;
-      ReadFlashOrExit(offset + AlignSize(sizeof(KeyInfo)) + i, data_buffer);
-      if (data_buffer != name[i])
-      {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * @brief 在主块里按名称查找键，并在删除项过多时触发回收
-   *        (Search one key by name in the main block and trigger recycle when
-   *        too many tombstones are observed).
-   * @param name 待查找键名 (Key name to search for).
-   * @return 找到时返回键头偏移，找不到返回 `0`
-   *         (Returns the key-header offset when found, otherwise `0`).
-   * @note 这里会顺手统计沿途遇到的失效键数量；超过阈值时，查找结束后会先做一次回收，
-   *       再重新查一遍。
-   *       This also counts invalidated keys seen along the scan; when that
-   *       count exceeds the threshold, it recycles first and then retries the
-   *       lookup once.
-   */
-  size_t SearchKey(const char* name)
-  {
-    if (IsBlockEmpty(BlockType::MAIN))
-    {
-      return 0;
-    }
-
-    KeyInfo key;
-    size_t key_offset = LibXR::OffsetOf(&FlashInfo::key);
-    ReadFlashOrExit(key_offset, key);
-
-    size_t ans = 0, need_cycle = 0;
-
-    while (true)
-    {
-      if (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.available_flag))
-      {
-        key_offset = GetNextKey(key_offset);
-        ReadFlashOrExit(key_offset, key);
-        need_cycle++;
-        continue;
-      }
-
-      if (!KeyNameCompare(key_offset, name))
-      {
-        ans = key_offset;
-        break;
-      }
-
-      if (BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key))
-      {
-        break;
-      }
-
       key_offset = GetNextKey(key_offset);
       ReadFlashOrExit(key_offset, key);
+      need_cycle++;
+      continue;
     }
 
-    if (need_cycle > recycle_threshold_)
+    if (!KeyNameCompare(key_offset, name))
     {
-      Recycle();
-      return SearchKey(name);
+      ans = key_offset;
+      break;
     }
 
-    return ans;
+    if (BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key))
+    {
+      break;
+    }
+
+    key_offset = GetNextKey(key_offset);
+    ReadFlashOrExit(key_offset, key);
   }
+
+  if (need_cycle > recycle_threshold_)
+  {
+    Recycle();
+    return SearchKey(name);
+  }
+
+  return ans;
+}

--- a/src/middleware/database/raw/layout.hpp
+++ b/src/middleware/database/raw/layout.hpp
@@ -1,186 +1,189 @@
-  /**
-   * @enum BlockType
-   * @brief 当前 raw 数据库使用的两个物理块角色 / Two physical block roles used by the
-   *        current raw database
-   *
-   * One block is treated as the current main data block, while the other acts
-   * as the scratch / backup block during recovery and recycle.
-   * 一个块承载当前主数据，另一个块在恢复和回收流程里充当暂存 / 备份块。
-   */
-  enum class BlockType : uint8_t
-  {
-    MAIN = 0,   ///< 主块 (Main block).
-    BACKUP = 1  ///< 备份块 (Backup block).
-  };
+/**
+ * @enum BlockType
+ * @brief 当前 raw 数据库使用的两个物理块角色 / Two physical block roles used by the
+ *        current raw database
+ *
+ * One block is treated as the current main data block, while the other acts
+ * as the scratch / backup block during recovery and recycle.
+ * 一个块承载当前主数据，另一个块在恢复和回收流程里充当暂存 / 备份块。
+ */
+enum class BlockType : uint8_t
+{
+  MAIN = 0,   ///< 主块 (Main block).
+  BACKUP = 1  ///< 备份块 (Backup block).
+};
 
 LIBXR_PACKED_BEGIN
-  /**
-   * @brief 按最小写入单元存放布尔位图块
-   *        (Boolean flag block stored in one aligned write unit span).
-   * @tparam BlockSize 位图块字节数 (Flag-block size in bytes).
-   */
-  template <size_t BlockSize>
-  struct BlockBoolData
-  {
-    uint8_t data[BlockSize];
-  };
+/**
+ * @brief 按最小写入单元存放布尔位图块
+ *        (Boolean flag block stored in one aligned write unit span).
+ * @tparam BlockSize 位图块字节数 (Flag-block size in bytes).
+ */
+template <size_t BlockSize>
+struct BlockBoolData
+{
+  uint8_t data[BlockSize];
+};
 LIBXR_PACKED_END
 
+/**
+ * @brief 读写对齐布尔位图块的工具
+ *        (Helpers for reading and writing aligned boolean flag blocks).
+ * @tparam BlockSize 位图块字节数 (Flag-block size in bytes).
+ */
+template <size_t BlockSize>
+class BlockBoolUtil
+{
+ public:
   /**
-   * @brief 读写对齐布尔位图块的工具
-   *        (Helpers for reading and writing aligned boolean flag blocks).
-   * @tparam BlockSize 位图块字节数 (Flag-block size in bytes).
+   * @brief 把一个布尔值编码进位图块 (Encode one boolean value into a flag block).
+   * @param obj 目标位图块 (Target flag block).
+   * @param value 待编码布尔值 (Boolean value to encode).
    */
-  template <size_t BlockSize>
-  class BlockBoolUtil
+  static void SetFlag(BlockBoolData<BlockSize>& obj, bool value)
   {
-   public:
-    /**
-     * @brief 把一个布尔值编码进位图块 (Encode one boolean value into a flag block).
-     * @param obj 目标位图块 (Target flag block).
-     * @param value 待编码布尔值 (Boolean value to encode).
-     */
-    static void SetFlag(BlockBoolData<BlockSize>& obj, bool value)
+    Memory::FastSet(obj.data, 0xFF, BlockSize);
+    if (!value)
     {
-      Memory::FastSet(obj.data, 0xFF, BlockSize);
-      if (!value)
-      {
-        obj.data[BlockSize - 1] &= 0xF0;
-      }
+      obj.data[BlockSize - 1] &= 0xF0;
+    }
+  }
+
+  /**
+   * @brief 从位图块读取布尔值 (Decode one boolean value from a flag block).
+   * @param obj 待读取位图块 (Flag block to inspect).
+   * @return 解码出的布尔值 (Decoded boolean value).
+   */
+  static bool ReadFlag(const BlockBoolData<BlockSize>& obj)
+  {
+    uint8_t last_4bits = obj.data[BlockSize - 1] & 0x0F;
+    return last_4bits == 0x0F;
+  }
+
+  /**
+   * @brief 检查位图块内容是否仍是合法编码 (Check whether a flag block still contains
+   *        a valid encoding).
+   * @param obj 待检查位图块 (Flag block to validate).
+   * @return 若编码合法则返回 `true` (Returns `true` when the encoding is valid).
+   */
+  static bool Valid(const BlockBoolData<BlockSize>& obj)
+  {
+    if (BlockSize == 0)
+    {
+      return false;
     }
 
-    /**
-     * @brief 从位图块读取布尔值 (Decode one boolean value from a flag block).
-     * @param obj 待读取位图块 (Flag block to inspect).
-     * @return 解码出的布尔值 (Decoded boolean value).
-     */
-    static bool ReadFlag(const BlockBoolData<BlockSize>& obj)
+    for (size_t i = 0; i < BlockSize - 1; ++i)
     {
-      uint8_t last_4bits = obj.data[BlockSize - 1] & 0x0F;
-      return last_4bits == 0x0F;
-    }
-
-    /**
-     * @brief 检查位图块内容是否仍是合法编码 (Check whether a flag block still contains
-     *        a valid encoding).
-     * @param obj 待检查位图块 (Flag block to validate).
-     * @return 若编码合法则返回 `true` (Returns `true` when the encoding is valid).
-     */
-    static bool Valid(const BlockBoolData<BlockSize>& obj)
-    {
-      if (BlockSize == 0)
+      if (obj.data[i] != 0xFF)
       {
         return false;
       }
-
-      for (size_t i = 0; i < BlockSize - 1; ++i)
-      {
-        if (obj.data[i] != 0xFF)
-        {
-          return false;
-        }
-      }
-
-      uint8_t last_byte = obj.data[BlockSize - 1];
-      if ((last_byte & 0xF0) != 0xF0)
-      {
-        return false;
-      }
-
-      uint8_t last_4bits = last_byte & 0x0F;
-      if (!(last_4bits == 0x0F || last_4bits == 0x00))
-      {
-        return false;
-      }
-
-      return true;
     }
-  };
+
+    uint8_t last_byte = obj.data[BlockSize - 1];
+    if ((last_byte & 0xF0) != 0xF0)
+    {
+      return false;
+    }
+
+    uint8_t last_4bits = last_byte & 0x0F;
+    if (!(last_4bits == 0x0F || last_4bits == 0x00))
+    {
+      return false;
+    }
+
+    return true;
+  }
+};
 
 LIBXR_PACKED_BEGIN
+/**
+ * @brief 键信息结构，存储键的元数据
+ *        (Structure containing key metadata).
+ */
+struct KeyInfo
+{
+  BlockBoolData<MinWriteSize> no_next_key;     ///< 是否是最后一个键
+  BlockBoolData<MinWriteSize> available_flag;  ///< 该键是否有效
+  BlockBoolData<MinWriteSize> uninit;          ///< 该键是否未初始化
+
+  uint32_t raw_info =
+      0;  ///< 高 7 位保存 nameLength，低 25 位保存 dataSize。
+          ///< Upper 7 bits store nameLength and lower 25 bits store dataSize.
+
   /**
-   * @brief 键信息结构，存储键的元数据
-   *        (Structure containing key metadata).
+   * @brief 构造一个默认可写的键头元数据
+   *        (Construct one default writable key-header metadata object).
    */
-  struct KeyInfo
+  KeyInfo()
   {
-    BlockBoolData<MinWriteSize> no_next_key;     ///< 是否是最后一个键
-    BlockBoolData<MinWriteSize> available_flag;  ///< 该键是否有效
-    BlockBoolData<MinWriteSize> uninit;          ///< 该键是否未初始化
+    BlockBoolUtil<MinWriteSize>::SetFlag(no_next_key, true);
+    BlockBoolUtil<MinWriteSize>::SetFlag(available_flag, true);
+    BlockBoolUtil<MinWriteSize>::SetFlag(uninit, true);
+  }
 
-    uint32_t raw_info = 0;  ///< 高 7 位保存 nameLength，低 25 位保存 dataSize。
-                            ///< Upper 7 bits store nameLength and lower 25 bits store dataSize.
+  /**
+   * @brief 设置键名长度 (Set the key name length).
+   * @param len 键名长度 (Key name length).
+   */
+  void SetNameLength(uint8_t len)
+  {
+    raw_info = (raw_info & 0x01FFFFFF) | ((len & 0x7F) << 25);
+  }
 
-    /**
-     * @brief 构造一个默认可写的键头元数据
-     *        (Construct one default writable key-header metadata object).
-     */
-    KeyInfo()
-    {
-      BlockBoolUtil<MinWriteSize>::SetFlag(no_next_key, true);
-      BlockBoolUtil<MinWriteSize>::SetFlag(available_flag, true);
-      BlockBoolUtil<MinWriteSize>::SetFlag(uninit, true);
-    }
+  /**
+   * @brief 获取键名长度 (Get the key name length).
+   * @return 键名长度 (Key name length).
+   */
+  uint8_t GetNameLength() const { return (raw_info >> 25) & 0x7F; }
 
-    /**
-     * @brief 设置键名长度 (Set the key name length).
-     * @param len 键名长度 (Key name length).
-     */
-    void SetNameLength(uint8_t len)
-    {
-      raw_info = (raw_info & 0x01FFFFFF) | ((len & 0x7F) << 25);
-    }
+  /**
+   * @brief 设置数据字节数 (Set the payload size in bytes).
+   * @param size 数据字节数 (Payload size in bytes).
+   */
+  void SetDataSize(uint32_t size)
+  {
+    raw_info = (raw_info & 0xFE000000) | (size & 0x01FFFFFF);
+  }
 
-    /**
-     * @brief 获取键名长度 (Get the key name length).
-     * @return 键名长度 (Key name length).
-     */
-    uint8_t GetNameLength() const { return (raw_info >> 25) & 0x7F; }
-
-    /**
-     * @brief 设置数据字节数 (Set the payload size in bytes).
-     * @param size 数据字节数 (Payload size in bytes).
-     */
-    void SetDataSize(uint32_t size)
-    {
-      raw_info = (raw_info & 0xFE000000) | (size & 0x01FFFFFF);
-    }
-
-    /**
-     * @brief 获取数据字节数 (Get the payload size in bytes).
-     * @return 数据字节数 (Payload size in bytes).
-     */
-    uint32_t GetDataSize() const { return raw_info & 0x01FFFFFF; }
-  };
+  /**
+   * @brief 获取数据字节数 (Get the payload size in bytes).
+   * @return 数据字节数 (Payload size in bytes).
+   */
+  uint32_t GetDataSize() const { return raw_info & 0x01FFFFFF; }
+};
 LIBXR_PACKED_END
 
 LIBXR_PACKED_BEGIN
+/**
+ * @brief Flash 存储的块信息结构
+ *        (Structure representing a Flash storage block).
+ */
+struct FlashInfo
+{
   /**
-   * @brief Flash 存储的块信息结构
-   *        (Structure representing a Flash storage block).
+   * @brief 构造一个擦除态 FlashInfo 缓冲对象
+   *        (Construct one erased-state FlashInfo buffer object).
    */
-  struct FlashInfo
+  FlashInfo()
   {
-    /**
-     * @brief 构造一个擦除态 FlashInfo 缓冲对象
-     *        (Construct one erased-state FlashInfo buffer object).
-     */
-    FlashInfo()
-    {
-      header = 0xFFFFFFFF;
-      Memory::FastSet(padding, 0xFF, MinWriteSize);
-    }
+    header = 0xFFFFFFFF;
+    Memory::FastSet(padding, 0xFF, MinWriteSize);
+  }
 
-    /**
-     * @brief 让块前缀既能按签名读取，也能按最小写入单元整体写入 /
-     *        Expose the block prefix both as a signature field and as one full
-     *        minimum-write-unit write span
-     */
-    union
-    {
-      uint32_t header;  ///< Flash 块头签名 / Flash block-header signature.
-      uint8_t padding[MinWriteSize];  ///< 按最小写入单元对齐的原始块前缀 / Raw block prefix aligned to one minimum write unit.
-    };
-    KeyInfo key;  ///< 紧跟在块头后的首个键头 / First key header stored right after the block header.
+  /**
+   * @brief 让块前缀既能按签名读取，也能按最小写入单元整体写入 /
+   *        Expose the block prefix both as a signature field and as one full
+   *        minimum-write-unit write span
+   */
+  union
+  {
+    uint32_t header;                ///< Flash 块头签名 / Flash block-header signature.
+    uint8_t padding[MinWriteSize];  ///< 按最小写入单元对齐的原始块前缀 / Raw block prefix
+                                    ///< aligned to one minimum write unit.
   };
+  KeyInfo key;  ///< 紧跟在块头后的首个键头 / First key header stored right after the
+                ///< block header.
+};
 LIBXR_PACKED_END

--- a/src/middleware/database/raw/lifecycle.hpp
+++ b/src/middleware/database/raw/lifecycle.hpp
@@ -1,237 +1,237 @@
-  /**
-   * @brief `DatabaseRaw` 的生命周期与主流程片段 / Lifecycle and main-flow fragment of
-   *        `DatabaseRaw`
-   *
-   * @note 这一组函数组成后端真正对外可见的行为：构造时约束检查、启动恢复、运行期
-   *       读写、显式还原，以及回收流程。
-   *       This group forms the backend's externally visible behavior: contract
-   *       checks during construction, startup recovery, runtime read/write,
-   *       explicit restore, and recycling flow.
-   */
+/**
+ * @brief `DatabaseRaw` 的生命周期与主流程片段 / Lifecycle and main-flow fragment of
+ *        `DatabaseRaw`
+ *
+ * @note 这一组函数组成后端真正对外可见的行为：构造时约束检查、启动恢复、运行期
+ *       读写、显式还原，以及回收流程。
+ *       This group forms the backend's externally visible behavior: contract
+ *       checks during construction, startup recovery, runtime read/write,
+ *       explicit restore, and recycling flow.
+ */
 
-  /**
-   * @brief 获取数据库中的键值
-   *        (Retrieve the key's value from the database).
-   * @param key 需要获取的键 (Key to retrieve).
-   * @return 操作结果，如果找到则返回 `ErrorCode::OK`，否则返回 `ErrorCode::NOT_FOUND`
-   *         (Operation result, returns `ErrorCode::OK` if found, otherwise
-   *         `ErrorCode::NOT_FOUND`).
-   */
-  ErrorCode Get(Database::KeyBase& key) override
+/**
+ * @brief 获取数据库中的键值
+ *        (Retrieve the key's value from the database).
+ * @param key 需要获取的键 (Key to retrieve).
+ * @return 操作结果，如果找到则返回 `ErrorCode::OK`，否则返回 `ErrorCode::NOT_FOUND`
+ *         (Operation result, returns `ErrorCode::OK` if found, otherwise
+ *         `ErrorCode::NOT_FOUND`).
+ */
+ErrorCode Get(Database::KeyBase& key) override
+{
+  auto ans = SearchKey(key.name_);
+  if (!ans)
   {
-    auto ans = SearchKey(key.name_);
-    if (!ans)
+    return ErrorCode::NOT_FOUND;
+  }
+
+  KeyInfo key_buffer;
+  ReadFlashOrExit(ans, key_buffer);
+
+  if (key.raw_data_.size_ != key_buffer.GetDataSize())
+  {
+    return ErrorCode::FAILED;
+  }
+
+  ReadFlashOrExit(GetKeyData(ans), key.raw_data_);
+
+  return ErrorCode::OK;
+}
+
+/**
+ * @brief 设置数据库中的键值
+ *        (Set the key's value in the database).
+ * @param key 目标键 (Target key).
+ * @param data 需要存储的新值 (New value to store).
+ * @return 操作结果 (Operation result).
+ */
+ErrorCode Set(KeyBase& key, RawData data) override
+{
+  return SetKey(key.name_, data.addr_, data.size_);
+}
+
+/**
+ * @brief 添加新键到数据库 (Add a new key to the database).
+ * @param key 需要添加的键 (Key to add).
+ * @return 操作结果 (Operation result).
+ */
+ErrorCode Add(KeyBase& key) override
+{
+  return AddKey(key.name_, key.raw_data_.addr_, key.raw_data_.size_);
+}
+
+/**
+ * @brief 构造函数，初始化 Flash 存储和缓冲区
+ *        (Constructor to initialize Flash storage and buffer).
+ *
+ * @param flash 目标 Flash 存储设备 (Target Flash storage device).
+ * @param recycle_threshold 回收阈值 (Recycle threshold).
+ */
+explicit DatabaseRaw(Flash& flash, size_t recycle_threshold = 128)
+    : recycle_threshold_(recycle_threshold), flash_(flash)
+{
+  ASSERT(flash.MinEraseSize() * 2 <= flash_.Size());
+  ASSERT(flash_.MinWriteSize() <= MinWriteSize);
+  auto block_num = static_cast<size_t>(flash_.Size() / flash.MinEraseSize());
+  block_size_ = block_num / 2 * flash.MinEraseSize();
+  Init();
+}
+
+/**
+ * @brief 初始化数据库存储区，确保主备块正确
+ *        (Initialize database storage, ensuring main and backup blocks are valid).
+ * @note 启动策略是：优先相信合法主块；主块损坏时才尝试从合法且非空的备份块恢复；若
+ *       主块已好而备份块仍残留，则把备份块失效掉，避免它继续被当作恢复来源。
+ *       The startup policy is: trust a valid main block first; recover from a
+ *       valid non-empty backup block only when the main block is broken; and
+ *       invalidate any stale backup once the main block is already good so it
+ *       cannot remain a recovery source.
+ */
+void Init()
+{
+  if (!IsBlockValid(BlockType::MAIN))
+  {
+    if (!IsBlockValid(BlockType::BACKUP) || IsBlockEmpty(BlockType::BACKUP))
     {
-      return ErrorCode::NOT_FOUND;
+      InitBlock(BlockType::MAIN);
     }
-
-    KeyInfo key_buffer;
-    ReadFlashOrExit(ans, key_buffer);
-
-    if (key.raw_data_.size_ != key_buffer.GetDataSize())
+    else
     {
-      return ErrorCode::FAILED;
-    }
-
-    ReadFlashOrExit(GetKeyData(ans), key.raw_data_);
-
-    return ErrorCode::OK;
-  }
-
-  /**
-   * @brief 设置数据库中的键值
-   *        (Set the key's value in the database).
-   * @param key 目标键 (Target key).
-   * @param data 需要存储的新值 (New value to store).
-   * @return 操作结果 (Operation result).
-   */
-  ErrorCode Set(KeyBase& key, RawData data) override
-  {
-    return SetKey(key.name_, data.addr_, data.size_);
-  }
-
-  /**
-   * @brief 添加新键到数据库 (Add a new key to the database).
-   * @param key 需要添加的键 (Key to add).
-   * @return 操作结果 (Operation result).
-   */
-  ErrorCode Add(KeyBase& key) override
-  {
-    return AddKey(key.name_, key.raw_data_.addr_, key.raw_data_.size_);
-  }
-
-  /**
-   * @brief 构造函数，初始化 Flash 存储和缓冲区
-   *        (Constructor to initialize Flash storage and buffer).
-   *
-   * @param flash 目标 Flash 存储设备 (Target Flash storage device).
-   * @param recycle_threshold 回收阈值 (Recycle threshold).
-   */
-  explicit DatabaseRaw(Flash& flash, size_t recycle_threshold = 128)
-      : recycle_threshold_(recycle_threshold), flash_(flash)
-  {
-    ASSERT(flash.MinEraseSize() * 2 <= flash_.Size());
-    ASSERT(flash_.MinWriteSize() <= MinWriteSize);
-    auto block_num = static_cast<size_t>(flash_.Size() / flash.MinEraseSize());
-    block_size_ = block_num / 2 * flash.MinEraseSize();
-    Init();
-  }
-
-  /**
-   * @brief 初始化数据库存储区，确保主备块正确
-   *        (Initialize database storage, ensuring main and backup blocks are valid).
-   * @note 启动策略是：优先相信合法主块；主块损坏时才尝试从合法且非空的备份块恢复；若
-   *       主块已好而备份块仍残留，则把备份块失效掉，避免它继续被当作恢复来源。
-   *       The startup policy is: trust a valid main block first; recover from a
-   *       valid non-empty backup block only when the main block is broken; and
-   *       invalidate any stale backup once the main block is already good so it
-   *       cannot remain a recovery source.
-   */
-  void Init()
-  {
-    if (!IsBlockValid(BlockType::MAIN))
-    {
-      if (!IsBlockValid(BlockType::BACKUP) || IsBlockEmpty(BlockType::BACKUP))
+      size_t used_size = 0;
+      if (!TryGetUsedBlockSize(BlockType::BACKUP, used_size))
       {
+        InvalidateBlock(BlockType::BACKUP);
         InitBlock(BlockType::MAIN);
       }
       else
       {
-        size_t used_size = 0;
-        if (!TryGetUsedBlockSize(BlockType::BACKUP, used_size))
-        {
-          InvalidateBlock(BlockType::BACKUP);
-          InitBlock(BlockType::MAIN);
-        }
-        else
-        {
-          EraseFlashOrExit(0, block_size_);
-          CopyBlockPrefixAndChecksum(BlockType::MAIN, BlockType::BACKUP, used_size);
-          InvalidateBlock(BlockType::BACKUP);
-        }
+        EraseFlashOrExit(0, block_size_);
+        CopyBlockPrefixAndChecksum(BlockType::MAIN, BlockType::BACKUP, used_size);
+        InvalidateBlock(BlockType::BACKUP);
       }
     }
-    else if (IsBlockValid(BlockType::BACKUP) && !IsBlockEmpty(BlockType::BACKUP))
+  }
+  else if (IsBlockValid(BlockType::BACKUP) && !IsBlockEmpty(BlockType::BACKUP))
+  {
+    // A stale backup must not stay recoverable once the main block is already good.
+    InvalidateBlock(BlockType::BACKUP);
+  }
+
+  KeyInfo key;
+  size_t key_offset = LibXR::OffsetOf(&FlashInfo::key);
+  ReadFlashOrExit(key_offset, key);
+  size_t need_cycle = 0;
+  while (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key))
+  {
+    key_offset = GetNextKey(key_offset);
+
+    if (key_offset + AlignSize(sizeof(KeyInfo)) > GetChecksumOffset())
     {
-      // A stale backup must not stay recoverable once the main block is already good.
-      InvalidateBlock(BlockType::BACKUP);
+      InitBlock(BlockType::MAIN);
+      break;
     }
 
-    KeyInfo key;
-    size_t key_offset = LibXR::OffsetOf(&FlashInfo::key);
     ReadFlashOrExit(key_offset, key);
-    size_t need_cycle = 0;
-    while (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key))
+
+    // 当前策略仍然是“看到未完成键就整块重建”，还没有实现更细粒度的坏数据恢复。
+    // The current policy still rebuilds the whole block when it sees an
+    // incomplete key; finer-grained damaged-data recovery is not implemented
+    // yet.
+    if (BlockBoolUtil<MinWriteSize>::ReadFlag(key.uninit))
     {
-      key_offset = GetNextKey(key_offset);
-
-      if (key_offset + AlignSize(sizeof(KeyInfo)) > GetChecksumOffset())
-      {
-        InitBlock(BlockType::MAIN);
-        break;
-      }
-
-      ReadFlashOrExit(key_offset, key);
-
-      // 当前策略仍然是“看到未完成键就整块重建”，还没有实现更细粒度的坏数据恢复。
-      // The current policy still rebuilds the whole block when it sees an
-      // incomplete key; finer-grained damaged-data recovery is not implemented
-      // yet.
-      if (BlockBoolUtil<MinWriteSize>::ReadFlag(key.uninit))
-      {
-        InitBlock(BlockType::MAIN);
-        break;
-      }
-      if (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.available_flag))
-      {
-        need_cycle += 1;
-      }
+      InitBlock(BlockType::MAIN);
+      break;
     }
-
-    if (need_cycle > recycle_threshold_)
+    if (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.available_flag))
     {
-      Recycle();
+      need_cycle += 1;
     }
   }
 
-  /**
-   * @brief 还原存储数据，清空 Flash 区域
-   *        (Restore storage data, clearing Flash memory area).
-   * @note 这里会把主块和备份块都重新初始化为空块，不保留任何旧键。
-   *       This reinitializes both the main block and the backup block into
-   *       empty blocks and keeps no previous key.
-   */
-  void Restore()
+  if (need_cycle > recycle_threshold_)
   {
-    InitBlock(BlockType::MAIN);
-    InitBlock(BlockType::BACKUP);
+    Recycle();
   }
+}
 
-  /**
-   * @brief 回收 Flash 空间，整理数据
-   *        (Recycle Flash storage space and organize data).
-   *
-   * Moves valid keys from the main block to the backup block and erases the main
-   * block.
-   * 将主存储块中的有效键移动到备份块，并擦除主存储块。
-   *
-   * @return 操作结果 (Operation result).
-   * @note 当前流程把备份块当作临时整理区：先把主块中的活跃键顺序搬过去，再用备份块的
-   *       活跃前缀回写主块，最后把备份块重新清为空块。
-   *       The current flow treats the backup block as a temporary compaction
-   *       area: it first copies live keys from the main block into the backup
-   *       block in order, then rewrites the main block from the backup's live
-   *       prefix, and finally clears the backup block back to empty.
-   */
-  ErrorCode Recycle()
+/**
+ * @brief 还原存储数据，清空 Flash 区域
+ *        (Restore storage data, clearing Flash memory area).
+ * @note 这里会把主块和备份块都重新初始化为空块，不保留任何旧键。
+ *       This reinitializes both the main block and the backup block into
+ *       empty blocks and keeps no previous key.
+ */
+void Restore()
+{
+  InitBlock(BlockType::MAIN);
+  InitBlock(BlockType::BACKUP);
+}
+
+/**
+ * @brief 回收 Flash 空间，整理数据
+ *        (Recycle Flash storage space and organize data).
+ *
+ * Moves valid keys from the main block to the backup block and erases the main
+ * block.
+ * 将主存储块中的有效键移动到备份块，并擦除主存储块。
+ *
+ * @return 操作结果 (Operation result).
+ * @note 当前流程把备份块当作临时整理区：先把主块中的活跃键顺序搬过去，再用备份块的
+ *       活跃前缀回写主块，最后把备份块重新清为空块。
+ *       The current flow treats the backup block as a temporary compaction
+ *       area: it first copies live keys from the main block into the backup
+ *       block in order, then rewrites the main block from the backup's live
+ *       prefix, and finally clears the backup block back to empty.
+ */
+ErrorCode Recycle()
+{
+  if (IsBlockEmpty(BlockType::MAIN))
   {
-    if (IsBlockEmpty(BlockType::MAIN))
-    {
-      return ErrorCode::OK;
-    }
-
-    KeyInfo key;
-    size_t key_offset = LibXR::OffsetOf(&FlashInfo::key);
-    ReadFlashOrExit(key_offset, key);
-
-    if (!IsBlockValid(BlockType::BACKUP) || !IsBlockEmpty(BlockType::BACKUP))
-    {
-      InitBlock(BlockType::BACKUP);
-    }
-
-    size_t write_buff_offset = LibXR::OffsetOf(&FlashInfo::key) + block_size_;
-
-    auto new_key = KeyInfo{};
-    BlockBoolUtil<MinWriteSize>::SetFlag(new_key.uninit, false);
-    BlockBoolUtil<MinWriteSize>::SetFlag(new_key.available_flag, false);
-    BlockBoolUtil<MinWriteSize>::SetFlag(new_key.no_next_key, false);
-    WriteFlashOrExit(write_buff_offset, new_key);
-
-    write_buff_offset += GetKeySize(write_buff_offset);
-
-    do
-    {
-      key_offset = GetNextKey(key_offset);
-      ReadFlashOrExit(key_offset, key);
-
-      if (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.available_flag))
-      {
-        continue;
-      }
-
-      WriteFlashOrExit(write_buff_offset, key);
-      write_buff_offset += AlignSize(sizeof(KeyInfo));
-      CopyFlashData(write_buff_offset, GetKeyName(key_offset), key.GetNameLength());
-      write_buff_offset += AlignSize(key.GetNameLength());
-      CopyFlashData(write_buff_offset, GetKeyData(key_offset), key.GetDataSize());
-      write_buff_offset += AlignSize(key.GetDataSize());
-    } while (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key));
-
-    const size_t used_size = write_buff_offset - block_size_;
-    EraseFlashOrExit(0, block_size_);
-    CopyBlockPrefixAndChecksum(BlockType::MAIN, BlockType::BACKUP, used_size);
-
-    InitBlock(BlockType::BACKUP);
-
     return ErrorCode::OK;
   }
+
+  KeyInfo key;
+  size_t key_offset = LibXR::OffsetOf(&FlashInfo::key);
+  ReadFlashOrExit(key_offset, key);
+
+  if (!IsBlockValid(BlockType::BACKUP) || !IsBlockEmpty(BlockType::BACKUP))
+  {
+    InitBlock(BlockType::BACKUP);
+  }
+
+  size_t write_buff_offset = LibXR::OffsetOf(&FlashInfo::key) + block_size_;
+
+  auto new_key = KeyInfo{};
+  BlockBoolUtil<MinWriteSize>::SetFlag(new_key.uninit, false);
+  BlockBoolUtil<MinWriteSize>::SetFlag(new_key.available_flag, false);
+  BlockBoolUtil<MinWriteSize>::SetFlag(new_key.no_next_key, false);
+  WriteFlashOrExit(write_buff_offset, new_key);
+
+  write_buff_offset += GetKeySize(write_buff_offset);
+
+  do
+  {
+    key_offset = GetNextKey(key_offset);
+    ReadFlashOrExit(key_offset, key);
+
+    if (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.available_flag))
+    {
+      continue;
+    }
+
+    WriteFlashOrExit(write_buff_offset, key);
+    write_buff_offset += AlignSize(sizeof(KeyInfo));
+    CopyFlashData(write_buff_offset, GetKeyName(key_offset), key.GetNameLength());
+    write_buff_offset += AlignSize(key.GetNameLength());
+    CopyFlashData(write_buff_offset, GetKeyData(key_offset), key.GetDataSize());
+    write_buff_offset += AlignSize(key.GetDataSize());
+  } while (!BlockBoolUtil<MinWriteSize>::ReadFlag(key.no_next_key));
+
+  const size_t used_size = write_buff_offset - block_size_;
+  EraseFlashOrExit(0, block_size_);
+  CopyBlockPrefixAndChecksum(BlockType::MAIN, BlockType::BACKUP, used_size);
+
+  InitBlock(BlockType::BACKUP);
+
+  return ErrorCode::OK;
+}

--- a/src/middleware/database/raw/raw.hpp
+++ b/src/middleware/database/raw/raw.hpp
@@ -43,9 +43,8 @@ class DatabaseRaw : public Database
    *       Both the main block and the backup block use this signature to decide
    *       whether the block at least looks like it was written by the same raw
    *       database format version.
-  */
-  static constexpr uint32_t FLASH_HEADER =
-      0x12345678 + LIBXR_DATABASE_VERSION;
+   */
+  static constexpr uint32_t FLASH_HEADER = 0x12345678 + LIBXR_DATABASE_VERSION;
 
   /**
    * @brief 当前 raw 后端使用的块尾校验常量 / Trailing checksum constant used by the
@@ -54,7 +53,7 @@ class DatabaseRaw : public Database
    * @note 这里不是通用 CRC 计算结果，而是“块已完整写完”的固定尾标记。
    *       This is not a generic computed CRC result; it is the fixed trailing
    *       marker meaning "this block has been fully written".
-  */
+   */
   static constexpr uint32_t CHECKSUM_BYTE = 0x9abcedf0;
 
   // 存储布局定义：块角色、位图编码、键头与块头。

--- a/src/middleware/database/raw_sequential.hpp
+++ b/src/middleware/database/raw_sequential.hpp
@@ -11,7 +11,8 @@ namespace LibXR
 
 /**
  * @brief 适用于不支持逆序写入的 Flash 存储的数据库实现
- *        (Database implementation for Flash storage that does not support reverse writing).
+ *        (Database implementation for Flash storage that does not support reverse
+ * writing).
  *
  * This class manages key-value storage in a Flash memory region where
  * data can only be written sequentially. It maintains a backup system
@@ -109,15 +110,16 @@ class DatabaseRawSequential : public Database
     BACKUP = 1  ///< 备份块 (Backup block).
   };
 
-LIBXR_PACKED_BEGIN
+  LIBXR_PACKED_BEGIN
   /**
    * @brief 键信息结构，存储键的元数据
    *        (Structure containing key metadata).
    */
   struct KeyInfo
   {
-    uint32_t raw_data;  ///< 1 位后继键标志、7 位键名长度、24 位数据长度
-                        ///< (1-bit next-key flag, 7-bit name length, 24-bit payload size).
+    uint32_t
+        raw_data;  ///< 1 位后继键标志、7 位键名长度、24 位数据长度
+                   ///< (1-bit next-key flag, 7-bit name length, 24-bit payload size).
 
     /**
      * @brief 构造一个擦除态键头 (Construct one erased-state key header).
@@ -172,7 +174,7 @@ LIBXR_PACKED_BEGIN
   };
 
   static_assert(sizeof(KeyInfo) == 4, "KeyInfo size must be 4 bytes");
-LIBXR_PACKED_END
+  LIBXR_PACKED_END
 
   /**
    * @brief Flash 存储的块信息结构

--- a/src/middleware/logger/literal.hpp
+++ b/src/middleware/logger/literal.hpp
@@ -32,7 +32,8 @@ enum class Resolution : uint8_t
   None,       ///< matches neither frontend / 两个前端都不匹配
   Format,     ///< select brace-style frontend / 选择 brace 风格前端
   Printf,     ///< select printf-style frontend / 选择 printf 风格前端
-  Ambiguous,  ///< both frontends remain valid and both syntaxes are used / 两个前端都可用且都真的使用了自己的语法
+  Ambiguous,  ///< both frontends remain valid and both syntaxes are used /
+              ///< 两个前端都可用且都真的使用了自己的语法
 };
 
 /**
@@ -200,8 +201,9 @@ template <Frontend Forced, Print::Text Source, typename... Args>
 
   if constexpr (Forced == Frontend::Format)
   {
-    static_assert(resolution == Resolution::Format,
-                  "LibXR::Logger: XR_FMT(...) literal is not accepted by the brace frontend");
+    static_assert(
+        resolution == Resolution::Format,
+        "LibXR::Logger: XR_FMT(...) literal is not accepted by the brace frontend");
     return Frontend::Format;
   }
   else if constexpr (Forced == Frontend::Printf)
@@ -222,7 +224,8 @@ template <Frontend Forced, Print::Text Source, typename... Args>
   else if constexpr (resolution == Resolution::Ambiguous)
   {
     static_assert(resolution != Resolution::Ambiguous,
-                  "LibXR::Logger: literal is ambiguous between brace and printf frontends; use XR_FMT(...) or XR_PRINTF(...)");
+                  "LibXR::Logger: literal is ambiguous between brace and printf "
+                  "frontends; use XR_FMT(...) or XR_PRINTF(...)");
     return Frontend::Auto;
   }
   else

--- a/src/middleware/logger/logger.hpp
+++ b/src/middleware/logger/logger.hpp
@@ -88,8 +88,9 @@ class Logger
   template <Detail::LoggerLiteral::Frontend Forced, Print::Text Source, typename... Args>
   static void Publish(LogLevel level, const char* file, uint32_t line, Args&&... args)
   {
-    static_assert(Forced != Detail::LoggerLiteral::Frontend::Auto,
-                  "LibXR::Logger: explicit literal tag must be XR_FMT(...) or XR_PRINTF(...)");
+    static_assert(
+        Forced != Detail::LoggerLiteral::Frontend::Auto,
+        "LibXR::Logger: explicit literal tag must be XR_FMT(...) or XR_PRINTF(...)");
 
     constexpr auto frontend =
         Detail::LoggerLiteral::SelectFrontend<Forced, Source, Args...>();
@@ -154,7 +155,9 @@ class Logger
    */
   static void PublishToTopic(LogData& data);
 
-  static inline bool initialized_ = false;  ///< 是否已经完成日志 topic 初始化 / Whether logger-topic initialization has completed.
+  static inline bool initialized_ =
+      false;  ///< 是否已经完成日志 topic 初始化 / Whether logger-topic initialization has
+              ///< completed.
 };
 
 }  // namespace LibXR

--- a/src/middleware/logger/macros.hpp
+++ b/src/middleware/logger/macros.hpp
@@ -14,7 +14,8 @@
 #define XR_FMT(fmt) LibXR::Detail::LoggerLiteral::Frontend::Format, fmt
 
 /**
- * @brief 显式指定 logger 使用 printf 风格前端 / Explicitly force the logger printf frontend
+ * @brief 显式指定 logger 使用 printf 风格前端 / Explicitly force the logger printf
+ * frontend
  */
 #define XR_PRINTF(fmt) LibXR::Detail::LoggerLiteral::Frontend::Printf, fmt
 
@@ -22,7 +23,7 @@
 /**
  * @brief 输出调试日志 / Output debug log
  */
-#define XR_LOG_DEBUG(fmt, ...)                                                          \
+#define XR_LOG_DEBUG(fmt, ...)                                                         \
   LibXR::Logger::Publish<fmt>(LibXR::LogLevel::XR_LOG_LEVEL_DEBUG, __FILE__, __LINE__, \
                               ##__VA_ARGS__)
 #else
@@ -66,7 +67,7 @@
 /**
  * @brief 输出错误日志 / Output error log
  */
-#define XR_LOG_ERROR(fmt, ...)                                                          \
+#define XR_LOG_ERROR(fmt, ...)                                                         \
   LibXR::Logger::Publish<fmt>(LibXR::LogLevel::XR_LOG_LEVEL_ERROR, __FILE__, __LINE__, \
                               ##__VA_ARGS__)
 #else

--- a/src/middleware/message/message.hpp
+++ b/src/middleware/message/message.hpp
@@ -10,10 +10,10 @@
  *       internal module boundaries
  */
 
-#include "topic.hpp"
 #include "packet/packet.hpp"
 #include "server/server.hpp"
 #include "subscriber/async.hpp"
 #include "subscriber/callback.hpp"
 #include "subscriber/queue.hpp"
 #include "subscriber/sync.hpp"
+#include "topic.hpp"

--- a/src/middleware/message/packet/packet.hpp
+++ b/src/middleware/message/packet/packet.hpp
@@ -19,10 +19,13 @@ LIBXR_PACKED_BEGIN
  */
 struct Topic::PackedDataHeader
 {
-  uint8_t prefix;               ///< 包前缀字节。Packet prefix byte.
-  uint8_t data_len_raw[3];      ///< 小端 24 位 payload 长度。Little-endian 24-bit payload length.
-  uint32_t topic_name_crc32;    ///< 目标 topic 名称 CRC32 键。CRC32 key of the target topic name.
-  uint8_t timestamp_us_raw[6];  ///< 小端 48 位微秒时间戳。Little-endian 48-bit microsecond timestamp.
+  uint8_t prefix;  ///< 包前缀字节。Packet prefix byte.
+  uint8_t
+      data_len_raw[3];  ///< 小端 24 位 payload 长度。Little-endian 24-bit payload length.
+  uint32_t topic_name_crc32;  ///< 目标 topic 名称 CRC32 键。CRC32 key of the target topic
+                              ///< name.
+  uint8_t timestamp_us_raw[6];  ///< 小端 48 位微秒时间戳。Little-endian 48-bit
+                                ///< microsecond timestamp.
   uint8_t version;              ///< 包协议版本。Packet protocol version.
   uint8_t pack_header_crc8;     ///< 头部 CRC8。Header CRC8.
 
@@ -82,7 +85,8 @@ class Topic::PackedData
   {
     PackedDataHeader header_;     ///< 固定头。Fixed packet header.
     uint8_t data_[sizeof(Data)];  ///< payload 原始字节区。Raw payload byte area.
-  } raw;                          ///< 固定头和 payload 组成的原始字节布局。Raw byte layout made of the fixed header and payload.
+  } raw;  ///< 固定头和 payload 组成的原始字节布局。Raw byte layout made of the fixed
+          ///< header and payload.
 
   uint8_t crc8_;  ///< 尾部 CRC8。Trailing CRC8.
 

--- a/src/middleware/message/server/server.hpp
+++ b/src/middleware/message/server/server.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "../topic.hpp"
-
 #include "queue.hpp"
 
 namespace LibXR
@@ -17,13 +16,12 @@ namespace LibXR
  *       itself; it relies only on each registered topic's `payload_size`,
  *       `payload_alignment`, and name CRC key.
  * @note 当前兼容规则：
- *       收到的 packet payload 短于 topic 固定大小时，仅保证前缀部分有效，后半段保持未定义；
- *       长于 topic 固定大小时，仅保留前缀部分，其余字节直接截断。
- *       Current compatibility rule:
- *       when an incoming packet payload is shorter than the topic's fixed size,
- *       only the leading prefix is guaranteed valid and the remaining tail stays
- *       unspecified; when it is longer, only the prefix matching the topic size
- *       is kept and the rest is truncated.
+ *       收到的 packet payload 短于 topic
+ * 固定大小时，仅保证前缀部分有效，后半段保持未定义； 长于 topic
+ * 固定大小时，仅保留前缀部分，其余字节直接截断。 Current compatibility rule: when an
+ * incoming packet payload is shorter than the topic's fixed size, only the leading prefix
+ * is guaranteed valid and the remaining tail stays unspecified; when it is longer, only
+ * the prefix matching the topic size is kept and the rest is truncated.
  */
 class Topic::Server
 {
@@ -35,8 +33,10 @@ class Topic::Server
   enum class Status : uint8_t
   {
     WAIT_START,     ///< 正在找下一包前缀。Searching for the next packet prefix.
-    WAIT_TOPIC,     ///< 已读到前缀，正在等完整头。Prefix received; waiting for the full header.
-    WAIT_DATA_CRC,  ///< 头已接受，正在等 payload 和尾 CRC。Header accepted; waiting for payload plus trailing CRC.
+    WAIT_TOPIC,     ///< 已读到前缀，正在等完整头。Prefix received; waiting for the full
+                    ///< header.
+    WAIT_DATA_CRC,  ///< 头已接受，正在等 payload 和尾 CRC。Header accepted; waiting for
+                    ///< payload plus trailing CRC.
   };
 
   /**
@@ -134,11 +134,16 @@ class Topic::Server
   void ResetParser();
 
   Status status_ = Status::WAIT_START;  ///< 当前 parser 阶段。Current parser stage.
-  uint32_t data_len_ = 0;               ///< 当前包头声明的 payload 长度。Payload length declared by the current header.
-  RBTree<uint32_t> topic_map_;          ///< 从 topic 名称 CRC32 到 topic 句柄的映射。Map from topic-name CRC32 to topic handle.
-  QueueBase queue_;                     ///< 输入字节 FIFO。Input byte FIFO.
-  RawData parse_buff_;                  ///< 当前包头和 payload 的暂存缓冲区。Staging buffer holding the current header and payload.
-  TopicHandle current_topic_ = nullptr;  ///< 当前包命中的目标 topic。Target topic matched by the current packet.
-  MicrosecondTimestamp current_timestamp_;  ///< 当前包头里的时间戳。Timestamp carried by the current packet header.
+  uint32_t data_len_ =
+      0;  ///< 当前包头声明的 payload 长度。Payload length declared by the current header.
+  RBTree<uint32_t> topic_map_;  ///< 从 topic 名称 CRC32 到 topic 句柄的映射。Map from
+                                ///< topic-name CRC32 to topic handle.
+  QueueBase queue_;             ///< 输入字节 FIFO。Input byte FIFO.
+  RawData parse_buff_;  ///< 当前包头和 payload 的暂存缓冲区。Staging buffer holding the
+                        ///< current header and payload.
+  TopicHandle current_topic_ =
+      nullptr;  ///< 当前包命中的目标 topic。Target topic matched by the current packet.
+  MicrosecondTimestamp current_timestamp_;  ///< 当前包头里的时间戳。Timestamp carried by
+                                            ///< the current packet header.
 };
 }  // namespace LibXR

--- a/src/middleware/message/subscriber/async.hpp
+++ b/src/middleware/message/subscriber/async.hpp
@@ -10,9 +10,12 @@ namespace LibXR
  */
 enum class Topic::ASyncSubscriberState : uint32_t
 {
-  IDLE = 0,               ///< 当前没有等待，也没有待消费的新数据。No wait is pending and no unread data is buffered.
-  WAITING = 1,            ///< 等待下一次发布填充本地缓冲区。Waiting for the next publish to fill the local buffer.
-  DATA_READY = UINT32_MAX ///< 本地缓冲区已有一份待消费的新数据。One unread fresh sample is buffered locally.
+  IDLE = 0,     ///< 当前没有等待，也没有待消费的新数据。No wait is pending and no unread
+                ///< data is buffered.
+  WAITING = 1,  ///< 等待下一次发布填充本地缓冲区。Waiting for the next publish to fill
+                ///< the local buffer.
+  DATA_READY = UINT32_MAX  ///< 本地缓冲区已有一份待消费的新数据。One unread fresh sample
+                           ///< is buffered locally.
 };
 
 /**
@@ -21,10 +24,14 @@ enum class Topic::ASyncSubscriberState : uint32_t
  */
 struct Topic::ASyncBlock : public Topic::SuberBlock
 {
-  void* buff_addr;                 ///< 长期存在的本地接收对象地址。Long-lived local receive object address.
-  void (*copy_payload)(void* dst,
-                       void* payload_addr);    ///< 按订阅精确类型执行负载拷贝的适配函数。Adapter that copies one payload using the subscriber's exact type.
-  MicrosecondTimestamp timestamp;  ///< 最近接收的消息时间戳。Latest received message timestamp.
+  void* buff_addr;  ///< 长期存在的本地接收对象地址。Long-lived local receive object
+                    ///< address.
+  void (*copy_payload)(
+      void* dst,
+      void* payload_addr);  ///< 按订阅精确类型执行负载拷贝的适配函数。Adapter that copies
+                            ///< one payload using the subscriber's exact type.
+  MicrosecondTimestamp
+      timestamp;  ///< 最近接收的消息时间戳。Latest received message timestamp.
   std::atomic<ASyncSubscriberState> state =
       ASyncSubscriberState::IDLE;  ///< 当前异步订阅状态。Current async subscriber state.
 };
@@ -40,10 +47,12 @@ class Topic::ASyncSubscriber
 {
  public:
   /**
-   * @brief 通过主题名称构造异步订阅者 / Construct an asynchronous subscriber by topic name
+   * @brief 通过主题名称构造异步订阅者 / Construct an asynchronous subscriber by topic
+   * name
    * @param name 订阅的主题名称 / Name of the subscribed topic
    * @param domain 可选的域指针 / Optional domain pointer
-   * @note 包含初始化期动态内存分配，订阅者应长期存在 / Contains initialization-time dynamic allocation; subscribers are expected to be long-lived
+   * @note 包含初始化期动态内存分配，订阅者应长期存在 / Contains initialization-time
+   * dynamic allocation; subscribers are expected to be long-lived
    */
   ASyncSubscriber(const char* name, Domain* domain = nullptr)
       : ASyncSubscriber(Topic(WaitTopic(name, UINT32_MAX, domain)))
@@ -54,7 +63,8 @@ class Topic::ASyncSubscriber
    * @brief 通过 `Topic` 句柄构造异步订阅者 / Construct an asynchronous subscriber from a
    *        `Topic` handle
    * @param topic 订阅的主题 / Subscribed topic
-   * @note 包含初始化期动态内存分配，订阅者应长期存在 / Contains initialization-time dynamic allocation; subscribers are expected to be long-lived
+   * @note 包含初始化期动态内存分配，订阅者应长期存在 / Contains initialization-time
+   * dynamic allocation; subscribers are expected to be long-lived
    */
   ASyncSubscriber(Topic topic)
   {
@@ -118,7 +128,8 @@ class Topic::ASyncSubscriber
 
   /**
    * @brief 检查数据是否可用 / Check whether data is available
-   * @return 数据已准备好返回 `true`，否则返回 `false` / Returns `true` if data is ready, otherwise `false`
+   * @return 数据已准备好返回 `true`，否则返回 `false` / Returns `true` if data is ready,
+   * otherwise `false`
    */
   bool Available()
   {
@@ -154,20 +165,19 @@ class Topic::ASyncSubscriber
 
   /**
    * @brief 开始等待数据更新 / Start waiting for a data update
-   * @note 异步订阅者只接收 `WAITING` 状态下的下一次发布；`IDLE` 或 `DATA_READY` 状态下的新发布会被忽略 /
-   *       Async subscribers only capture the next publish while in `WAITING`
-   *       state; new publishes in `IDLE` or `DATA_READY` state are ignored
+   * @note 异步订阅者只接收 `WAITING` 状态下的下一次发布；`IDLE` 或 `DATA_READY`
+   * 状态下的新发布会被忽略 / Async subscribers only capture the next publish while in
+   * `WAITING` state; new publishes in `IDLE` or `DATA_READY` state are ignored
    */
   void StartWaiting()
   {
-    if (block_->data_.state.load(std::memory_order_acquire) ==
-        ASyncSubscriberState::IDLE)
+    if (block_->data_.state.load(std::memory_order_acquire) == ASyncSubscriberState::IDLE)
     {
-      block_->data_.state.store(ASyncSubscriberState::WAITING,
-                                std::memory_order_release);
+      block_->data_.state.store(ASyncSubscriberState::WAITING, std::memory_order_release);
     }
   }
 
-  LockFreeList::Node<ASyncBlock>* block_ = nullptr;  ///< 订阅者数据块。Subscriber data block.
+  LockFreeList::Node<ASyncBlock>* block_ =
+      nullptr;  ///< 订阅者数据块。Subscriber data block.
 };
 }  // namespace LibXR

--- a/src/middleware/message/subscriber/callback.hpp
+++ b/src/middleware/message/subscriber/callback.hpp
@@ -2,9 +2,8 @@
 
 #include <new>
 
-#include "libxr_def.hpp"
-
 #include "../topic.hpp"
+#include "libxr_def.hpp"
 
 namespace LibXR
 {
@@ -54,7 +53,8 @@ class Topic::Callback
   template <typename T>
   struct MessageViewTraits
   {
-    static constexpr bool VALUE = false;  ///< 默认不是 `MessageView`。Not a `MessageView` by default.
+    static constexpr bool VALUE =
+        false;  ///< 默认不是 `MessageView`。Not a `MessageView` by default.
   };
 
   /**
@@ -67,8 +67,10 @@ class Topic::Callback
   template <typename Data>
   struct MessageViewTraits<MessageView<Data>>
   {
-    static constexpr bool VALUE = true;  ///< 该参数是 `MessageView`。This argument is a `MessageView`.
-    using DataType = Data;  ///< `MessageView` 对应的数据类型。Payload type behind the `MessageView`.
+    static constexpr bool VALUE =
+        true;  ///< 该参数是 `MessageView`。This argument is a `MessageView`.
+    using DataType =
+        Data;  ///< `MessageView` 对应的数据类型。Payload type behind the `MessageView`.
   };
 
   /**
@@ -85,8 +87,10 @@ class Topic::Callback
    * @tparam T 待判断的参数类型 / Argument type to inspect
    */
   template <typename T>
-  static constexpr bool IS_MESSAGE_VIEW =
-      MessageViewTraits<RemoveCVRef<T>>::VALUE;  ///< 是否为带时间戳的类型化消息视图参数。Whether the argument is a timestamped typed message view.
+  static constexpr bool IS_MESSAGE_VIEW = MessageViewTraits<
+      RemoveCVRef<T>>::VALUE;  ///< 是否为带时间戳的类型化消息视图参数。Whether
+                               ///< the argument is a timestamped typed
+                               ///< message view.
 
   /**
    * @brief 是否为只读 raw payload 视图参数 / Whether one callback payload argument is a
@@ -94,9 +98,8 @@ class Topic::Callback
    * @tparam T 待判断的参数类型 / Argument type to inspect
    */
   template <typename T>
-  static constexpr bool IS_RAW_DATA_VIEW =
-      std::same_as<RemoveCVRef<T>, ConstRawData> ||
-      std::same_as<RemoveCVRef<T>, RawMessageView>;
+  static constexpr bool IS_RAW_DATA_VIEW = std::same_as<RemoveCVRef<T>, ConstRawData> ||
+                                           std::same_as<RemoveCVRef<T>, RawMessageView>;
 
   /**
    * @brief 是否把 payload 直接当成一个对象接收 / Whether one callback payload argument
@@ -106,7 +109,9 @@ class Topic::Callback
   template <typename T>
   static constexpr bool IS_TYPED_DATA =
       !IS_MESSAGE_VIEW<T> && !IS_RAW_DATA_VIEW<T> &&
-      TopicPayload<RemoveCVRef<T>>;  ///< 是否把负载直接当成一个对象来接收。Whether the payload is received directly as one typed object.
+      TopicPayload<RemoveCVRef<T>>;  ///< 是否把负载直接当成一个对象来接收。Whether the
+                                     ///< payload is received directly as one typed
+                                     ///< object.
 
   /**
    * @brief 是否是回调接口允许的 payload 参数写法 / Whether one payload argument form is
@@ -116,7 +121,8 @@ class Topic::Callback
   template <typename T>
   static constexpr bool IS_CALLBACK_PAYLOAD =
       IS_MESSAGE_VIEW<T> || IS_RAW_DATA_VIEW<T> ||
-      IS_TYPED_DATA<T>;  ///< 是否是这个回调接口允许的负载参数写法。Whether this callback interface accepts this payload argument form.
+      IS_TYPED_DATA<T>;  ///< 是否是这个回调接口允许的负载参数写法。Whether this callback
+                         ///< interface accepts this payload argument form.
 
   /**
    * @brief 是否错误地使用了可变 `MessageView<T>&` / Whether one payload argument is an
@@ -144,11 +150,14 @@ class Topic::Callback
   struct BlockHeader
   {
     using RunFun = void (*)(const BlockHeader*, bool, MicrosecondTimestamp, void*,
-                            size_t);  ///< 所有具体回调块共用的执行入口。Shared execution entry used by all concrete callback blocks.
+                            size_t);  ///< 所有具体回调块共用的执行入口。Shared execution
+                                      ///< entry used by all concrete callback blocks.
 
     RunFun run = nullptr;  ///< 当前块的执行函数。Execution function of the current block.
-    TypeID::ID payload_type_id = nullptr;  ///< 该回调期望的主题负载类型标识。Expected topic payload type identifier.
-    bool accepts_raw_payload = false;  ///< 是否按 raw payload 视图接收。Whether this callback receives a raw payload view.
+    TypeID::ID payload_type_id = nullptr;  ///< 该回调期望的主题负载类型标识。Expected
+                                           ///< topic payload type identifier.
+    bool accepts_raw_payload = false;      ///< 是否按 raw payload 视图接收。Whether this
+                                           ///< callback receives a raw payload view.
   };
 
   /**
@@ -254,8 +263,7 @@ class Topic::Callback
      * @param arg 绑定到回调中的参数 / Argument bound into the callback
      */
     PayloadOnlyBlock(Function fun, BoundArg&& arg)
-        : BlockHeader{&Run, PayloadTypeID<PayloadArg>(),
-                      AcceptsRawPayload<PayloadArg>()},
+        : BlockHeader{&Run, PayloadTypeID<PayloadArg>(), AcceptsRawPayload<PayloadArg>()},
           fun_(fun),
           arg_(std::move(arg))
     {
@@ -302,8 +310,7 @@ class Topic::Callback
      * @param arg 绑定到回调中的参数 / Argument bound into the callback
      */
     TimestampPayloadBlock(Function fun, BoundArg&& arg)
-        : BlockHeader{&Run, PayloadTypeID<PayloadArg>(),
-                      AcceptsRawPayload<PayloadArg>()},
+        : BlockHeader{&Run, PayloadTypeID<PayloadArg>(), AcceptsRawPayload<PayloadArg>()},
           fun_(fun),
           arg_(std::move(arg))
     {
@@ -337,9 +344,8 @@ class Topic::Callback
       {
         using View = MessageViewTraits<RemoveCVRef<PayloadArg>>;
         using Data = typename View::DataType;
-        block->fun_(
-            in_isr, block->arg_, timestamp,
-            MessageView<Data>{timestamp, reinterpret_cast<Data*>(payload_addr)});
+        block->fun_(in_isr, block->arg_, timestamp,
+                    MessageView<Data>{timestamp, reinterpret_cast<Data*>(payload_addr)});
       }
       else
       {
@@ -380,7 +386,9 @@ class Topic::Callback
   {
     using Traits = FunctionTraits<Function>;  ///< 回调签名信息。Callback signature info.
     using PayloadArg =
-        typename Traits::template Arg<2>;  ///< 第三个参数，即负载参数类型。Third argument, namely the payload argument type.
+        typename Traits::template Arg<2>;  ///< 第三个参数，即负载参数类型。Third
+                                           ///< argument, namely the
+                                           ///< payload argument type.
 
     /**
      * @brief 创建只转发负载的回调块 / Create one callback block that forwards only the
@@ -410,9 +418,13 @@ class Topic::Callback
   {
     using Traits = FunctionTraits<Function>;  ///< 回调签名信息。Callback signature info.
     using TimestampArg =
-        typename Traits::template Arg<2>;  ///< 第三个参数，即时间戳参数类型。Third argument, namely the timestamp argument type.
+        typename Traits::template Arg<2>;  ///< 第三个参数，即时间戳参数类型。Third
+                                           ///< argument, namely the
+                                           ///< timestamp argument type.
     using PayloadArg =
-        typename Traits::template Arg<3>;  ///< 第四个参数，即负载参数类型。Fourth argument, namely the payload argument type.
+        typename Traits::template Arg<3>;  ///< 第四个参数，即负载参数类型。Fourth
+                                           ///< argument, namely the
+                                           ///< payload argument type.
 
     /**
      * @brief 创建同时转发时间戳和负载的回调块 / Create one callback block that forwards
@@ -453,8 +465,8 @@ class Topic::Callback
   }
 
   inline static BlockHeader empty_block_{
-      &EmptyRun, nullptr,
-      false};  ///< 空回调句柄共用的静态空执行块。Shared static empty execution block used by empty callback handles.
+      &EmptyRun, nullptr, false};  ///< 空回调句柄共用的静态空执行块。Shared static empty
+                                   ///< execution block used by empty callback handles.
 
  public:
   /**
@@ -527,7 +539,8 @@ class Topic::Callback
   /**
    * @brief 判断该回调是否按 raw payload 视图接收消息 / Tell whether this callback
    *        receives messages as a raw payload view
-   * @return 是 raw payload 视图回调则返回 true / Returns true for raw payload view callbacks
+   * @return 是 raw payload 视图回调则返回 true / Returns true for raw payload view
+   * callbacks
    */
   bool IsRawPayloadView() const { return block_->accepts_raw_payload; }
 
@@ -540,7 +553,8 @@ class Topic::Callback
    */
   explicit Callback(BlockHeader* block) : block_(block ? block : &empty_block_) {}
 
-  BlockHeader* block_ = &empty_block_;  ///< 当前回调句柄绑定的执行块。Execution block bound to the current callback handle.
+  BlockHeader* block_ = &empty_block_;  ///< 当前回调句柄绑定的执行块。Execution block
+                                        ///< bound to the current callback handle.
 };
 
 /**
@@ -584,8 +598,10 @@ struct Topic::CallbackBlock : public Topic::SuberBlock
  * @brief 注册回调函数 / Register a callback function
  * @param cb 需要注册的回调函数 / Callback function to register
  *
- * @note 包含初始化期动态内存分配，回调订阅应长期存在 / Contains initialization-time dynamic allocation; callback subscriptions are expected to be long-lived
- * @note 回调在发布锁内运行，不应重入发布同一个主题 / The callback runs while the publish lock is held and should not re-enter publishing on the same topic
+ * @note 包含初始化期动态内存分配，回调订阅应长期存在 / Contains initialization-time
+ * dynamic allocation; callback subscriptions are expected to be long-lived
+ * @note 回调在发布锁内运行，不应重入发布同一个主题 / The callback runs while the publish
+ * lock is held and should not re-enter publishing on the same topic
  */
 inline void Topic::RegisterCallback(Callback& cb)
 {

--- a/src/middleware/message/subscriber/queue.hpp
+++ b/src/middleware/message/subscriber/queue.hpp
@@ -12,7 +12,8 @@ struct Topic::QueueBlock : public Topic::SuberBlock
 {
   SPSCQueueBase* queue;  ///< 指向订阅队列基类。Pointer to the subscribed queue base.
   void (*fun)(MicrosecondTimestamp, void*,
-              QueueBlock&);  ///< 把一条发布转发进队列。Adapter that forwards one publish into the queue.
+              QueueBlock&);  ///< 把一条发布转发进队列。Adapter that forwards one publish
+                             ///< into the queue.
 };
 
 /**
@@ -28,8 +29,10 @@ class Topic::QueuedSubscriber
    * @tparam Data 队列存储的数据类型 / Data type stored in the queue
    * @param name 订阅的主题名称 / Name of the subscribed topic
    * @param queue 订阅的数据队列 / Subscribed data queue
-   * @param domain 可选的域指针，默认为 `nullptr` / Optional domain pointer, default `nullptr`
-   * @note 包含初始化期动态内存分配，订阅者应长期存在 / Contains initialization-time dynamic allocation; subscribers are expected to be long-lived
+   * @param domain 可选的域指针，默认为 `nullptr` / Optional domain pointer, default
+   * `nullptr`
+   * @note 包含初始化期动态内存分配，订阅者应长期存在 / Contains initialization-time
+   * dynamic allocation; subscribers are expected to be long-lived
    * @note 队列订阅者只保存 `queue` 的指针；队列对象本身必须至少活到订阅者不再使用
    *       为止 /
    *       Queued subscribers keep only a pointer to `queue`; the queue object
@@ -46,11 +49,13 @@ class Topic::QueuedSubscriber
   }
 
   /**
-   * @brief 通过主题名称构造带时间戳消息队列订阅者 / Construct a queue subscriber for timestamped messages by topic name
+   * @brief 通过主题名称构造带时间戳消息队列订阅者 / Construct a queue subscriber for
+   * timestamped messages by topic name
    * @tparam Data 队列消息的数据类型 / Data type stored in the queue message
    * @param name 订阅的主题名称 / Name of the subscribed topic
    * @param queue 订阅的消息队列 / Subscribed message queue
-   * @param domain 可选的域指针，默认为 `nullptr` / Optional domain pointer, default `nullptr`
+   * @param domain 可选的域指针，默认为 `nullptr` / Optional domain pointer, default
+   * `nullptr`
    * @note 队列订阅者只保存 `queue` 的指针；队列对象本身必须至少活到订阅者不再使用
    *       为止 /
    *       Queued subscribers keep only a pointer to `queue`; the queue object
@@ -68,11 +73,13 @@ class Topic::QueuedSubscriber
   }
 
   /**
-   * @brief 使用 `Topic` 和无锁队列构造订阅者 / Construct a subscriber from a `Topic` and a lock-free queue
+   * @brief 使用 `Topic` 和无锁队列构造订阅者 / Construct a subscriber from a `Topic` and
+   * a lock-free queue
    * @tparam Data 队列存储的数据类型 / Data type stored in the queue
    * @param topic 订阅的主题 / Subscribed topic
    * @param queue 订阅的数据队列 / Subscribed data queue
-   * @note 包含初始化期动态内存分配，订阅者应长期存在 / Contains initialization-time dynamic allocation; subscribers are expected to be long-lived
+   * @note 包含初始化期动态内存分配，订阅者应长期存在 / Contains initialization-time
+   * dynamic allocation; subscribers are expected to be long-lived
    * @note 队列订阅者只保存 `queue` 的指针；队列对象本身必须至少活到订阅者不再使用
    *       为止 /
    *       Queued subscribers keep only a pointer to `queue`; the queue object
@@ -91,15 +98,14 @@ class Topic::QueuedSubscriber
     block_->data_.type = SuberType::QUEUE;
     block_->data_.queue = &queue;
     block_->data_.fun = [](MicrosecondTimestamp, void* payload_addr, QueueBlock& block)
-    {
-      (void)block.queue->PushBytes(payload_addr);
-    };
+    { (void)block.queue->PushBytes(payload_addr); };
 
     topic.block_->data_.subers.Add(*block_);
   }
 
   /**
-   * @brief 使用 `Topic` 和带时间戳消息队列构造订阅者 / Construct a subscriber from a `Topic` and a timestamped message queue
+   * @brief 使用 `Topic` 和带时间戳消息队列构造订阅者 / Construct a subscriber from a
+   * `Topic` and a timestamped message queue
    * @tparam Data 队列消息的数据类型 / Data type stored in the queue message
    * @param topic 订阅的主题 / Subscribed topic
    * @param queue 订阅的消息队列 / Subscribed message queue
@@ -177,6 +183,7 @@ class Topic::QueuedSubscriber
   }
 
  private:
-  LockFreeList::Node<QueueBlock>* block_ = nullptr;  ///< 订阅者数据块。Subscriber data block.
+  LockFreeList::Node<QueueBlock>* block_ =
+      nullptr;  ///< 订阅者数据块。Subscriber data block.
 };
 }  // namespace LibXR

--- a/src/middleware/message/subscriber/sync.hpp
+++ b/src/middleware/message/subscriber/sync.hpp
@@ -22,16 +22,21 @@ struct Topic::SyncBlock : public SuberBlock
    */
   enum WaitState : uint32_t
   {
-    WAIT_IDLE = 0,   ///< 当前没有挂起等待。No wait is currently pending.
-    WAITING = 1,     ///< 当前有一个挂起的等待者。One waiter is currently pending.
-    WAIT_CLAIMED = 2 ///< 某次发布已归一个刚超时的等待者所有。One publish wakeup is reserved for a waiter that just timed out.
+    WAIT_IDLE = 0,    ///< 当前没有挂起等待。No wait is currently pending.
+    WAITING = 1,      ///< 当前有一个挂起的等待者。One waiter is currently pending.
+    WAIT_CLAIMED = 2  ///< 某次发布已归一个刚超时的等待者所有。One publish wakeup is
+                      ///< reserved for a waiter that just timed out.
   };
 
-  void* buff_addr;                 ///< 收到消息后要拷到这里。Received payloads are copied here.
-  void (*copy_payload)(void* dst,
-                       void* payload_addr);    ///< 按订阅精确类型执行负载拷贝的适配函数。Adapter that copies one payload using the subscriber's exact type.
-  MicrosecondTimestamp timestamp;  ///< 这里对应那份数据的时间戳。Timestamp paired with the buffered data.
-  std::atomic<uint32_t> wait_state = WAIT_IDLE;  ///< 当前 `Wait()` 的挂起状态。Current pending state of `Wait()`.
+  void* buff_addr;  ///< 收到消息后要拷到这里。Received payloads are copied here.
+  void (*copy_payload)(
+      void* dst,
+      void* payload_addr);  ///< 按订阅精确类型执行负载拷贝的适配函数。Adapter that copies
+                            ///< one payload using the subscriber's exact type.
+  MicrosecondTimestamp
+      timestamp;  ///< 这里对应那份数据的时间戳。Timestamp paired with the buffered data.
+  std::atomic<uint32_t> wait_state =
+      WAIT_IDLE;  ///< 当前 `Wait()` 的挂起状态。Current pending state of `Wait()`.
   Semaphore sem;  ///< 用来唤醒 `Wait()` 的信号量。Semaphore used to wake `Wait()`.
 };
 
@@ -50,7 +55,8 @@ class Topic::SyncSubscriber
    * @param name 主题名称 / Topic name
    * @param data 用来接收消息的对象 / Destination object receiving subscribed data
    * @param domain 可选的主题域 / Optional topic domain
-   * @note 包含初始化期动态内存分配，订阅者应长期存在 / Contains initialization-time dynamic allocation; subscribers are expected to be long-lived
+   * @note 包含初始化期动态内存分配，订阅者应长期存在 / Contains initialization-time
+   * dynamic allocation; subscribers are expected to be long-lived
    * @note 同步订阅者不会自建接收缓冲区，而是直接把收到的数据写进 `data`；`data`
    *       必须至少活到订阅者不再使用为止 /
    *       Synchronous subscribers do not allocate their own receive buffer;
@@ -63,10 +69,12 @@ class Topic::SyncSubscriber
   }
 
   /**
-   * @brief 通过 `Topic` 句柄构造同步订阅者 / Construct a synchronous subscriber using a `Topic` handle
+   * @brief 通过 `Topic` 句柄构造同步订阅者 / Construct a synchronous subscriber using a
+   * `Topic` handle
    * @param topic 订阅的主题 / Topic being subscribed to
    * @param data 用来接收消息的对象 / Destination object receiving subscribed data
-   * @note 包含初始化期动态内存分配，订阅者应长期存在 / Contains initialization-time dynamic allocation; subscribers are expected to be long-lived
+   * @note 包含初始化期动态内存分配，订阅者应长期存在 / Contains initialization-time
+   * dynamic allocation; subscribers are expected to be long-lived
    * @note 同步订阅者不会自建接收缓冲区，而是直接把收到的数据写进 `data`；`data`
    *       必须至少活到订阅者不再使用为止 /
    *       Synchronous subscribers do not allocate their own receive buffer;
@@ -191,6 +199,7 @@ class Topic::SyncSubscriber
    */
   MicrosecondTimestamp GetTimestamp() const { return block_->data_.timestamp; }
 
-  LockFreeList::Node<SyncBlock>* block_ = nullptr;  ///< 订阅者数据块。Subscriber data block.
+  LockFreeList::Node<SyncBlock>* block_ =
+      nullptr;  ///< 订阅者数据块。Subscriber data block.
 };
 }  // namespace LibXR

--- a/src/middleware/message/topic.hpp
+++ b/src/middleware/message/topic.hpp
@@ -4,15 +4,14 @@
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
-#include <cstddef>
 
 #include "libxr_cb.hpp"
 #include "libxr_def.hpp"
 #include "libxr_time.hpp"
 #include "libxr_type.hpp"
 #include "lockfree_list.hpp"
-#include "queue.hpp"
 #include "mutex.hpp"
+#include "queue.hpp"
 #include "rbt.hpp"
 #include "semaphore.hpp"
 #include "thread.hpp"
@@ -61,9 +60,11 @@ class Topic
    */
   enum class LockState : uint32_t
   {
-    UNLOCKED = 0,          ///< 当前未持有发布锁。The publish path is currently unlocked.
-    LOCKED = 1,            ///< 当前通过原子快路径持有发布权。The publish path is locked through the atomic fast path.
-    USE_MUTEX = UINT32_MAX ///< 当前主题改走互斥量串行化。This topic currently serializes publishers through a mutex.
+    UNLOCKED = 0,  ///< 当前未持有发布锁。The publish path is currently unlocked.
+    LOCKED = 1,  ///< 当前通过原子快路径持有发布权。The publish path is locked through the
+                 ///< atomic fast path.
+    USE_MUTEX = UINT32_MAX  ///< 当前主题改走互斥量串行化。This topic currently serializes
+                            ///< publishers through a mutex.
   };
 
  public:
@@ -79,13 +80,17 @@ class Topic
    */
   struct Block
   {
-    std::atomic<LockState> busy;  ///< 发布路径串行化状态。Publish-path serialization state.
-    LockFreeList subers;          ///< 已挂接订阅者链表。List of attached subscribers.
-    TypeID::ID payload_type_id;   ///< 精确 payload 类型标识。Exact payload type identifier.
-    uint32_t payload_size;        ///< 该 topic 固定 payload 字节数。Fixed payload size in bytes of this topic.
-    uint32_t payload_alignment;   ///< 该 topic payload 所需对齐。Required payload alignment of this topic.
-    uint32_t crc32;               ///< 主题名 CRC32 键。CRC32 key of the topic name.
-    Mutex* mutex;                 ///< 多发布者主题使用的互斥量。Mutex used by multi-publisher topics.
+    std::atomic<LockState>
+        busy;             ///< 发布路径串行化状态。Publish-path serialization state.
+    LockFreeList subers;  ///< 已挂接订阅者链表。List of attached subscribers.
+    TypeID::ID
+        payload_type_id;    ///< 精确 payload 类型标识。Exact payload type identifier.
+    uint32_t payload_size;  ///< 该 topic 固定 payload 字节数。Fixed payload size in bytes
+                            ///< of this topic.
+    uint32_t payload_alignment;  ///< 该 topic payload 所需对齐。Required payload
+                                 ///< alignment of this topic.
+    uint32_t crc32;              ///< 主题名 CRC32 键。CRC32 key of the topic name.
+    Mutex* mutex;  ///< 多发布者主题使用的互斥量。Mutex used by multi-publisher topics.
   };
 
 #ifndef __DOXYGEN__
@@ -103,9 +108,13 @@ class Topic
    */
   template <typename Data>
   class PackedData;
-  static constexpr uint8_t PACKET_PREFIX = 0x5A;  ///< 打包消息前缀字节。Packed-message prefix byte.
-  static constexpr uint8_t PACKET_VERSION = 0x01;  ///< 打包消息协议版本。Packed-message protocol version.
-  static constexpr size_t PACK_BASE_SIZE = 17;  ///< 固定非 payload 开销：16 字节头 + 1 字节尾 CRC8。Fixed non-payload overhead: 16-byte header plus 1-byte trailing CRC8.
+  static constexpr uint8_t PACKET_PREFIX =
+      0x5A;  ///< 打包消息前缀字节。Packed-message prefix byte.
+  static constexpr uint8_t PACKET_VERSION =
+      0x01;  ///< 打包消息协议版本。Packed-message protocol version.
+  static constexpr size_t PACK_BASE_SIZE =
+      17;  ///< 固定非 payload 开销：16 字节头 + 1 字节尾 CRC8。Fixed non-payload
+           ///< overhead: 16-byte header plus 1-byte trailing CRC8.
 #endif
 
   /**
@@ -126,7 +135,8 @@ class Topic
   {
     static_assert(TopicPayload<Data>);
     MicrosecondTimestamp timestamp;  ///< 消息时间戳。Message timestamp.
-    Data* data;                      ///< 指向本次发布 payload 对象的指针。Pointer to the payload object of this publish.
+    Data* data;  ///< 指向本次发布 payload 对象的指针。Pointer to the payload object of
+                 ///< this publish.
   };
 
   /**
@@ -143,7 +153,8 @@ class Topic
   struct RawMessageView
   {
     MicrosecondTimestamp timestamp;  ///< 消息时间戳。Message timestamp.
-    ConstRawData payload;            ///< 本次发布 payload 的只读字节视图。Read-only byte view of this publish payload.
+    ConstRawData payload;  ///< 本次发布 payload 的只读字节视图。Read-only byte view of
+                           ///< this publish payload.
   };
 
   /**
@@ -201,7 +212,9 @@ class Topic
      */
     Domain(const char* name);
 
-    RBTree<uint32_t>::Node<RBTree<uint32_t>>* node_;  ///< 该域在全局域表里的节点。This domain's node inside the global domain tree.
+    RBTree<uint32_t>::Node<RBTree<uint32_t>>*
+        node_;  ///< 该域在全局域表里的节点。This domain's node inside the global domain
+                ///< tree.
   };
 
   /**
@@ -210,10 +223,10 @@ class Topic
    */
   enum class SuberType : uint8_t
   {
-    SYNC,     ///< 同步等待型订阅者。Synchronous wait-based subscriber.
-    ASYNC,    ///< 异步本地缓冲型订阅者。Asynchronous local-buffer subscriber.
-    QUEUE,    ///< 队列转发型订阅者。Queue-forwarding subscriber.
-    CALLBACK, ///< 回调执行型订阅者。Callback-executing subscriber.
+    SYNC,      ///< 同步等待型订阅者。Synchronous wait-based subscriber.
+    ASYNC,     ///< 异步本地缓冲型订阅者。Asynchronous local-buffer subscriber.
+    QUEUE,     ///< 队列转发型订阅者。Queue-forwarding subscriber.
+    CALLBACK,  ///< 回调执行型订阅者。Callback-executing subscriber.
   };
 
   /**
@@ -324,11 +337,11 @@ class Topic
    *        Required payload alignment of this topic; must be a non-zero power of
    *        two
    * @param domain 可选主题域 / Optional topic domain
-   * @param multi_publisher 是否允许多发布者串行化 / Whether to allow serialized multi-publisher use
+   * @param multi_publisher 是否允许多发布者串行化 / Whether to allow serialized
+   * multi-publisher use
    */
   Topic(const char* name, TypeID::ID payload_type_id, size_t payload_size,
-        size_t payload_alignment, Domain* domain = nullptr,
-        bool multi_publisher = false);
+        size_t payload_alignment, Domain* domain = nullptr, bool multi_publisher = false);
 
   /**
    * @brief 用精确类型创建或查找一个 topic / Create or look up one topic using one
@@ -471,8 +484,10 @@ class Topic
   /**
    * @brief 供 packet/server 路径按字节发布一条消息 / Publish one message from the
    *        packet/server path using bytes already arranged as the exact payload object
-   * @param payload_addr 已满足对齐的 payload 起始地址 / Start address of the already-aligned payload object
-   * @param payload_size payload 字节数，必须等于 topic 固定大小 / Payload size, must equal the fixed topic size
+   * @param payload_addr 已满足对齐的 payload 起始地址 / Start address of the
+   * already-aligned payload object
+   * @param payload_size payload 字节数，必须等于 topic 固定大小 / Payload size, must
+   * equal the fixed topic size
    * @param timestamp 这条消息的时间戳 / Timestamp of this message
    */
   void PublishBytesFromServer(void* payload_addr, size_t payload_size,
@@ -483,10 +498,12 @@ class Topic
 
   /**
    * @brief 供回调/ISR 上下文里的 packet/server 路径按字节发布一条消息 / Publish one
-   *        packet/server message from callback/ISR context using bytes already arranged as
-   *        the exact payload object
-   * @param payload_addr 已满足对齐的 payload 起始地址 / Start address of the already-aligned payload object
-   * @param payload_size payload 字节数，必须等于 topic 固定大小 / Payload size, must equal the fixed topic size
+   *        packet/server message from callback/ISR context using bytes already arranged
+   * as the exact payload object
+   * @param payload_addr 已满足对齐的 payload 起始地址 / Start address of the
+   * already-aligned payload object
+   * @param payload_size payload 字节数，必须等于 topic 固定大小 / Payload size, must
+   * equal the fixed topic size
    * @param timestamp 这条消息的时间戳 / Timestamp of this message
    * @param in_isr 当前是否位于 ISR / Whether the current path is in ISR context
    */
@@ -525,7 +542,8 @@ class Topic
 
   /**
    * @brief 将一段 raw payload 按当前 topic 元数据打包成 packet / Pack a raw payload
-   *        byte view into one packet using the current topic metadata and current timestamp
+   *        byte view into one packet using the current topic metadata and current
+   * timestamp
    * @param data 待打包 payload 字节 / Payload bytes to pack
    * @param packet 输出 packet 缓冲区 / Output packet buffer
    * @return 操作结果错误码 / Error code
@@ -537,7 +555,8 @@ class Topic
 
   /**
    * @brief 将一段 raw payload 按当前 topic 元数据和指定时间戳打包成 packet / Pack a raw
-   *        payload byte view into one packet using the current topic metadata and timestamp
+   *        payload byte view into one packet using the current topic metadata and
+   * timestamp
    * @param data 待打包 payload 字节 / Payload bytes to pack
    * @param packet 输出 packet 缓冲区 / Output packet buffer
    * @param timestamp 指定时间戳 / Explicit timestamp
@@ -588,10 +607,12 @@ class Topic
   uint32_t GetKey() const;
 
  private:
-  TopicHandle block_ = nullptr;  ///< 当前 topic 视图绑定的状态块。Runtime state block bound to the current topic view.
+  TopicHandle block_ = nullptr;  ///< 当前 topic 视图绑定的状态块。Runtime state block
+                                 ///< bound to the current topic view.
 
-  static inline RBTree<uint32_t>* domain_ = nullptr;  ///< 全局 topic 域注册表。Global registry of topic domains.
-  static inline Domain* def_domain_ = nullptr;        ///< 缺省 topic 域。Default topic domain.
+  static inline RBTree<uint32_t>* domain_ =
+      nullptr;  ///< 全局 topic 域注册表。Global registry of topic domains.
+  static inline Domain* def_domain_ = nullptr;  ///< 缺省 topic 域。Default topic domain.
 
   /**
    * @brief 确保全局域注册表已创建 / Ensure the global domain registry exists
@@ -764,12 +785,12 @@ class Topic
    * @param payload_addr 已满足对齐的 payload 地址 / Already-aligned payload address
    * @param payload_size payload 字节数 / Payload size in bytes
    * @param timestamp 消息时间戳 / Message timestamp
-   * @param from_callback 是否来自回调发布路径 / Whether this publish comes from callback path
+   * @param from_callback 是否来自回调发布路径 / Whether this publish comes from callback
+   * path
    * @param in_isr 当前是否位于 ISR / Whether the current path is in ISR context
    */
   void PublishServerBytes(void* payload_addr, size_t payload_size,
-                          MicrosecondTimestamp timestamp, bool from_callback,
-                          bool in_isr)
+                          MicrosecondTimestamp timestamp, bool from_callback, bool in_isr)
   {
     CheckServerPublishContract(block_, payload_addr, payload_size);
 

--- a/src/middleware/ramfs/custom.hpp
+++ b/src/middleware/ramfs/custom.hpp
@@ -1,30 +1,30 @@
+/**
+ * @brief `RamFS` 的自定义节点片段 / Custom-node fragment of `RamFS`
+ */
+/**
+ * @class Custom
+ * @brief 用户自定义节点，RamFS 仅负责命名和查找 / User-defined node; RamFS only
+ * stores and finds it by name
+ */
+class Custom : public FsNode
+{
+ public:
   /**
-   * @brief `RamFS` 的自定义节点片段 / Custom-node fragment of `RamFS`
+   * @brief 构造自定义节点 / Construct a custom node
+   * @param name 节点名称 / Node name
+   * @param kind 用户定义类型 / User-defined kind
+   * @param context 用户上下文指针 / User context pointer
+   *
+   * @note 包含动态内存分配 / Contains dynamic memory allocation
    */
+  explicit Custom(const char* name, uint32_t kind = 0, void* context = nullptr);
+
+  uint32_t kind_ = 0;        ///< 用户定义类型标签 / User-defined kind tag.
+  void* context_ = nullptr;  ///< 用户自管上下文指针 / Caller-owned user context pointer.
+
+ private:
   /**
-   * @class Custom
-   * @brief 用户自定义节点，RamFS 仅负责命名和查找 / User-defined node; RamFS only
-   * stores and finds it by name
+   * @brief 构造一个空自定义节点壳 / Construct one empty custom-node shell
    */
-  class Custom : public FsNode
-  {
-   public:
-    /**
-     * @brief 构造自定义节点 / Construct a custom node
-     * @param name 节点名称 / Node name
-     * @param kind 用户定义类型 / User-defined kind
-     * @param context 用户上下文指针 / User context pointer
-     *
-     * @note 包含动态内存分配 / Contains dynamic memory allocation
-     */
-    explicit Custom(const char* name, uint32_t kind = 0, void* context = nullptr);
-
-    uint32_t kind_ = 0;        ///< 用户定义类型标签 / User-defined kind tag.
-    void* context_ = nullptr;  ///< 用户自管上下文指针 / Caller-owned user context pointer.
-
-   private:
-    /**
-     * @brief 构造一个空自定义节点壳 / Construct one empty custom-node shell
-     */
-    Custom();
-  };
+  Custom();
+};

--- a/src/middleware/ramfs/dir.hpp
+++ b/src/middleware/ramfs/dir.hpp
@@ -1,130 +1,130 @@
+/**
+ * @brief `RamFS` 的目录节点片段 / Directory-node fragment of `RamFS`
+ */
+/**
+ * @class Dir
+ * @brief 目录节点，管理直属子节点 / Directory node that owns a child namespace
+ */
+class Dir : public FsNode
+{
+ public:
   /**
-   * @brief `RamFS` 的目录节点片段 / Directory-node fragment of `RamFS`
+   * @brief 添加直属文件节点 / Add a direct child file node
+   * @param file 文件节点 / File node
    */
+  void Add(File& file) { AddNode(file); }
+
   /**
-   * @class Dir
-   * @brief 目录节点，管理直属子节点 / Directory node that owns a child namespace
+   * @brief 添加直属目录节点 / Add a direct child directory node
+   * @param dir 目录节点 / Directory node
    */
-  class Dir : public FsNode
+  void Add(Dir& dir) { AddNode(dir); }
+
+  /**
+   * @brief 添加直属自定义节点 / Add a direct child custom node
+   * @param custom 自定义节点 / Custom node
+   */
+  void Add(Custom& custom) { AddNode(custom); }
+
+  /**
+   * @brief 查找直属子节点 / Find a direct child node
+   * @param name 节点名称 / Node name
+   * @return 子节点指针；未找到返回 nullptr / Child node pointer, or nullptr
+   */
+  FsNode* FindNode(const char* name);
+
+  /**
+   * @brief 查找直属文件 / Find a direct child file
+   * @param name 文件名 / File name
+   * @return 文件指针；未找到返回 nullptr / File pointer, or nullptr
+   */
+  File* FindFile(const char* name);
+
+  /**
+   * @brief 递归查找文件 / Find a file recursively
+   * @param name 文件名 / File name
+   * @return 文件指针；未找到返回 nullptr / File pointer, or nullptr
+   */
+  File* FindFileRev(const char* name);
+
+  /**
+   * @brief 查找直属目录，支持 "." 和 ".." / Find a direct child directory,
+   * supporting "." and ".."
+   * @param name 目录名 / Directory name
+   * @return 目录指针；未找到返回 nullptr / Directory pointer, or nullptr
+   */
+  Dir* FindDir(const char* name);
+
+  /**
+   * @brief 递归查找目录，支持 "." 和 ".." / Find a directory recursively,
+   * supporting "." and ".."
+   * @param name 目录名 / Directory name
+   * @return 目录指针；未找到返回 nullptr / Directory pointer, or nullptr
+   */
+  Dir* FindDirRev(const char* name);
+
+  /**
+   * @brief 查找直属自定义节点 / Find a direct child custom node
+   * @param name 节点名称 / Node name
+   * @return 自定义节点指针；未找到返回 nullptr / Custom node pointer, or nullptr
+   */
+  Custom* FindCustom(const char* name);
+
+  /**
+   * @brief 递归查找自定义节点 / Find a custom node recursively
+   * @param name 节点名称 / Node name
+   * @return 自定义节点指针；未找到返回 nullptr / Custom node pointer, or nullptr
+   */
+  Custom* FindCustomRev(const char* name);
+
+  /**
+   * @brief 遍历直属子节点 / Iterate over direct child nodes
+   * @tparam Func 回调类型 / Callback type
+   * @param func 回调函数，返回非 OK 时停止遍历 / Callback; non-OK stops iteration
+   * @return 遍历结果 / Iteration result
+   */
+  template <typename Func>
+  ErrorCode Foreach(Func func)
   {
-   public:
-    /**
-     * @brief 添加直属文件节点 / Add a direct child file node
-     * @param file 文件节点 / File node
-     */
-    void Add(File& file) { AddNode(file); }
+    return rbt_.Foreach<FsNode*>([&](Tree::Node<FsNode*>& node)
+                                 { return func(*node.data_); });
+  }
 
-    /**
-     * @brief 添加直属目录节点 / Add a direct child directory node
-     * @param dir 目录节点 / Directory node
-     */
-    void Add(Dir& dir) { AddNode(dir); }
+ private:
+  /**
+   * @brief 构造一个空目录壳 / Construct one empty directory shell
+   */
+  Dir();
 
-    /**
-     * @brief 添加直属自定义节点 / Add a direct child custom node
-     * @param custom 自定义节点 / Custom node
-     */
-    void Add(Custom& custom) { AddNode(custom); }
+  /**
+   * @brief 构造一个具名目录壳 / Construct one named directory shell
+   * @param name 目录名称 / Directory name
+   */
+  explicit Dir(const char* name);
 
-    /**
-     * @brief 查找直属子节点 / Find a direct child node
-     * @param name 节点名称 / Node name
-     * @return 子节点指针；未找到返回 nullptr / Child node pointer, or nullptr
-     */
-    FsNode* FindNode(const char* name);
+  /**
+   * @brief 把一个节点挂到当前目录下 / Attach one node under the current directory
+   * @param node 待挂接节点 / Node to attach
+   */
+  void AddNode(FsNode& node);
 
-    /**
-     * @brief 查找直属文件 / Find a direct child file
-     * @param name 文件名 / File name
-     * @return 文件指针；未找到返回 nullptr / File pointer, or nullptr
-     */
-    File* FindFile(const char* name);
+  /**
+   * @brief 在当前目录按类型查找直属节点 / Find one direct child node of a given type
+   * @param name 节点名称 / Node name
+   * @param type 目标节点类型 / Desired node type
+   * @return 找到的节点；未找到返回 nullptr / Matching node, or nullptr
+   */
+  FsNode* FindNodeByType(const char* name, FsNodeType type);
 
-    /**
-     * @brief 递归查找文件 / Find a file recursively
-     * @param name 文件名 / File name
-     * @return 文件指针；未找到返回 nullptr / File pointer, or nullptr
-     */
-    File* FindFileRev(const char* name);
+  /**
+   * @brief 递归查找指定类型节点 / Find one node of a given type recursively
+   * @param name 节点名称 / Node name
+   * @param type 目标节点类型 / Desired node type
+   * @return 找到的节点；未找到返回 nullptr / Matching node, or nullptr
+   */
+  FsNode* FindNodeRevByType(const char* name, FsNodeType type);
 
-    /**
-     * @brief 查找直属目录，支持 "." 和 ".." / Find a direct child directory,
-     * supporting "." and ".."
-     * @param name 目录名 / Directory name
-     * @return 目录指针；未找到返回 nullptr / Directory pointer, or nullptr
-     */
-    Dir* FindDir(const char* name);
+  Tree rbt_;  ///< 当前目录直属子节点的名称索引树 / Name index tree of direct child nodes.
 
-    /**
-     * @brief 递归查找目录，支持 "." 和 ".." / Find a directory recursively,
-     * supporting "." and ".."
-     * @param name 目录名 / Directory name
-     * @return 目录指针；未找到返回 nullptr / Directory pointer, or nullptr
-     */
-    Dir* FindDirRev(const char* name);
-
-    /**
-     * @brief 查找直属自定义节点 / Find a direct child custom node
-     * @param name 节点名称 / Node name
-     * @return 自定义节点指针；未找到返回 nullptr / Custom node pointer, or nullptr
-     */
-    Custom* FindCustom(const char* name);
-
-    /**
-     * @brief 递归查找自定义节点 / Find a custom node recursively
-     * @param name 节点名称 / Node name
-     * @return 自定义节点指针；未找到返回 nullptr / Custom node pointer, or nullptr
-     */
-    Custom* FindCustomRev(const char* name);
-
-    /**
-     * @brief 遍历直属子节点 / Iterate over direct child nodes
-     * @tparam Func 回调类型 / Callback type
-     * @param func 回调函数，返回非 OK 时停止遍历 / Callback; non-OK stops iteration
-     * @return 遍历结果 / Iteration result
-     */
-    template <typename Func>
-    ErrorCode Foreach(Func func)
-    {
-      return rbt_.Foreach<FsNode*>([&](Tree::Node<FsNode*>& node)
-                                   { return func(*node.data_); });
-    }
-
-   private:
-    /**
-     * @brief 构造一个空目录壳 / Construct one empty directory shell
-     */
-    Dir();
-
-    /**
-     * @brief 构造一个具名目录壳 / Construct one named directory shell
-     * @param name 目录名称 / Directory name
-     */
-    explicit Dir(const char* name);
-
-    /**
-     * @brief 把一个节点挂到当前目录下 / Attach one node under the current directory
-     * @param node 待挂接节点 / Node to attach
-     */
-    void AddNode(FsNode& node);
-
-    /**
-     * @brief 在当前目录按类型查找直属节点 / Find one direct child node of a given type
-     * @param name 节点名称 / Node name
-     * @param type 目标节点类型 / Desired node type
-     * @return 找到的节点；未找到返回 nullptr / Matching node, or nullptr
-     */
-    FsNode* FindNodeByType(const char* name, FsNodeType type);
-
-    /**
-     * @brief 递归查找指定类型节点 / Find one node of a given type recursively
-     * @param name 节点名称 / Node name
-     * @param type 目标节点类型 / Desired node type
-     * @return 找到的节点；未找到返回 nullptr / Matching node, or nullptr
-     */
-    FsNode* FindNodeRevByType(const char* name, FsNodeType type);
-
-    Tree rbt_;  ///< 当前目录直属子节点的名称索引树 / Name index tree of direct child nodes.
-
-    friend class RamFS;
-  };
+  friend class RamFS;
+};

--- a/src/middleware/ramfs/factory.hpp
+++ b/src/middleware/ramfs/factory.hpp
@@ -1,148 +1,148 @@
-  /**
-   * @brief `RamFS` 的工厂与根入口片段 / Factory and root-entry fragment of `RamFS`
-   */
-  /**
-   * @brief 创建引用外部数据的文件 / Create a file referencing external data
-   * @tparam DataType 外部数据类型 / External data type
-   * @param name 文件名 / File name
-   * @param raw 外部数据引用 / External data reference
-   * @return 文件节点 / File node
-   *
-   * @note 包含动态内存分配 / Contains dynamic memory allocation
-   */
-  template <typename DataType>
-  static File CreateFile(const char* name, DataType& raw)
+/**
+ * @brief `RamFS` 的工厂与根入口片段 / Factory and root-entry fragment of `RamFS`
+ */
+/**
+ * @brief 创建引用外部数据的文件 / Create a file referencing external data
+ * @tparam DataType 外部数据类型 / External data type
+ * @param name 文件名 / File name
+ * @param raw 外部数据引用 / External data reference
+ * @return 文件节点 / File node
+ *
+ * @note 包含动态内存分配 / Contains dynamic memory allocation
+ */
+template <typename DataType>
+static File CreateFile(const char* name, DataType& raw)
+{
+  using StoredType = std::remove_reference_t<DataType>;
+
+  File file(name);
+  if constexpr (std::is_const_v<StoredType>)
   {
-    using StoredType = std::remove_reference_t<DataType>;
-
-    File file(name);
-    if constexpr (std::is_const_v<StoredType>)
-    {
-      file.file_type_ = FileType::READ_ONLY;
-      file.addr_const_ = &raw;
-    }
-    else
-    {
-      file.file_type_ = FileType::READ_WRITE;
-      file.addr_ = &raw;
-    }
-
-    file.size_ = sizeof(StoredType);
-    return file;
+    file.file_type_ = FileType::READ_ONLY;
+    file.addr_const_ = &raw;
+  }
+  else
+  {
+    file.file_type_ = FileType::READ_WRITE;
+    file.addr_ = &raw;
   }
 
-  /**
-   * @brief 创建可执行文件 / Create an executable file
-   * @tparam ArgType 执行上下文参数类型 / Execution context argument type
-   * @param name 文件名 / File name
-   * @param exec 执行函数 / Execution function
-   * @param arg 执行上下文参数 / Execution context argument
-   * @return 可执行文件节点 / Executable file node
-   *
-   * @note 包含动态内存分配 / Contains dynamic memory allocation
-   * @note 可执行块按当前 RamFS 设计属于初始化后常驻状态；
-   *       当前实现不提供运行期回收路径。
-   *       Executable blocks are retained for startup / lifetime registration in
-   *       the current RamFS design; the implementation does not provide a
-   *       runtime reclamation path for them.
-   */
-  template <typename ArgType>
-  static File CreateFile(const char* name,
-                         int (*exec)(ArgType arg, int argc, char** argv), ArgType&& arg)
+  file.size_ = sizeof(StoredType);
+  return file;
+}
+
+/**
+ * @brief 创建可执行文件 / Create an executable file
+ * @tparam ArgType 执行上下文参数类型 / Execution context argument type
+ * @param name 文件名 / File name
+ * @param exec 执行函数 / Execution function
+ * @param arg 执行上下文参数 / Execution context argument
+ * @return 可执行文件节点 / Executable file node
+ *
+ * @note 包含动态内存分配 / Contains dynamic memory allocation
+ * @note 可执行块按当前 RamFS 设计属于初始化后常驻状态；
+ *       当前实现不提供运行期回收路径。
+ *       Executable blocks are retained for startup / lifetime registration in
+ *       the current RamFS design; the implementation does not provide a
+ *       runtime reclamation path for them.
+ */
+template <typename ArgType>
+static File CreateFile(const char* name, int (*exec)(ArgType arg, int argc, char** argv),
+                       ArgType&& arg)
+{
+  using StoredArgType = std::remove_reference_t<ArgType>;
+  struct ExecutableBlock
   {
-    using StoredArgType = std::remove_reference_t<ArgType>;
-    struct ExecutableBlock
-    {
-      StoredArgType arg_;
-      decltype(exec) exec_fun_;
-    };
+    StoredArgType arg_;
+    decltype(exec) exec_fun_;
+  };
 
-    File file(name);
+  File file(name);
 
-    auto block = new ExecutableBlock{std::forward<ArgType>(arg), exec};
-    file.file_type_ = FileType::EXEC;
-    file.arg_ = block;
+  auto block = new ExecutableBlock{std::forward<ArgType>(arg), exec};
+  file.file_type_ = FileType::EXEC;
+  file.arg_ = block;
 
-    file.exec_ = [](void* raw, int argc, char** argv)
-    {
-      auto* block = static_cast<ExecutableBlock*>(raw);
-      return block->exec_fun_(block->arg_, argc, argv);
-    };
-
-    return file;
-  }
-
-  /**
-   * @brief 创建命令兼容入口，返回可执行文件 / Create a command-compatible executable
-   * file
-   * @tparam ArgType 执行上下文参数类型 / Execution context argument type
-   * @param name 文件名 / File name
-   * @param exec 执行函数 / Execution function
-   * @param arg 执行上下文参数 / Execution context argument
-   * @return 可执行文件节点 / Executable file node
-   *
-   * @note 包含动态内存分配 / Contains dynamic memory allocation
-   * @note 运行期持久化语义与上面的 executable factory 相同；
-   *       命令块按当前设计默认常驻。
-   *       This follows the same lifetime-retained semantics as the executable
-   *       factory above; command blocks are intentionally retained by design.
-   */
-  template <typename ArgType>
-  static File CreateCommand(const char* name,
-                            int (*exec)(ArgType arg, int argc, char** argv),
-                            ArgType&& arg)
+  file.exec_ = [](void* raw, int argc, char** argv)
   {
-    return CreateFile(name, exec, std::forward<ArgType>(arg));
-  }
+    auto* block = static_cast<ExecutableBlock*>(raw);
+    return block->exec_fun_(block->arg_, argc, argv);
+  };
 
-  /**
-   * @brief 创建目录节点 / Create a directory node
-   * @param name 目录名称 / Directory name
-   * @return 目录节点 / Directory node
-   *
-   * @note 包含动态内存分配 / Contains dynamic memory allocation
-   */
-  static Dir CreateDir(const char* name) { return Dir(name); }
+  return file;
+}
 
-  /**
-   * @brief 添加文件节点到根目录 / Add a file node to the root directory
-   * @param file 文件节点 / File node
-   */
-  void Add(File& file) { root_.Add(file); }
+/**
+ * @brief 创建命令兼容入口，返回可执行文件 / Create a command-compatible executable
+ * file
+ * @tparam ArgType 执行上下文参数类型 / Execution context argument type
+ * @param name 文件名 / File name
+ * @param exec 执行函数 / Execution function
+ * @param arg 执行上下文参数 / Execution context argument
+ * @return 可执行文件节点 / Executable file node
+ *
+ * @note 包含动态内存分配 / Contains dynamic memory allocation
+ * @note 运行期持久化语义与上面的 executable factory 相同；
+ *       命令块按当前设计默认常驻。
+ *       This follows the same lifetime-retained semantics as the executable
+ *       factory above; command blocks are intentionally retained by design.
+ */
+template <typename ArgType>
+static File CreateCommand(const char* name,
+                          int (*exec)(ArgType arg, int argc, char** argv), ArgType&& arg)
+{
+  return CreateFile(name, exec, std::forward<ArgType>(arg));
+}
 
-  /**
-   * @brief 添加目录节点到根目录 / Add a directory node to the root directory
-   * @param dir 目录节点 / Directory node
-   */
-  void Add(Dir& dir) { root_.Add(dir); }
+/**
+ * @brief 创建目录节点 / Create a directory node
+ * @param name 目录名称 / Directory name
+ * @return 目录节点 / Directory node
+ *
+ * @note 包含动态内存分配 / Contains dynamic memory allocation
+ */
+static Dir CreateDir(const char* name) { return Dir(name); }
 
-  /**
-   * @brief 添加自定义节点到根目录 / Add a custom node to the root directory
-   * @param custom 自定义节点 / Custom node
-   */
-  void Add(Custom& custom) { root_.Add(custom); }
+/**
+ * @brief 添加文件节点到根目录 / Add a file node to the root directory
+ * @param file 文件节点 / File node
+ */
+void Add(File& file) { root_.Add(file); }
 
-  /**
-   * @brief 从整个 RamFS 递归查找文件 / Find a file recursively from the RamFS root
-   * @param name 文件名 / File name
-   * @return 文件指针；未找到返回 nullptr / File pointer, or nullptr
-   */
-  File* FindFile(const char* name) { return root_.FindFileRev(name); }
+/**
+ * @brief 添加目录节点到根目录 / Add a directory node to the root directory
+ * @param dir 目录节点 / Directory node
+ */
+void Add(Dir& dir) { root_.Add(dir); }
 
-  /**
-   * @brief 从整个 RamFS 递归查找目录 / Find a directory recursively from the RamFS root
-   * @param name 目录名 / Directory name
-   * @return 目录指针；未找到返回 nullptr / Directory pointer, or nullptr
-   */
-  Dir* FindDir(const char* name) { return root_.FindDirRev(name); }
+/**
+ * @brief 添加自定义节点到根目录 / Add a custom node to the root directory
+ * @param custom 自定义节点 / Custom node
+ */
+void Add(Custom& custom) { root_.Add(custom); }
 
-  /**
-   * @brief 从整个 RamFS 递归查找自定义节点 / Find a custom node recursively from the
-   * RamFS root
-   * @param name 节点名称 / Node name
-   * @return 自定义节点指针；未找到返回 nullptr / Custom node pointer, or nullptr
-   */
-  Custom* FindCustom(const char* name) { return root_.FindCustomRev(name); }
+/**
+ * @brief 从整个 RamFS 递归查找文件 / Find a file recursively from the RamFS root
+ * @param name 文件名 / File name
+ * @return 文件指针；未找到返回 nullptr / File pointer, or nullptr
+ */
+File* FindFile(const char* name) { return root_.FindFileRev(name); }
 
-  Dir root_;  ///< 根目录；所有外部 Add()/Find*() 默认都从这里进入 / Root directory; all external Add()/Find*() entry through here.
-  Dir bin_;   ///< 预留的可执行文件目录 / Reserved executable-file directory.
+/**
+ * @brief 从整个 RamFS 递归查找目录 / Find a directory recursively from the RamFS root
+ * @param name 目录名 / Directory name
+ * @return 目录指针；未找到返回 nullptr / Directory pointer, or nullptr
+ */
+Dir* FindDir(const char* name) { return root_.FindDirRev(name); }
+
+/**
+ * @brief 从整个 RamFS 递归查找自定义节点 / Find a custom node recursively from the
+ * RamFS root
+ * @param name 节点名称 / Node name
+ * @return 自定义节点指针；未找到返回 nullptr / Custom node pointer, or nullptr
+ */
+Custom* FindCustom(const char* name) { return root_.FindCustomRev(name); }
+
+Dir root_;  ///< 根目录；所有外部 Add()/Find*() 默认都从这里进入 / Root directory; all
+            ///< external Add()/Find*() entry through here.
+Dir bin_;   ///< 预留的可执行文件目录 / Reserved executable-file directory.

--- a/src/middleware/ramfs/file.hpp
+++ b/src/middleware/ramfs/file.hpp
@@ -1,196 +1,194 @@
+/**
+ * @brief `RamFS` 的文件节点片段 / File-node fragment of `RamFS`
+ */
+/**
+ * @class File
+ * @brief 内存文件或可执行文件 / Memory file or executable file
+ */
+class File : public FsNode
+{
+ public:
   /**
-   * @brief `RamFS` 的文件节点片段 / File-node fragment of `RamFS`
+   * @brief 判断文件是否只读 / Check whether the file is read-only
+   * @return 只读返回 true / True if the file is read-only
    */
+  [[nodiscard]] bool IsReadOnly() const { return file_type_ == FileType::READ_ONLY; }
+
   /**
-   * @class File
-   * @brief 内存文件或可执行文件 / Memory file or executable file
+   * @brief 判断文件是否可写 / Check whether the file is writable
+   * @return 可写返回 true / True if the file is writable
    */
-  class File : public FsNode
+  [[nodiscard]] bool IsReadWrite() const { return file_type_ == FileType::READ_WRITE; }
+
+  /**
+   * @brief 判断文件是否可执行 / Check whether the file is executable
+   * @return 可执行返回 true / True if the file is executable
+   */
+  [[nodiscard]] bool IsExecutable() const { return file_type_ == FileType::EXEC; }
+
+  /**
+   * @brief 执行可执行文件 / Run an executable file
+   * @param argc 参数数量 / Argument count
+   * @param argv 参数数组 / Argument vector
+   * @return 执行返回值 / Execution return value
+   */
+  int Run(int argc, char** argv);
+
+  /**
+   * @brief 访问类型化数据 / Access typed data
+   *
+   * `Data<T>()` 返回可写引用并要求 READ_WRITE / `Data<T>()` returns a writable
+   * reference and requires READ_WRITE.
+   * `Data<const T>()` 返回只读引用 / `Data<const T>()` returns a read-only
+   * reference for both READ_ONLY and READ_WRITE.
+   *
+   * @tparam DataType 数据类型；使用 const T 表示只读访问 / Data type; use const T
+   *                  for read-only access.
+   * @tparam LimitMode 大小检查模式 / Size-check mode
+   * @return 类型化数据引用 / Typed data reference
+   */
+  template <typename DataType, SizeLimitMode LimitMode = SizeLimitMode::MORE>
+  decltype(auto) Data()
   {
-   public:
-    /**
-     * @brief 判断文件是否只读 / Check whether the file is read-only
-     * @return 只读返回 true / True if the file is read-only
-     */
-    [[nodiscard]] bool IsReadOnly() const { return file_type_ == FileType::READ_ONLY; }
+    using RequestedType = std::remove_reference_t<DataType>;
+    using StoredType = std::remove_cv_t<RequestedType>;
+    static_assert(!std::is_reference_v<DataType>);
+    static_assert(!std::is_volatile_v<RequestedType>);
 
-    /**
-     * @brief 判断文件是否可写 / Check whether the file is writable
-     * @return 可写返回 true / True if the file is writable
-     */
-    [[nodiscard]] bool IsReadWrite() const { return file_type_ == FileType::READ_WRITE; }
-
-    /**
-     * @brief 判断文件是否可执行 / Check whether the file is executable
-     * @return 可执行返回 true / True if the file is executable
-     */
-    [[nodiscard]] bool IsExecutable() const { return file_type_ == FileType::EXEC; }
-
-    /**
-     * @brief 执行可执行文件 / Run an executable file
-     * @param argc 参数数量 / Argument count
-     * @param argv 参数数组 / Argument vector
-     * @return 执行返回值 / Execution return value
-     */
-    int Run(int argc, char** argv);
-
-    /**
-     * @brief 访问类型化数据 / Access typed data
-     *
-     * `Data<T>()` 返回可写引用并要求 READ_WRITE / `Data<T>()` returns a writable
-     * reference and requires READ_WRITE.
-     * `Data<const T>()` 返回只读引用 / `Data<const T>()` returns a read-only
-     * reference for both READ_ONLY and READ_WRITE.
-     *
-     * @tparam DataType 数据类型；使用 const T 表示只读访问 / Data type; use const T
-     *                  for read-only access.
-     * @tparam LimitMode 大小检查模式 / Size-check mode
-     * @return 类型化数据引用 / Typed data reference
-     */
-    template <typename DataType, SizeLimitMode LimitMode = SizeLimitMode::MORE>
-    decltype(auto) Data()
+    ASSERT(LibXR::SizeLimitCheck(LimitMode, sizeof(StoredType), size_));
+    if constexpr (std::is_const_v<RequestedType>)
     {
-      using RequestedType = std::remove_reference_t<DataType>;
-      using StoredType = std::remove_cv_t<RequestedType>;
-      static_assert(!std::is_reference_v<DataType>);
-      static_assert(!std::is_volatile_v<RequestedType>);
-
-      ASSERT(LibXR::SizeLimitCheck(LimitMode, sizeof(StoredType), size_));
-      if constexpr (std::is_const_v<RequestedType>)
-      {
-        return *ReadableDataPtr<StoredType>();
-      }
-      else
-      {
-        return *WritableDataPtr<StoredType>();
-      }
-    }
-
-    /**
-     * @brief 从 const 文件对象访问类型化只读数据 / Access typed read-only data from a
-     * const file object
-     *
-     * @tparam DataType 数据类型 / Data type
-     * @tparam LimitMode 大小检查模式 / Size-check mode
-     * @return 类型化只读数据引用 / Typed read-only data reference
-     */
-    template <typename DataType, SizeLimitMode LimitMode = SizeLimitMode::MORE>
-    decltype(auto) Data() const
-    {
-      using RequestedType = std::remove_reference_t<DataType>;
-      using StoredType = std::remove_cv_t<RequestedType>;
-      static_assert(!std::is_reference_v<DataType>);
-      static_assert(!std::is_volatile_v<RequestedType>);
-
-      ASSERT(LibXR::SizeLimitCheck(LimitMode, sizeof(StoredType), size_));
       return *ReadableDataPtr<StoredType>();
     }
-
-    /**
-     * @brief 访问可写原始数据，要求文件为 READ_WRITE / Access writable raw data;
-     * requires READ_WRITE
-     * @return 可写原始数据视图 / Writable raw data view
-     */
-    [[nodiscard]] RawData Data()
+    else
     {
-      return RawData(WritableDataPtr<void>(), size_);
+      return *WritableDataPtr<StoredType>();
     }
+  }
 
-    /**
-     * @brief 访问只读原始数据 / Access read-only raw data
-     * @return 只读原始数据视图 / Read-only raw data view
-     */
-    [[nodiscard]] ConstRawData Data() const
+  /**
+   * @brief 从 const 文件对象访问类型化只读数据 / Access typed read-only data from a
+   * const file object
+   *
+   * @tparam DataType 数据类型 / Data type
+   * @tparam LimitMode 大小检查模式 / Size-check mode
+   * @return 类型化只读数据引用 / Typed read-only data reference
+   */
+  template <typename DataType, SizeLimitMode LimitMode = SizeLimitMode::MORE>
+  decltype(auto) Data() const
+  {
+    using RequestedType = std::remove_reference_t<DataType>;
+    using StoredType = std::remove_cv_t<RequestedType>;
+    static_assert(!std::is_reference_v<DataType>);
+    static_assert(!std::is_volatile_v<RequestedType>);
+
+    ASSERT(LibXR::SizeLimitCheck(LimitMode, sizeof(StoredType), size_));
+    return *ReadableDataPtr<StoredType>();
+  }
+
+  /**
+   * @brief 访问可写原始数据，要求文件为 READ_WRITE / Access writable raw data;
+   * requires READ_WRITE
+   * @return 可写原始数据视图 / Writable raw data view
+   */
+  [[nodiscard]] RawData Data() { return RawData(WritableDataPtr<void>(), size_); }
+
+  /**
+   * @brief 访问只读原始数据 / Access read-only raw data
+   * @return 只读原始数据视图 / Read-only raw data view
+   */
+  [[nodiscard]] ConstRawData Data() const
+  {
+    return ConstRawData(ReadableDataPtr<void>(), size_);
+  }
+
+ private:
+  /**
+   * @brief 可执行文件调用入口类型 / Executable entry function type
+   */
+  using ExecFun = int (*)(void* raw, int argc, char** argv);
+
+  /**
+   * @brief 处理不应到达的 File 数据访问路径
+   *        Handle one File data-access path that should be unreachable
+   *
+   * @note 这里保留强约束终止语义，但不再依赖“断言后继续解引用空指针”来满足返回类型，
+   *       从而避免发布构建中的未定义行为。
+   *       This keeps the strong-failure semantics while no longer relying on
+   *       "assert then dereference a null pointer" to satisfy the return
+   *       type, avoiding undefined behavior in release builds.
+   */
+  [[noreturn]] static void DataAccessPanic()
+  {
+    REQUIRE(false);
+    std::abort();
+  }
+
+  /**
+   * @brief 获取只读数据地址
+   *        Get the readable data pointer
+   * @tparam DataType 目标数据类型 / Target data type
+   * @return 只读数据指针 / Read-only data pointer
+   */
+  template <typename DataType>
+  const DataType* ReadableDataPtr() const
+  {
+    if (file_type_ == FileType::READ_WRITE)
     {
-      return ConstRawData(ReadableDataPtr<void>(), size_);
+      return static_cast<const DataType*>(addr_);
     }
-
-   private:
-    /**
-     * @brief 可执行文件调用入口类型 / Executable entry function type
-     */
-    using ExecFun = int (*)(void* raw, int argc, char** argv);
-
-    /**
-     * @brief 处理不应到达的 File 数据访问路径
-     *        Handle one File data-access path that should be unreachable
-     *
-     * @note 这里保留强约束终止语义，但不再依赖“断言后继续解引用空指针”来满足返回类型，
-     *       从而避免发布构建中的未定义行为。
-     *       This keeps the strong-failure semantics while no longer relying on
-     *       "assert then dereference a null pointer" to satisfy the return
-     *       type, avoiding undefined behavior in release builds.
-     */
-    [[noreturn]] static void DataAccessPanic()
+    if (file_type_ == FileType::READ_ONLY)
     {
-      REQUIRE(false);
-      std::abort();
+      return static_cast<const DataType*>(addr_const_);
     }
+    DataAccessPanic();
+  }
 
-    /**
-     * @brief 获取只读数据地址
-     *        Get the readable data pointer
-     * @tparam DataType 目标数据类型 / Target data type
-     * @return 只读数据指针 / Read-only data pointer
-     */
-    template <typename DataType>
-    const DataType* ReadableDataPtr() const
+  /**
+   * @brief 获取可写数据地址
+   *        Get the writable data pointer
+   * @tparam DataType 目标数据类型 / Target data type
+   * @return 可写数据指针 / Writable data pointer
+   */
+  template <typename DataType>
+  DataType* WritableDataPtr()
+  {
+    if (file_type_ != FileType::READ_WRITE)
     {
-      if (file_type_ == FileType::READ_WRITE)
-      {
-        return static_cast<const DataType*>(addr_);
-      }
-      if (file_type_ == FileType::READ_ONLY)
-      {
-        return static_cast<const DataType*>(addr_const_);
-      }
       DataAccessPanic();
     }
+    return static_cast<DataType*>(addr_);
+  }
 
-    /**
-     * @brief 获取可写数据地址
-     *        Get the writable data pointer
-     * @tparam DataType 目标数据类型 / Target data type
-     * @return 可写数据指针 / Writable data pointer
-     */
-    template <typename DataType>
-    DataType* WritableDataPtr()
-    {
-      if (file_type_ != FileType::READ_WRITE)
-      {
-        DataAccessPanic();
-      }
-      return static_cast<DataType*>(addr_);
-    }
+  /**
+   * @brief 构造一个空文件壳 / Construct one empty file shell
+   */
+  File();
 
-    /**
-     * @brief 构造一个空文件壳 / Construct one empty file shell
-     */
-    File();
+  /**
+   * @brief 构造一个具名文件壳 / Construct one named file shell
+   * @param name 文件名 / File name
+   */
+  explicit File(const char* name);
 
-    /**
-     * @brief 构造一个具名文件壳 / Construct one named file shell
-     * @param name 文件名 / File name
-     */
-    explicit File(const char* name);
-
-    /**
-     * @brief 文件负载联合体 / File payload union
-     *
-     * The same storage is interpreted either as mutable data, const data, or an
-     * executable entry depending on `file_type_`.
-     * 这块存储会根据 `file_type_` 被解释成可写数据、只读数据或可执行入口。
-     */
-    union
-    {
-      void* addr_;              ///< 可写数据地址 / Writable payload address.
-      const void* addr_const_;  ///< 只读数据地址 / Read-only payload address.
-      ExecFun exec_;            ///< 可执行入口函数 / Executable entry function.
-    };
-
-    void* arg_ = nullptr;                       ///< 可执行文件上下文块 / Executable context block.
-    size_t size_ = 0;                          ///< 数据负载字节数 / Payload size in bytes.
-    FileType file_type_ = FileType::READ_ONLY;  ///< 当前文件存储形态 / Current file storage kind.
-
-    friend class RamFS;
+  /**
+   * @brief 文件负载联合体 / File payload union
+   *
+   * The same storage is interpreted either as mutable data, const data, or an
+   * executable entry depending on `file_type_`.
+   * 这块存储会根据 `file_type_` 被解释成可写数据、只读数据或可执行入口。
+   */
+  union
+  {
+    void* addr_;              ///< 可写数据地址 / Writable payload address.
+    const void* addr_const_;  ///< 只读数据地址 / Read-only payload address.
+    ExecFun exec_;            ///< 可执行入口函数 / Executable entry function.
   };
+
+  void* arg_ = nullptr;  ///< 可执行文件上下文块 / Executable context block.
+  size_t size_ = 0;      ///< 数据负载字节数 / Payload size in bytes.
+  FileType file_type_ =
+      FileType::READ_ONLY;  ///< 当前文件存储形态 / Current file storage kind.
+
+  friend class RamFS;
+};

--- a/src/middleware/ramfs/fs_node.hpp
+++ b/src/middleware/ramfs/fs_node.hpp
@@ -1,49 +1,51 @@
+/**
+ * @brief `RamFS` 的公共节点基类片段 / Common node-base fragment of `RamFS`
+ */
+/**
+ * @class FsNode
+ * @brief 文件系统节点基类 / Base class for all RamFS nodes
+ */
+class FsNode
+{
+ public:
   /**
-   * @brief `RamFS` 的公共节点基类片段 / Common node-base fragment of `RamFS`
+   * @brief 获取节点类型 / Get the node type
+   * @return 节点类型 / Node type
    */
+  [[nodiscard]] FsNodeType GetNodeType() const { return type_; }
+
   /**
-   * @class FsNode
-   * @brief 文件系统节点基类 / Base class for all RamFS nodes
+   * @brief 获取节点名称 / Get the node name
+   * @return 节点名称 / Node name
    */
-  class FsNode
-  {
-   public:
-    /**
-     * @brief 获取节点类型 / Get the node type
-     * @return 节点类型 / Node type
-     */
-    [[nodiscard]] FsNodeType GetNodeType() const { return type_; }
+  [[nodiscard]] const char* GetName() const { return name_; }
 
-    /**
-     * @brief 获取节点名称 / Get the node name
-     * @return 节点名称 / Node name
-     */
-    [[nodiscard]] const char* GetName() const { return name_; }
+ protected:
+  const char* name_ = nullptr;  ///< 节点名称缓冲区 / Retained node-name buffer.
+  FsNodeType type_;             ///< 节点运行时类型 / Runtime node type.
+  Dir* parent_ =
+      nullptr;  ///< 父目录；根目录保持为空 / Parent directory; stays null for the root.
 
-   protected:
-    const char* name_ = nullptr;  ///< 节点名称缓冲区 / Retained node-name buffer.
-    FsNodeType type_;             ///< 节点运行时类型 / Runtime node type.
-    Dir* parent_ = nullptr;       ///< 父目录；根目录保持为空 / Parent directory; stays null for the root.
+  /**
+   * @brief 用指定节点类型构造基类部分 / Construct the base node with a given node type
+   * @param node_type 节点类型 / Node type
+   */
+  explicit FsNode(FsNodeType node_type);
 
-    /**
-     * @brief 用指定节点类型构造基类部分 / Construct the base node with a given node type
-     * @param node_type 节点类型 / Node type
-     */
-    explicit FsNode(FsNodeType node_type);
+  /**
+   * @brief 拷贝构造节点基类部分 / Copy-construct the base-node portion
+   * @param other 被拷贝的节点 / Node to copy from
+   *
+   * @note 这里只复制节点元数据，不复制父目录关系；新对象默认重新脱离原目录树。
+   *       This copies only node metadata and does not preserve parent
+   *       linkage; the new object is detached from the original directory
+   *       tree by default.
+   */
+  FsNode(const FsNode& other);
+  FsNode& operator=(const FsNode&) = delete;
 
-    /**
-     * @brief 拷贝构造节点基类部分 / Copy-construct the base-node portion
-     * @param other 被拷贝的节点 / Node to copy from
-     *
-     * @note 这里只复制节点元数据，不复制父目录关系；新对象默认重新脱离原目录树。
-     *       This copies only node metadata and does not preserve parent
-     *       linkage; the new object is detached from the original directory
-     *       tree by default.
-     */
-    FsNode(const FsNode& other);
-    FsNode& operator=(const FsNode&) = delete;
+  Tree::Node<FsNode*> tree_node_;  ///< 当前节点挂进目录树时使用的树节点包装 / Tree node
+                                   ///< wrapper used when inserted into a directory tree.
 
-    Tree::Node<FsNode*> tree_node_;  ///< 当前节点挂进目录树时使用的树节点包装 / Tree node wrapper used when inserted into a directory tree.
-
-    friend class Dir;
-  };
+  friend class Dir;
+};

--- a/src/middleware/terminal/command.hpp
+++ b/src/middleware/terminal/command.hpp
@@ -1,380 +1,380 @@
-  /**
-   * @brief  `Terminal` 的命令解析片段
-   *         Command-parsing fragment of `Terminal`
-   *
-   * @note 这一组函数只负责把当前输入行解释成命令：参数切分、路径解析、内建命令执行、
-   *       可执行文件查找以及自动补全。
-   *       This group is responsible only for interpreting the current input
-   *       line as a command: argument tokenization, path resolution, built-in
-   *       command execution, executable lookup, and auto-completion.
-   */
+/**
+ * @brief  `Terminal` 的命令解析片段
+ *         Command-parsing fragment of `Terminal`
+ *
+ * @note 这一组函数只负责把当前输入行解释成命令：参数切分、路径解析、内建命令执行、
+ *       可执行文件查找以及自动补全。
+ *       This group is responsible only for interpreting the current input
+ *       line as a command: argument tokenization, path resolution, built-in
+ *       command execution, executable lookup, and auto-completion.
+ */
 
-  /**
-   * @brief  解析输入行，将其拆分为参数数组
-   *         Parses the input line and splits it into argument array
-   *
-   * @note 该过程会原地把空格改成 `\0`，并把每个参数起始位置填进 `arg_tab_`。
-   *       This process overwrites spaces in-place with `\0` and stores each
-   *       argument start pointer into `arg_tab_`.
-   */
-  void GetArgs()
+/**
+ * @brief  解析输入行，将其拆分为参数数组
+ *         Parses the input line and splits it into argument array
+ *
+ * @note 该过程会原地把空格改成 `\0`，并把每个参数起始位置填进 `arg_tab_`。
+ *       This process overwrites spaces in-place with `\0` and stores each
+ *       argument start pointer into `arg_tab_`.
+ */
+void GetArgs()
+{
+  for (int i = 0; input_line_[i] != '\0'; i++)
   {
-    for (int i = 0; input_line_[i] != '\0'; i++)
+    if (input_line_[i] == ' ')
     {
-      if (input_line_[i] == ' ')
+      input_line_[i] = '\0';
+    }
+    else if (i == 0 || input_line_[i - 1] == '\0')
+    {
+      if (arg_number_ >= MAX_ARG_NUMBER)
       {
-        input_line_[i] = '\0';
+        return;
       }
-      else if (i == 0 || input_line_[i - 1] == '\0')
-      {
-        if (arg_number_ >= MAX_ARG_NUMBER)
-        {
-          return;
-        }
-        arg_tab_[arg_number_++] = &input_line_[i];
-      }
+      arg_tab_[arg_number_++] = &input_line_[i];
+    }
+  }
+}
+
+/**
+ * @brief  将路径字符串解析为目录对象
+ *         Converts a path string into a directory object
+ * @param  path 目录路径字符串 The directory path string
+ * @return RamFS::Dir* 解析出的目录指针，若找不到则返回 nullptr
+ *         Pointer to the resolved directory, or nullptr if not found
+ *
+ * @note 解析过程中会暂时把路径中的 `/` 改写成 `\0` 再恢复，所以调用方必须传入可写
+ *       缓冲区，而不是字符串常量。
+ *       The resolver temporarily rewrites `/` to `\0` and restores it later,
+ *       so callers must provide a writable buffer rather than a string literal.
+ */
+RamFS::Dir* Path2Dir(char* path)
+{
+  if (path == nullptr)
+  {
+    return nullptr;
+  }
+
+  size_t index = 0;
+  RamFS::Dir* dir = current_dir_;
+
+  if (*path == '/')
+  {
+    index++;
+    dir = &ramfs_.root_;
+    if (path[index] == '\0')
+    {
+      return dir;
     }
   }
 
-  /**
-   * @brief  将路径字符串解析为目录对象
-   *         Converts a path string into a directory object
-   * @param  path 目录路径字符串 The directory path string
-   * @return RamFS::Dir* 解析出的目录指针，若找不到则返回 nullptr
-   *         Pointer to the resolved directory, or nullptr if not found
-   *
-   * @note 解析过程中会暂时把路径中的 `/` 改写成 `\0` 再恢复，所以调用方必须传入可写
-   *       缓冲区，而不是字符串常量。
-   *       The resolver temporarily rewrites `/` to `\0` and restores it later,
-   *       so callers must provide a writable buffer rather than a string literal.
-   */
-  RamFS::Dir* Path2Dir(char* path)
+  for (size_t i = 0; i < MAX_LINE_SIZE; i++)
   {
-    if (path == nullptr)
+    auto tmp = strchr(path + index, '/');
+    if (tmp == nullptr)
+    {
+      return dir->FindDir(path + index);
+    }
+    else if (tmp == path + index)
     {
       return nullptr;
     }
-
-    size_t index = 0;
-    RamFS::Dir* dir = current_dir_;
-
-    if (*path == '/')
+    else
     {
-      index++;
-      dir = &ramfs_.root_;
-      if (path[index] == '\0')
+      tmp[0] = '\0';
+      dir = dir->FindDir(path + index);
+      tmp[0] = '/';
+      index = static_cast<size_t>(tmp - path + 1);
+      if (path[index] == '\0' || dir == nullptr)
       {
         return dir;
       }
     }
+  }
 
-    for (size_t i = 0; i < MAX_LINE_SIZE; i++)
-    {
-      auto tmp = strchr(path + index, '/');
-      if (tmp == nullptr)
-      {
-        return dir->FindDir(path + index);
-      }
-      else if (tmp == path + index)
-      {
-        return nullptr;
-      }
-      else
-      {
-        tmp[0] = '\0';
-        dir = dir->FindDir(path + index);
-        tmp[0] = '/';
-        index = static_cast<size_t>(tmp - path + 1);
-        if (path[index] == '\0' || dir == nullptr)
-        {
-          return dir;
-        }
-      }
-    }
+  return nullptr;
+}
 
+/**
+ * @brief  将路径字符串解析为文件对象
+ *         Converts a path string into a file object
+ * @param  path 文件路径字符串 The file path string
+ * @return RamFS::File* 解析出的文件指针，若找不到则返回 nullptr
+ *         Pointer to the resolved file, or nullptr if not found
+ *
+ * @note 这个解析同样会临时切开路径字符串，因此也要求 `path` 可写。
+ *       This resolver also temporarily splits the path string and therefore
+ *       requires `path` to be writable.
+ */
+RamFS::File* Path2File(char* path)
+{
+  if (path == nullptr)
+  {
     return nullptr;
   }
 
-  /**
-   * @brief  将路径字符串解析为文件对象
-   *         Converts a path string into a file object
-   * @param  path 文件路径字符串 The file path string
-   * @return RamFS::File* 解析出的文件指针，若找不到则返回 nullptr
-   *         Pointer to the resolved file, or nullptr if not found
-   *
-   * @note 这个解析同样会临时切开路径字符串，因此也要求 `path` 可写。
-   *       This resolver also temporarily splits the path string and therefore
-   *       requires `path` to be writable.
-   */
-  RamFS::File* Path2File(char* path)
+  auto name = StrchrRev(path, '/');
+
+  if (name == nullptr)
   {
-    if (path == nullptr)
-    {
-      return nullptr;
-    }
+    return current_dir_->FindFile(path);
+  }
 
-    auto name = StrchrRev(path, '/');
+  if (name[1] == '\0')
+  {
+    return nullptr;
+  }
 
-    if (name == nullptr)
-    {
-      return current_dir_->FindFile(path);
-    }
+  *name = '\0';
+  RamFS::Dir* dir = name == path ? &ramfs_.root_ : Path2Dir(path);
+  *name = '/';
+  if (dir != nullptr)
+  {
+    return dir->FindFile(name + 1);
+  }
+  else
+  {
+    return nullptr;
+  }
+}
 
-    if (name[1] == '\0')
-    {
-      return nullptr;
-    }
+/**
+ * @brief  解析并执行输入的命令
+ *         Parses and executes the entered command
+ *
+ * @note 当前实现只内建了 `cd` 和 `ls`；其它命令都按“把第一个参数当 RamFS 可执行文件
+ *       路径”来处理。
+ *       The current implementation provides only the built-in `cd` and `ls`;
+ *       every other command is handled by treating the first argument as the
+ *       path of an executable RamFS file.
+ */
+void ExecuteCommand()
+{
+  AddHistory();
 
-    *name = '\0';
-    RamFS::Dir* dir = name == path ? &ramfs_.root_ : Path2Dir(path);
-    *name = '/';
+  GetArgs();
+
+  if (arg_number_ < 1 || arg_number_ > MAX_ARG_NUMBER)
+  {
+    return;
+  }
+
+  if (strcmp(arg_tab_[0], "cd") == 0)
+  {
+    RamFS::Dir* dir = arg_number_ >= 2 ? Path2Dir(arg_tab_[1]) : nullptr;
     if (dir != nullptr)
     {
-      return dir->FindFile(name + 1);
+      current_dir_ = dir;
     }
-    else
-    {
-      return nullptr;
-    }
+    LineFeed();
+    return;
   }
 
-  /**
-   * @brief  解析并执行输入的命令
-   *         Parses and executes the entered command
-   *
-   * @note 当前实现只内建了 `cd` 和 `ls`；其它命令都按“把第一个参数当 RamFS 可执行文件
-   *       路径”来处理。
-   *       The current implementation provides only the built-in `cd` and `ls`;
-   *       every other command is handled by treating the first argument as the
-   *       path of an executable RamFS file.
-   */
-  void ExecuteCommand()
+  if (strcmp(arg_tab_[0], "ls") == 0)
   {
-    AddHistory();
-
-    GetArgs();
-
-    if (arg_number_ < 1 || arg_number_ > MAX_ARG_NUMBER)
+    auto ls_fun = [&](RamFS::FsNode& item)
     {
-      return;
-    }
-
-    if (strcmp(arg_tab_[0], "cd") == 0)
-    {
-      RamFS::Dir* dir = arg_number_ >= 2 ? Path2Dir(arg_tab_[1]) : nullptr;
-      if (dir != nullptr)
+      switch (item.GetNodeType())
       {
-        current_dir_ = dir;
+        case RamFS::FsNodeType::DIR:
+          write_stream_ << ConstRawData("d ");
+          break;
+        case RamFS::FsNodeType::FILE:
+          if (static_cast<RamFS::File&>(item).IsExecutable())
+          {
+            write_stream_ << ConstRawData("x ");
+          }
+          else
+          {
+            write_stream_ << ConstRawData("f ");
+          }
+          break;
+        case RamFS::FsNodeType::CUSTOM:
+          write_stream_ << ConstRawData("? ");
+          break;
+        default:
+          write_stream_ << ConstRawData("? ");
+          break;
       }
-      LineFeed();
-      return;
-    }
+      write_stream_ << ConstRawData(item.GetName());
+      this->LineFeed();
+      return ErrorCode::OK;
+    };
 
-    if (strcmp(arg_tab_[0], "ls") == 0)
-    {
-      auto ls_fun = [&](RamFS::FsNode& item)
-      {
-        switch (item.GetNodeType())
-        {
-          case RamFS::FsNodeType::DIR:
-            write_stream_ << ConstRawData("d ");
-            break;
-          case RamFS::FsNodeType::FILE:
-            if (static_cast<RamFS::File&>(item).IsExecutable())
-            {
-              write_stream_ << ConstRawData("x ");
-            }
-            else
-            {
-              write_stream_ << ConstRawData("f ");
-            }
-            break;
-          case RamFS::FsNodeType::CUSTOM:
-            write_stream_ << ConstRawData("? ");
-            break;
-          default:
-            write_stream_ << ConstRawData("? ");
-            break;
-        }
-        write_stream_ << ConstRawData(item.GetName());
-        this->LineFeed();
-        return ErrorCode::OK;
-      };
-
-      current_dir_->Foreach(ls_fun);
-      return;
-    }
-
-    auto* ans = Path2File(arg_tab_[0]);
-
-    if (ans == nullptr)
-    {
-      write_stream_ << ConstRawData("Command not found.");
-      LineFeed();
-      return;
-    }
-
-    if (!ans->IsExecutable())
-    {
-      write_stream_ << ConstRawData("Not an executable file.");
-      LineFeed();
-      return;
-    }
-
-    write_stream_.Commit();
-    write_mutex_->Unlock();
-    ans->Run(arg_number_, arg_tab_);
-    write_mutex_->Lock();
+    current_dir_->Foreach(ls_fun);
+    return;
   }
 
-  /**
-   * @brief  实现命令自动补全，匹配目录或文件名
-   *         Implements command auto-completion by matching directories or file names
-   *
-   * @note 当前自动补全只处理“第一参数且光标在该参数尾部”这一种情况，不会解析后续参数。
-   *       The current auto-completion handles only the first argument when the
-   *       cursor is at that argument's tail; it does not parse later arguments.
-   */
-  void AutoComplete()
+  auto* ans = Path2File(arg_tab_[0]);
+
+  if (ans == nullptr)
   {
-    /* skip space */
-    char* path = &input_line_[0];
-    while (*path == ' ')
+    write_stream_ << ConstRawData("Command not found.");
+    LineFeed();
+    return;
+  }
+
+  if (!ans->IsExecutable())
+  {
+    write_stream_ << ConstRawData("Not an executable file.");
+    LineFeed();
+    return;
+  }
+
+  write_stream_.Commit();
+  write_mutex_->Unlock();
+  ans->Run(arg_number_, arg_tab_);
+  write_mutex_->Lock();
+}
+
+/**
+ * @brief  实现命令自动补全，匹配目录或文件名
+ *         Implements command auto-completion by matching directories or file names
+ *
+ * @note 当前自动补全只处理“第一参数且光标在该参数尾部”这一种情况，不会解析后续参数。
+ *       The current auto-completion handles only the first argument when the
+ *       cursor is at that argument's tail; it does not parse later arguments.
+ */
+void AutoComplete()
+{
+  /* skip space */
+  char* path = &input_line_[0];
+  while (*path == ' ')
+  {
+    path++;
+  }
+
+  /* find last '/' in first argument */
+  char *tmp = path, *path_end = path;
+
+  while (*tmp != ' ' && *tmp != '\0')
+  {
+    if (*tmp == '/')
     {
-      path++;
+      path_end = tmp;
     }
+    tmp++;
+  }
 
-    /* find last '/' in first argument */
-    char *tmp = path, *path_end = path;
+  /* return if not need complete */
+  if (tmp - &input_line_[0] != static_cast<int>(input_line_.Size() + offset_))
+  {
+    return;
+  }
 
-    while (*tmp != ' ' && *tmp != '\0')
-    {
-      if (*tmp == '/')
-      {
-        path_end = tmp;
-      }
-      tmp++;
-    }
+  /* get start of prefix */
+  char* prefix_start = nullptr;
+  RamFS::Dir* dir = nullptr;
 
-    /* return if not need complete */
-    if (tmp - &input_line_[0] != static_cast<int>(input_line_.Size() + offset_))
-    {
-      return;
-    }
+  if (path_end == path)
+  {
+    dir = current_dir_;
+    prefix_start = path_end;
+  }
+  else
+  {
+    prefix_start = path_end + 1;
+  }
 
-    /* get start of prefix */
-    char* prefix_start = nullptr;
-    RamFS::Dir* dir = nullptr;
-
-    if (path_end == path)
-    {
-      dir = current_dir_;
-      prefix_start = path_end;
-    }
-    else
-    {
-      prefix_start = path_end + 1;
-    }
-
-    /* find dir*/
+  /* find dir*/
+  if (dir == nullptr)
+  {
+    *path_end = '\0';
+    dir = Path2Dir(path);
+    *path_end = '/';
     if (dir == nullptr)
     {
-      *path_end = '\0';
-      dir = Path2Dir(path);
-      *path_end = '/';
-      if (dir == nullptr)
-      {
-        return;
-      }
+      return;
     }
+  }
 
-    /* prepre for match */
-    RamFS::FsNode* ans_node = nullptr;
-    uint32_t number = 0;
-    size_t shared_prefix_len = 0;
+  /* prepre for match */
+  RamFS::FsNode* ans_node = nullptr;
+  uint32_t number = 0;
+  size_t shared_prefix_len = 0;
 
-    if (*prefix_start == '/')
+  if (*prefix_start == '/')
+  {
+    prefix_start++;
+  }
+
+  int prefix_len = static_cast<int>(tmp - prefix_start);
+
+  auto foreach_fun_find = [&](RamFS::FsNode& node)
+  {
+    if (strncmp(node.GetName(), prefix_start, prefix_len) == 0)
     {
-      prefix_start++;
+      ans_node = &node;
+      number++;
     }
 
-    int prefix_len = static_cast<int>(tmp - prefix_start);
+    return ErrorCode::OK;
+  };
 
-    auto foreach_fun_find = [&](RamFS::FsNode& node)
+  /* start match */
+  dir->Foreach(foreach_fun_find);
+
+  if (number == 0)
+  {
+    return;
+  }
+  else if (number == 1)
+  {
+    auto name_len = strlen(ans_node->GetName());
+    for (size_t i = 0; i < name_len - prefix_len; i++)
+    {
+      DisplayChar(ans_node->GetName()[i + prefix_len]);
+    }
+  }
+  else
+  {
+    ans_node = nullptr;
+    LineFeed();
+
+    auto foreach_fun_show = [&](RamFS::FsNode& node)
     {
       if (strncmp(node.GetName(), prefix_start, prefix_len) == 0)
       {
+        auto name_len = strlen(node.GetName());
+        write_stream_ << ConstRawData(node.GetName(), name_len);
+        this->LineFeed();
+        if (ans_node == nullptr)
+        {
+          ans_node = &node;
+          shared_prefix_len = name_len;
+          return ErrorCode::OK;
+        }
+
+        for (size_t i = 0; i < name_len; i++)
+        {
+          if (node.GetName()[i] != ans_node->GetName()[i])
+          {
+            shared_prefix_len = i;
+            break;
+          }
+        }
+
+        // Once one candidate is shorter than the previously retained shared
+        // prefix, the shared prefix must shrink to this candidate length.
+        if (shared_prefix_len > name_len)
+        {
+          shared_prefix_len = name_len;
+        }
+
         ans_node = &node;
-        number++;
       }
 
       return ErrorCode::OK;
     };
 
-    /* start match */
-    dir->Foreach(foreach_fun_find);
+    dir->Foreach(foreach_fun_show);
 
-    if (number == 0)
+    ShowHeader();
+    write_stream_ << ConstRawData(&input_line_[0], input_line_.Size());
+
+    for (size_t i = 0; i < shared_prefix_len - prefix_len; i++)
     {
-      return;
-    }
-    else if (number == 1)
-    {
-      auto name_len = strlen(ans_node->GetName());
-      for (size_t i = 0; i < name_len - prefix_len; i++)
-      {
-        DisplayChar(ans_node->GetName()[i + prefix_len]);
-      }
-    }
-    else
-    {
-      ans_node = nullptr;
-      LineFeed();
-
-      auto foreach_fun_show = [&](RamFS::FsNode& node)
-      {
-        if (strncmp(node.GetName(), prefix_start, prefix_len) == 0)
-        {
-          auto name_len = strlen(node.GetName());
-          write_stream_ << ConstRawData(node.GetName(), name_len);
-          this->LineFeed();
-          if (ans_node == nullptr)
-          {
-            ans_node = &node;
-            shared_prefix_len = name_len;
-            return ErrorCode::OK;
-          }
-
-          for (size_t i = 0; i < name_len; i++)
-          {
-            if (node.GetName()[i] != ans_node->GetName()[i])
-            {
-              shared_prefix_len = i;
-              break;
-            }
-          }
-
-          // Once one candidate is shorter than the previously retained shared
-          // prefix, the shared prefix must shrink to this candidate length.
-          if (shared_prefix_len > name_len)
-          {
-            shared_prefix_len = name_len;
-          }
-
-          ans_node = &node;
-        }
-
-        return ErrorCode::OK;
-      };
-
-      dir->Foreach(foreach_fun_show);
-
-      ShowHeader();
-      write_stream_ << ConstRawData(&input_line_[0], input_line_.Size());
-
-      for (size_t i = 0; i < shared_prefix_len - prefix_len; i++)
-      {
-        DisplayChar(ans_node->GetName()[i + prefix_len]);
-      }
+      DisplayChar(ans_node->GetName()[i + prefix_len]);
     }
   }
+}

--- a/src/middleware/terminal/display.hpp
+++ b/src/middleware/terminal/display.hpp
@@ -1,303 +1,303 @@
-  /**
-   * @brief  `Terminal` 的显示与历史记录片段
-   *         Display and history fragment of `Terminal`
-   *
-   * @note 这一组函数只负责行编辑、提示符显示、光标移动，以及历史记录的展示/拷回。
-   *       This group is responsible only for line editing, prompt rendering,
-   *       cursor movement, and displaying / restoring history entries.
-   */
+/**
+ * @brief  `Terminal` 的显示与历史记录片段
+ *         Display and history fragment of `Terminal`
+ *
+ * @note 这一组函数只负责行编辑、提示符显示、光标移动，以及历史记录的展示/拷回。
+ *       This group is responsible only for line editing, prompt rendering,
+ *       cursor movement, and displaying / restoring history entries.
+ */
 
-  /**
-   * @brief  计算一条历史命令的实际文本长度
-   *         Calculates the actual text length of one stored history line
-   * @param  line 历史命令缓存 / Stored history line
-   * @return size_t 历史命令的实际长度
-   *         Actual length of the history line
-   */
-  static size_t HistoryLineSize(const HistoryLine& line)
+/**
+ * @brief  计算一条历史命令的实际文本长度
+ *         Calculates the actual text length of one stored history line
+ * @param  line 历史命令缓存 / Stored history line
+ * @return size_t 历史命令的实际长度
+ *         Actual length of the history line
+ */
+static size_t HistoryLineSize(const HistoryLine& line)
+{
+  size_t size = 0;
+  while (size < MAX_LINE_SIZE && line[size] != '\0')
   {
-    size_t size = 0;
-    while (size < MAX_LINE_SIZE && line[size] != '\0')
-    {
-      size++;
-    }
-    return size;
+    size++;
+  }
+  return size;
+}
+
+/**
+ * @brief  按“从最新到最旧”的顺序取历史记录
+ *         Fetches one history entry counting from newest to oldest
+ * @param  index_from_newest 从最新一条开始的偏移；0 表示最新一条
+ *         Offset counted from the newest entry; 0 means the newest one
+ * @return const HistoryLine& 对应的历史记录
+ *         Reference to the requested history entry
+ *
+ * @note `Queue::operator[]` 支持负索引从尾部反向访问，但这里把这个细节包起来，
+ *       避免调用点直接暴露 `history_[-index - 1]` 这种难读写法。
+ *       `Queue::operator[]` supports negative indices to walk backward from
+ *       the tail, but this helper hides that detail so call sites do not have
+ *       to expose the hard-to-read `history_[-index - 1]` form directly.
+ */
+const HistoryLine& HistoryFromNewest(int index_from_newest)
+{
+  ASSERT(index_from_newest >= 0);
+  ASSERT(index_from_newest < static_cast<int>(history_.Size()));
+  return history_[-index_from_newest - 1];
+}
+
+/**
+ * @brief  执行换行操作
+ *         Performs a line feed operation
+ *
+ * @note 具体输出 `\r\n`、`\n` 还是 `\r` 由构造时选定的 `MODE` 决定。
+ *       The actual emitted line ending is selected by the `MODE` chosen at
+ *       construction time.
+ */
+void LineFeed()
+{
+  if (MODE == Mode::CRLF)
+  {
+    write_stream_ << ConstRawData("\r\n");
+  }
+  else if (MODE == Mode::LF)
+  {
+    write_stream_ << ConstRawData('\n');
+  }
+  else if (MODE == Mode::CR)
+  {
+    write_stream_ << ConstRawData('\r');
+  }
+}
+
+/**
+ * @brief  更新光标位置
+ *         Updates cursor position
+ *
+ * @note 这里只重绘光标右侧的可见后缀；光标左侧的内容已经在输入缓冲区中保留。
+ *       This redraws only the visible suffix to the right of the cursor; the
+ *       left side is already preserved in the input buffer.
+ */
+void UpdateDisplayPosition()
+{
+  write_stream_ << ConstRawData(KEY_SAVE) << ConstRawData(CLEAR_BEHIND)
+                << ConstRawData(&input_line_[input_line_.Size() + offset_], -offset_)
+                << ConstRawData(KEY_LOAD);
+}
+
+/**
+ * @brief  检查是否可以显示字符
+ *         Checks if a character can be displayed
+ * @return bool 是否可以显示字符 Whether the character can be displayed
+ */
+bool CanDisplayChar() { return input_line_.EmptySize() > 1; }
+
+/**
+ * @brief  检查是否可以删除字符
+ *         Checks if a character can be deleted
+ * @return bool 是否可以删除字符 Whether the character can be deleted
+ */
+bool CanDeleteChar() { return input_line_.Size() + offset_ > 0; }
+
+/**
+ * @brief  向输入行中添加字符，支持在光标位置插入
+ *         Adds a character to the input line, supports insertion at the cursor position
+ * @param  data 要添加的字符 The character to add
+ */
+void AddCharToInputLine(char data)
+{
+  if (offset_ == 0)
+  {
+    input_line_.Push(data);
+  }
+  else
+  {
+    input_line_.Insert(data, input_line_.Size() + offset_);
+  }
+  input_line_[input_line_.Size()] = '\0';
+}
+
+/**
+ * @brief  在终端上显示字符，并根据历史记录模式进行相应操作
+ *         Displays a character on the terminal and updates accordingly if history mode
+ * is active
+ * @param  data 要显示的字符 The character to display
+ */
+void DisplayChar(char data)
+{
+  bool use_history = false;
+
+  if (history_index_ >= 0)
+  {
+    CopyHistoryToInputLine();
+    use_history = true;
   }
 
-  /**
-   * @brief  按“从最新到最旧”的顺序取历史记录
-   *         Fetches one history entry counting from newest to oldest
-   * @param  index_from_newest 从最新一条开始的偏移；0 表示最新一条
-   *         Offset counted from the newest entry; 0 means the newest one
-   * @return const HistoryLine& 对应的历史记录
-   *         Reference to the requested history entry
-   *
-   * @note `Queue::operator[]` 支持负索引从尾部反向访问，但这里把这个细节包起来，
-   *       避免调用点直接暴露 `history_[-index - 1]` 这种难读写法。
-   *       `Queue::operator[]` supports negative indices to walk backward from
-   *       the tail, but this helper hides that detail so call sites do not have
-   *       to expose the hard-to-read `history_[-index - 1]` form directly.
-   */
-  const HistoryLine& HistoryFromNewest(int index_from_newest)
+  if (CanDisplayChar())
   {
-    ASSERT(index_from_newest >= 0);
-    ASSERT(index_from_newest < static_cast<int>(history_.Size()));
-    return history_[-index_from_newest - 1];
-  }
-
-  /**
-   * @brief  执行换行操作
-   *         Performs a line feed operation
-   *
-   * @note 具体输出 `\r\n`、`\n` 还是 `\r` 由构造时选定的 `MODE` 决定。
-   *       The actual emitted line ending is selected by the `MODE` chosen at
-   *       construction time.
-   */
-  void LineFeed()
-  {
-    if (MODE == Mode::CRLF)
+    AddCharToInputLine(data);
+    if (use_history)
     {
-      write_stream_ << ConstRawData("\r\n");
-    }
-    else if (MODE == Mode::LF)
-    {
-      write_stream_ << ConstRawData('\n');
-    }
-    else if (MODE == Mode::CR)
-    {
-      write_stream_ << ConstRawData('\r');
-    }
-  }
-
-  /**
-   * @brief  更新光标位置
-   *         Updates cursor position
-   *
-   * @note 这里只重绘光标右侧的可见后缀；光标左侧的内容已经在输入缓冲区中保留。
-   *       This redraws only the visible suffix to the right of the cursor; the
-   *       left side is already preserved in the input buffer.
-   */
-  void UpdateDisplayPosition()
-  {
-    write_stream_ << ConstRawData(KEY_SAVE) << ConstRawData(CLEAR_BEHIND)
-                  << ConstRawData(&input_line_[input_line_.Size() + offset_], -offset_)
-                  << ConstRawData(KEY_LOAD);
-  }
-
-  /**
-   * @brief  检查是否可以显示字符
-   *         Checks if a character can be displayed
-   * @return bool 是否可以显示字符 Whether the character can be displayed
-   */
-  bool CanDisplayChar() { return input_line_.EmptySize() > 1; }
-
-  /**
-   * @brief  检查是否可以删除字符
-   *         Checks if a character can be deleted
-   * @return bool 是否可以删除字符 Whether the character can be deleted
-   */
-  bool CanDeleteChar() { return input_line_.Size() + offset_ > 0; }
-
-  /**
-   * @brief  向输入行中添加字符，支持在光标位置插入
-   *         Adds a character to the input line, supports insertion at the cursor position
-   * @param  data 要添加的字符 The character to add
-   */
-  void AddCharToInputLine(char data)
-  {
-    if (offset_ == 0)
-    {
-      input_line_.Push(data);
+      ShowHistory();
     }
     else
     {
-      input_line_.Insert(data, input_line_.Size() + offset_);
+      write_stream_ << ConstRawData(input_line_[input_line_.Size() - 1 + offset_]);
     }
-    input_line_[input_line_.Size()] = '\0';
-  }
-
-  /**
-   * @brief  在终端上显示字符，并根据历史记录模式进行相应操作
-   *         Displays a character on the terminal and updates accordingly if history mode
-   * is active
-   * @param  data 要显示的字符 The character to display
-   */
-  void DisplayChar(char data)
-  {
-    bool use_history = false;
-
-    if (history_index_ >= 0)
+    if (offset_ != 0)
     {
-      CopyHistoryToInputLine();
-      use_history = true;
-    }
-
-    if (CanDisplayChar())
-    {
-      AddCharToInputLine(data);
-      if (use_history)
-      {
-        ShowHistory();
-      }
-      else
-      {
-        write_stream_ << ConstRawData(input_line_[input_line_.Size() - 1 + offset_]);
-      }
-      if (offset_ != 0)
-      {
-        UpdateDisplayPosition();
-      }
+      UpdateDisplayPosition();
     }
   }
+}
 
-  /**
-   * @brief  从输入行中删除字符，支持在光标位置删除
-   *         Removes a character from the input line, supports deletion at the cursor
-   * position
-   */
-  void RemoveCharFromInputLine()
+/**
+ * @brief  从输入行中删除字符，支持在光标位置删除
+ *         Removes a character from the input line, supports deletion at the cursor
+ * position
+ */
+void RemoveCharFromInputLine()
+{
+  if (offset_ == 0)
   {
-    if (offset_ == 0)
+    input_line_.Pop();
+  }
+  else
+  {
+    input_line_.Delete(input_line_.Size() + offset_ - 1);
+  }
+  input_line_[input_line_.Size()] = '\0';
+}
+
+/**
+ * @brief  处理删除字符操作，支持回退删除，并在历史模式下更新显示
+ *         Handles the delete character operation, supports backspace deletion, and
+ * updates display in history mode
+ */
+void DeleteChar()
+{
+  bool use_history = false;
+
+  if (history_index_ >= 0)
+  {
+    CopyHistoryToInputLine();
+    use_history = true;
+  }
+
+  if (CanDeleteChar())
+  {
+    RemoveCharFromInputLine();
+    if (use_history)
     {
-      input_line_.Pop();
+      ShowHistory();
     }
     else
     {
-      input_line_.Delete(input_line_.Size() + offset_ - 1);
-    }
-    input_line_[input_line_.Size()] = '\0';
-  }
-
-  /**
-   * @brief  处理删除字符操作，支持回退删除，并在历史模式下更新显示
-   *         Handles the delete character operation, supports backspace deletion, and
-   * updates display in history mode
-   */
-  void DeleteChar()
-  {
-    bool use_history = false;
-
-    if (history_index_ >= 0)
-    {
-      CopyHistoryToInputLine();
-      use_history = true;
+      write_stream_ << ConstRawData(DELETE_CHAR);
     }
 
-    if (CanDeleteChar())
+    if (offset_ != 0)
     {
-      RemoveCharFromInputLine();
-      if (use_history)
-      {
-        ShowHistory();
-      }
-      else
-      {
-        write_stream_ << ConstRawData(DELETE_CHAR);
-      }
-
-      if (offset_ != 0)
-      {
-        UpdateDisplayPosition();
-      }
+      UpdateDisplayPosition();
     }
   }
+}
 
-  /**
-   * @brief  显示终端提示符，包括当前目录信息
-   *         Displays the terminal prompt, including the current directory information
-   */
-  void ShowHeader()
+/**
+ * @brief  显示终端提示符，包括当前目录信息
+ *         Displays the terminal prompt, including the current directory information
+ */
+void ShowHeader()
+{
+  write_stream_ << ConstRawData(ramfs_.root_.GetName(), strlen(ramfs_.root_.GetName()));
+  if (current_dir_ == &ramfs_.root_)
   {
-    write_stream_ << ConstRawData(ramfs_.root_.GetName(), strlen(ramfs_.root_.GetName()));
-    if (current_dir_ == &ramfs_.root_)
-    {
-      write_stream_ << ConstRawData(":/");
-    }
-    else
-    {
-      write_stream_ << ConstRawData(":") << ConstRawData(current_dir_->GetName());
-    }
-
-    write_stream_ << ConstRawData("$ ");
+    write_stream_ << ConstRawData(":/");
+  }
+  else
+  {
+    write_stream_ << ConstRawData(":") << ConstRawData(current_dir_->GetName());
   }
 
-  /**
-   * @brief  清除当前行
-   *         Clears the current line
-   */
-  void ClearLine() { write_stream_ << ConstRawData(CLEAR_LINE); }
+  write_stream_ << ConstRawData("$ ");
+}
 
-  /**
-   * @brief  清除整个终端屏幕
-   *         Clears the entire terminal screen
-   */
-  void Clear() { write_stream_ << ConstRawData(CLEAR_ALL); }
+/**
+ * @brief  清除当前行
+ *         Clears the current line
+ */
+void ClearLine() { write_stream_ << ConstRawData(CLEAR_LINE); }
 
-  /**
-   * @brief  显示历史记录中的输入行，更新终端显示
-   *         Displays the input line from history and updates the terminal display
-   *
-   * @note 当 `history_index_ < 0` 时，这里回显的是当前尚未提交的输入行，而不是历史项。
-   *       When `history_index_ < 0`, this echoes the current in-progress input
-   *       line rather than one history entry.
-   */
-  void ShowHistory()
+/**
+ * @brief  清除整个终端屏幕
+ *         Clears the entire terminal screen
+ */
+void Clear() { write_stream_ << ConstRawData(CLEAR_ALL); }
+
+/**
+ * @brief  显示历史记录中的输入行，更新终端显示
+ *         Displays the input line from history and updates the terminal display
+ *
+ * @note 当 `history_index_ < 0` 时，这里回显的是当前尚未提交的输入行，而不是历史项。
+ *       When `history_index_ < 0`, this echoes the current in-progress input
+ *       line rather than one history entry.
+ */
+void ShowHistory()
+{
+  ClearLine();
+  ShowHeader();
+  offset_ = 0;
+  if (history_index_ >= 0)
   {
-    ClearLine();
-    ShowHeader();
-    offset_ = 0;
-    if (history_index_ >= 0)
-    {
-      const auto& line = HistoryFromNewest(history_index_);
-      write_stream_ << ConstRawData(line.data(), HistoryLineSize(line));
-    }
-    else
-    {
-      write_stream_ << ConstRawData(&input_line_[0], input_line_.Size());
-    }
-  }
-
-  /**
-   * @brief  将历史命令复制到输入行，并重置历史索引和光标偏移
-   *         Copies the history command to the input line and resets history index and
-   * cursor offset
-   */
-  void CopyHistoryToInputLine()
-  {
-    input_line_.Reset();
     const auto& line = HistoryFromNewest(history_index_);
-    for (size_t i = 0; i < HistoryLineSize(line); i++)
-    {
-      input_line_.Push(line[i]);
-    }
-    input_line_[input_line_.Size()] = '\0';
-    history_index_ = -1;
-    offset_ = 0;
+    write_stream_ << ConstRawData(line.data(), HistoryLineSize(line));
   }
-
-  /**
-   * @brief  将当前输入行添加到历史记录
-   *         Adds the current input line to the history
-   *
-   * @note 超过 `MAX_HISTORY_NUMBER` 时，当前实现会丢掉最旧的一条，再压入最新输入。
-   *       When `MAX_HISTORY_NUMBER` is exceeded, the current implementation
-   *       drops the oldest entry before pushing the newest input line.
-   */
-  void AddHistory()
+  else
   {
-    HistoryLine line{};
-    const size_t line_size =
-        LibXR::min(static_cast<size_t>(input_line_.Size()), MAX_LINE_SIZE);
-    input_line_.Push('\0');
-    if (line_size > 0)
-    {
-      std::memcpy(line.data(), &input_line_[0], line_size);
-    }
-    line[line_size] = '\0';
-
-    if (history_.EmptySize() == 0)
-    {
-      history_.Pop();
-    }
-    history_.Push(line);
+    write_stream_ << ConstRawData(&input_line_[0], input_line_.Size());
   }
+}
+
+/**
+ * @brief  将历史命令复制到输入行，并重置历史索引和光标偏移
+ *         Copies the history command to the input line and resets history index and
+ * cursor offset
+ */
+void CopyHistoryToInputLine()
+{
+  input_line_.Reset();
+  const auto& line = HistoryFromNewest(history_index_);
+  for (size_t i = 0; i < HistoryLineSize(line); i++)
+  {
+    input_line_.Push(line[i]);
+  }
+  input_line_[input_line_.Size()] = '\0';
+  history_index_ = -1;
+  offset_ = 0;
+}
+
+/**
+ * @brief  将当前输入行添加到历史记录
+ *         Adds the current input line to the history
+ *
+ * @note 超过 `MAX_HISTORY_NUMBER` 时，当前实现会丢掉最旧的一条，再压入最新输入。
+ *       When `MAX_HISTORY_NUMBER` is exceeded, the current implementation
+ *       drops the oldest entry before pushing the newest input line.
+ */
+void AddHistory()
+{
+  HistoryLine line{};
+  const size_t line_size =
+      LibXR::min(static_cast<size_t>(input_line_.Size()), MAX_LINE_SIZE);
+  input_line_.Push('\0');
+  if (line_size > 0)
+  {
+    std::memcpy(line.data(), &input_line_[0], line_size);
+  }
+  line[line_size] = '\0';
+
+  if (history_.EmptySize() == 0)
+  {
+    history_.Pop();
+  }
+  history_.Push(line);
+}

--- a/src/middleware/terminal/driver.hpp
+++ b/src/middleware/terminal/driver.hpp
@@ -1,119 +1,118 @@
-  /**
-   * @brief  `Terminal` 的驱动入口片段
-   *         Driver-entry fragment of `Terminal`
-   *
-   * @note 这一组函数只决定“什么时候读、什么时候解析、什么时候提交输出”，不负责
-   *       行编辑、命令语义或显示细节。
-   *       This group decides only when to read, when to parse, and when to
-   *       commit output; it does not own line editing, command semantics, or
-   *       display details.
-   */
+/**
+ * @brief  `Terminal` 的驱动入口片段
+ *         Driver-entry fragment of `Terminal`
+ *
+ * @note 这一组函数只决定“什么时候读、什么时候解析、什么时候提交输出”，不负责
+ *       行编辑、命令语义或显示细节。
+ *       This group decides only when to read, when to parse, and when to
+ *       commit output; it does not own line editing, command semantics, or
+ *       display details.
+ */
 
-  /**
-   * @brief  终端线程函数，以独立线程方式持续驱动终端
-   *         Terminal thread function, continuously drives the terminal as an independent
-   * thread
-   *
-   * @details
-   * 该函数用于以独立线程的方式驱动终端，持续从输入流读取数据并解析，适用于高实时性应用。
-   * 它会在循环中不断检查输入流的大小，并在数据可用时进行解析。
-   *
-   * This function runs as a separate thread to continuously drive the terminal,
-   * reading and parsing input data in a loop. It is suitable for high real-time
-   * applications. It continuously checks the input stream size and processes data when
-   * available.
-   *
-   * @param  term 指向 Terminal 实例的指针 Pointer to the Terminal instance
-   * @note 每次真正拿到一批输入后，解析和输出提交都在 `write_mutex_` 保护下完成，
-   *       以免和外部写口共享同一个输出流时交错。
-   *       Once one input batch is actually obtained, parsing and output commit
-   *       are both completed under `write_mutex_` so they do not interleave
-   *       with other writers sharing the same output stream.
-   */
-  static void ThreadFun(Terminal* term)
+/**
+ * @brief  终端线程函数，以独立线程方式持续驱动终端
+ *         Terminal thread function, continuously drives the terminal as an independent
+ * thread
+ *
+ * @details
+ * 该函数用于以独立线程的方式驱动终端，持续从输入流读取数据并解析，适用于高实时性应用。
+ * 它会在循环中不断检查输入流的大小，并在数据可用时进行解析。
+ *
+ * This function runs as a separate thread to continuously drive the terminal,
+ * reading and parsing input data in a loop. It is suitable for high real-time
+ * applications. It continuously checks the input stream size and processes data when
+ * available.
+ *
+ * @param  term 指向 Terminal 实例的指针 Pointer to the Terminal instance
+ * @note 每次真正拿到一批输入后，解析和输出提交都在 `write_mutex_` 保护下完成，
+ *       以免和外部写口共享同一个输出流时交错。
+ *       Once one input batch is actually obtained, parsing and output commit
+ *       are both completed under `write_mutex_` so they do not interleave
+ *       with other writers sharing the same output stream.
+ */
+static void ThreadFun(Terminal* term)
+{
+  Semaphore read_sem, write_sem;
+  ReadOperation op(read_sem);
+
+  term->write_op_ = WriteOperation(write_sem, 10);
+
+  while (true)
   {
-    Semaphore read_sem, write_sem;
-    ReadOperation op(read_sem);
+    term->request_read_size_ = LibXR::min(term->read_port_->Size(), READ_BUFF_SIZE);
+    auto buffer = RawData(term->read_buff_, term->request_read_size_);
 
-    term->write_op_ = WriteOperation(write_sem, 10);
-
-    while (true)
+    if ((*term->read_port_)(buffer, op) == ErrorCode::OK && term->request_read_size_ > 0)
     {
-      term->request_read_size_ = LibXR::min(term->read_port_->Size(), READ_BUFF_SIZE);
-      auto buffer = RawData(term->read_buff_, term->request_read_size_);
+      term->write_mutex_->Lock();
+      term->Parse(buffer);
+      term->write_stream_.Commit();
+      term->write_mutex_->Unlock();
+    }
+  }
+}
 
-      if ((*term->read_port_)(buffer, op) == ErrorCode::OK &&
-          term->request_read_size_ > 0)
+/**
+ * @brief  终端任务函数，以定时器任务方式驱动终端
+ *         Terminal task function, drives the terminal using a scheduled task
+ *
+ * @details
+ * 该函数用于以定时任务（或轮询方式）驱动终端，适用于资源受限的系统。
+ * 它不会持续运行，而是在定时器触发或系统任务调度时运行，执行一次数据读取和解析后返回。
+ *
+ * This function drives the terminal using a scheduled task (or polling mode),
+ * making it suitable for resource-constrained systems.
+ * Unlike the thread-based approach, it only runs when scheduled
+ * (e.g., triggered by a timer) and processes available input data before returning.
+ *
+ * @param  term 指向 Terminal 实例的指针 Pointer to the Terminal instance
+ * @note `TaskFun()` 每次只推进有限一步状态机：发起读取、等待完成、消费完成结果，
+ *       然后立即返回给调度方。
+ *       `TaskFun()` advances the state machine by only a bounded step each
+ *       time: start one read, wait for completion, consume one completed
+ *       result, then return to the scheduler immediately.
+ */
+static void TaskFun(Terminal* term)
+{
+  ReadOperation op(term->read_status_);
+
+  auto start_read = [&]()
+  {
+    term->request_read_size_ =
+        LibXR::min(LibXR::max(1u, term->read_port_->Size()), READ_BUFF_SIZE);
+    auto buffer = RawData(term->read_buff_, term->request_read_size_);
+    (*term->read_port_)(buffer, op);
+  };
+
+  while (true)
+  {
+    switch (term->read_status_)
+    {
+      case ReadOperation::OperationPollingStatus::READY:
+      {
+        term->request_read_size_ =
+            LibXR::min(LibXR::max(1u, term->read_port_->Size()), READ_BUFF_SIZE);
+        auto buffer = RawData(term->read_buff_, term->request_read_size_);
+        (*term->read_port_)(buffer, op);
+        continue;
+      }
+      case ReadOperation::OperationPollingStatus::RUNNING:
+        return;
+      case ReadOperation::OperationPollingStatus::DONE:
       {
         term->write_mutex_->Lock();
+        auto buffer = RawData(term->read_buff_, term->request_read_size_);
         term->Parse(buffer);
         term->write_stream_.Commit();
         term->write_mutex_->Unlock();
+        start_read();
+        return;
       }
-    }
-  }
-
-  /**
-   * @brief  终端任务函数，以定时器任务方式驱动终端
-   *         Terminal task function, drives the terminal using a scheduled task
-   *
-   * @details
-   * 该函数用于以定时任务（或轮询方式）驱动终端，适用于资源受限的系统。
-   * 它不会持续运行，而是在定时器触发或系统任务调度时运行，执行一次数据读取和解析后返回。
-   *
-   * This function drives the terminal using a scheduled task (or polling mode),
-   * making it suitable for resource-constrained systems.
-   * Unlike the thread-based approach, it only runs when scheduled
-   * (e.g., triggered by a timer) and processes available input data before returning.
-   *
-   * @param  term 指向 Terminal 实例的指针 Pointer to the Terminal instance
-   * @note `TaskFun()` 每次只推进有限一步状态机：发起读取、等待完成、消费完成结果，
-   *       然后立即返回给调度方。
-   *       `TaskFun()` advances the state machine by only a bounded step each
-   *       time: start one read, wait for completion, consume one completed
-   *       result, then return to the scheduler immediately.
-   */
-  static void TaskFun(Terminal* term)
-  {
-    ReadOperation op(term->read_status_);
-
-    auto start_read = [&]()
-    {
-      term->request_read_size_ =
-          LibXR::min(LibXR::max(1u, term->read_port_->Size()), READ_BUFF_SIZE);
-      auto buffer = RawData(term->read_buff_, term->request_read_size_);
-      (*term->read_port_)(buffer, op);
-    };
-
-    while (true)
-    {
-      switch (term->read_status_)
+      case ReadOperation::OperationPollingStatus::ERROR:
       {
-        case ReadOperation::OperationPollingStatus::READY:
-        {
-          term->request_read_size_ =
-              LibXR::min(LibXR::max(1u, term->read_port_->Size()), READ_BUFF_SIZE);
-          auto buffer = RawData(term->read_buff_, term->request_read_size_);
-          (*term->read_port_)(buffer, op);
-          continue;
-        }
-        case ReadOperation::OperationPollingStatus::RUNNING:
-          return;
-        case ReadOperation::OperationPollingStatus::DONE:
-        {
-          term->write_mutex_->Lock();
-          auto buffer = RawData(term->read_buff_, term->request_read_size_);
-          term->Parse(buffer);
-          term->write_stream_.Commit();
-          term->write_mutex_->Unlock();
-          start_read();
-          return;
-        }
-        case ReadOperation::OperationPollingStatus::ERROR:
-        {
-          start_read();
-          return;
-        }
+        start_read();
+        return;
       }
     }
   }
+}

--- a/src/middleware/terminal/input.hpp
+++ b/src/middleware/terminal/input.hpp
@@ -1,179 +1,179 @@
-  /**
-   * @brief  `Terminal` 的输入解析片段
-   *         Input-parsing fragment of `Terminal`
-   *
-   * @note 这一组函数只负责把读到的原始字节分发成 ANSI 序列、可显示字符或控制字符，
-   *       不直接处理文件系统命令语义。
-   *       This group is responsible only for routing raw bytes into ANSI
-   *       sequences, printable characters, or control characters; it does not
-   *       directly own filesystem-command semantics.
-   */
+/**
+ * @brief  `Terminal` 的输入解析片段
+ *         Input-parsing fragment of `Terminal`
+ *
+ * @note 这一组函数只负责把读到的原始字节分发成 ANSI 序列、可显示字符或控制字符，
+ *       不直接处理文件系统命令语义。
+ *       This group is responsible only for routing raw bytes into ANSI
+ *       sequences, printable characters, or control characters; it does not
+ *       directly own filesystem-command semantics.
+ */
 
-  /**
-   * @brief  解析输入数据流，将其转换为字符并处理
-   *         Parses the input data stream, converting it into characters and processing
-   * them
-   * @param  raw_data 输入的原始数据 Input raw data
-   */
-  void Parse(RawData& raw_data)
+/**
+ * @brief  解析输入数据流，将其转换为字符并处理
+ *         Parses the input data stream, converting it into characters and processing
+ * them
+ * @param  raw_data 输入的原始数据 Input raw data
+ */
+void Parse(RawData& raw_data)
+{
+  char* buff = static_cast<char*>(raw_data.addr_);
+  for (size_t i = 0; i < raw_data.size_; i++)
   {
-    char* buff = static_cast<char*>(raw_data.addr_);
-    for (size_t i = 0; i < raw_data.size_; i++)
-    {
-      HandleCharacter(buff[i]);
-    }
+    HandleCharacter(buff[i]);
   }
+}
 
-  /**
-   * @brief  处理 ANSI 序列中的后续字符
-   *         Handles the follow-up characters of an ANSI sequence
-   * @param  data 输入字符 The input character
-   *
-   * @note 当前实现只识别箭头键对应的尾字符；其它 ANSI 序列会被静默忽略。
-   *       The current implementation recognizes only the tail characters used
-   *       by arrow keys; other ANSI sequences are ignored silently.
-   */
-  void HandleAnsiCharacter(char data)
+/**
+ * @brief  处理 ANSI 序列中的后续字符
+ *         Handles the follow-up characters of an ANSI sequence
+ * @param  data 输入字符 The input character
+ *
+ * @note 当前实现只识别箭头键对应的尾字符；其它 ANSI 序列会被静默忽略。
+ *       The current implementation recognizes only the tail characters used
+ *       by arrow keys; other ANSI sequences are ignored silently.
+ */
+void HandleAnsiCharacter(char data)
+{
+  if (flag_ansi_ == 1)
   {
-    if (flag_ansi_ == 1)
+    if (std::isprint(static_cast<unsigned char>(data)))
     {
-      if (std::isprint(static_cast<unsigned char>(data)))
-      {
-        flag_ansi_++;
-      }
-      else
-      {
-        flag_ansi_ = 0;
-      }
+      flag_ansi_++;
     }
-    else if (flag_ansi_ == 2)
+    else
     {
-      switch (data)
-      {
-        case 'A':
-          if (history_index_ < int(history_.Size()) - 1)
-          {
-            history_index_++;
-            ShowHistory();
-          }
-          break;
-        case 'B':
-          if (history_index_ >= 0)
-          {
-            history_index_--;
-            ShowHistory();
-          }
-          break;
-        case 'C':
-          if (history_index_ >= 0)
-          {
-            CopyHistoryToInputLine();
-            ShowHistory();
-          }
-          if (offset_ < 0)
-          {
-            offset_++;
-            write_stream_ << ConstRawData(KEY_RIGHT, sizeof(KEY_RIGHT) - 1);
-          }
-
-          break;
-        case 'D':
-          if (history_index_ >= 0)
-          {
-            CopyHistoryToInputLine();
-            ShowHistory();
-          }
-          if (offset_ + input_line_.Size() > 0)
-          {
-            offset_--;
-            write_stream_ << ConstRawData(KEY_LEFT, sizeof(KEY_LEFT) - 1);
-          }
-          break;
-        default:
-          break;
-      }
-
       flag_ansi_ = 0;
     }
   }
-
-  /**
-   * @brief  处理控制字符，包括换行、删除、制表符等
-   *         Handles control characters such as newline, delete, and tab
-   * @param  data 输入的控制字符 The input control character
-   *
-   * @note 这里还负责去掉一对 `\r\n` / `\n\r` 双换行中的重复第二字节，避免一次回车被
-   *       当成两次命令提交。
-   *       This path also suppresses the duplicated second byte of one `\r\n`
-   *       / `\n\r` pair so a single Enter key does not submit the command twice.
-   */
-  void HandleControlCharacter(char data)
+  else if (flag_ansi_ == 2)
   {
-    if (data != '\r' && data != '\n')
-    {
-      linefeed_flag_ = false;
-      linefeed_char_ = '\0';
-    }
-
     switch (data)
     {
-      case '\n':
-      case '\r':
-        if (linefeed_flag_ && data != linefeed_char_)
+      case 'A':
+        if (history_index_ < int(history_.Size()) - 1)
         {
-          linefeed_flag_ = false;
-          linefeed_char_ = '\0';
-          return;
+          history_index_++;
+          ShowHistory();
         }
-        linefeed_flag_ = true;
-        linefeed_char_ = data;
+        break;
+      case 'B':
+        if (history_index_ >= 0)
+        {
+          history_index_--;
+          ShowHistory();
+        }
+        break;
+      case 'C':
         if (history_index_ >= 0)
         {
           CopyHistoryToInputLine();
+          ShowHistory();
         }
-        LineFeed();
-        if (input_line_.Size() > 0)
+        if (offset_ < 0)
         {
-          ExecuteCommand();
-          arg_number_ = 0;
+          offset_++;
+          write_stream_ << ConstRawData(KEY_RIGHT, sizeof(KEY_RIGHT) - 1);
         }
-        ShowHeader();
-        input_line_.Reset();
-        input_line_[0] = '\0';
-        offset_ = 0;
+
         break;
-      case 0x7f:
-      case '\b':
-        DeleteChar();
-        break;
-      case '\t':
-        AutoComplete();
-        break;
-      case '\033':
-        flag_ansi_ = 1;
+      case 'D':
+        if (history_index_ >= 0)
+        {
+          CopyHistoryToInputLine();
+          ShowHistory();
+        }
+        if (offset_ + input_line_.Size() > 0)
+        {
+          offset_--;
+          write_stream_ << ConstRawData(KEY_LEFT, sizeof(KEY_LEFT) - 1);
+        }
         break;
       default:
         break;
     }
+
+    flag_ansi_ = 0;
+  }
+}
+
+/**
+ * @brief  处理控制字符，包括换行、删除、制表符等
+ *         Handles control characters such as newline, delete, and tab
+ * @param  data 输入的控制字符 The input control character
+ *
+ * @note 这里还负责去掉一对 `\r\n` / `\n\r` 双换行中的重复第二字节，避免一次回车被
+ *       当成两次命令提交。
+ *       This path also suppresses the duplicated second byte of one `\r\n`
+ *       / `\n\r` pair so a single Enter key does not submit the command twice.
+ */
+void HandleControlCharacter(char data)
+{
+  if (data != '\r' && data != '\n')
+  {
+    linefeed_flag_ = false;
+    linefeed_char_ = '\0';
   }
 
-  /**
-   * @brief  处理输入字符，根据类型调用相应的处理函数
-   *         Handles input characters, dispatching them to the appropriate handler
-   * @param  data 输入的字符 The input character
-   */
-  void HandleCharacter(char data)
+  switch (data)
   {
-    if (flag_ansi_)
-    {
-      HandleAnsiCharacter(data);
-    }
-    else if (std::isprint(static_cast<unsigned char>(data)))
-    {
-      DisplayChar(data);
-    }
-    else
-    {
-      HandleControlCharacter(data);
-    }
+    case '\n':
+    case '\r':
+      if (linefeed_flag_ && data != linefeed_char_)
+      {
+        linefeed_flag_ = false;
+        linefeed_char_ = '\0';
+        return;
+      }
+      linefeed_flag_ = true;
+      linefeed_char_ = data;
+      if (history_index_ >= 0)
+      {
+        CopyHistoryToInputLine();
+      }
+      LineFeed();
+      if (input_line_.Size() > 0)
+      {
+        ExecuteCommand();
+        arg_number_ = 0;
+      }
+      ShowHeader();
+      input_line_.Reset();
+      input_line_[0] = '\0';
+      offset_ = 0;
+      break;
+    case 0x7f:
+    case '\b':
+      DeleteChar();
+      break;
+    case '\t':
+      AutoComplete();
+      break;
+    case '\033':
+      flag_ansi_ = 1;
+      break;
+    default:
+      break;
   }
+}
+
+/**
+ * @brief  处理输入字符，根据类型调用相应的处理函数
+ *         Handles input characters, dispatching them to the appropriate handler
+ * @param  data 输入的字符 The input character
+ */
+void HandleCharacter(char data)
+{
+  if (flag_ansi_)
+  {
+    HandleAnsiCharacter(data);
+  }
+  else if (std::isprint(static_cast<unsigned char>(data)))
+  {
+    DisplayChar(data);
+  }
+  else
+  {
+    HandleControlCharacter(data);
+  }
+}

--- a/src/middleware/terminal/terminal.hpp
+++ b/src/middleware/terminal/terminal.hpp
@@ -142,7 +142,8 @@ class Terminal
 
   ReadOperation::OperationPollingStatus read_status_;
   WriteOperation::OperationPollingStatus
-      write_status_;  ///< 当前读/写轮询状态 / Current polling status of the read / write side.
+      write_status_;  ///< 当前读/写轮询状态 / Current polling status of the read / write
+                      ///< side.
 
   const Mode MODE;                  ///< 终端换行模式 Terminal line feed mode
   WriteOperation write_op_;         ///< 终端写操作 Terminal write operation
@@ -155,7 +156,8 @@ class Terminal
   RamFS& ramfs_;                    ///< 关联的文件系统 Associated file system
   char read_buff_[READ_BUFF_SIZE];  ///< 读取缓冲区 Read buffer
 
-  size_t request_read_size_ = 0;   ///< 本轮计划读取的字节数 / Byte count requested for the current read attempt.
+  size_t request_read_size_ =
+      0;  ///< 本轮计划读取的字节数 / Byte count requested for the current read attempt.
   RamFS::Dir* current_dir_;        ///< 当前目录 Current directory
   uint8_t flag_ansi_ = 0;          ///< ANSI 控制字符状态 ANSI control character state
   int offset_ = 0;                 ///< 光标偏移 Cursor offset

--- a/src/structure/double_buffer.hpp
+++ b/src/structure/double_buffer.hpp
@@ -187,7 +187,7 @@ class DoubleBuffer
  private:
   uint8_t* buffer_[2] = {nullptr, nullptr};  ///< 双缓冲区指针 / Double buffer pointers
   size_t size_ = 0;                          ///< 单个缓冲区大小 / Size of each buffer
-  int active_ = 0;      ///< 当前活动缓冲区编号 / Index of active buffer
+  int active_ = 0;  ///< 当前活动缓冲区编号 / Index of active buffer
   bool pending_valid_ =
       false;                ///< 标记备用区是否准备好 / Whether pending buffer is ready
   size_t active_len_ = 0;   ///< 当前活动缓冲区有效数据长度 / Length of active data

--- a/src/structure/object_pool.hpp
+++ b/src/structure/object_pool.hpp
@@ -29,15 +29,14 @@ namespace LibXR
  * - `Size()`
  */
 template <typename QueueType>
-concept PoolIndexQueue = requires(QueueType queue,
-                                  const typename QueueType::ValueType& index_const,
-                                  typename QueueType::ValueType& index_mut)
-{
-  typename QueueType::ValueType;
-  { queue.Push(index_const) } -> std::same_as<ErrorCode>;
-  { queue.Pop(index_mut) } -> std::same_as<ErrorCode>;
-  { queue.Size() } -> std::convertible_to<size_t>;
-};
+concept PoolIndexQueue =
+    requires(QueueType queue, const typename QueueType::ValueType& index_const,
+             typename QueueType::ValueType& index_mut) {
+      typename QueueType::ValueType;
+      { queue.Push(index_const) } -> std::same_as<ErrorCode>;
+      { queue.Pop(index_mut) } -> std::same_as<ErrorCode>;
+      { queue.Size() } -> std::convertible_to<size_t>;
+    };
 
 /**
  * @class BasicObjectPool
@@ -59,9 +58,9 @@ template <typename Data, PoolIndexQueue FreeQueue>
 class BasicObjectPool
 {
  public:
-  using ValueType = Data;                           ///< 槽内对象类型。 Slot object type.
-  using QueueType = FreeQueue;                     ///< 空闲索引队列类型。 Free-index queue type.
-  using IndexType = typename FreeQueue::ValueType; ///< 槽索引类型。 Slot index type.
+  using ValueType = Data;       ///< 槽内对象类型。 Slot object type.
+  using QueueType = FreeQueue;  ///< 空闲索引队列类型。 Free-index queue type.
+  using IndexType = typename FreeQueue::ValueType;  ///< 槽索引类型。 Slot index type.
 
   /// @brief 槽索引必须是整数类型。 Slot indices must use an integral type.
   static_assert(std::is_integral_v<IndexType>,
@@ -234,7 +233,7 @@ class BasicObjectPool
    * @param slot_count 槽位数量。 Number of slots.
    */
   template <typename T = Data>
-  requires std::is_default_constructible_v<T>
+    requires std::is_default_constructible_v<T>
   explicit BasicObjectPool(size_t slot_count) : slot_count_(slot_count)
   {
     ASSERT(slot_count_ > 0);
@@ -253,8 +252,7 @@ class BasicObjectPool
    *       The caller must ensure that `slots` points to at least `slot_count`
    *       `Data` slots.
    */
-  BasicObjectPool(size_t slot_count, Data* slots)
-      : slot_count_(slot_count), slots_(slots)
+  BasicObjectPool(size_t slot_count, Data* slots) : slot_count_(slot_count), slots_(slots)
   {
     ASSERT(slot_count_ > 0);
     ASSERT(slots_ != nullptr);
@@ -274,7 +272,7 @@ class BasicObjectPool
    *       The caller must ensure that `free_queue` capacity is at least `slot_count`.
    */
   template <typename T = Data>
-  requires std::is_default_constructible_v<T>
+    requires std::is_default_constructible_v<T>
   BasicObjectPool(FreeQueue& free_queue, size_t slot_count)
       : free_queue_(&free_queue), slot_count_(slot_count)
   {
@@ -341,7 +339,8 @@ class BasicObjectPool
    * @brief Acquire one slot handle.
    * @param handle 用于接收成功获取的 handle。 Handle receiving the acquired slot.
    * @return 成功返回 `ErrorCode::OK`，池空返回 `ErrorCode::EMPTY`。
-   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when the pool is empty.
+   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when the pool is
+   * empty.
    */
   [[nodiscard]] ErrorCode Acquire(Handle& handle)
   {
@@ -451,8 +450,7 @@ class BasicObjectPool
   void InitializeFreeQueue()
   {
     ASSERT(slot_count_ > 0);
-    ASSERT(slot_count_ - 1 <=
-           static_cast<size_t>(std::numeric_limits<IndexType>::max()));
+    ASSERT(slot_count_ - 1 <= static_cast<size_t>(std::numeric_limits<IndexType>::max()));
     for (size_t index = 0; index < slot_count_; ++index)
     {
       const ErrorCode ec = free_queue_->Push(static_cast<IndexType>(index));
@@ -460,13 +458,17 @@ class BasicObjectPool
     }
   }
 
-  /// @brief 内部自拥有 queue 的原地构造存储区。 In-place storage for an internally owned queue.
+  /// @brief 内部自拥有 queue 的原地构造存储区。 In-place storage for an internally owned
+  /// queue.
   alignas(FreeQueue) std::byte free_queue_storage_[sizeof(FreeQueue)] = {};
-  FreeQueue* free_queue_ = nullptr; ///< 空闲索引队列指针。 Pointer to the free-index queue.
-  const size_t slot_count_;         ///< 槽位总数。 Total slot count.
-  Data* slots_ = nullptr;           ///< 槽数组指针。 Pointer to slot storage.
-  bool owns_free_queue_ = false;    ///< 是否拥有内部 queue。 Whether this pool owns the free queue.
-  bool owns_slots_ = false;         ///< 是否拥有内部 slots。 Whether this pool owns the slot storage.
+  FreeQueue* free_queue_ =
+      nullptr;               ///< 空闲索引队列指针。 Pointer to the free-index queue.
+  const size_t slot_count_;  ///< 槽位总数。 Total slot count.
+  Data* slots_ = nullptr;    ///< 槽数组指针。 Pointer to slot storage.
+  bool owns_free_queue_ =
+      false;  ///< 是否拥有内部 queue。 Whether this pool owns the free queue.
+  bool owns_slots_ =
+      false;  ///< 是否拥有内部 slots。 Whether this pool owns the slot storage.
 };
 
 /**

--- a/src/structure/queue/basic_queue.hpp
+++ b/src/structure/queue/basic_queue.hpp
@@ -84,7 +84,8 @@ class Queue final : public QueueTypedBase<Queue<Data>, Data>, public QueueBase
    * @brief Peek the front element without removing it.
    * @param data 用于接收查看结果的引用。 Reference receiving the peeked element.
    * @return 成功返回 `ErrorCode::OK`，队列空返回 `ErrorCode::EMPTY`。
-   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when the queue is empty.
+   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when the queue is
+   * empty.
    */
   ErrorCode Peek(Data& data) { return QueueBase::PeekBytes(&data); }
 
@@ -94,7 +95,8 @@ class Queue final : public QueueTypedBase<Queue<Data>, Data>, public QueueBase
    * @param data 指向元素数组的指针。 Pointer to the array of elements to push.
    * @param size 要推入的元素个数。 Number of elements to push.
    * @return 成功返回 `ErrorCode::OK`，空间不足返回 `ErrorCode::FULL`。
-   *         Returns `ErrorCode::OK` on success and `ErrorCode::FULL` when free space is insufficient.
+   *         Returns `ErrorCode::OK` on success and `ErrorCode::FULL` when free space is
+   * insufficient.
    */
   ErrorCode PushBatch(const Data* data, size_t size)
   {
@@ -107,7 +109,8 @@ class Queue final : public QueueTypedBase<Queue<Data>, Data>, public QueueBase
    * @param data 指向输出数组的指针。 Pointer to the array receiving popped elements.
    * @param size 要移除的元素个数。 Number of elements to remove.
    * @return 成功返回 `ErrorCode::OK`，元素不足返回 `ErrorCode::EMPTY`。
-   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when stored elements are insufficient.
+   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when stored
+   * elements are insufficient.
    */
   ErrorCode PopBatch(Data* data, size_t size)
   {
@@ -120,7 +123,8 @@ class Queue final : public QueueTypedBase<Queue<Data>, Data>, public QueueBase
    * @param data 指向输出数组的指针。 Pointer to the array receiving peeked elements.
    * @param size 要查看的元素个数。 Number of elements to retrieve.
    * @return 成功返回 `ErrorCode::OK`，元素不足返回 `ErrorCode::EMPTY`。
-   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when stored elements are insufficient.
+   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when stored
+   * elements are insufficient.
    */
   ErrorCode PeekBatch(Data* data, size_t size)
   {

--- a/src/structure/queue/mpmc_queue.hpp
+++ b/src/structure/queue/mpmc_queue.hpp
@@ -47,9 +47,6 @@ class MPMCQueue final : public QueueTypedBase<MPMCQueue<Payload>, Payload>,
    *
    * @note 包含动态内存分配。 Contains dynamic memory allocation.
    */
-  explicit MPMCQueue(size_t capacity)
-      : MPMCQueueBase(sizeof(Payload), capacity)
-  {
-  }
+  explicit MPMCQueue(size_t capacity) : MPMCQueueBase(sizeof(Payload), capacity) {}
 };
 }  // namespace LibXR

--- a/src/structure/queue/mpmc_queue_base.hpp
+++ b/src/structure/queue/mpmc_queue_base.hpp
@@ -28,9 +28,11 @@ namespace LibXR
 class MPMCQueueBase
 {
  public:
-  using SequenceType = size_t;  ///< 单调递增的逻辑序号类型 / Monotonic logical sequence type.
+  using SequenceType =
+      size_t;  ///< 单调递增的逻辑序号类型 / Monotonic logical sequence type.
   using SequenceDiffType =
-      std::make_signed_t<SequenceType>;  ///< 序号差值判定类型 / Signed type used for sequence-delta checks.
+      std::make_signed_t<SequenceType>;  ///< 序号差值判定类型 / Signed type used for
+                                         ///< sequence-delta checks.
 
   /**
    * @brief 构造一个字节队列内核 / Construct one byte-queue core
@@ -97,19 +99,22 @@ class MPMCQueueBase
   /// @brief 每个逻辑槽对应的序号单元。 Sequence cell for one logical slot.
   struct alignas(LibXR::CONCURRENCY_ALIGNMENT) SequenceCell
   {
-    std::atomic<SequenceType> value;  ///< 当前槽的逻辑序号。 Current logical sequence of the slot.
+    std::atomic<SequenceType>
+        value;  ///< 当前槽的逻辑序号。 Current logical sequence of the slot.
   };
 
   /// @brief 获取指定槽位 payload 起始地址。 Get the payload base address of one slot.
   [[nodiscard]] void* PayloadPtr(size_t index);
-  /// @brief 获取指定槽位 payload 起始地址（只读）。 Get the payload base address of one slot (const).
+  /// @brief 获取指定槽位 payload 起始地址（只读）。 Get the payload base address of one
+  /// slot (const).
   [[nodiscard]] const void* PayloadPtr(size_t index) const;
   /// @brief 安全地向上对齐字节数。 Safely align one byte count upward.
   [[nodiscard]] static size_t AlignUpChecked(size_t value, size_t align);
   /// @brief 安全地计算乘积。 Safely multiply two size values.
   [[nodiscard]] static size_t MultiplyChecked(size_t lhs, size_t rhs);
   /**
-   * @brief payload 缓冲区整体分配对齐 / Allocation alignment used for the whole payload buffer
+   * @brief payload 缓冲区整体分配对齐 / Allocation alignment used for the whole payload
+   * buffer
    */
   static constexpr size_t PAYLOAD_ALLOC_ALIGN =
       std::max(alignof(size_t), alignof(std::max_align_t));
@@ -125,13 +130,14 @@ class MPMCQueueBase
 
   const size_t element_size_;    ///< 单个 payload 的字节数。 Byte size of one payload.
   const size_t capacity_;        ///< 队列容量。 Queue capacity.
-  const size_t payload_stride_;  ///< 相邻 payload 槽位之间的步长。 Byte stride between adjacent payload slots.
+  const size_t payload_stride_;  ///< 相邻 payload 槽位之间的步长。 Byte stride between
+                                 ///< adjacent payload slots.
   SequenceCell* sequences_;      ///< 槽序号数组。 Array of per-slot sequence cells.
   std::byte* payloads_;          ///< payload 字节缓冲区。 Byte buffer storing payloads.
 
-  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<SequenceType>
-      head_;  ///< 下一个待出队的逻辑位置。 Next logical dequeue position.
-  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<SequenceType>
-      tail_;  ///< 下一个待入队的逻辑位置。 Next logical enqueue position.
+  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<
+      SequenceType> head_;  ///< 下一个待出队的逻辑位置。 Next logical dequeue position.
+  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<
+      SequenceType> tail_;  ///< 下一个待入队的逻辑位置。 Next logical enqueue position.
 };
 }  // namespace LibXR

--- a/src/structure/queue/queue.hpp
+++ b/src/structure/queue/queue.hpp
@@ -13,5 +13,5 @@
  */
 
 #include "basic_queue.hpp"
-#include "spsc_queue.hpp"
 #include "mpmc_queue.hpp"
+#include "spsc_queue.hpp"

--- a/src/structure/queue/queue_base.hpp
+++ b/src/structure/queue/queue_base.hpp
@@ -48,7 +48,8 @@ class QueueBase
    * @brief 访问指定物理槽位的原始元素地址。
    * @brief Access the raw element address of one physical slot.
    * @param index 目标物理槽位下标。 Target physical slot index.
-   * @return 指向该槽位元素起始地址的指针。 Pointer to the element base address of the slot.
+   * @return 指向该槽位元素起始地址的指针。 Pointer to the element base address of the
+   * slot.
    */
   [[nodiscard]] void* operator[](uint32_t index);
 
@@ -57,7 +58,8 @@ class QueueBase
    * @brief Enqueue one element by bytes.
    * @param data 指向待入队元素的指针。 Pointer to the element to enqueue.
    * @return 成功返回 `ErrorCode::OK`，队列满返回 `ErrorCode::FULL`。
-   *         Returns `ErrorCode::OK` on success and `ErrorCode::FULL` when the queue is full.
+   *         Returns `ErrorCode::OK` on success and `ErrorCode::FULL` when the queue is
+   * full.
    */
   ErrorCode PushBytes(const void* data);
 
@@ -66,7 +68,8 @@ class QueueBase
    * @brief Peek the front element by bytes without dequeuing it.
    * @param data 接收队头元素的缓冲区。 Buffer receiving the front element.
    * @return 成功返回 `ErrorCode::OK`，队列空返回 `ErrorCode::EMPTY`。
-   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when the queue is empty.
+   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when the queue is
+   * empty.
    */
   ErrorCode PeekBytes(void* data);
 
@@ -76,7 +79,8 @@ class QueueBase
    * @param data 接收出队元素的缓冲区；传 `nullptr` 时仅丢弃。
    *             Buffer receiving the dequeued element; pass `nullptr` to discard only.
    * @return 成功返回 `ErrorCode::OK`，队列空返回 `ErrorCode::EMPTY`。
-   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when the queue is empty.
+   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when the queue is
+   * empty.
    */
   ErrorCode PopBytes(void* data = nullptr);
 
@@ -84,7 +88,8 @@ class QueueBase
    * @brief 获取当前最后一个已入队元素的物理槽位下标。
    * @brief Get the physical slot index of the current last queued element.
    * @return 队列非空时返回最后一个元素的物理槽位下标，否则返回 `-1`。
-   *         Returns the physical slot index of the last element, or `-1` when the queue is empty.
+   *         Returns the physical slot index of the last element, or `-1` when the queue
+   * is empty.
    */
   int GetLastElementIndex() const;
 
@@ -92,7 +97,8 @@ class QueueBase
    * @brief 获取当前第一个已入队元素的物理槽位下标。
    * @brief Get the physical slot index of the current first queued element.
    * @return 队列非空时返回第一个元素的物理槽位下标，否则返回 `-1`。
-   *         Returns the physical slot index of the first element, or `-1` when the queue is empty.
+   *         Returns the physical slot index of the first element, or `-1` when the queue
+   * is empty.
    */
   int GetFirstElementIndex() const;
 
@@ -102,7 +108,8 @@ class QueueBase
    * @param data 指向元素数组的缓冲区。 Buffer pointing to the element array.
    * @param size 要入队的元素个数。 Number of elements to enqueue.
    * @return 成功返回 `ErrorCode::OK`，空间不足返回 `ErrorCode::FULL`。
-   *         Returns `ErrorCode::OK` on success and `ErrorCode::FULL` when free space is insufficient.
+   *         Returns `ErrorCode::OK` on success and `ErrorCode::FULL` when free space is
+   * insufficient.
    */
   ErrorCode PushBatchBytes(const void* data, size_t size);
 
@@ -113,7 +120,8 @@ class QueueBase
    *             Buffer receiving dequeued elements; pass `nullptr` to discard only.
    * @param size 要出队的元素个数。 Number of elements to dequeue.
    * @return 成功返回 `ErrorCode::OK`，元素不足返回 `ErrorCode::EMPTY`。
-   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when stored elements are insufficient.
+   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when stored
+   * elements are insufficient.
    */
   ErrorCode PopBatchBytes(void* data, size_t size);
 
@@ -123,7 +131,8 @@ class QueueBase
    * @param data 接收查看结果的缓冲区。 Buffer receiving the peeked elements.
    * @param size 要查看的元素个数。 Number of elements to peek.
    * @return 成功返回 `ErrorCode::OK`，元素不足返回 `ErrorCode::EMPTY`。
-   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when stored elements are insufficient.
+   *         Returns `ErrorCode::OK` on success and `ErrorCode::EMPTY` when stored
+   * elements are insufficient.
    */
   ErrorCode PeekBatchBytes(void* data, size_t size);
 
@@ -177,10 +186,12 @@ class QueueBase
  public:
   uint8_t* queue_array_;        ///< 队列数据缓冲区。 Queue data buffer.
   const uint16_t ELEMENT_SIZE;  ///< 单个元素的字节数。 Byte size of one element.
-  size_t head_ = 0;             ///< 当前队头物理槽位下标。 Physical slot index of the current head.
-  size_t tail_ = 0;             ///< 下一个待写入物理槽位下标。 Physical slot index of the next enqueue position.
-  bool is_full_ = false;        ///< 当前队列是否已满。 Whether the queue is currently full.
-  size_t length_;               ///< 队列最大容量。 Maximum queue capacity.
-  bool own_buffer_ = false;     ///< 是否由当前队列拥有缓冲区。 Whether this queue owns the buffer.
+  size_t head_ = 0;  ///< 当前队头物理槽位下标。 Physical slot index of the current head.
+  size_t tail_ = 0;  ///< 下一个待写入物理槽位下标。 Physical slot index of the next
+                     ///< enqueue position.
+  bool is_full_ = false;  ///< 当前队列是否已满。 Whether the queue is currently full.
+  size_t length_;         ///< 队列最大容量。 Maximum queue capacity.
+  bool own_buffer_ =
+      false;  ///< 是否由当前队列拥有缓冲区。 Whether this queue owns the buffer.
 };
 }  // namespace LibXR

--- a/src/structure/queue/queue_typed_base.hpp
+++ b/src/structure/queue/queue_typed_base.hpp
@@ -42,19 +42,13 @@ class QueueTypedBase
    * @param item 用于接收出队元素的引用。 Reference receiving the dequeued element.
    * @return 底层字节队列返回的操作结果。 Operation result returned by the byte queue.
    */
-  ErrorCode Pop(Data& item)
-  {
-    return static_cast<Derived*>(this)->PopBytes(&item);
-  }
+  ErrorCode Pop(Data& item) { return static_cast<Derived*>(this)->PopBytes(&item); }
 
   /**
    * @brief 丢弃一个队头元素。
    * @brief Discard one front element.
    * @return 底层字节队列返回的操作结果。 Operation result returned by the byte queue.
    */
-  ErrorCode Pop()
-  {
-    return static_cast<Derived*>(this)->PopBytes(nullptr);
-  }
+  ErrorCode Pop() { return static_cast<Derived*>(this)->PopBytes(nullptr); }
 };
 }  // namespace LibXR

--- a/src/structure/queue/spsc_queue.hpp
+++ b/src/structure/queue/spsc_queue.hpp
@@ -25,8 +25,7 @@ namespace LibXR
  * @tparam Data 队列存储的数据类型。 Queue element type.
  */
 template <typename Data>
-class SPSCQueue final : public QueueTypedBase<SPSCQueue<Data>, Data>,
-                        public SPSCQueueBase
+class SPSCQueue final : public QueueTypedBase<SPSCQueue<Data>, Data>, public SPSCQueueBase
 {
  public:
   static_assert(alignof(Data) <= alignof(std::max_align_t),
@@ -45,8 +44,7 @@ class SPSCQueue final : public QueueTypedBase<SPSCQueue<Data>, Data>,
    *
    * @note 包含动态内存分配。 Contains dynamic memory allocation.
    */
-  explicit SPSCQueue(size_t length)
-      : SPSCQueueBase(sizeof(Data), alignof(Data), length)
+  explicit SPSCQueue(size_t length) : SPSCQueueBase(sizeof(Data), alignof(Data), length)
   {
   }
 
@@ -64,10 +62,7 @@ class SPSCQueue final : public QueueTypedBase<SPSCQueue<Data>, Data>,
    *         Returns `ErrorCode::OK` on success; returns `ErrorCode::EMPTY` when
    *         the queue is empty
    */
-  ErrorCode Peek(Data& item)
-  {
-    return SPSCQueueBase::PeekBytes(&item);
-  }
+  ErrorCode Peek(Data& item) { return SPSCQueueBase::PeekBytes(&item); }
 
   /**
    * @brief 批量推入多个 payload。
@@ -110,9 +105,9 @@ class SPSCQueue final : public QueueTypedBase<SPSCQueue<Data>, Data>,
    * @param size payload 个数。 Number of payloads.
    * @param writer 写入器回调，签名为 `ErrorCode(Data* buffer, size_t count)`。
    *        Writer callback with signature `ErrorCode(Data* buffer, size_t count)`.
-   * @return 成功返回 `ErrorCode::OK`；队列满返回 `ErrorCode::FULL`；否则返回写入器错误码。
-   *         Returns `ErrorCode::OK` on success; returns `ErrorCode::FULL` when the
-   *         queue is full; otherwise returns the writer error code.
+   * @return 成功返回 `ErrorCode::OK`；队列满返回
+   * `ErrorCode::FULL`；否则返回写入器错误码。 Returns `ErrorCode::OK` on success; returns
+   * `ErrorCode::FULL` when the queue is full; otherwise returns the writer error code.
    *
    * @note 仅当写入器处理完整批次后才提交入队。
    *       The enqueue is committed only after the writer accepts the full batch.
@@ -120,10 +115,12 @@ class SPSCQueue final : public QueueTypedBase<SPSCQueue<Data>, Data>,
   template <typename Writer>
   ErrorCode PushWithWriter(size_t size, Writer&& writer)
   {
-    static_assert(std::is_trivially_copyable_v<Data>,
-                  "batched SPSCQueue::PushWithWriter requires trivially copyable payloads");
-    static_assert(std::is_trivially_destructible_v<Data>,
-                  "batched SPSCQueue::PushWithWriter requires trivially destructible payloads");
+    static_assert(
+        std::is_trivially_copyable_v<Data>,
+        "batched SPSCQueue::PushWithWriter requires trivially copyable payloads");
+    static_assert(
+        std::is_trivially_destructible_v<Data>,
+        "batched SPSCQueue::PushWithWriter requires trivially destructible payloads");
     static_assert(std::is_invocable_v<Writer&, Data*, size_t>,
                   "PushWithWriter writer must be callable as "
                   "ErrorCode(Data* buffer, size_t count)");
@@ -133,11 +130,8 @@ class SPSCQueue final : public QueueTypedBase<SPSCQueue<Data>, Data>,
 
     Writer& writer_ref = writer;
     return SPSCQueueBase::PushBytesWithWriter(
-        size,
-        [&](void* buffer, size_t count) -> ErrorCode
-        {
-          return writer_ref(static_cast<Data*>(buffer), count);
-        });
+        size, [&](void* buffer, size_t count) -> ErrorCode
+        { return writer_ref(static_cast<Data*>(buffer), count); });
   }
 
   /**
@@ -167,9 +161,10 @@ class SPSCQueue final : public QueueTypedBase<SPSCQueue<Data>, Data>,
    * @param size payload 个数。 Number of payloads.
    * @param reader 读取器回调，签名为 `ErrorCode(const Data* buffer, size_t count)`。
    *        Reader callback with signature `ErrorCode(const Data* buffer, size_t count)`.
-   * @return 成功返回 `ErrorCode::OK`；队列空返回 `ErrorCode::EMPTY`；否则返回读取器错误码。
-   *         Returns `ErrorCode::OK` on success; returns `ErrorCode::EMPTY` when the
-   *         queue is empty; otherwise returns the reader error code.
+   * @return 成功返回 `ErrorCode::OK`；队列空返回
+   * `ErrorCode::EMPTY`；否则返回读取器错误码。 Returns `ErrorCode::OK` on success;
+   * returns `ErrorCode::EMPTY` when the queue is empty; otherwise returns the reader
+   * error code.
    *
    * @note 仅当读取器处理完整批次后才提交出队。
    *       The pop is committed only after the reader accepts the full batch.
@@ -177,10 +172,12 @@ class SPSCQueue final : public QueueTypedBase<SPSCQueue<Data>, Data>,
   template <typename Reader>
   ErrorCode PopWithReader(size_t size, Reader&& reader)
   {
-    static_assert(std::is_trivially_copyable_v<Data>,
-                  "batched SPSCQueue::PopWithReader requires trivially copyable payloads");
-    static_assert(std::is_trivially_destructible_v<Data>,
-                  "batched SPSCQueue::PopWithReader requires trivially destructible payloads");
+    static_assert(
+        std::is_trivially_copyable_v<Data>,
+        "batched SPSCQueue::PopWithReader requires trivially copyable payloads");
+    static_assert(
+        std::is_trivially_destructible_v<Data>,
+        "batched SPSCQueue::PopWithReader requires trivially destructible payloads");
     static_assert(std::is_invocable_v<Reader&, const Data*, size_t>,
                   "PopWithReader reader must be callable as "
                   "ErrorCode(const Data* buffer, size_t count)");
@@ -190,11 +187,8 @@ class SPSCQueue final : public QueueTypedBase<SPSCQueue<Data>, Data>,
 
     Reader& reader_ref = reader;
     return SPSCQueueBase::PopBytesWithReader(
-        size,
-        [&](const void* buffer, size_t count) -> ErrorCode
-        {
-          return reader_ref(static_cast<const Data*>(buffer), count);
-        });
+        size, [&](const void* buffer, size_t count) -> ErrorCode
+        { return reader_ref(static_cast<const Data*>(buffer), count); });
   }
 
   /**

--- a/src/structure/queue/spsc_queue_base.hpp
+++ b/src/structure/queue/spsc_queue_base.hpp
@@ -75,12 +75,11 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
     ASSERT((payload_alloc_align_ & (payload_alloc_align_ - 1)) == 0);
 
     const size_t payload_bytes = MultiplyChecked(payload_stride_, RingCapacity());
-    payloads_ = static_cast<std::byte*>(::operator new[](
-        payload_bytes, std::align_val_t(payload_alloc_align_)));
+    payloads_ = static_cast<std::byte*>(
+        ::operator new[](payload_bytes, std::align_val_t(payload_alloc_align_)));
   }
 
  public:
-
   /**
    * @brief 析构 SPSC 字节队列内核 / Destroy the SPSC byte-queue core
    */
@@ -145,7 +144,8 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
   }
 
   /**
-   * @brief 按字节查看一个队头 payload 但不出队 / Peek one front payload by bytes without dequeuing it
+   * @brief 按字节查看一个队头 payload 但不出队 / Peek one front payload by bytes without
+   * dequeuing it
    * @param value 用于接收 payload 的缓冲区 / Buffer that receives the payload
    * @return 成功返回 `ErrorCode::OK`；队列空返回 `ErrorCode::EMPTY`；空指针返回
    *         `ErrorCode::PTR_NULL`
@@ -191,9 +191,9 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
     const auto current_tail = tail_.load(std::memory_order_relaxed);
     const auto current_head = head_.load(std::memory_order_acquire);
     const size_t capacity = RingCapacity();
-    const size_t free_space =
-        (current_tail >= current_head) ? (capacity - (current_tail - current_head) - 1)
-                                       : (current_head - current_tail - 1);
+    const size_t free_space = (current_tail >= current_head)
+                                  ? (capacity - (current_tail - current_head) - 1)
+                                  : (current_head - current_tail - 1);
 
     if (free_space < count)
     {
@@ -217,9 +217,10 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
    * @param count payload 个数 / Number of payloads
    * @param writer 写入器，签名为 `ErrorCode(void* buffer, size_t chunk_count)`
    *               / Writer with signature `ErrorCode(void* buffer, size_t chunk_count)`
-   * @return 成功返回 `ErrorCode::OK`；空间不足返回 `ErrorCode::FULL`；否则返回写入器错误码
-   *         / Returns `ErrorCode::OK` on success, `ErrorCode::FULL` when free space
-   *         is insufficient, otherwise returns the writer error code
+   * @return 成功返回 `ErrorCode::OK`；空间不足返回
+   * `ErrorCode::FULL`；否则返回写入器错误码 / Returns `ErrorCode::OK` on success,
+   * `ErrorCode::FULL` when free space is insufficient, otherwise returns the writer error
+   * code
    * @note 写入器每次收到一段连续 payload 存储区，字节长度为
    *       `chunk_count * element_size` / The writer receives one contiguous
    *       payload storage chunk each time, with byte length
@@ -236,9 +237,9 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
     const auto current_tail = tail_.load(std::memory_order_relaxed);
     const auto current_head = head_.load(std::memory_order_acquire);
     const size_t capacity = RingCapacity();
-    const size_t free_space =
-        (current_tail >= current_head) ? (capacity - (current_tail - current_head) - 1)
-                                       : (current_head - current_tail - 1);
+    const size_t free_space = (current_tail >= current_head)
+                                  ? (capacity - (current_tail - current_head) - 1)
+                                  : (current_head - current_tail - 1);
 
     if (free_space < count)
     {
@@ -314,10 +315,12 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
    * @tparam Reader 读取器类型 / Reader callback type
    * @param count payload 个数 / Number of payloads
    * @param reader 读取器，签名为 `ErrorCode(const void* buffer, size_t chunk_count)`
-   *               / Reader with signature `ErrorCode(const void* buffer, size_t chunk_count)`
-   * @return 成功返回 `ErrorCode::OK`；元素不足返回 `ErrorCode::EMPTY`；否则返回读取器错误码
-   *         / Returns `ErrorCode::OK` on success, `ErrorCode::EMPTY` when there are
-   *         not enough payloads, otherwise returns the reader error code
+   *               / Reader with signature `ErrorCode(const void* buffer, size_t
+   * chunk_count)`
+   * @return 成功返回 `ErrorCode::OK`；元素不足返回
+   * `ErrorCode::EMPTY`；否则返回读取器错误码 / Returns `ErrorCode::OK` on success,
+   * `ErrorCode::EMPTY` when there are not enough payloads, otherwise returns the reader
+   * error code
    * @note 读取器每次收到一段连续 payload 存储区，字节长度为
    *       `chunk_count * element_size` / The reader receives one contiguous
    *       payload storage chunk each time, with byte length
@@ -423,8 +426,9 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
   {
     const auto current_head = head_.load(std::memory_order_acquire);
     const auto current_tail = tail_.load(std::memory_order_acquire);
-    return (current_tail >= current_head) ? (current_tail - current_head)
-                                          : (RingCapacity() - current_head + current_tail);
+    return (current_tail >= current_head)
+               ? (current_tail - current_head)
+               : (RingCapacity() - current_head + current_tail);
   }
 
   /**
@@ -443,12 +447,10 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
   /**
    * @brief 获取指定槽位 payload 起始地址 / Get the payload base address of one slot
    * @param index 目标槽位下标 / Target slot index
-   * @return 指向目标槽位 payload 起始地址的指针 / Pointer to the slot payload base address
+   * @return 指向目标槽位 payload 起始地址的指针 / Pointer to the slot payload base
+   * address
    */
-  std::byte* PayloadPtr(IndexType index)
-  {
-    return payloads_ + index * payload_stride_;
-  }
+  std::byte* PayloadPtr(IndexType index) { return payloads_ + index * payload_stride_; }
 
   /**
    * @brief 获取指定槽位 payload 起始地址（只读）
@@ -474,10 +476,7 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
    * @param index 当前槽位下标 / Current slot index
    * @return 推进后的槽位下标 / Advanced slot index
    */
-  IndexType Increment(IndexType index) const
-  {
-    return (index + 1) % RingCapacity();
-  }
+  IndexType Increment(IndexType index) const { return (index + 1) % RingCapacity(); }
 
   /// @brief 禁止拷贝构造。 Non-copyable.
   SPSCQueueBase(const SPSCQueueBase&);
@@ -527,15 +526,17 @@ class alignas(LibXR::CONCURRENCY_ALIGNMENT) SPSCQueueBase
     return lhs * rhs;
   }
 
-  const size_t element_size_;    ///< 单个 payload 的字节数。 Byte size of one payload.
-  const size_t capacity_;        ///< 队列容量。 Queue capacity.
-  const size_t payload_alloc_align_;  ///< 整体分配对齐。 Allocation alignment for the payload buffer.
-  const size_t payload_stride_;  ///< 相邻 payload 槽位之间的步长。 Byte stride between adjacent payload slots.
+  const size_t element_size_;  ///< 单个 payload 的字节数。 Byte size of one payload.
+  const size_t capacity_;      ///< 队列容量。 Queue capacity.
+  const size_t payload_alloc_align_;  ///< 整体分配对齐。 Allocation alignment for the
+                                      ///< payload buffer.
+  const size_t payload_stride_;  ///< 相邻 payload 槽位之间的步长。 Byte stride between
+                                 ///< adjacent payload slots.
   std::byte* payloads_;          ///< payload 字节缓冲区。 Byte buffer storing payloads.
 
-  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<IndexType>
-      head_;  ///< 下一个待出队的环形下标。 Next ring index to dequeue.
-  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<IndexType>
-      tail_;  ///< 下一个待入队的环形下标。 Next ring index to enqueue.
+  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<
+      IndexType> head_;  ///< 下一个待出队的环形下标。 Next ring index to dequeue.
+  alignas(LibXR::CONCURRENCY_ALIGNMENT) std::atomic<
+      IndexType> tail_;  ///< 下一个待入队的环形下标。 Next ring index to enqueue.
 };
 }  // namespace LibXR

--- a/system/freertos/async.cpp
+++ b/system/freertos/async.cpp
@@ -12,8 +12,7 @@ ASync::ASync(size_t stack_depth, Thread::Priority priority)
 ErrorCode ASync::AssignJob(Job job)
 {
   Status expected = Status::READY;
-  if (!status_.compare_exchange_strong(expected, Status::BUSY,
-                                       std::memory_order_relaxed,
+  if (!status_.compare_exchange_strong(expected, Status::BUSY, std::memory_order_relaxed,
                                        std::memory_order_relaxed))
   {
     return ErrorCode::BUSY;

--- a/system/freertos/thread.hpp
+++ b/system/freertos/thread.hpp
@@ -62,7 +62,7 @@ class Thread
    * configuration constraints defined by `configMAX_PRIORITIES`.
    */
   template <typename ArgType>
-  void Create(ArgType arg, void (*function)(ArgType arg), const char *name,
+  void Create(ArgType arg, void (*function)(ArgType arg), const char* name,
               size_t stack_depth, Thread::Priority priority)
   {
     ASSERT(configMAX_PRIORITIES >= 6);
@@ -72,9 +72,9 @@ class Thread
      public:
       ThreadBlock(decltype(function) fun, ArgType arg) : fun_(fun), arg_(arg) {}
 
-      static void Port(void *arg)
+      static void Port(void* arg)
       {
-        ThreadBlock *block = static_cast<ThreadBlock *>(arg);
+        ThreadBlock* block = static_cast<ThreadBlock*>(arg);
         block->fun_(block->arg_);
         delete block;
       }
@@ -111,10 +111,7 @@ class Thread
    *         Gets the current system time in milliseconds
    * @return 当前时间（毫秒） Current time in milliseconds
    */
-  static uint32_t GetTime()
-  {
-    return static_cast<uint32_t>(Timebase::GetMilliseconds());
-  }
+  static uint32_t GetTime() { return static_cast<uint32_t>(Timebase::GetMilliseconds()); }
 
   /**
    * @brief  让线程进入休眠状态

--- a/system/linux/async.cpp
+++ b/system/linux/async.cpp
@@ -13,8 +13,7 @@ ASync::ASync(size_t stack_depth, Thread::Priority priority)
 ErrorCode ASync::AssignJob(Job job)
 {
   Status expected = Status::READY;
-  if (!status_.compare_exchange_strong(expected, Status::BUSY,
-                                       std::memory_order_relaxed,
+  if (!status_.compare_exchange_strong(expected, Status::BUSY, std::memory_order_relaxed,
                                        std::memory_order_relaxed))
   {
     return ErrorCode::BUSY;

--- a/system/linux/libxr_system.cpp
+++ b/system/linux/libxr_system.cpp
@@ -89,7 +89,9 @@ void StdoThread(LibXR::WritePort* write_port)
       UNUSED(fflush_ans);
 
       write_port->Finish(
-          false, write_size == info.data.size_ ? LibXR::ErrorCode::OK : LibXR::ErrorCode::FAILED, info);
+          false,
+          write_size == info.data.size_ ? LibXR::ErrorCode::OK : LibXR::ErrorCode::FAILED,
+          info);
     }
   }
 }

--- a/system/linux/libxr_system.hpp
+++ b/system/linux/libxr_system.hpp
@@ -3,7 +3,6 @@
 #include <pthread.h>
 
 #include <atomic>
-
 #include <cstdint>
 
 namespace LibXR

--- a/system/linux/linux_shared_topic.hpp
+++ b/system/linux/linux_shared_topic.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
 // 平台 wrapper 先选择本平台 MonotonicTime，shared impl 只复用接口。
+// clang-format off
 #include "monotonic_time.hpp"
 #include "linux_shared_topic_impl.hpp"
+// clang-format on

--- a/system/linux/linux_shared_topic_impl.hpp
+++ b/system/linux/linux_shared_topic_impl.hpp
@@ -2,6 +2,15 @@
 
 #if defined(LIBXR_SYSTEM_POSIX_HOST)
 
+#include <fcntl.h>
+#include <linux/futex.h>
+#include <signal.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
+
 #include <atomic>
 #include <cerrno>
 #include <chrono>
@@ -16,15 +25,6 @@
 #include <string>
 #include <type_traits>
 
-#include <fcntl.h>
-#include <linux/futex.h>
-#include <sys/mman.h>
-#include <sys/stat.h>
-#include <sys/syscall.h>
-#include <time.h>
-#include <unistd.h>
-#include <signal.h>
-
 #include "crc.hpp"
 #include "libxr_def.hpp"
 #include "message.hpp"
@@ -37,9 +37,10 @@ namespace LibXR
  */
 enum class LinuxSharedSubscriberMode : uint8_t
 {
-  BROADCAST_FULL = 0,      ///< 广播到该订阅者，满队列时报错。Broadcast and fail on full.
-  BROADCAST_DROP_OLD = 1,  ///< 广播到该订阅者，满队列时丢最旧。Broadcast and drop oldest on full.
-  BALANCE_RR = 2,          ///< 参与 RR 负载均衡组。Participate in the RR balanced group.
+  BROADCAST_FULL = 0,  ///< 广播到该订阅者，满队列时报错。Broadcast and fail on full.
+  BROADCAST_DROP_OLD =
+      1,           ///< 广播到该订阅者，满队列时丢最旧。Broadcast and drop oldest on full.
+  BALANCE_RR = 2,  ///< 参与 RR 负载均衡组。Participate in the RR balanced group.
 };
 
 /**
@@ -48,9 +49,10 @@ enum class LinuxSharedSubscriberMode : uint8_t
  */
 struct LinuxSharedTopicConfig
 {
-  uint32_t slot_num = 64;  ///< 共享 payload 槽位数。Number of shared payload slots.
+  uint32_t slot_num = 64;       ///< 共享 payload 槽位数。Number of shared payload slots.
   uint32_t subscriber_num = 8;  ///< 最大订阅者数量。Maximum number of subscribers.
-  uint32_t queue_num = 64;      ///< 每订阅者描述符队列长度。Descriptor queue length per subscriber.
+  uint32_t queue_num =
+      64;  ///< 每订阅者描述符队列长度。Descriptor queue length per subscriber.
 };
 
 /**
@@ -93,7 +95,8 @@ class LinuxSharedTopic : public Topic
   /**
    * @class Subscriber
    * @brief 同步订阅者，用于从共享 Topic 中等待并读取消息。
-   *        Synchronous subscriber for waiting on and reading messages from a shared topic.
+   *        Synchronous subscriber for waiting on and reading messages from a shared
+   * topic.
    */
   class Subscriber
   {
@@ -101,7 +104,8 @@ class LinuxSharedTopic : public Topic
     using Data = SharedData;
 
     /**
-     * @brief 默认构造函数，创建空订阅者。Default constructor creating an empty subscriber.
+     * @brief 默认构造函数，创建空订阅者。Default constructor creating an empty
+     * subscriber.
      */
     Subscriber() = default;
 
@@ -113,9 +117,8 @@ class LinuxSharedTopic : public Topic
      * @note 包含动态内存分配。
      *       Contains dynamic memory allocation.
      */
-    explicit Subscriber(const char* name,
-                        LinuxSharedSubscriberMode mode =
-                            LinuxSharedSubscriberMode::BROADCAST_FULL)
+    explicit Subscriber(const char* name, LinuxSharedSubscriberMode mode =
+                                              LinuxSharedSubscriberMode::BROADCAST_FULL)
         : owned_topic_(new LinuxSharedTopic(name))
     {
       if (Attach(*owned_topic_, mode) != ErrorCode::OK)
@@ -153,9 +156,9 @@ class LinuxSharedTopic : public Topic
      * @param topic 已打开的共享 Topic。Opened shared topic.
      * @param mode 订阅模式。Subscriber mode.
      */
-    explicit Subscriber(LinuxSharedTopic& topic,
-                        LinuxSharedSubscriberMode mode =
-                            LinuxSharedSubscriberMode::BROADCAST_FULL)
+    explicit Subscriber(
+        LinuxSharedTopic& topic,
+        LinuxSharedSubscriberMode mode = LinuxSharedSubscriberMode::BROADCAST_FULL)
     {
       (void)Attach(topic, mode);
     }
@@ -200,10 +203,7 @@ class LinuxSharedTopic : public Topic
      * @return true 订阅者有效。Subscriber is valid.
      * @return false 订阅者无效。Subscriber is invalid.
      */
-    bool Valid() const
-    {
-      return topic_ != nullptr && subscriber_index_ != INVALID_INDEX;
-    }
+    bool Valid() const { return topic_ != nullptr && subscriber_index_ != INVALID_INDEX; }
 
     /**
      * @brief 等待一条消息，并把当前订阅者切到该 payload。
@@ -247,8 +247,8 @@ class LinuxSharedTopic : public Topic
           wait_ms = static_cast<uint32_t>(deadline_ms - now_ms);
         }
 
-        const ErrorCode wait_ans = topic_->WaitReady(topic_->subscribers_[subscriber_index_],
-                                                     wait_ms);
+        const ErrorCode wait_ans =
+            topic_->WaitReady(topic_->subscribers_[subscriber_index_], wait_ms);
         if (wait_ans == ErrorCode::OK)
         {
           continue;
@@ -303,8 +303,8 @@ class LinuxSharedTopic : public Topic
           wait_ms = static_cast<uint32_t>(deadline_ms - now_ms);
         }
 
-        const ErrorCode wait_ans = topic_->WaitReady(topic_->subscribers_[subscriber_index_],
-                                                     wait_ms);
+        const ErrorCode wait_ans =
+            topic_->WaitReady(topic_->subscribers_[subscriber_index_], wait_ms);
         if (wait_ans == ErrorCode::OK)
         {
           continue;
@@ -359,7 +359,8 @@ class LinuxSharedTopic : public Topic
     }
 
     /**
-     * @brief 获取该订阅者累计丢弃消息数。Get the accumulated drop count of this subscriber.
+     * @brief 获取该订阅者累计丢弃消息数。Get the accumulated drop count of this
+     * subscriber.
      */
     uint64_t GetDropNum() const
     {
@@ -402,9 +403,10 @@ class LinuxSharedTopic : public Topic
 
       topic_->UnregisterBalancedSubscriber(subscriber_index_);
       topic_->subscribers_[subscriber_index_].active.store(0, std::memory_order_release);
-      topic_->subscribers_[subscriber_index_].owner_pid.store(0, std::memory_order_release);
-      topic_->subscribers_[subscriber_index_].owner_starttime.store(0,
-                                                                    std::memory_order_release);
+      topic_->subscribers_[subscriber_index_].owner_pid.store(0,
+                                                              std::memory_order_release);
+      topic_->subscribers_[subscriber_index_].owner_starttime.store(
+          0, std::memory_order_release);
 
       Descriptor desc = {};
       while (topic_->TryPopDescriptor(subscriber_index_, desc) == ErrorCode::OK)
@@ -463,8 +465,7 @@ class LinuxSharedTopic : public Topic
             {
               topic.subscribers_[i].active.store(0, std::memory_order_release);
               topic.subscribers_[i].owner_pid.store(0, std::memory_order_release);
-              topic.subscribers_[i].owner_starttime.store(0,
-                                                          std::memory_order_release);
+              topic.subscribers_[i].owner_starttime.store(0, std::memory_order_release);
               topic.subscribers_[i].mode.store(
                   static_cast<uint32_t>(LinuxSharedSubscriberMode::BROADCAST_FULL),
                   std::memory_order_release);
@@ -509,8 +510,8 @@ class LinuxSharedTopic : public Topic
     SharedData() = default;
 
     /**
-     * @brief 析构函数，自动回收句柄持有的槽位。Destructor automatically releasing the held
-     * slot.
+     * @brief 析构函数，自动回收句柄持有的槽位。Destructor automatically releasing the
+     * held slot.
      */
     ~SharedData() { Reset(); }
 
@@ -973,9 +974,9 @@ class LinuxSharedTopic : public Topic
 
   static uint32_t ResolveDomainKey(const char* domain_name)
   {
-    const std::string resolved =
-        (domain_name == nullptr || domain_name[0] == '\0') ? std::string(DEFAULT_DOMAIN_NAME)
-                                                            : std::string(domain_name);
+    const std::string resolved = (domain_name == nullptr || domain_name[0] == '\0')
+                                     ? std::string(DEFAULT_DOMAIN_NAME)
+                                     : std::string(domain_name);
     return CRC32::Calculate(resolved.data(), resolved.size());
   }
 
@@ -989,7 +990,8 @@ class LinuxSharedTopic : public Topic
     const uint32_t topic_len = static_cast<uint32_t>(topic_name.size());
     std::string key_material;
     key_material.reserve(sizeof(domain_crc32) + sizeof(topic_len) + topic_len);
-    key_material.append(reinterpret_cast<const char*>(&domain_crc32), sizeof(domain_crc32));
+    key_material.append(reinterpret_cast<const char*>(&domain_crc32),
+                        sizeof(domain_crc32));
     key_material.append(reinterpret_cast<const char*>(&topic_len), sizeof(topic_len));
     key_material.append(topic_name.data(), topic_name.size());
     return CRC64::Calculate(key_material.data(), key_material.size());
@@ -1071,7 +1073,8 @@ class LinuxSharedTopic : public Topic
     return false;
   }
 
-  static int FutexWait(std::atomic<uint32_t>* word, uint32_t expected, uint32_t timeout_ms)
+  static int FutexWait(std::atomic<uint32_t>* word, uint32_t expected,
+                       uint32_t timeout_ms)
   {
     struct timespec timeout = {};
     struct timespec* timeout_ptr = nullptr;
@@ -1082,26 +1085,18 @@ class LinuxSharedTopic : public Topic
       timeout_ptr = &timeout;
     }
 
-    return static_cast<int>(syscall(SYS_futex,
-                                    reinterpret_cast<uint32_t*>(word),
-                                    FUTEX_WAIT,
-                                    expected,
-                                    timeout_ptr,
-                                    nullptr,
-                                    0));
+    return static_cast<int>(syscall(SYS_futex, reinterpret_cast<uint32_t*>(word),
+                                    FUTEX_WAIT, expected, timeout_ptr, nullptr, 0));
   }
 
   static int FutexWake(std::atomic<uint32_t>* word)
   {
-    return static_cast<int>(
-        syscall(SYS_futex, reinterpret_cast<uint32_t*>(word), FUTEX_WAKE, INT32_MAX, nullptr,
-                nullptr, 0));
+    return static_cast<int>(syscall(SYS_futex, reinterpret_cast<uint32_t*>(word),
+                                    FUTEX_WAKE, INT32_MAX, nullptr, nullptr, 0));
   }
 
-  static size_t ComputeSharedBytes(uint32_t slot_count,
-                                   uint32_t subscriber_capacity,
-                                   uint32_t queue_capacity,
-                                   uint32_t topic_name_len)
+  static size_t ComputeSharedBytes(uint32_t slot_count, uint32_t subscriber_capacity,
+                                   uint32_t queue_capacity, uint32_t topic_name_len)
   {
     size_t offset = 0;
     offset = AlignUp(offset, alignof(SharedHeader));
@@ -1240,7 +1235,8 @@ class LinuxSharedTopic : public Topic
     header_->queue_capacity = queue_capacity_;
     std::memcpy(topic_name_ptr_, topic_name_.c_str(), topic_name_.size() + 1U);
     header_->publisher_pid.store(self_identity_.pid, std::memory_order_release);
-    header_->publisher_starttime.store(self_identity_.starttime, std::memory_order_release);
+    header_->publisher_starttime.store(self_identity_.starttime,
+                                       std::memory_order_release);
     header_->free_queue_head.store(0, std::memory_order_release);
     header_->free_queue_tail.store(slot_count_, std::memory_order_release);
     header_->next_sequence.store(0, std::memory_order_release);
@@ -1260,8 +1256,9 @@ class LinuxSharedTopic : public Topic
     for (uint32_t i = 0; i < subscriber_capacity_; ++i)
     {
       subscribers_[i].active.store(0, std::memory_order_release);
-      subscribers_[i].mode.store(static_cast<uint32_t>(LinuxSharedSubscriberMode::BROADCAST_FULL),
-                                 std::memory_order_release);
+      subscribers_[i].mode.store(
+          static_cast<uint32_t>(LinuxSharedSubscriberMode::BROADCAST_FULL),
+          std::memory_order_release);
       subscribers_[i].queue_head.store(0, std::memory_order_release);
       subscribers_[i].queue_tail.store(0, std::memory_order_release);
       subscribers_[i].ready_sem_count.store(0, std::memory_order_release);
@@ -1274,7 +1271,8 @@ class LinuxSharedTopic : public Topic
 
     balanced_group_->rr_cursor.store(0, std::memory_order_release);
 
-    for (size_t i = 0; i < static_cast<size_t>(subscriber_capacity_) * queue_capacity_; ++i)
+    for (size_t i = 0; i < static_cast<size_t>(subscriber_capacity_) * queue_capacity_;
+         ++i)
     {
       descriptors_[i] = Descriptor{};
     }
@@ -1346,8 +1344,8 @@ class LinuxSharedTopic : public Topic
     }
     else
     {
-      void* mapping = mmap(nullptr, static_cast<size_t>(st.st_size), PROT_READ | PROT_WRITE,
-                           MAP_SHARED, stale_fd, 0);
+      void* mapping = mmap(nullptr, static_cast<size_t>(st.st_size),
+                           PROT_READ | PROT_WRITE, MAP_SHARED, stale_fd, 0);
       if (mapping != MAP_FAILED)
       {
         uint8_t* base = static_cast<uint8_t*>(mapping);
@@ -1557,11 +1555,13 @@ class LinuxSharedTopic : public Topic
 
   bool SelectBalancedSubscriber(uint32_t& subscriber_index)
   {
-    const uint64_t base = balanced_group_->rr_cursor.fetch_add(1, std::memory_order_acq_rel);
+    const uint64_t base =
+        balanced_group_->rr_cursor.fetch_add(1, std::memory_order_acq_rel);
     for (uint32_t offset = 0; offset < subscriber_capacity_; ++offset)
     {
       const uint32_t member_index =
-          balanced_members_[(base + offset) % subscriber_capacity_].load(std::memory_order_acquire);
+          balanced_members_[(base + offset) % subscriber_capacity_].load(
+              std::memory_order_acquire);
       if (member_index == INVALID_INDEX)
       {
         continue;
@@ -1619,9 +1619,8 @@ class LinuxSharedTopic : public Topic
         static_cast<uint32_t>(LinuxSharedSubscriberMode::BROADCAST_FULL),
         std::memory_order_release);
 
-    const uint32_t held_slot =
-        subscribers_[subscriber_index].held_slot.exchange(INVALID_INDEX,
-                                                          std::memory_order_acq_rel);
+    const uint32_t held_slot = subscribers_[subscriber_index].held_slot.exchange(
+        INVALID_INDEX, std::memory_order_acq_rel);
     if (held_slot != INVALID_INDEX)
     {
       ReleaseSlot(held_slot);
@@ -1760,8 +1759,8 @@ class LinuxSharedTopic : public Topic
 
       descriptor = ring[head];
       const uint32_t next_head = (head + 1U) % queue_capacity_;
-      if (control.queue_head.compare_exchange_weak(head, next_head, std::memory_order_acq_rel,
-                                                   std::memory_order_relaxed))
+      if (control.queue_head.compare_exchange_weak(
+              head, next_head, std::memory_order_acq_rel, std::memory_order_relaxed))
       {
         ConsumeReady(control);
         return ErrorCode::OK;
@@ -1785,8 +1784,8 @@ class LinuxSharedTopic : public Topic
 
       const Descriptor descriptor = ring[head];
       const uint32_t next_head = (head + 1U) % queue_capacity_;
-      if (control.queue_head.compare_exchange_weak(head, next_head, std::memory_order_acq_rel,
-                                                   std::memory_order_relaxed))
+      if (control.queue_head.compare_exchange_weak(
+              head, next_head, std::memory_order_acq_rel, std::memory_order_relaxed))
       {
         control.dropped_messages.fetch_add(1, std::memory_order_relaxed);
         ConsumeReady(control);
@@ -1807,9 +1806,8 @@ class LinuxSharedTopic : public Topic
 
       if (diff == 0)
       {
-        if (header_->free_queue_head.compare_exchange_weak(head, head + 1U,
-                                                           std::memory_order_acq_rel,
-                                                           std::memory_order_relaxed))
+        if (header_->free_queue_head.compare_exchange_weak(
+                head, head + 1U, std::memory_order_acq_rel, std::memory_order_relaxed))
         {
           slot_index = cell.slot_index;
           cell.sequence.store(head + slot_count_, std::memory_order_release);
@@ -1837,9 +1835,8 @@ class LinuxSharedTopic : public Topic
 
       if (diff == 0)
       {
-        if (header_->free_queue_tail.compare_exchange_weak(tail, tail + 1U,
-                                                           std::memory_order_acq_rel,
-                                                           std::memory_order_relaxed))
+        if (header_->free_queue_tail.compare_exchange_weak(
+                tail, tail + 1U, std::memory_order_acq_rel, std::memory_order_relaxed))
         {
           cell.slot_index = slot_index;
           cell.sequence.store(tail + 1U, std::memory_order_release);
@@ -1851,7 +1848,8 @@ class LinuxSharedTopic : public Topic
 
   void ReleaseSlot(uint32_t slot_index)
   {
-    const uint32_t prev = slots_[slot_index].refcount.fetch_sub(1, std::memory_order_acq_rel);
+    const uint32_t prev =
+        slots_[slot_index].refcount.fetch_sub(1, std::memory_order_acq_rel);
     ASSERT(prev > 0);
     if (prev == 1)
     {
@@ -2009,7 +2007,6 @@ class LinuxSharedTopic : public Topic
 
   bool open_ok_ = false;
   ErrorCode open_status_ = ErrorCode::STATE_ERR;
-
 };
 
 }  // namespace LibXR

--- a/system/linux/monotonic_time.hpp
+++ b/system/linux/monotonic_time.hpp
@@ -23,15 +23,9 @@ inline timespec NowSpec()
   return ts;
 }
 
-inline uint64_t NowMicroseconds()
-{
-  return SpecMicroseconds(NowSpec());
-}
+inline uint64_t NowMicroseconds() { return SpecMicroseconds(NowSpec()); }
 
-inline uint64_t NowMilliseconds()
-{
-  return NowMicroseconds() / 1000ULL;
-}
+inline uint64_t NowMilliseconds() { return NowMicroseconds() / 1000ULL; }
 
 inline uint64_t XrToSharedMicroseconds(uint64_t timestamp_us)
 {
@@ -82,10 +76,7 @@ inline int64_t ElapsedMicroseconds(const timespec& start)
          static_cast<int64_t>(now.tv_nsec - start.tv_nsec) / 1000LL;
 }
 
-inline uint32_t WaitSliceMilliseconds(uint32_t remaining_ms)
-{
-  return remaining_ms;
-}
+inline uint32_t WaitSliceMilliseconds(uint32_t remaining_ms) { return remaining_ms; }
 
 }  // namespace MonotonicTime
 }  // namespace LibXR

--- a/system/linux/semaphore.cpp
+++ b/system/linux/semaphore.cpp
@@ -17,29 +17,28 @@ using namespace LibXR;
 namespace
 {
 
-int FutexWait(std::atomic<uint32_t>* word, uint32_t expected, const struct timespec* timeout)
+int FutexWait(std::atomic<uint32_t>* word, uint32_t expected,
+              const struct timespec* timeout)
 {
-  return static_cast<int>(syscall(SYS_futex, reinterpret_cast<uint32_t*>(word), FUTEX_WAIT,
-                                  expected, timeout, nullptr, 0));
+  return static_cast<int>(syscall(SYS_futex, reinterpret_cast<uint32_t*>(word),
+                                  FUTEX_WAIT, expected, timeout, nullptr, 0));
 }
 
 int FutexWake(std::atomic<uint32_t>* word, int count)
 {
-  return static_cast<int>(syscall(SYS_futex, reinterpret_cast<uint32_t*>(word), FUTEX_WAKE,
-                                  count, nullptr, nullptr, 0));
+  return static_cast<int>(syscall(SYS_futex, reinterpret_cast<uint32_t*>(word),
+                                  FUTEX_WAKE, count, nullptr, nullptr, 0));
 }
 
 }  // namespace
 
-Semaphore::Semaphore(uint32_t init_count) : semaphore_handle_(new libxr_linux_futex_semaphore)
+Semaphore::Semaphore(uint32_t init_count)
+    : semaphore_handle_(new libxr_linux_futex_semaphore)
 {
   semaphore_handle_->count.store(init_count, std::memory_order_release);
 }
 
-Semaphore::~Semaphore()
-{
-  delete semaphore_handle_;
-}
+Semaphore::~Semaphore() { delete semaphore_handle_; }
 
 void Semaphore::Post()
 {

--- a/system/linux/thread.cpp
+++ b/system/linux/thread.cpp
@@ -32,15 +32,11 @@ void Thread::SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to
   }
 }
 
-uint32_t Thread::GetTime()
-{
-  return Timebase::GetMilliseconds();
-}
+uint32_t Thread::GetTime() { return Timebase::GetMilliseconds(); }
 
 void Thread::Yield() { sched_yield(); }
 
 ErrorCode Thread::Join()
 {
-  return pthread_join(thread_handle_, nullptr) == 0 ? ErrorCode::OK
-                                                    : ErrorCode::FAILED;
+  return pthread_join(thread_handle_, nullptr) == 0 ? ErrorCode::OK : ErrorCode::FAILED;
 }

--- a/system/linux/thread.hpp
+++ b/system/linux/thread.hpp
@@ -1,11 +1,10 @@
 #pragma once
 
 #include <climits>
-
 #include <cstring>
 
-#include "libxr_system.hpp"
 #include "libxr_mem.hpp"
+#include "libxr_system.hpp"
 #include "libxr_time.hpp"
 #include "logger.hpp"
 
@@ -36,14 +35,14 @@ class Thread
    * @brief  默认构造函数，初始化空线程
    *         Default constructor initializing an empty thread
    */
-  Thread(){};
+  Thread() {};
 
   /**
    * @brief  通过 POSIX 线程句柄创建线程对象
    *         Constructor to create a thread object from a POSIX thread handle
    * @param  handle POSIX 线程句柄 POSIX thread handle
    */
-  Thread(libxr_thread_handle handle) : thread_handle_(handle){};
+  Thread(libxr_thread_handle handle) : thread_handle_(handle) {};
 
   /**
    * @brief  创建新线程
@@ -66,7 +65,7 @@ class Thread
    * accordingly.
    */
   template <typename ArgType>
-  void Create(ArgType arg, void (*function)(ArgType arg), const char *name,
+  void Create(ArgType arg, void (*function)(ArgType arg), const char* name,
               size_t stack_depth, Thread::Priority priority)
   {
     pthread_attr_t attr;
@@ -87,9 +86,8 @@ class Thread
        * @param  arg 线程参数 Thread argument
        * @param  name 线程名称 Thread name
        */
-      ThreadBlock(decltype(function) fun, ArgType arg, const char *name)
-          : fun_(fun),
-            arg_(arg)
+      ThreadBlock(decltype(function) fun, ArgType arg, const char* name)
+          : fun_(fun), arg_(arg)
       {
         std::memset(name_, 0, sizeof(name_));
         if (name != nullptr)
@@ -105,9 +103,9 @@ class Thread
        * @return 返回值始终为 `nullptr`
        *         The return value is always `nullptr`
        */
-      static void *Port(void *arg)
+      static void* Port(void* arg)
       {
-        ThreadBlock *block = static_cast<ThreadBlock *>(arg);
+        ThreadBlock* block = static_cast<ThreadBlock*>(arg);
 
         if (block->name_[0] != '\0')
         {
@@ -116,12 +114,12 @@ class Thread
 
         block->fun_(block->arg_);
         delete block;
-        return static_cast<void *>(nullptr);
+        return static_cast<void*>(nullptr);
       }
 
       decltype(function) fun_;  ///< 线程执行的函数 Function executed by the thread
-      ArgType arg_;  ///< 线程函数的参数 Argument passed to the thread function
-      char name_[16];  ///< 线程名称 Thread name
+      ArgType arg_;             ///< 线程函数的参数 Argument passed to the thread function
+      char name_[16];           ///< 线程名称 Thread name
     };
 
     auto block = new ThreadBlock(function, arg, name);
@@ -174,7 +172,7 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程
@@ -199,7 +197,8 @@ class Thread
   static void ConfigureAttributes(pthread_attr_t& attr, size_t stack_depth,
                                   Thread::Priority priority)
   {
-    const size_t stack_size = LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
+    const size_t stack_size =
+        LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
     pthread_attr_setstacksize(&attr, stack_size);
     ConfigureScheduling(attr, priority);
   }

--- a/system/none/async.cpp
+++ b/system/none/async.cpp
@@ -14,8 +14,7 @@ ASync::ASync(size_t stack_depth, Thread::Priority priority)
 ErrorCode ASync::AssignJob(Job job)
 {
   Status expected = Status::READY;
-  if (!status_.compare_exchange_strong(expected, Status::BUSY,
-                                       std::memory_order_relaxed,
+  if (!status_.compare_exchange_strong(expected, Status::BUSY, std::memory_order_relaxed,
                                        std::memory_order_relaxed))
   {
     return ErrorCode::BUSY;

--- a/system/none/thread.hpp
+++ b/system/none/thread.hpp
@@ -62,7 +62,7 @@ class Thread
    * for testing purposes.
    */
   template <typename ArgType>
-  void Create(ArgType arg, void (*function)(ArgType arg), const char *name,
+  void Create(ArgType arg, void (*function)(ArgType arg), const char* name,
               size_t stack_depth, Thread::Priority priority)
   {
     UNUSED(name);
@@ -104,7 +104,7 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程

--- a/system/threadx/async.cpp
+++ b/system/threadx/async.cpp
@@ -13,8 +13,7 @@ ASync::ASync(size_t stack_depth, Thread::Priority priority)
 ErrorCode ASync::AssignJob(Job job)
 {
   Status expected = Status::READY;
-  if (!status_.compare_exchange_strong(expected, Status::BUSY,
-                                       std::memory_order_relaxed,
+  if (!status_.compare_exchange_strong(expected, Status::BUSY, std::memory_order_relaxed,
                                        std::memory_order_relaxed))
   {
     return ErrorCode::BUSY;

--- a/system/threadx/libxr_system.hpp
+++ b/system/threadx/libxr_system.hpp
@@ -1,13 +1,14 @@
 #pragma once
 
 #include <stdint.h>
+
 #include "tx_api.h"
 
 namespace LibXR
 {
-typedef TX_MUTEX  libxr_mutex_handle;
+typedef TX_MUTEX libxr_mutex_handle;
 typedef TX_SEMAPHORE libxr_semaphore_handle;
-typedef TX_THREAD * libxr_thread_handle;
+typedef TX_THREAD* libxr_thread_handle;
 
 /**
  * @brief  平台初始化函数

--- a/system/threadx/thread.hpp
+++ b/system/threadx/thread.hpp
@@ -40,7 +40,7 @@ class Thread
    *         Constructor to create a thread object from a FreeRTOS thread handle
    * @param  handle FreeRTOS 线程句柄 FreeRTOS thread handle
    */
-  Thread(TX_THREAD *handle) : thread_handle_(handle) {};
+  Thread(TX_THREAD* handle) : thread_handle_(handle) {};
 
   /**
    * @brief  创建新线程
@@ -62,7 +62,7 @@ class Thread
    * configuration constraints defined by `configMAX_PRIORITIES`.
    */
   template <typename ArgType>
-  void Create(ArgType arg, void (*function)(ArgType arg), const char *name,
+  void Create(ArgType arg, void (*function)(ArgType arg), const char* name,
               size_t stack_depth, Thread::Priority priority)
   {
     class ThreadBlock
@@ -71,7 +71,7 @@ class Thread
       ThreadBlock(decltype(function) fun, ArgType arg) : fun_(fun), arg_(arg) {}
       static void Port(ULONG ptr)
       {
-        ThreadBlock *block = reinterpret_cast<ThreadBlock *>(ptr);
+        ThreadBlock* block = reinterpret_cast<ThreadBlock*>(ptr);
         block->fun_(block->arg_);
         delete block;
       }
@@ -79,12 +79,12 @@ class Thread
       ArgType arg_;
     };
 
-    auto *block = new ThreadBlock(function, arg);
+    auto* block = new ThreadBlock(function, arg);
     auto stack_buffer = new ULONG[stack_depth / sizeof(ULONG)];
     thread_handle_ = new TX_THREAD;
 
     UINT status = tx_thread_create(
-        thread_handle_, const_cast<char *>(name), ThreadBlock::Port, ULONG(block),
+        thread_handle_, const_cast<char*>(name), ThreadBlock::Port, ULONG(block),
         stack_buffer, stack_depth, static_cast<UINT>(priority),
         static_cast<UINT>(priority), TX_NO_TIME_SLICE, TX_AUTO_START);
     ASSERT(status == TX_SUCCESS);
@@ -117,7 +117,7 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程
@@ -130,7 +130,7 @@ class Thread
    *         Converts the thread object to a FreeRTOS thread handle
    * @return FreeRTOS 线程句柄 FreeRTOS thread handle
    */
-  operator TX_THREAD *() { return thread_handle_; }
+  operator TX_THREAD*() { return thread_handle_; }
 
  private:
   libxr_thread_handle thread_handle_;

--- a/system/webasm/async.cpp
+++ b/system/webasm/async.cpp
@@ -14,8 +14,7 @@ ASync::ASync(size_t stack_depth, Thread::Priority priority)
 ErrorCode ASync::AssignJob(Job job)
 {
   Status expected = Status::READY;
-  if (!status_.compare_exchange_strong(expected, Status::BUSY,
-                                       std::memory_order_relaxed,
+  if (!status_.compare_exchange_strong(expected, Status::BUSY, std::memory_order_relaxed,
                                        std::memory_order_relaxed))
   {
     return ErrorCode::BUSY;

--- a/system/webasm/thread.hpp
+++ b/system/webasm/thread.hpp
@@ -62,7 +62,7 @@ class Thread
    * for testing purposes.
    */
   template <typename ArgType>
-  void Create(ArgType arg, void (*function)(ArgType arg), const char *name,
+  void Create(ArgType arg, void (*function)(ArgType arg), const char* name,
               size_t stack_depth, Thread::Priority priority)
   {
     UNUSED(name);
@@ -104,7 +104,7 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程

--- a/system/webots/async.cpp
+++ b/system/webots/async.cpp
@@ -13,8 +13,7 @@ ASync::ASync(size_t stack_depth, Thread::Priority priority)
 ErrorCode ASync::AssignJob(Job job)
 {
   Status expected = Status::READY;
-  if (!status_.compare_exchange_strong(expected, Status::BUSY,
-                                       std::memory_order_relaxed,
+  if (!status_.compare_exchange_strong(expected, Status::BUSY, std::memory_order_relaxed,
                                        std::memory_order_relaxed))
   {
     return ErrorCode::BUSY;

--- a/system/webots/libxr_system.cpp
+++ b/system/webots/libxr_system.cpp
@@ -1,8 +1,5 @@
 #include "libxr_system.hpp"
 
-#include <cerrno>
-#include <cmath>
-#include <list>
 #include <poll.h>
 #include <sys/ioctl.h>
 #include <sys/select.h>
@@ -11,9 +8,12 @@
 #include <termios.h>
 #include <unistd.h>
 
+#include <cerrno>
+#include <cmath>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <list>
 
 #include "libxr_def.hpp"
 #include "libxr_rw.hpp"
@@ -50,7 +50,8 @@ pthread_cond_t g_webots_realtime_threads_cond = PTHREAD_COND_INITIALIZER;
 uint64_t g_webots_step_epoch = 0;
 thread_local LibXR::WebotsRealtimeThreadRegistration* g_current_realtime_thread = nullptr;
 
-void RemoveWebotsRealtimeThreadUnlocked(LibXR::WebotsRealtimeThreadRegistration* registration)
+void RemoveWebotsRealtimeThreadUnlocked(
+    LibXR::WebotsRealtimeThreadRegistration* registration)
 {
   for (auto it = g_webots_realtime_threads.begin(); it != g_webots_realtime_threads.end();
        ++it)
@@ -152,7 +153,9 @@ void StdoThread(LibXR::WritePort* write_port)
       UNUSED(fflush_ans);
 
       write_port->Finish(
-          false, write_size == info.data.size_ ? LibXR::ErrorCode::OK : LibXR::ErrorCode::FAILED, info);
+          false,
+          write_size == info.data.size_ ? LibXR::ErrorCode::OK : LibXR::ErrorCode::FAILED,
+          info);
     }
   }
 }
@@ -298,9 +301,9 @@ void LibXR::PlatformInit(webots::Robot* robot, uint32_t timer_pri,
   };
 
   LibXR::Thread webots_timebase_thread;
-  webots_timebase_thread.Create<void*>(
-      reinterpret_cast<void*>(0), webots_timebase_thread_fun, "webots_timebase",
-      1024, Thread::Priority::REALTIME);
+  webots_timebase_thread.Create<void*>(reinterpret_cast<void*>(0),
+                                       webots_timebase_thread_fun, "webots_timebase",
+                                       1024, Thread::Priority::REALTIME);
 }
 
 LibXR::WebotsRealtimeThreadRegistration* LibXR::WebotsRegisterRealtimeThread()
@@ -313,7 +316,8 @@ LibXR::WebotsRealtimeThreadRegistration* LibXR::WebotsRegisterRealtimeThread()
   return registration;
 }
 
-void LibXR::WebotsBindCurrentRealtimeThread(WebotsRealtimeThreadRegistration* registration)
+void LibXR::WebotsBindCurrentRealtimeThread(
+    WebotsRealtimeThreadRegistration* registration)
 {
   if (registration == nullptr)
   {

--- a/system/webots/libxr_system.hpp
+++ b/system/webots/libxr_system.hpp
@@ -16,7 +16,7 @@ extern uint64_t _libxr_webots_time_count;  // NOLINT
  * @brief  Webots 机器人句柄
  *         Webots robot handle
  */
-extern webots::Robot *_libxr_webots_robot_handle;  // NOLINT
+extern webots::Robot* _libxr_webots_robot_handle;  // NOLINT
 
 namespace LibXR
 {
@@ -33,7 +33,7 @@ typedef pthread_mutex_t libxr_mutex_handle;
  * @brief  信号量句柄类型定义
  *         Semaphore handle type definition
  */
-typedef sem_t *libxr_semaphore_handle;
+typedef sem_t* libxr_semaphore_handle;
 
 /**
  * @brief  线程句柄类型定义
@@ -73,7 +73,7 @@ typedef struct
  * the `_libxr_webots_robot_handle` variable and initializing the simulation
  * time counter `_libxr_webots_time_count`.
  */
-void PlatformInit(webots::Robot *robot = nullptr, uint32_t timer_pri = 2,
+void PlatformInit(webots::Robot* robot = nullptr, uint32_t timer_pri = 2,
                   uint32_t timer_stack_depth = 65536,
                   double sim_flow_rate = 1.0);  // NOLINT
 
@@ -81,19 +81,19 @@ void PlatformInit(webots::Robot *robot = nullptr, uint32_t timer_pri = 2,
  * @brief  为 REALTIME 线程预留一条注册项
  * @return  注册项句柄，在线程创建成功后由线程自身完成绑定
  */
-WebotsRealtimeThreadRegistration *WebotsRegisterRealtimeThread();
+WebotsRealtimeThreadRegistration* WebotsRegisterRealtimeThread();
 
 /**
  * @brief  将当前线程绑定到已注册的 REALTIME 项
  * @param  registration 线程创建阶段预留的注册项
  */
-void WebotsBindCurrentRealtimeThread(WebotsRealtimeThreadRegistration *registration);
+void WebotsBindCurrentRealtimeThread(WebotsRealtimeThreadRegistration* registration);
 
 /**
  * @brief  释放一条 REALTIME 线程注册项
  * @param  registration 需要释放的注册项
  */
-void WebotsReleaseRealtimeThread(WebotsRealtimeThreadRegistration *registration);
+void WebotsReleaseRealtimeThread(WebotsRealtimeThreadRegistration* registration);
 
 /**
  * @brief  标记当前 REALTIME 线程进入运行态

--- a/system/webots/linux_shared_topic.hpp
+++ b/system/webots/linux_shared_topic.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
 // 平台 wrapper 先选择本平台 MonotonicTime，shared impl 只复用接口。
+// clang-format off
 #include "monotonic_time.hpp"
 #include "../linux/linux_shared_topic_impl.hpp"
+// clang-format on

--- a/system/webots/monotonic_time.hpp
+++ b/system/webots/monotonic_time.hpp
@@ -17,25 +17,13 @@ namespace LibXR
 namespace MonotonicTime
 {
 
-inline uint64_t NowMilliseconds()
-{
-  return _libxr_webots_time_count;
-}
+inline uint64_t NowMilliseconds() { return _libxr_webots_time_count; }
 
-inline uint64_t NowMicroseconds()
-{
-  return _libxr_webots_time_count * 1000ULL;
-}
+inline uint64_t NowMicroseconds() { return _libxr_webots_time_count * 1000ULL; }
 
-inline uint64_t XrToSharedMicroseconds(uint64_t timestamp_us)
-{
-  return timestamp_us;
-}
+inline uint64_t XrToSharedMicroseconds(uint64_t timestamp_us) { return timestamp_us; }
 
-inline uint64_t SharedToXrMicroseconds(uint64_t timestamp_us)
-{
-  return timestamp_us;
-}
+inline uint64_t SharedToXrMicroseconds(uint64_t timestamp_us) { return timestamp_us; }
 
 inline uint32_t RemainingMilliseconds(uint64_t deadline_ms)
 {
@@ -54,7 +42,8 @@ inline uint32_t WaitSliceMilliseconds(uint32_t remaining_ms)
     return 0;
   }
 
-  const uint32_t poll_ms = _libxr_webots_poll_period_ms != 0 ? _libxr_webots_poll_period_ms : 1U;
+  const uint32_t poll_ms =
+      _libxr_webots_poll_period_ms != 0 ? _libxr_webots_poll_period_ms : 1U;
   return remaining_ms < poll_ms ? remaining_ms : poll_ms;
 }
 

--- a/system/webots/thread.cpp
+++ b/system/webots/thread.cpp
@@ -14,8 +14,7 @@ Thread Thread::Current(void) { return Thread(pthread_self()); }
 
 ErrorCode Thread::Join()
 {
-  return pthread_join(thread_handle_, nullptr) == 0 ? ErrorCode::OK
-                                                    : ErrorCode::FAILED;
+  return pthread_join(thread_handle_, nullptr) == 0 ? ErrorCode::OK : ErrorCode::FAILED;
 }
 
 static ErrorCode ConditionVarWait(uint32_t timeout)
@@ -63,6 +62,9 @@ void Thread::SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to
   }
 }
 
-uint32_t Thread::GetTime() { return static_cast<uint32_t>(MonotonicTime::NowMilliseconds()); }
+uint32_t Thread::GetTime()
+{
+  return static_cast<uint32_t>(MonotonicTime::NowMilliseconds());
+}
 
 void Thread::Yield() { sched_yield(); }

--- a/system/webots/thread.hpp
+++ b/system/webots/thread.hpp
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "libxr_system.hpp"
-#include "libxr_mem.hpp"
-#include "libxr_time.hpp"
-#include "logger.hpp"
-
 #include <algorithm>
 #include <cstring>
+
+#include "libxr_mem.hpp"
+#include "libxr_system.hpp"
+#include "libxr_time.hpp"
+#include "logger.hpp"
 
 namespace LibXR
 {
@@ -66,11 +66,11 @@ class Thread
    * accordingly.
    */
   template <typename ArgType>
-  void Create(ArgType arg, void (*function)(ArgType arg), const char *name,
+  void Create(ArgType arg, void (*function)(ArgType arg), const char* name,
               size_t stack_depth, Thread::Priority priority)
   {
     const bool is_realtime = priority == Thread::Priority::REALTIME;
-    WebotsRealtimeThreadRegistration *realtime_registration = nullptr;
+    WebotsRealtimeThreadRegistration* realtime_registration = nullptr;
     if (is_realtime)
     {
       realtime_registration = WebotsRegisterRealtimeThread();
@@ -94,8 +94,8 @@ class Thread
        * @param  arg 线程参数 Thread argument
        * @param  name 线程名称 Thread name
        */
-      ThreadBlock(decltype(function) fun, ArgType arg, const char *name, bool is_realtime,
-                  WebotsRealtimeThreadRegistration *realtime_registration)
+      ThreadBlock(decltype(function) fun, ArgType arg, const char* name, bool is_realtime,
+                  WebotsRealtimeThreadRegistration* realtime_registration)
           : fun_(fun),
             arg_(arg),
             is_realtime_(is_realtime),
@@ -116,9 +116,9 @@ class Thread
        * @return 返回值始终为 `nullptr`
        *         The return value is always `nullptr`
        */
-      static void *Port(void *arg)
+      static void* Port(void* arg)
       {
-        ThreadBlock *block = static_cast<ThreadBlock *>(arg);
+        ThreadBlock* block = static_cast<ThreadBlock*>(arg);
         if (block->is_realtime_)
         {
           WebotsBindCurrentRealtimeThread(block->realtime_registration_);
@@ -129,18 +129,17 @@ class Thread
           WebotsReleaseRealtimeThread(block->realtime_registration_);
         }
         delete block;
-        return static_cast<void *>(nullptr);
+        return static_cast<void*>(nullptr);
       }
 
       decltype(function) fun_;  ///< 线程执行的函数 Function executed by the thread
       ArgType arg_;             ///< 线程函数的参数 Argument passed to the thread function
       bool is_realtime_{false};
-      WebotsRealtimeThreadRegistration *realtime_registration_{nullptr};
-      char name_[16];           ///< 线程名称 Thread name
+      WebotsRealtimeThreadRegistration* realtime_registration_{nullptr};
+      char name_[16];  ///< 线程名称 Thread name
     };
 
-    auto block =
-        new ThreadBlock(function, arg, name, is_realtime, realtime_registration);
+    auto block = new ThreadBlock(function, arg, name, is_realtime, realtime_registration);
 
     // 创建线程
     int ans = pthread_create(&this->thread_handle_, &attr, ThreadBlock::Port, block);
@@ -195,7 +194,7 @@ class Thread
    * @param  last_waskup_time 上次唤醒时间 Last wake-up time
    * @param  time_to_sleep 休眠时长（毫秒） Sleep duration in milliseconds
    */
-  static void SleepUntil(MillisecondTimestamp &last_waskup_time, uint32_t time_to_sleep);
+  static void SleepUntil(MillisecondTimestamp& last_waskup_time, uint32_t time_to_sleep);
 
   /**
    * @brief  让出 CPU 以执行其他线程
@@ -220,7 +219,8 @@ class Thread
   static void ConfigureAttributes(pthread_attr_t& attr, size_t stack_depth,
                                   Thread::Priority priority)
   {
-    const size_t stack_size = LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
+    const size_t stack_size =
+        LibXR::max(static_cast<size_t>(PTHREAD_STACK_MIN), stack_depth);
     pthread_attr_setstacksize(&attr, stack_size);
     ConfigureScheduling(attr, priority);
   }

--- a/test/base/callback/cb_test_common.hpp
+++ b/test/base/callback/cb_test_common.hpp
@@ -5,7 +5,8 @@
  *          1. 提供直接回调、guarded 回调和 lambda 绑定的探针结构。
  *          2. 统一记录值顺序、ISR 标记和重入深度。
  *          Test items:
- *          1. Provide probes for direct callbacks, guarded callbacks, and lambda bindings.
+ *          1. Provide probes for direct callbacks, guarded callbacks, and lambda
+ * bindings.
  *          2. Record value order, ISR flags, and reentry depth consistently.
  */
 #pragma once
@@ -32,8 +33,11 @@ struct DirectCallbackProbe
 
   /**
    * @brief 辅助函数 `OnCallback`。 Helper function `OnCallback`.
-   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
-   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+   * measure, or validate shared state for later test steps.
+   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+   * repeated helper logic locally so the main test body stays focused on the test item
+   * itself.
    */
   static void OnCallback(bool in_isr, DirectCallbackProbe* self, int value)
   {
@@ -73,8 +77,11 @@ struct GuardedCreationProbe
 
   /**
    * @brief 辅助函数 `OnCallback`。 Helper function `OnCallback`.
-   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
-   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+   * measure, or validate shared state for later test steps.
+   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+   * repeated helper logic locally so the main test body stays focused on the test item
+   * itself.
    */
   static void OnCallback(bool in_isr, GuardedCreationProbe* self, int value)
   {

--- a/test/base/callback/test_cb.cpp
+++ b/test/base/callback/test_cb.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_cb.cpp
- * @brief `LibXR::Callback` 测试聚合入口。 Aggregation entry for split `LibXR::Callback` tests.
+ * @brief `LibXR::Callback` 测试聚合入口。 Aggregation entry for split `LibXR::Callback`
+ * tests.
  * @details 测试项目：
  *          1. 聚合空回调与直接重入子场景。
  *          2. 聚合 guarded 与 lambda 绑定子场景。
@@ -15,8 +16,9 @@ void RunGuardedCallbackTests();
 
 /**
  * @brief 测试入口函数 `test_cb`。 Test entry function `test_cb`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_cb()
 {

--- a/test/base/callback/test_cb_direct.cpp
+++ b/test/base/callback/test_cb_direct.cpp
@@ -1,12 +1,14 @@
 /**
  * @file test_cb_direct.cpp
- * @brief `LibXR::Callback` 空回调与直接重入场景子测试。 Split test unit for empty-callback and direct-reentry scenarios.
+ * @brief `LibXR::Callback` 空回调与直接重入场景子测试。 Split test unit for
+ * empty-callback and direct-reentry scenarios.
  * @details 测试项目：
  *          1. 默认空回调允许 no-op 运行。
  *          2. 非 guarded 直接回调在 ISR 与非 ISR 路径都会立即重入。
  *          Test items:
  *          1. Default empty callbacks allow no-op execution.
- *          2. Non-guarded direct callbacks reenter immediately on both ISR and non-ISR paths.
+ *          2. Non-guarded direct callbacks reenter immediately on both ISR and non-ISR
+ * paths.
  */
 #include "cb_test_common.hpp"
 
@@ -14,14 +16,19 @@ namespace
 {
 
 /**
- * @brief 测试项函数 `TestEmptyAndDirectCallbacks`。 Test-item function `TestEmptyAndDirectCallbacks`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestEmptyAndDirectCallbacks`。 Test-item function
+ * `TestEmptyAndDirectCallbacks`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestEmptyAndDirectCallbacks()
 {
   // 测试内容：验证空回调默认行为，以及直接回调的即刻重入和 ISR 标记传递。
-  // Test coverage: verify default empty-callback behavior and immediate direct reentry with ISR-flag propagation.
+  // Test coverage: verify default empty-callback behavior and immediate direct reentry
+  // with ISR-flag propagation.
   {
     LibXR::Callback<int> empty_cb;
     ASSERT(empty_cb.Empty());
@@ -56,11 +63,10 @@ void TestEmptyAndDirectCallbacks()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunDirectCallbackTests`。 Test-item function `RunDirectCallbackTests`.
- * @details 测试内容：执行空回调与直接重入子场景。 Execute empty-callback and direct-reentry sub-scenarios.
- *          测试原理：把直接回调语义单独成组，避免和 guarded/lambda 场景混在一起。 Group direct-callback semantics away from guarded/lambda scenarios.
+ * @brief 测试项函数 `RunDirectCallbackTests`。 Test-item function
+ * `RunDirectCallbackTests`.
+ * @details 测试内容：执行空回调与直接重入子场景。 Execute empty-callback and
+ * direct-reentry sub-scenarios. 测试原理：把直接回调语义单独成组，避免和 guarded/lambda
+ * 场景混在一起。 Group direct-callback semantics away from guarded/lambda scenarios.
  */
-void RunDirectCallbackTests()
-{
-  TestEmptyAndDirectCallbacks();
-}
+void RunDirectCallbackTests() { TestEmptyAndDirectCallbacks(); }

--- a/test/base/callback/test_cb_guarded.cpp
+++ b/test/base/callback/test_cb_guarded.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_cb_guarded.cpp
- * @brief `LibXR::Callback` guarded 与 lambda 场景子测试。 Split test unit for guarded-callback and lambda-binding scenarios.
+ * @brief `LibXR::Callback` guarded 与 lambda 场景子测试。 Split test unit for
+ * guarded-callback and lambda-binding scenarios.
  * @details 测试项目：
  *          1. `CreateGuarded()` 会把自递归压平成单层回放。
  *          2. lambda 绑定仍会透传值和 ISR 标记。
@@ -14,14 +15,19 @@ namespace
 {
 
 /**
- * @brief 测试项函数 `TestGuardedAndLambdaCallbacks`。 Test-item function `TestGuardedAndLambdaCallbacks`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestGuardedAndLambdaCallbacks`。 Test-item function
+ * `TestGuardedAndLambdaCallbacks`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestGuardedAndLambdaCallbacks()
 {
   // 测试内容：验证 guarded 压平语义和 lambda 绑定上下文转发。
-  // Test coverage: verify guarded flattening semantics and lambda-binding context forwarding.
+  // Test coverage: verify guarded flattening semantics and lambda-binding context
+  // forwarding.
   {
     GuardedCreationProbe probe;
     probe.cb.Run(false, 1);
@@ -44,11 +50,11 @@ void TestGuardedAndLambdaCallbacks()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunGuardedCallbackTests`。 Test-item function `RunGuardedCallbackTests`.
- * @details 测试内容：执行 guarded 与 lambda 绑定子场景。 Execute guarded-callback and lambda-binding sub-scenarios.
- *          测试原理：把递归压平语义和绑定转发语义单独成组，便于定位回归。 Group flattening and binding-forwarding semantics for easier regression localization.
+ * @brief 测试项函数 `RunGuardedCallbackTests`。 Test-item function
+ * `RunGuardedCallbackTests`.
+ * @details 测试内容：执行 guarded 与 lambda 绑定子场景。 Execute guarded-callback and
+ * lambda-binding sub-scenarios.
+ *          测试原理：把递归压平语义和绑定转发语义单独成组，便于定位回归。 Group
+ * flattening and binding-forwarding semantics for easier regression localization.
  */
-void RunGuardedCallbackTests()
-{
-  TestGuardedAndLambdaCallbacks();
-}
+void RunGuardedCallbackTests() { TestGuardedAndLambdaCallbacks(); }

--- a/test/base/middleware/app_framework/test_application.cpp
+++ b/test/base/middleware/app_framework/test_application.cpp
@@ -1,14 +1,21 @@
 /**
  * @file test_application.cpp
- * @brief `ApplicationManager` 注册与调度测试。 `ApplicationManager` registration and dispatch tests.
+ * @brief `ApplicationManager` 注册与调度测试。 `ApplicationManager` registration and
+ * dispatch tests.
  *
  * 测试项目 / Test items:
- * 1. 注册计数行为。 Registration accounting: verify manager size grows with each registered application.
- * 2. `MonitorAll()` 的覆盖与重复调用行为。 Monitor dispatch coverage: verify `MonitorAll()` reaches every registered application and can be called repeatedly.
+ * 1. 注册计数行为。 Registration accounting: verify manager size grows with each
+ * registered application.
+ * 2. `MonitorAll()` 的覆盖与重复调用行为。 Monitor dispatch coverage: verify
+ * `MonitorAll()` reaches every registered application and can be called repeatedly.
  *
  * 测试原理 / Test principles:
- * 1. 使用 seen bitmask 和 hit count，而不是假定遍历顺序，因为源码本身不保证顺序。 Record a seen-bitmask and hit count instead of asserting callback order, because the source contract explicitly does not guarantee traversal order.
- * 2. 重复调用 `MonitorAll()`，验证 steady-state 行为而不只是一轮调用。 Call `MonitorAll()` more than once so the test documents steady-state repeatability rather than only first-use behavior.
+ * 1. 使用 seen bitmask 和 hit count，而不是假定遍历顺序，因为源码本身不保证顺序。 Record
+ * a seen-bitmask and hit count instead of asserting callback order, because the source
+ * contract explicitly does not guarantee traversal order.
+ * 2. 重复调用 `MonitorAll()`，验证 steady-state 行为而不只是一轮调用。 Call
+ * `MonitorAll()` more than once so the test documents steady-state repeatability rather
+ * than only first-use behavior.
  */
 #include "libxr.hpp"
 #include "test.hpp"
@@ -26,8 +33,11 @@ class CountingApp : public LibXR::Application
 
   /**
    * @brief 辅助函数 `OnMonitor`。 Helper function `OnMonitor`.
-   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
-   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+   * measure, or validate shared state for later test steps.
+   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+   * repeated helper logic locally so the main test body stays focused on the test item
+   * itself.
    */
   void OnMonitor() override
   {
@@ -44,9 +54,11 @@ class CountingApp : public LibXR::Application
 }  // namespace
 
 /**
- * @brief 测试入口函数 `test_app_framework_application`。 Test entry function `test_app_framework_application`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_app_framework_application`。 Test entry function
+ * `test_app_framework_application`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_app_framework_application()
 {

--- a/test/base/middleware/app_framework/test_hardware.cpp
+++ b/test/base/middleware/app_framework/test_hardware.cpp
@@ -1,15 +1,24 @@
 /**
  * @file test_hardware.cpp
- * @brief `HardwareContainer` 别名注册与类型化查找测试。 `HardwareContainer` alias registration and typed lookup tests.
+ * @brief `HardwareContainer` 别名注册与类型化查找测试。 `HardwareContainer` alias
+ * registration and typed lookup tests.
  *
  * 测试项目 / Test items:
- * 1. 主别名直接查找。 Direct alias lookup: verify each registered device is found by its primary alias.
- * 2. 共享别名下的类型过滤。 Shared alias filtering: verify the same alias can resolve different objects only when the requested type matches.
- * 3. 回退别名与运行时追加注册。 Fallback-alias search and post-construction registration: verify multi-alias search and later `Register()` calls both become visible to typed lookup.
+ * 1. 主别名直接查找。 Direct alias lookup: verify each registered device is found by its
+ * primary alias.
+ * 2. 共享别名下的类型过滤。 Shared alias filtering: verify the same alias can resolve
+ * different objects only when the requested type matches.
+ * 3. 回退别名与运行时追加注册。 Fallback-alias search and post-construction registration:
+ * verify multi-alias search and later `Register()` calls both become visible to typed
+ * lookup.
  *
  * 测试原理 / Test principles:
- * 1. 用同名别名在不同类型下交叉查找，验证真正契约是“名字 + 精确类型”。 Cross-check the same alias under multiple requested types, because the core contract is "name + exact type" rather than name alone.
- * 2. 同时覆盖构造期和运行时注册路径，避免两条别名填充路径漂移。 Exercise both constructor-time and runtime registration so the test covers both alias population paths.
+ * 1. 用同名别名在不同类型下交叉查找，验证真正契约是“名字 + 精确类型”。 Cross-check the
+ * same alias under multiple requested types, because the core contract is "name + exact
+ * type" rather than name alone.
+ * 2. 同时覆盖构造期和运行时注册路径，避免两条别名填充路径漂移。 Exercise both
+ * constructor-time and runtime registration so the test covers both alias population
+ * paths.
  */
 #include "libxr.hpp"
 #include "test.hpp"
@@ -40,9 +49,11 @@ struct DeviceD
 }  // namespace
 
 /**
- * @brief 测试入口函数 `test_app_framework_hardware`。 Test entry function `test_app_framework_hardware`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_app_framework_hardware`。 Test entry function
+ * `test_app_framework_hardware`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_app_framework_hardware()
 {
@@ -53,10 +64,9 @@ void test_app_framework_hardware()
   DeviceC dev_c;
   DeviceD dev_d;
 
-  LibXR::HardwareContainer hw(
-      LibXR::Entry<DeviceA>{dev_a, {"a", "shared", "fallback-a"}},
-      LibXR::Entry<DeviceB>{dev_b, {"b", "shared"}},
-      LibXR::Entry<DeviceC>{dev_c, {"c-only"}});
+  LibXR::HardwareContainer hw(LibXR::Entry<DeviceA>{dev_a, {"a", "shared", "fallback-a"}},
+                              LibXR::Entry<DeviceB>{dev_b, {"b", "shared"}},
+                              LibXR::Entry<DeviceC>{dev_c, {"c-only"}});
 
   ASSERT(hw.Find<DeviceA>("a") == &dev_a);
   ASSERT(hw.Find<DeviceB>("b") == &dev_b);

--- a/test/base/middleware/database/test_database.cpp
+++ b/test/base/middleware/database/test_database.cpp
@@ -3,13 +3,20 @@
  * @brief base 平面 `Database::Key` 契约测试。 Base-plane `Database::Key` contract tests.
  *
  * 测试项目 / Test items:
- * 1. `Save()` 使用当前内存值。 Save path: verify `Save()` writes the key's current in-memory value, not a stale constructor value.
- * 2. `Set()` 先更新本地缓存再落库。 Set path: verify `Set()` updates the local cached value before delegating persistence.
- * 3. `Get()` 失败时的默认值回退。 Get/default path: verify constructor fallback to explicit default or zero when `Get()` fails.
+ * 1. `Save()` 使用当前内存值。 Save path: verify `Save()` writes the key's current
+ * in-memory value, not a stale constructor value.
+ * 2. `Set()` 先更新本地缓存再落库。 Set path: verify `Set()` updates the local cached
+ * value before delegating persistence.
+ * 3. `Get()` 失败时的默认值回退。 Get/default path: verify constructor fallback to
+ * explicit default or zero when `Get()` fails.
  *
  * 测试原理 / Test principles:
- * 1. 用极小的内存数据库 stub 隔离 key 对象语义，不把 flash 布局问题混进来。 Use a tiny in-memory database stub so the test isolates key-object semantics from flash layout or backend persistence behavior.
- * 2. 同时观察后端调用计数和本地缓存值，因为 key 契约涵盖两者。 Observe both backend call counters and local cached values, because the key contract covers caller-visible state as well as backend dispatch.
+ * 1. 用极小的内存数据库 stub 隔离 key 对象语义，不把 flash 布局问题混进来。 Use a tiny
+ * in-memory database stub so the test isolates key-object semantics from flash layout or
+ * backend persistence behavior.
+ * 2. 同时观察后端调用计数和本地缓存值，因为 key 契约涵盖两者。 Observe both backend call
+ * counters and local cached values, because the key contract covers caller-visible state
+ * as well as backend dispatch.
  */
 #include <cstdint>
 
@@ -70,9 +77,13 @@ class MemoryDatabase : public Database
 };
 
 /**
- * @brief 测试项函数 `TestDatabaseKeySaveUsesCurrentData`。 Test-item function `TestDatabaseKeySaveUsesCurrentData`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabaseKeySaveUsesCurrentData`。 Test-item function
+ * `TestDatabaseKeySaveUsesCurrentData`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabaseKeySaveUsesCurrentData()
 {
@@ -96,9 +107,13 @@ void TestDatabaseKeySaveUsesCurrentData()
 }
 
 /**
- * @brief 测试项函数 `TestDatabaseKeySetUpdatesCurrentValueBeforeSave`。 Test-item function `TestDatabaseKeySetUpdatesCurrentValueBeforeSave`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabaseKeySetUpdatesCurrentValueBeforeSave`。 Test-item
+ * function `TestDatabaseKeySetUpdatesCurrentValueBeforeSave`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabaseKeySetUpdatesCurrentValueBeforeSave()
 {
@@ -114,9 +129,13 @@ void TestDatabaseKeySetUpdatesCurrentValueBeforeSave()
 }
 
 /**
- * @brief 测试项函数 `TestDatabaseKeyUsesDefaultOnGetFailure`。 Test-item function `TestDatabaseKeyUsesDefaultOnGetFailure`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabaseKeyUsesDefaultOnGetFailure`。 Test-item function
+ * `TestDatabaseKeyUsesDefaultOnGetFailure`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabaseKeyUsesDefaultOnGetFailure()
 {
@@ -141,8 +160,9 @@ void TestDatabaseKeyUsesDefaultOnGetFailure()
 
 /**
  * @brief 测试入口函数 `test_database`。 Test entry function `test_database`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_database()
 {

--- a/test/base/middleware/event/test_event.cpp
+++ b/test/base/middleware/event/test_event.cpp
@@ -1,16 +1,25 @@
 /**
  * @file test_event.cpp
- * @brief `Event` 注册、绑定与回调上下文透传测试。 `Event` registration, binding and callback-context propagation tests.
+ * @brief `Event` 注册、绑定与回调上下文透传测试。 `Event` registration, binding and
+ * callback-context propagation tests.
  *
  * 测试项目 / Test items:
- * 1. 普通 `Active()` 分发。 Direct activation: verify normal `Active()` dispatch reaches the registered callback in non-ISR context.
- * 2. `ActiveFromCallback()` 的 ISR 标志透传。 Callback-safe activation: verify `ActiveFromCallback()` preserves the explicit or legacy-default ISR flag.
- * 3. 事件绑定后的上下文保持。 Bound-event forwarding: verify event binding preserves the source callback context when one event triggers another.
- * 4. 高值 event id 分发。 High-value event IDs: verify large event IDs still compare and dispatch correctly.
+ * 1. 普通 `Active()` 分发。 Direct activation: verify normal `Active()` dispatch reaches
+ * the registered callback in non-ISR context.
+ * 2. `ActiveFromCallback()` 的 ISR 标志透传。 Callback-safe activation: verify
+ * `ActiveFromCallback()` preserves the explicit or legacy-default ISR flag.
+ * 3. 事件绑定后的上下文保持。 Bound-event forwarding: verify event binding preserves the
+ * source callback context when one event triggers another.
+ * 4. 高值 event id 分发。 High-value event IDs: verify large event IDs still compare and
+ * dispatch correctly.
  *
  * 测试原理 / Test principles:
- * 1. 直接检查回调观察到的 `in_isr`，因为这是这个模块的高风险语义。 Check the callback's observed `in_isr` flag directly, because context propagation is the high-risk semantic in this subsystem.
- * 2. 同时驱动直接分发和绑定转发路径，覆盖事件树和回调链两层行为。 Exercise both direct lookup and bound forwarding paths so the event tree and callback chain are both covered.
+ * 1. 直接检查回调观察到的 `in_isr`，因为这是这个模块的高风险语义。 Check the callback's
+ * observed `in_isr` flag directly, because context propagation is the high-risk semantic
+ * in this subsystem.
+ * 2. 同时驱动直接分发和绑定转发路径，覆盖事件树和回调链两层行为。 Exercise both direct
+ * lookup and bound forwarding paths so the event tree and callback chain are both
+ * covered.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -18,8 +27,9 @@
 
 /**
  * @brief 测试入口函数 `test_event`。 Test entry function `test_event`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_event()
 {

--- a/test/base/middleware/logger/test_logger.cpp
+++ b/test/base/middleware/logger/test_logger.cpp
@@ -1,14 +1,21 @@
 /**
  * @file test_logger.cpp
- * @brief logger 前端选择与终端输出渲染测试。 Logger frontend resolution and terminal-output rendering tests.
+ * @brief logger 前端选择与终端输出渲染测试。 Logger frontend resolution and
+ * terminal-output rendering tests.
  *
  * 测试项目 / Test items:
- * 1. brace/printf 字面量前端选择。 Frontend selection: verify brace-style and printf-style literals resolve to the expected logger frontend at compile time.
- * 2. 运行时日志发布后的颜色、前缀和消息输出。 Runtime publish path: verify published logs carry level color, file/line prefix, formatted message text and terminal reset suffix.
+ * 1. brace/printf 字面量前端选择。 Frontend selection: verify brace-style and
+ * printf-style literals resolve to the expected logger frontend at compile time.
+ * 2. 运行时日志发布后的颜色、前缀和消息输出。 Runtime publish path: verify published logs
+ * carry level color, file/line prefix, formatted message text and terminal reset suffix.
  *
  * 测试原理 / Test principles:
- * 1. 把 `STDIO` 绑定到 `Pipe`，直接读 logger 真正输出的字节流。 Bind `STDIO` to a `Pipe` so the test reads the logger's real output bytes instead of inspecting intermediate buffers.
- * 2. 同时验证编译期前端选择和运行时渲染文本，因为 logger 跨两层工作。 Validate both compile-time frontend choice and runtime rendered text, because logger correctness spans both layers.
+ * 1. 把 `STDIO` 绑定到 `Pipe`，直接读 logger 真正输出的字节流。 Bind `STDIO` to a `Pipe`
+ * so the test reads the logger's real output bytes instead of inspecting intermediate
+ * buffers.
+ * 2. 同时验证编译期前端选择和运行时渲染文本，因为 logger 跨两层工作。 Validate both
+ * compile-time frontend choice and runtime rendered text, because logger correctness
+ * spans both layers.
  */
 #include <cstddef>
 #include <string>
@@ -33,8 +40,11 @@ namespace
 
 /**
  * @brief 辅助函数 `CountSubstring`。 Helper function `CountSubstring`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 size_t CountSubstring(std::string_view text, std::string_view needle)
 {
@@ -52,8 +62,11 @@ size_t CountSubstring(std::string_view text, std::string_view needle)
 
 /**
  * @brief 辅助函数 `ReadPipeText`。 Helper function `ReadPipeText`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 std::string ReadPipeText(LibXR::Pipe& pipe)
 {
@@ -73,8 +86,9 @@ std::string ReadPipeText(LibXR::Pipe& pipe)
 
 /**
  * @brief 测试入口函数 `test_logger`。 Test entry function `test_logger`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_logger()
 {
@@ -89,8 +103,8 @@ void test_logger()
 
   LibXR::Logger::Publish<"brace {}">(LibXR::LogLevel::XR_LOG_LEVEL_ERROR,
                                      "logger_test.cpp", 123, 7);
-  LibXR::Logger::Publish<XR_PRINTF("printf %d")>(
-      LibXR::LogLevel::XR_LOG_LEVEL_ERROR, "logger_test.cpp", 124, 9);
+  LibXR::Logger::Publish<XR_PRINTF("printf %d")>(LibXR::LogLevel::XR_LOG_LEVEL_ERROR,
+                                                 "logger_test.cpp", 124, 9);
   LibXR::Logger::Publish<"plain literal">(LibXR::LogLevel::XR_LOG_LEVEL_ERROR,
                                           "logger_test.cpp", 125);
 
@@ -99,12 +113,13 @@ void test_logger()
   LibXR::STDIO::write_ = old_write;
   LibXR::STDIO::write_stream_ = old_stream;
 
-  ASSERT(text.find(LibXR::LIBXR_FOREGROUND_STR[static_cast<size_t>(
-                        LibXR::Foreground::RED)]) != std::string::npos);
+  ASSERT(text.find(
+             LibXR::LIBXR_FOREGROUND_STR[static_cast<size_t>(LibXR::Foreground::RED)]) !=
+         std::string::npos);
   ASSERT(text.find("(logger_test.cpp:123) brace 7") != std::string::npos);
   ASSERT(text.find("(logger_test.cpp:124) printf 9") != std::string::npos);
   ASSERT(text.find("(logger_test.cpp:125) plain literal") != std::string::npos);
   ASSERT(text.find(LibXR::LIBXR_TERMINAL_CONTROL_STR[static_cast<size_t>(
-                        LibXR::TerminalControl::RESET)]) != std::string::npos);
+             LibXR::TerminalControl::RESET)]) != std::string::npos);
   ASSERT(CountSubstring(text, "\r\n") == 3);
 }

--- a/test/base/middleware/message/message_packet_test_common.hpp
+++ b/test/base/middleware/message/message_packet_test_common.hpp
@@ -25,9 +25,8 @@ inline void RewritePacketPayloadLengthForTest(Packet& packet, size_t payload_len
   const auto crc_offset = sizeof(LibXR::Topic::PackedDataHeader) + payload_len;
 
   packet.raw.header_.SetDataLen(static_cast<uint32_t>(payload_len));
-  packet.raw.header_.pack_header_crc8 =
-      LibXR::CRC8::Calculate(&packet.raw,
-                             sizeof(LibXR::Topic::PackedDataHeader) - sizeof(uint8_t));
+  packet.raw.header_.pack_header_crc8 = LibXR::CRC8::Calculate(
+      &packet.raw, sizeof(LibXR::Topic::PackedDataHeader) - sizeof(uint8_t));
   packet_bytes[crc_offset] = LibXR::CRC8::Calculate(packet_bytes, crc_offset);
 }
 

--- a/test/base/middleware/message/message_test_payloads.hpp
+++ b/test/base/middleware/message/message_test_payloads.hpp
@@ -3,12 +3,18 @@
  * @brief 消息总线测试共用 payload 类型。 / Shared payload types for message-bus tests.
  *
  * 提供的测试载荷 / Provided payload shapes:
- * 1. `ByteStablePayload`：用于验证非平凡但 topic 合法 payload 的 typed 传输。 *    `ByteStablePayload`: used to verify typed topic transport for a non-trivially-copyable but topic-legal payload.
- * 2. `WideAlignedPayload`：用于验证 packet/server 的高对齐处理。 *    `WideAlignedPayload`: used to verify packet/server alignment handling.
- * 3. `PrefixIntPayload`：用于验证更短 packet payload 长度兼容路径。 *    `PrefixIntPayload`: used to verify shorter packet-length compatibility.
+ * 1. `ByteStablePayload`：用于验证非平凡但 topic 合法 payload 的 typed 传输。 *
+ * `ByteStablePayload`: used to verify typed topic transport for a non-trivially-copyable
+ * but topic-legal payload.
+ * 2. `WideAlignedPayload`：用于验证 packet/server 的高对齐处理。 * `WideAlignedPayload`:
+ * used to verify packet/server alignment handling.
+ * 3. `PrefixIntPayload`：用于验证更短 packet payload 长度兼容路径。 * `PrefixIntPayload`:
+ * used to verify shorter packet-length compatibility.
  *
  * 设计原理 / Design principle:
- * 1. 把 message 测试里复用的 payload 形状集中到一个头里，避免 topic 侧和 packet 侧各自漂移。 *    Keep shared message-test payload shapes in one header so topic-side and packet-side tests do not drift independently.
+ * 1. 把 message 测试里复用的 payload 形状集中到一个头里，避免 topic 侧和 packet
+ * 侧各自漂移。 *    Keep shared message-test payload shapes in one header so topic-side
+ * and packet-side tests do not drift independently.
  */
 #pragma once
 

--- a/test/base/middleware/message/test_packet.cpp
+++ b/test/base/middleware/message/test_packet.cpp
@@ -6,8 +6,10 @@
 
 /**
  * @brief 测试入口函数 `test_message_packet`。 Test entry function `test_message_packet`.
- * @details 测试内容：聚合执行拆分后的 message packet 子测试组。 Aggregate and execute the split message-packet subtest groups.
- *          测试原理：保持原 runner 入口不变，同时把 packet 大文件按语义拆分。 Preserve the original runner entry while splitting the oversized packet test by semantic groups.
+ * @details 测试内容：聚合执行拆分后的 message packet 子测试组。 Aggregate and execute the
+ * split message-packet subtest groups. 测试原理：保持原 runner 入口不变，同时把 packet
+ * 大文件按语义拆分。 Preserve the original runner entry while splitting the oversized
+ * packet test by semantic groups.
  */
 void test_message_packet()
 {

--- a/test/base/middleware/message/test_packet_alignment.cpp
+++ b/test/base/middleware/message/test_packet_alignment.cpp
@@ -1,15 +1,20 @@
 /**
  * @file test_packet_alignment.cpp
- * @brief message packet 对齐与长度兼容子测试。 Split test unit for message packet alignment and length compatibility.
+ * @brief message packet 对齐与长度兼容子测试。 Split test unit for message packet
+ * alignment and length compatibility.
  */
 #include "message_packet_test_common.hpp"
 
 namespace
 {
 /**
- * @brief 测试项函数 `TestPacketAlignmentAndLengthCompatibility`。 Test-item function `TestPacketAlignmentAndLengthCompatibility`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestPacketAlignmentAndLengthCompatibility`。 Test-item function
+ * `TestPacketAlignmentAndLengthCompatibility`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestPacketAlignmentAndLengthCompatibility()
 {
@@ -42,9 +47,9 @@ void TestPacketAlignmentAndLengthCompatibility()
   auto prefix_topic =
       LibXR::Topic::CreateTopic<PrefixIntPayload>("prefix_int_tp", &domain);
   static PrefixIntPayload prefix_rx{};
-  auto prefix_cb = LibXR::Topic::Callback::Create(
-      [](bool, void*, PrefixIntPayload& data) { prefix_rx = data; },
-      reinterpret_cast<void*>(0));
+  auto prefix_cb =
+      LibXR::Topic::Callback::Create([](bool, void*, PrefixIntPayload& data)
+                                     { prefix_rx = data; }, reinterpret_cast<void*>(0));
   prefix_topic.RegisterCallback(prefix_cb);
   LibXR::Topic::Server prefix_server(512);
   prefix_server.Register(prefix_topic);
@@ -55,20 +60,20 @@ void TestPacketAlignmentAndLengthCompatibility()
          LibXR::ErrorCode::OK);
   RewritePacketPayloadLengthForTest(prefix_packet, sizeof(int32_t));
   prefix_rx = PrefixIntPayload{-1, -1};
-  ASSERT(prefix_server.ParseData(
-             LibXR::ConstRawData(&prefix_packet, LibXR::Topic::PACK_BASE_SIZE +
-                                                     sizeof(int32_t))) == 1);
+  ASSERT(prefix_server.ParseData(LibXR::ConstRawData(
+             &prefix_packet, LibXR::Topic::PACK_BASE_SIZE + sizeof(int32_t))) == 1);
   ASSERT(prefix_rx.value == prefix_tx.value);
 }
 
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunMessagePacketAlignmentTests`。 Test-item function `RunMessagePacketAlignmentTests`.
- * @details 测试内容：执行当前分组里的 message packet 子场景。 Execute the grouped message-packet sub-scenarios for this split file.
- *          测试原理：把解析、失败校验和对齐兼容语义拆开，降低 packet 测试文件复杂度。 Split parsing, validation-failure, and alignment-compatibility semantics into separate files to reduce packet-test complexity.
+ * @brief 测试项函数 `RunMessagePacketAlignmentTests`。 Test-item function
+ * `RunMessagePacketAlignmentTests`.
+ * @details 测试内容：执行当前分组里的 message packet 子场景。 Execute the grouped
+ * message-packet sub-scenarios for this split file.
+ *          测试原理：把解析、失败校验和对齐兼容语义拆开，降低 packet 测试文件复杂度。
+ * Split parsing, validation-failure, and alignment-compatibility semantics into separate
+ * files to reduce packet-test complexity.
  */
-void RunMessagePacketAlignmentTests()
-{
-  TestPacketAlignmentAndLengthCompatibility();
-}
+void RunMessagePacketAlignmentTests() { TestPacketAlignmentAndLengthCompatibility(); }

--- a/test/base/middleware/message/test_packet_parse.cpp
+++ b/test/base/middleware/message/test_packet_parse.cpp
@@ -1,15 +1,20 @@
 /**
  * @file test_packet_parse.cpp
- * @brief message packet 头部编码与解析子测试。 Split test unit for message packet header encoding and parsing.
+ * @brief message packet 头部编码与解析子测试。 Split test unit for message packet header
+ * encoding and parsing.
  */
 #include "message_packet_test_common.hpp"
 
 namespace
 {
 /**
- * @brief 测试项函数 `TestPacketHeaderAndServerParse`。 Test-item function `TestPacketHeaderAndServerParse`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestPacketHeaderAndServerParse`。 Test-item function
+ * `TestPacketHeaderAndServerParse`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestPacketHeaderAndServerParse()
 {
@@ -91,8 +96,8 @@ void TestPacketHeaderAndServerParse()
   const LibXR::MicrosecondTimestamp raw_timestamp(6006);
   uint8_t raw_packet[PACKET_SIZE] = {};
   ASSERT(topic.PackRaw(LibXR::ConstRawData(raw_value),
-                       LibXR::RawData(raw_packet, sizeof(raw_packet)), raw_timestamp) ==
-         LibXR::ErrorCode::OK);
+                       LibXR::RawData(raw_packet, sizeof(raw_packet)),
+                       raw_timestamp) == LibXR::ErrorCode::OK);
   rx_value = -1.0;
   ASSERT(topic_server.ParseData(LibXR::ConstRawData(raw_packet, sizeof(raw_packet))) ==
          1);
@@ -102,23 +107,24 @@ void TestPacketHeaderAndServerParse()
   uint8_t small_packet[PACKET_SIZE - 1] = {};
   uint32_t wrong_size_payload = 0;
   ASSERT(topic.PackRaw(LibXR::ConstRawData(wrong_size_payload),
-                       LibXR::RawData(raw_packet, sizeof(raw_packet)), raw_timestamp) ==
-         LibXR::ErrorCode::SIZE_ERR);
+                       LibXR::RawData(raw_packet, sizeof(raw_packet)),
+                       raw_timestamp) == LibXR::ErrorCode::SIZE_ERR);
   ASSERT(topic.PackRaw(LibXR::ConstRawData(raw_value),
                        LibXR::RawData(small_packet, sizeof(small_packet)),
                        raw_timestamp) == LibXR::ErrorCode::NO_BUFF);
-  ASSERT(topic.PackRaw(LibXR::ConstRawData(raw_value), LibXR::RawData(),
-                       raw_timestamp) == LibXR::ErrorCode::PTR_NULL);
+  ASSERT(topic.PackRaw(LibXR::ConstRawData(raw_value), LibXR::RawData(), raw_timestamp) ==
+         LibXR::ErrorCode::PTR_NULL);
 }
 
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunMessagePacketParseTests`。 Test-item function `RunMessagePacketParseTests`.
- * @details 测试内容：执行当前分组里的 message packet 子场景。 Execute the grouped message-packet sub-scenarios for this split file.
- *          测试原理：把解析、失败校验和对齐兼容语义拆开，降低 packet 测试文件复杂度。 Split parsing, validation-failure, and alignment-compatibility semantics into separate files to reduce packet-test complexity.
+ * @brief 测试项函数 `RunMessagePacketParseTests`。 Test-item function
+ * `RunMessagePacketParseTests`.
+ * @details 测试内容：执行当前分组里的 message packet 子场景。 Execute the grouped
+ * message-packet sub-scenarios for this split file.
+ *          测试原理：把解析、失败校验和对齐兼容语义拆开，降低 packet 测试文件复杂度。
+ * Split parsing, validation-failure, and alignment-compatibility semantics into separate
+ * files to reduce packet-test complexity.
  */
-void RunMessagePacketParseTests()
-{
-  TestPacketHeaderAndServerParse();
-}
+void RunMessagePacketParseTests() { TestPacketHeaderAndServerParse(); }

--- a/test/base/middleware/message/test_packet_validation.cpp
+++ b/test/base/middleware/message/test_packet_validation.cpp
@@ -1,15 +1,20 @@
 /**
  * @file test_packet_validation.cpp
- * @brief message packet 失败校验子测试。 Split test unit for message packet validation-failure scenarios.
+ * @brief message packet 失败校验子测试。 Split test unit for message packet
+ * validation-failure scenarios.
  */
 #include "message_packet_test_common.hpp"
 
 namespace
 {
 /**
- * @brief 测试项函数 `TestPacketValidationFailures`。 Test-item function `TestPacketValidationFailures`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestPacketValidationFailures`。 Test-item function
+ * `TestPacketValidationFailures`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestPacketValidationFailures()
 {
@@ -82,11 +87,12 @@ void TestPacketValidationFailures()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunMessagePacketValidationTests`。 Test-item function `RunMessagePacketValidationTests`.
- * @details 测试内容：执行当前分组里的 message packet 子场景。 Execute the grouped message-packet sub-scenarios for this split file.
- *          测试原理：把解析、失败校验和对齐兼容语义拆开，降低 packet 测试文件复杂度。 Split parsing, validation-failure, and alignment-compatibility semantics into separate files to reduce packet-test complexity.
+ * @brief 测试项函数 `RunMessagePacketValidationTests`。 Test-item function
+ * `RunMessagePacketValidationTests`.
+ * @details 测试内容：执行当前分组里的 message packet 子场景。 Execute the grouped
+ * message-packet sub-scenarios for this split file.
+ *          测试原理：把解析、失败校验和对齐兼容语义拆开，降低 packet 测试文件复杂度。
+ * Split parsing, validation-failure, and alignment-compatibility semantics into separate
+ * files to reduce packet-test complexity.
  */
-void RunMessagePacketValidationTests()
-{
-  TestPacketValidationFailures();
-}
+void RunMessagePacketValidationTests() { TestPacketValidationFailures(); }

--- a/test/base/middleware/message/test_topic.cpp
+++ b/test/base/middleware/message/test_topic.cpp
@@ -15,8 +15,9 @@ void RunTopicMutationTests();
 
 /**
  * @brief 测试入口函数 `test_message_topic`。 Test entry function `test_message_topic`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_message_topic()
 {

--- a/test/base/middleware/message/test_topic_dispatch.cpp
+++ b/test/base/middleware/message/test_topic_dispatch.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_topic_dispatch.cpp
- * @brief 类型化 `Topic` 分发路径子测试。 Split test unit for typed `Topic` dispatch scenarios.
+ * @brief 类型化 `Topic` 分发路径子测试。 Split test unit for typed `Topic` dispatch
+ * scenarios.
  * @details 测试项目：
  *          1. async、队列和 callback 订阅者 fan-out。
  *          2. callback-context 发布保持时间戳和 ISR 语义。
@@ -19,14 +20,19 @@ namespace
 {
 
 /**
- * @brief 测试项函数 `TestTopicSubscriberDispatch`。 Test-item function `TestTopicSubscriberDispatch`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestTopicSubscriberDispatch`。 Test-item function
+ * `TestTopicSubscriberDispatch`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestTopicSubscriberDispatch()
 {
   // 测试内容：验证同一发布在不同订阅者类型上的 fan-out 与时间戳/ISR 语义。
-  // Test coverage: verify fan-out of one publish across subscriber types plus timestamp/ISR semantics.
+  // Test coverage: verify fan-out of one publish across subscriber types plus
+  // timestamp/ISR semantics.
   ASSERT(LibXR::Topic::Find("missing_default_topic") == nullptr);
 
   auto domain = LibXR::Topic::Domain("message_topic_domain");
@@ -85,7 +91,8 @@ void TestTopicSubscriberDispatch()
   topic.RegisterCallback(raw_view_cb);
 
   auto raw_arg_cb = LibXR::Topic::Callback::Create(
-      [](bool, void*, LibXR::MicrosecondTimestamp timestamp, const LibXR::ConstRawData& data)
+      [](bool, void*, LibXR::MicrosecondTimestamp timestamp,
+         const LibXR::ConstRawData& data)
       {
         raw_arg_timestamp = timestamp;
         raw_arg_size = data.size_;
@@ -155,8 +162,7 @@ void TestTopicSubscriberDispatch()
   const LibXR::MicrosecondTimestamp byte_stable_timestamp(1501);
   byte_stable_topic.Publish(byte_stable_tx, byte_stable_timestamp);
   ASSERT(byte_stable_view_value == byte_stable_tx.data[2]);
-  ASSERT(TimestampUs(byte_stable_view_timestamp) ==
-         TimestampUs(byte_stable_timestamp));
+  ASSERT(TimestampUs(byte_stable_view_timestamp) == TimestampUs(byte_stable_timestamp));
 
   msg[0] = 32.32;
   msg[3] = -1.0f;
@@ -192,10 +198,9 @@ void TestTopicSubscriberDispatch()
 
 /**
  * @brief 测试项函数 `RunTopicDispatchTests`。 Test-item function `RunTopicDispatchTests`.
- * @details 测试内容：执行类型化 `Topic` 分发子场景。 Execute typed `Topic` dispatch sub-scenarios.
- *          测试原理：把 fan-out 与时间戳语义单独成组，避免与可变 payload/丢包场景缠在一起。 Group fan-out and timestamp semantics away from mutable-payload and drop scenarios.
+ * @details 测试内容：执行类型化 `Topic` 分发子场景。 Execute typed `Topic` dispatch
+ * sub-scenarios. 测试原理：把 fan-out 与时间戳语义单独成组，避免与可变
+ * payload/丢包场景缠在一起。 Group fan-out and timestamp semantics away from
+ * mutable-payload and drop scenarios.
  */
-void RunTopicDispatchTests()
-{
-  TestTopicSubscriberDispatch();
-}
+void RunTopicDispatchTests() { TestTopicSubscriberDispatch(); }

--- a/test/base/middleware/message/test_topic_mutation.cpp
+++ b/test/base/middleware/message/test_topic_mutation.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_topic_mutation.cpp
- * @brief 类型化 `Topic` 可变 payload 与队列背压子测试。 Split test unit for typed `Topic` mutable-payload and queue-backpressure scenarios.
+ * @brief 类型化 `Topic` 可变 payload 与队列背压子测试。 Split test unit for typed `Topic`
+ * mutable-payload and queue-backpressure scenarios.
  * @details 测试项目：
  *          1. 可变 callback 订阅者能修改调用者可见 payload。
  *          2. 队列订阅者满载时会丢弃后续发布。
@@ -14,14 +15,19 @@ namespace
 {
 
 /**
- * @brief 测试项函数 `TestTopicMutationAndQueueDrop`。 Test-item function `TestTopicMutationAndQueueDrop`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestTopicMutationAndQueueDrop`。 Test-item function
+ * `TestTopicMutationAndQueueDrop`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestTopicMutationAndQueueDrop()
 {
   // 测试内容：验证可变 payload 回写语义，以及队列背压下的溢出丢弃契约。
-  // Test coverage: verify mutable-payload writeback semantics and overflow-drop behavior under queue backpressure.
+  // Test coverage: verify mutable-payload writeback semantics and overflow-drop behavior
+  // under queue backpressure.
   auto domain = LibXR::Topic::Domain("message_topic_mutation_domain");
 
   auto mutable_topic = LibXR::Topic::CreateTopic<int>("mutable_payload_tp", &domain);
@@ -59,10 +65,9 @@ void TestTopicMutationAndQueueDrop()
 
 /**
  * @brief 测试项函数 `RunTopicMutationTests`。 Test-item function `RunTopicMutationTests`.
- * @details 测试内容：执行类型化 `Topic` 可变 payload 与丢包子场景。 Execute typed `Topic` mutable-payload and drop-behavior sub-scenarios.
- *          测试原理：把 payload 回写和背压丢弃单独成组，聚焦订阅者副作用契约。 Group payload writeback and backpressure-drop behavior around subscriber side-effect contracts.
+ * @details 测试内容：执行类型化 `Topic` 可变 payload 与丢包子场景。 Execute typed `Topic`
+ * mutable-payload and drop-behavior sub-scenarios. 测试原理：把 payload
+ * 回写和背压丢弃单独成组，聚焦订阅者副作用契约。 Group payload writeback and
+ * backpressure-drop behavior around subscriber side-effect contracts.
  */
-void RunTopicMutationTests()
-{
-  TestTopicMutationAndQueueDrop();
-}
+void RunTopicMutationTests() { TestTopicMutationAndQueueDrop(); }

--- a/test/base/middleware/message/topic_test_common.hpp
+++ b/test/base/middleware/message/topic_test_common.hpp
@@ -22,8 +22,11 @@ namespace
 
 /**
  * @brief 辅助函数 `TimestampUs`。 Helper function `TimestampUs`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 uint64_t TimestampUs(const LibXR::MicrosecondTimestamp& timestamp)
 {

--- a/test/base/middleware/ramfs/test_ramfs.cpp
+++ b/test/base/middleware/ramfs/test_ramfs.cpp
@@ -1,15 +1,24 @@
 /**
  * @file test_ramfs.cpp
- * @brief `RamFS` 节点创建、层级查找与类型化文件访问测试。 `RamFS` node creation, hierarchy and typed-file access tests.
+ * @brief `RamFS` 节点创建、层级查找与类型化文件访问测试。 `RamFS` node creation,
+ * hierarchy and typed-file access tests.
  *
  * 测试项目 / Test items:
- * 1. 可执行文件行为。 Executable file behavior: verify executable files run, mutate bound state and stay distinguishable from ordinary files.
- * 2. 可写/只读文件的数据访问视图。 Read/write and read-only data views: verify typed access, const access and raw view sizing for writable and read-only files.
- * 3. 目录、文件、自定义节点的层级查找与遍历。 Hierarchy lookup: verify recursive file/dir/custom lookup, `.` / `..` directory traversal and direct-child enumeration counts.
+ * 1. 可执行文件行为。 Executable file behavior: verify executable files run, mutate bound
+ * state and stay distinguishable from ordinary files.
+ * 2. 可写/只读文件的数据访问视图。 Read/write and read-only data views: verify typed
+ * access, const access and raw view sizing for writable and read-only files.
+ * 3. 目录、文件、自定义节点的层级查找与遍历。 Hierarchy lookup: verify recursive
+ * file/dir/custom lookup, `.` / `..` directory traversal and direct-child enumeration
+ * counts.
  *
  * 测试原理 / Test principles:
- * 1. 构造一个混合节点树，让查找和遍历都跑在真实运行时结构上。 Construct a real mixed node tree containing file, dir, exec and custom nodes so lookup and traversal execute on the same structure users build at runtime.
- * 2. 同时检查数据访问和结构查询，因为 RamFS 契约覆盖存储和命名空间两部分。 Observe both typed data access and structural queries, because RamFS correctness spans storage semantics and namespace semantics together.
+ * 1. 构造一个混合节点树，让查找和遍历都跑在真实运行时结构上。 Construct a real mixed node
+ * tree containing file, dir, exec and custom nodes so lookup and traversal execute on the
+ * same structure users build at runtime.
+ * 2. 同时检查数据访问和结构查询，因为 RamFS 契约覆盖存储和命名空间两部分。 Observe both
+ * typed data access and structural queries, because RamFS correctness spans storage
+ * semantics and namespace semantics together.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -17,8 +26,9 @@
 
 /**
  * @brief 测试入口函数 `test_ramfs`。 Test entry function `test_ramfs`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_ramfs()
 {

--- a/test/base/middleware/terminal/terminal_display_test_common.hpp
+++ b/test/base/middleware/terminal/terminal_display_test_common.hpp
@@ -1,6 +1,7 @@
 /**
  * @file terminal_display_test_common.hpp
- * @brief `Terminal` 显示类测试共用 helper。 Shared helpers for `Terminal` display-oriented tests.
+ * @brief `Terminal` 显示类测试共用 helper。 Shared helpers for `Terminal`
+ * display-oriented tests.
  * @details 测试项目：
  *          1. 提供不同换行模式下的显示 fixture。
  *          2. 提供输入行填充和输出刷出 helper。
@@ -38,8 +39,11 @@ struct TerminalDisplayFixture
 
   /**
    * @brief 辅助函数 `FlushOutput`。 Helper function `FlushOutput`.
-   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
-   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+   * measure, or validate shared state for later test steps.
+   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+   * repeated helper logic locally so the main test body stays focused on the test item
+   * itself.
    */
   std::string FlushOutput()
   {
@@ -61,8 +65,11 @@ struct TerminalDisplayFixture
 
 /**
  * @brief 辅助函数 `FillInputLine`。 Helper function `FillInputLine`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void FillInputLine(LibXR::Terminal<>& terminal, const char* text)
 {

--- a/test/base/middleware/terminal/terminal_session_test_common.hpp
+++ b/test/base/middleware/terminal/terminal_session_test_common.hpp
@@ -1,12 +1,14 @@
 /**
  * @file terminal_session_test_common.hpp
- * @brief `Terminal` 输入与命令测试共用 session helper。 Shared session helpers for `Terminal` input and command tests.
+ * @brief `Terminal` 输入与命令测试共用 session helper。 Shared session helpers for
+ * `Terminal` input and command tests.
  * @details 测试项目：
  *          1. 提供命令计数上下文和 ANSI 输出计数 helper。
  *          2. 提供可发送原始输入/文本并驱动 `TaskFun()` 的交互 fixture。
  *          Test items:
  *          1. Provide command-count contexts and ANSI-substring counting helpers.
- *          2. Provide an interactive fixture that sends raw input/text and drives `TaskFun()`.
+ *          2. Provide an interactive fixture that sends raw input/text and drives
+ * `TaskFun()`.
  */
 #pragma once
 
@@ -30,8 +32,11 @@ struct CommandState
 
 /**
  * @brief 辅助函数 `CountCommand`。 Helper function `CountCommand`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 int CountCommand(CommandState* state, int argc, char** argv)
 {
@@ -47,8 +52,11 @@ int CountCommand(CommandState* state, int argc, char** argv)
 
 /**
  * @brief 辅助函数 `CountSubstring`。 Helper function `CountSubstring`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 size_t CountSubstring(std::string_view text, std::string_view needle)
 {
@@ -80,8 +88,10 @@ struct TerminalFixture
 
   /**
    * @brief 执行辅助函数 `RunUntilIdle`。 Execution helper function `RunUntilIdle`.
-   * @details 测试内容：执行一个子 case、子流程或基准场景。 Execute one sub-case, sub-flow, or benchmark scenario.
-   *          测试原理：把重复执行逻辑集中封装，保证不同 case 走同一执行路径。 Centralize repeated execution logic so different cases use the same execution path.
+   * @details 测试内容：执行一个子 case、子流程或基准场景。 Execute one sub-case,
+   * sub-flow, or benchmark scenario. 测试原理：把重复执行逻辑集中封装，保证不同 case
+   * 走同一执行路径。 Centralize repeated execution logic so different cases use the same
+   * execution path.
    */
   void RunUntilIdle()
   {
@@ -101,8 +111,11 @@ struct TerminalFixture
 
   /**
    * @brief 辅助函数 `DrainOutput`。 Helper function `DrainOutput`.
-   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
-   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+   * measure, or validate shared state for later test steps.
+   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+   * repeated helper logic locally so the main test body stays focused on the test item
+   * itself.
    */
   std::string DrainOutput()
   {
@@ -121,8 +134,11 @@ struct TerminalFixture
 
   /**
    * @brief 辅助函数 `SendRaw`。 Helper function `SendRaw`.
-   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
-   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+   * measure, or validate shared state for later test steps.
+   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+   * repeated helper logic locally so the main test body stays focused on the test item
+   * itself.
    */
   std::string SendRaw(const void* data, size_t size)
   {
@@ -135,8 +151,11 @@ struct TerminalFixture
 
   /**
    * @brief 辅助函数 `SendText`。 Helper function `SendText`.
-   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
-   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+   * measure, or validate shared state for later test steps.
+   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+   * repeated helper logic locally so the main test body stays focused on the test item
+   * itself.
    */
   std::string SendText(const char* text) { return SendRaw(text, std::strlen(text)); }
 };

--- a/test/base/middleware/terminal/test_command.cpp
+++ b/test/base/middleware/terminal/test_command.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_command.cpp
- * @brief `Terminal` 内建命令测试聚合入口。 Aggregation entry for split `Terminal` builtin-command tests.
+ * @brief `Terminal` 内建命令测试聚合入口。 Aggregation entry for split `Terminal`
+ * builtin-command tests.
  * @details 测试项目：
  *          1. 聚合 `cd` 内建命令子场景。
  *          2. 聚合 `ls` 内建命令子场景。
@@ -14,9 +15,11 @@ void RunTerminalCommandCdTests();
 void RunTerminalCommandLsTests();
 
 /**
- * @brief 测试入口函数 `test_terminal_command`。 Test entry function `test_terminal_command`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_terminal_command`。 Test entry function
+ * `test_terminal_command`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_terminal_command()
 {

--- a/test/base/middleware/terminal/test_command_cd.cpp
+++ b/test/base/middleware/terminal/test_command_cd.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_command_cd.cpp
- * @brief `Terminal` `cd` 内建命令场景子测试。 Split test unit for `Terminal` `cd` builtin scenarios.
+ * @brief `Terminal` `cd` 内建命令场景子测试。 Split test unit for `Terminal` `cd` builtin
+ * scenarios.
  * @details 测试项目：
  *          1. 相对路径、`.`、`..`、根路径切换。
  *          2. 无效路径不会破坏当前目录与 prompt。
@@ -15,8 +16,11 @@ namespace
 
 /**
  * @brief 测试项函数 `TestCdBuiltins`。 Test-item function `TestCdBuiltins`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestCdBuiltins()
 {
@@ -58,11 +62,10 @@ void TestCdBuiltins()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunTerminalCommandCdTests`。 Test-item function `RunTerminalCommandCdTests`.
- * @details 测试内容：执行 `Terminal` `cd` 内建命令子场景。 Execute `Terminal` `cd` builtin sub-scenarios.
- *          测试原理：把目录切换语义单独成组，避免与 `ls` 输出标记场景缠绕。 Group directory-transition semantics away from `ls` marker output scenarios.
+ * @brief 测试项函数 `RunTerminalCommandCdTests`。 Test-item function
+ * `RunTerminalCommandCdTests`.
+ * @details 测试内容：执行 `Terminal` `cd` 内建命令子场景。 Execute `Terminal` `cd`
+ * builtin sub-scenarios. 测试原理：把目录切换语义单独成组，避免与 `ls` 输出标记场景缠绕。
+ * Group directory-transition semantics away from `ls` marker output scenarios.
  */
-void RunTerminalCommandCdTests()
-{
-  TestCdBuiltins();
-}
+void RunTerminalCommandCdTests() { TestCdBuiltins(); }

--- a/test/base/middleware/terminal/test_command_ls.cpp
+++ b/test/base/middleware/terminal/test_command_ls.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_command_ls.cpp
- * @brief `Terminal` `ls` 内建命令场景子测试。 Split test unit for `Terminal` `ls` builtin scenarios.
+ * @brief `Terminal` `ls` 内建命令场景子测试。 Split test unit for `Terminal` `ls` builtin
+ * scenarios.
  * @details 测试项目：
  *          1. 根目录下不同节点类型的输出标记。
  *          2. 切换目录后 listing scope 跟随当前目录。
@@ -15,13 +16,17 @@ namespace
 
 /**
  * @brief 测试项函数 `TestLsBuiltin`。 Test-item function `TestLsBuiltin`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestLsBuiltin()
 {
   // 测试内容：验证 `ls` 在不同目录和节点类型下的输出标记与作用域。
-  // Test coverage: verify `ls` output markers and scope under different directories and node types.
+  // Test coverage: verify `ls` output markers and scope under different directories and
+  // node types.
   TerminalFixture fixture;
 
   int file_value = 42;
@@ -65,11 +70,11 @@ void TestLsBuiltin()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunTerminalCommandLsTests`。 Test-item function `RunTerminalCommandLsTests`.
- * @details 测试内容：执行 `Terminal` `ls` 内建命令子场景。 Execute `Terminal` `ls` builtin sub-scenarios.
- *          测试原理：把 listing 作用域与节点类型标记单独成组，聚焦可见输出契约。 Group listing scope and node-type markers around the visible-output contract.
+ * @brief 测试项函数 `RunTerminalCommandLsTests`。 Test-item function
+ * `RunTerminalCommandLsTests`.
+ * @details 测试内容：执行 `Terminal` `ls` 内建命令子场景。 Execute `Terminal` `ls`
+ * builtin sub-scenarios. 测试原理：把 listing
+ * 作用域与节点类型标记单独成组，聚焦可见输出契约。 Group listing scope and node-type
+ * markers around the visible-output contract.
  */
-void RunTerminalCommandLsTests()
-{
-  TestLsBuiltin();
-}
+void RunTerminalCommandLsTests() { TestLsBuiltin(); }

--- a/test/base/middleware/terminal/test_display.cpp
+++ b/test/base/middleware/terminal/test_display.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_display.cpp
- * @brief `Terminal` 显示测试聚合入口。 Aggregation entry for split `Terminal` display tests.
+ * @brief `Terminal` 显示测试聚合入口。 Aggregation entry for split `Terminal` display
+ * tests.
  * @details 测试项目：
  *          1. 聚合换行/清屏显示子场景。
  *          2. 聚合历史显示与行内重绘子场景。
@@ -14,9 +15,11 @@ void RunTerminalDisplayModeTests();
 void RunTerminalDisplayHistoryTests();
 
 /**
- * @brief 测试入口函数 `test_terminal_display`。 Test entry function `test_terminal_display`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_terminal_display`。 Test entry function
+ * `test_terminal_display`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_terminal_display()
 {

--- a/test/base/middleware/terminal/test_display_history.cpp
+++ b/test/base/middleware/terminal/test_display_history.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_display_history.cpp
- * @brief `Terminal` 历史显示与行内重绘场景子测试。 Split test unit for `Terminal` history display and inline-redraw scenarios.
+ * @brief `Terminal` 历史显示与行内重绘场景子测试。 Split test unit for `Terminal` history
+ * display and inline-redraw scenarios.
  * @details 测试项目：
  *          1. 历史显示与 `CopyHistoryToInputLine()` 恢复。
  *          2. 光标偏移下的插入/删除重绘后缀。
@@ -14,14 +15,19 @@ namespace
 {
 
 /**
- * @brief 测试项函数 `TestHistoryDisplayAndRestore`。 Test-item function `TestHistoryDisplayAndRestore`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestHistoryDisplayAndRestore`。 Test-item function
+ * `TestHistoryDisplayAndRestore`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestHistoryDisplayAndRestore()
 {
   // 测试内容：验证历史回显、索引推进和复制回输入行后的保留状态。
-  // Test coverage: verify history rendering, index movement, and retained state after copying back to the input line.
+  // Test coverage: verify history rendering, index movement, and retained state after
+  // copying back to the input line.
   TerminalDisplayFixture<LibXR::Terminal<>::Mode::CRLF> fixture;
 
   FillInputLine(fixture.terminal, "alpha");
@@ -47,14 +53,19 @@ void TestHistoryDisplayAndRestore()
 }
 
 /**
- * @brief 测试项函数 `TestMidLineDisplayEditing`。 Test-item function `TestMidLineDisplayEditing`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestMidLineDisplayEditing`。 Test-item function
+ * `TestMidLineDisplayEditing`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestMidLineDisplayEditing()
 {
   // 测试内容：验证有光标偏移时的插入/删除如何重绘尾部内容。
-  // Test coverage: verify how insertion and deletion redraw the trailing text when the cursor is offset from the end.
+  // Test coverage: verify how insertion and deletion redraw the trailing text when the
+  // cursor is offset from the end.
   TerminalDisplayFixture<LibXR::Terminal<>::Mode::CRLF> fixture;
 
   FillInputLine(fixture.terminal, "ab");
@@ -71,9 +82,13 @@ void TestMidLineDisplayEditing()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunTerminalDisplayHistoryTests`。 Test-item function `RunTerminalDisplayHistoryTests`.
- * @details 测试内容：执行 `Terminal` 历史显示与行内重绘子场景。 Execute `Terminal` history-display and inline-redraw sub-scenarios.
- *          测试原理：把历史与行内重绘语义单独成组，集中覆盖保留状态和可见输出的一致性。 Group history and inline-redraw semantics around the consistency between retained state and visible output.
+ * @brief 测试项函数 `RunTerminalDisplayHistoryTests`。 Test-item function
+ * `RunTerminalDisplayHistoryTests`.
+ * @details 测试内容：执行 `Terminal` 历史显示与行内重绘子场景。 Execute `Terminal`
+ * history-display and inline-redraw sub-scenarios.
+ *          测试原理：把历史与行内重绘语义单独成组，集中覆盖保留状态和可见输出的一致性。
+ * Group history and inline-redraw semantics around the consistency between retained state
+ * and visible output.
  */
 void RunTerminalDisplayHistoryTests()
 {

--- a/test/base/middleware/terminal/test_display_modes.cpp
+++ b/test/base/middleware/terminal/test_display_modes.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_display_modes.cpp
- * @brief `Terminal` 换行与清屏显示场景子测试。 Split test unit for `Terminal` line-feed and clear-sequence scenarios.
+ * @brief `Terminal` 换行与清屏显示场景子测试。 Split test unit for `Terminal` line-feed
+ * and clear-sequence scenarios.
  * @details 测试项目：
  *          1. `CRLF` / `LF` / `CR` 三种换行模式输出。
  *          2. prompt、清行和清屏序列输出。
@@ -15,13 +16,17 @@ namespace
 
 /**
  * @brief 测试项函数 `TestLineFeedModes`。 Test-item function `TestLineFeedModes`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestLineFeedModes()
 {
   // 测试内容：验证三种换行模式各自输出的终端换行字节。
-  // Test coverage: verify the terminal line-ending bytes emitted by the three line-feed modes.
+  // Test coverage: verify the terminal line-ending bytes emitted by the three line-feed
+  // modes.
   TerminalDisplayFixture<LibXR::Terminal<>::Mode::CRLF> crlf_fixture;
   crlf_fixture.terminal.LineFeed();
   ASSERT(crlf_fixture.FlushOutput() == "\r\n");
@@ -36,14 +41,19 @@ void TestLineFeedModes()
 }
 
 /**
- * @brief 测试项函数 `TestHeaderAndClearSequences`。 Test-item function `TestHeaderAndClearSequences`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestHeaderAndClearSequences`。 Test-item function
+ * `TestHeaderAndClearSequences`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestHeaderAndClearSequences()
 {
   // 测试内容：验证 header、清行和清屏输出的精确 escape 序列。
-  // Test coverage: verify the exact escape sequences for header, clear-line, and clear-screen output.
+  // Test coverage: verify the exact escape sequences for header, clear-line, and
+  // clear-screen output.
   TerminalDisplayFixture<LibXR::Terminal<>::Mode::CRLF> fixture;
 
   fixture.terminal.ShowHeader();
@@ -65,9 +75,12 @@ void TestHeaderAndClearSequences()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunTerminalDisplayModeTests`。 Test-item function `RunTerminalDisplayModeTests`.
- * @details 测试内容：执行 `Terminal` 换行与清屏显示子场景。 Execute `Terminal` line-feed and clear-sequence display sub-scenarios.
- *          测试原理：把纯输出序列语义单独成组，避免与历史和行内编辑场景缠绕。 Group pure output-sequence semantics away from history and inline-edit scenarios.
+ * @brief 测试项函数 `RunTerminalDisplayModeTests`。 Test-item function
+ * `RunTerminalDisplayModeTests`.
+ * @details 测试内容：执行 `Terminal` 换行与清屏显示子场景。 Execute `Terminal` line-feed
+ * and clear-sequence display sub-scenarios.
+ *          测试原理：把纯输出序列语义单独成组，避免与历史和行内编辑场景缠绕。 Group pure
+ * output-sequence semantics away from history and inline-edit scenarios.
  */
 void RunTerminalDisplayModeTests()
 {

--- a/test/base/middleware/terminal/test_input.cpp
+++ b/test/base/middleware/terminal/test_input.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_input.cpp
- * @brief `Terminal` 输入测试聚合入口。 Aggregation entry for split `Terminal` input tests.
+ * @brief `Terminal` 输入测试聚合入口。 Aggregation entry for split `Terminal` input
+ * tests.
  * @details 测试项目：
  *          1. 聚合 CRLF 抑制与历史导航子场景。
  *          2. 聚合行内编辑子场景。
@@ -15,8 +16,9 @@ void RunTerminalInputEditTests();
 
 /**
  * @brief 测试入口函数 `test_terminal_input`。 Test entry function `test_terminal_input`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_terminal_input()
 {

--- a/test/base/middleware/terminal/test_input_edit.cpp
+++ b/test/base/middleware/terminal/test_input_edit.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_input_edit.cpp
- * @brief `Terminal` 光标移动后插入编辑场景子测试。 Split test unit for `Terminal` mid-line edit-after-cursor-move scenarios.
+ * @brief `Terminal` 光标移动后插入编辑场景子测试。 Split test unit for `Terminal`
+ * mid-line edit-after-cursor-move scenarios.
  * @details 测试项目：
  *          1. 左移后插入字符会在命令中间生效。
  *          2. 行内编辑后的最终命令会按期望名称执行。
@@ -14,14 +15,19 @@ namespace
 {
 
 /**
- * @brief 测试项函数 `TestMidLineInputEditing`。 Test-item function `TestMidLineInputEditing`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestMidLineInputEditing`。 Test-item function
+ * `TestMidLineInputEditing`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestMidLineInputEditing()
 {
   // 测试内容：验证左移后继续输入时，命令缓冲区和最终执行名称都会按中间插入语义更新。
-  // Test coverage: verify that after moving left, continued typing updates both the command buffer and the final executed name as a mid-line insertion.
+  // Test coverage: verify that after moving left, continued typing updates both the
+  // command buffer and the final executed name as a mid-line insertion.
   TerminalFixture fixture;
 
   int acbd_count = 0;
@@ -42,11 +48,10 @@ void TestMidLineInputEditing()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunTerminalInputEditTests`。 Test-item function `RunTerminalInputEditTests`.
- * @details 测试内容：执行 `Terminal` 行内编辑子场景。 Execute `Terminal` inline-edit sub-scenarios.
- *          测试原理：把行内编辑单独成组，聚焦光标移动后的输入缓冲区更新契约。 Group inline editing around the buffer-update contract after cursor movement.
+ * @brief 测试项函数 `RunTerminalInputEditTests`。 Test-item function
+ * `RunTerminalInputEditTests`.
+ * @details 测试内容：执行 `Terminal` 行内编辑子场景。 Execute `Terminal` inline-edit
+ * sub-scenarios. 测试原理：把行内编辑单独成组，聚焦光标移动后的输入缓冲区更新契约。 Group
+ * inline editing around the buffer-update contract after cursor movement.
  */
-void RunTerminalInputEditTests()
-{
-  TestMidLineInputEditing();
-}
+void RunTerminalInputEditTests() { TestMidLineInputEditing(); }

--- a/test/base/middleware/terminal/test_input_history.cpp
+++ b/test/base/middleware/terminal/test_input_history.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_input_history.cpp
- * @brief `Terminal` 输入 CRLF 与历史导航场景子测试。 Split test unit for `Terminal` CRLF-suppression and history-navigation scenarios.
+ * @brief `Terminal` 输入 CRLF 与历史导航场景子测试。 Split test unit for `Terminal`
+ * CRLF-suppression and history-navigation scenarios.
  * @details 测试项目：
  *          1. `\r\n` 双字节提交只执行一次命令。
  *          2. `Up` / `Down` 历史导航回放新旧命令。
@@ -14,14 +15,19 @@ namespace
 {
 
 /**
- * @brief 测试项函数 `TestInputCrLfAndHistory`。 Test-item function `TestInputCrLfAndHistory`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestInputCrLfAndHistory`。 Test-item function
+ * `TestInputCrLfAndHistory`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestInputCrLfAndHistory()
 {
   // 测试内容：验证 CRLF 去重和上下箭头历史导航的执行副作用与回显。
-  // Test coverage: verify CRLF suppression plus the side effects and echoes of up/down history navigation.
+  // Test coverage: verify CRLF suppression plus the side effects and echoes of up/down
+  // history navigation.
   TerminalFixture fixture;
 
   int one_count = 0;
@@ -29,8 +35,10 @@ void TestInputCrLfAndHistory()
   CommandState one_state{"one", &one_count};
   CommandState two_state{"two", &two_count};
 
-  auto one_cmd = LibXR::RamFS::CreateCommand<CommandState*>("one", CountCommand, &one_state);
-  auto two_cmd = LibXR::RamFS::CreateCommand<CommandState*>("two", CountCommand, &two_state);
+  auto one_cmd =
+      LibXR::RamFS::CreateCommand<CommandState*>("one", CountCommand, &one_state);
+  auto two_cmd =
+      LibXR::RamFS::CreateCommand<CommandState*>("two", CountCommand, &two_state);
 
   fixture.ramfs.Add(one_cmd);
   fixture.ramfs.Add(two_cmd);
@@ -63,11 +71,12 @@ void TestInputCrLfAndHistory()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunTerminalInputHistoryTests`。 Test-item function `RunTerminalInputHistoryTests`.
- * @details 测试内容：执行 `Terminal` CRLF 与历史导航子场景。 Execute `Terminal` CRLF-suppression and history-navigation sub-scenarios.
- *          测试原理：把提交去重和历史导航单独成组，聚焦 parser 与 history 的联动契约。 Group submission suppression and history navigation around the parser/history interaction contract.
+ * @brief 测试项函数 `RunTerminalInputHistoryTests`。 Test-item function
+ * `RunTerminalInputHistoryTests`.
+ * @details 测试内容：执行 `Terminal` CRLF 与历史导航子场景。 Execute `Terminal`
+ * CRLF-suppression and history-navigation sub-scenarios.
+ *          测试原理：把提交去重和历史导航单独成组，聚焦 parser 与 history 的联动契约。
+ * Group submission suppression and history navigation around the parser/history
+ * interaction contract.
  */
-void RunTerminalInputHistoryTests()
-{
-  TestInputCrLfAndHistory();
-}
+void RunTerminalInputHistoryTests() { TestInputCrLfAndHistory(); }

--- a/test/base/middleware/terminal/test_integration.cpp
+++ b/test/base/middleware/terminal/test_integration.cpp
@@ -1,15 +1,23 @@
 /**
  * @file test_integration.cpp
- * @brief 混合 RamFS 树上的 `Terminal` 集成命令路径测试。 Integrated `Terminal` command-path test over a mixed RamFS tree.
+ * @brief 混合 RamFS 树上的 `Terminal` 集成命令路径测试。 Integrated `Terminal`
+ * command-path test over a mixed RamFS tree.
  *
  * 测试项目 / Test items:
- * 1. 相对/绝对可执行路径执行。 Executable-path dispatch: verify relative and absolute executable paths both run the target command.
- * 2. 非可执行文件和未知命令报错。 Non-executable and unknown command handling: verify ordinary files and unknown commands emit the expected error text.
- * 3. 自动补全与非打印字符过滤。 Auto-complete and input sanitization: verify tab-complete lists matching entries and non-printable bytes are filtered from command parsing.
+ * 1. 相对/绝对可执行路径执行。 Executable-path dispatch: verify relative and absolute
+ * executable paths both run the target command.
+ * 2. 非可执行文件和未知命令报错。 Non-executable and unknown command handling: verify
+ * ordinary files and unknown commands emit the expected error text.
+ * 3. 自动补全与非打印字符过滤。 Auto-complete and input sanitization: verify tab-complete
+ * lists matching entries and non-printable bytes are filtered from command parsing.
  *
  * 测试原理 / Test principles:
- * 1. 在真实 RamFS 树上驱动 `TaskFun()`，让路径解析、输入解析和输出报告保持集成。 Run a realistic RamFS tree through `Terminal::TaskFun()` so path resolution, input parsing and output reporting stay integrated.
- * 2. 以最终终端 transcript 为准，而不是只看局部 helper 状态。 Inspect the final terminal transcript rather than helper internals, because this test covers the end-to-end shell behavior contract.
+ * 1. 在真实 RamFS 树上驱动 `TaskFun()`，让路径解析、输入解析和输出报告保持集成。 Run a
+ * realistic RamFS tree through `Terminal::TaskFun()` so path resolution, input parsing
+ * and output reporting stay integrated.
+ * 2. 以最终终端 transcript 为准，而不是只看局部 helper 状态。 Inspect the final terminal
+ * transcript rather than helper internals, because this test covers the end-to-end shell
+ * behavior contract.
  */
 #include <cstring>
 #include <vector>
@@ -21,8 +29,9 @@
 
 /**
  * @brief 测试入口函数 `test_terminal`。 Test entry function `test_terminal`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_terminal()
 {
@@ -97,9 +106,7 @@ void test_terminal()
   };
 
   auto write_line = [&](const char* command_line)
-  {
-    write_raw(command_line, std::strlen(command_line));
-  };
+  { write_raw(command_line, std::strlen(command_line)); };
 
   write_line("dir1/dir2/dir3/run\n");
   ASSERT(command_count == 1);
@@ -110,7 +117,7 @@ void test_terminal()
   write_line("unknown\n");
   write_line("alph\t\n");
   const unsigned char non_printable_unknown[] = {0xFF, 'u', 'n', 'k', 'n',
-                                                 'o', 'w', 'n', '\n'};
+                                                 'o',  'w', 'n', '\n'};
   write_raw(non_printable_unknown, sizeof(non_printable_unknown));
 
   const size_t output_size = output.GetReadPort().Size();

--- a/test/base/print/test_format_frontend.cpp
+++ b/test/base/print/test_format_frontend.cpp
@@ -78,8 +78,7 @@ void TestFormatFrontendSemantics()
   }
 
   // Keep brace-format float behavior aligned with the shared printf writer path.
-  if (!SameFormatAsExpected<"{:.0f}|{:.0f}|{:.0f}|{:.0f}">("0|2|2|4", 0.5, 1.5,
-                                                                2.5, 3.5))
+  if (!SameFormatAsExpected<"{:.0f}|{:.0f}|{:.0f}|{:.0f}">("0|2|2|4", 0.5, 1.5, 2.5, 3.5))
   {
     Fail("format frontend float half-even mismatch");
   }
@@ -102,8 +101,8 @@ void TestFormatFrontendSemantics()
   }
 
   if (!SameFormatAsExpected<"{:.6g}|{:.6g}|{:.5g}|{:.4g}|{:.6g}|{:.6g}">(
-          "999999|1e+06|1e+05|1e+04|9.99999e-05|0.0001", 999999.4,
-          999999.5, 99999.9, 9999.9, 0.0000999999, 0.00009999999))
+          "999999|1e+06|1e+05|1e+04|9.99999e-05|0.0001", 999999.4, 999999.5, 99999.9,
+          9999.9, 0.0000999999, 0.00009999999))
   {
     Fail("format frontend rounded exponent mismatch");
   }
@@ -138,8 +137,7 @@ void TestFormatFrontendSemantics()
 
   // {:.2f} with a float: non-finite values must format as nan/inf/-inf.
   if (!SameFormatAsExpected<"{:.2f}|{:.2f}|{:.2f}">(
-          "nan|inf|-inf",
-          std::numeric_limits<float>::quiet_NaN(),
+          "nan|inf|-inf", std::numeric_limits<float>::quiet_NaN(),
           std::numeric_limits<float>::infinity(),
           -std::numeric_limits<float>::infinity()))
   {
@@ -148,8 +146,7 @@ void TestFormatFrontendSemantics()
 
   // NaN sign policy: signbit is ignored; explicit sign flag is honored.
   if (!SameFormatAsExpected<"{:.2f}|{:-.2f}|{:+.2f}|{: .2f}">(
-          "nan|nan|+nan| nan",
-          std::numeric_limits<float>::quiet_NaN(),
+          "nan|nan|+nan| nan", std::numeric_limits<float>::quiet_NaN(),
           std::numeric_limits<float>::quiet_NaN(),
           std::numeric_limits<float>::quiet_NaN(),
           std::numeric_limits<float>::quiet_NaN()))

--- a/test/base/rw/rw_test_common.hpp
+++ b/test/base/rw/rw_test_common.hpp
@@ -1,6 +1,7 @@
 /**
  * @file rw_test_common.hpp
- * @brief base `rw` / `pipe` 测试聚合 helper 入口。 Aggregation helper entry for base `rw` / `pipe` tests.
+ * @brief base `rw` / `pipe` 测试聚合 helper 入口。 Aggregation helper entry for base `rw`
+ * / `pipe` tests.
  * @details 测试项目：
  *          1. 聚合共享的模式、端口状态机和 `Pipe` helper。
  *          2. 对外仅保留 base `rw` / `pipe` 分组运行入口声明。
@@ -8,12 +9,12 @@
  *          Test items:
  *          1. Aggregate the shared mode, port-state, and `Pipe` helpers.
  *          2. Expose only the base `rw` / `pipe` group runner declarations.
- *          3. Keep scenario files depending on one thin wrapper instead of long include chains.
+ *          3. Keep scenario files depending on one thin wrapper instead of long include
+ * chains.
  */
 #pragma once
 
 #include "../../common/rw/pipe_test_common.hpp"
-
 
 void RunBaseRwReadQueueTests();
 void RunBaseRwPendingTests();

--- a/test/base/rw/test_pipe_basic.cpp
+++ b/test/base/rw/test_pipe_basic.cpp
@@ -1,13 +1,15 @@
 /**
  * @file test_pipe_basic.cpp
- * @brief base `Pipe` 基础传输场景子测试。 Split test unit for base `Pipe` basic transport scenarios.
+ * @brief base `Pipe` 基础传输场景子测试。 Split test unit for base `Pipe` basic transport
+ * scenarios.
  */
 #include "rw_test_common.hpp"
 
 /**
  * @brief 测试入口函数 `test_pipe_basic`。 Test entry function `test_pipe_basic`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_pipe_basic()
 {
@@ -36,9 +38,11 @@ void test_pipe_basic()
 }
 
 /**
- * @brief 测试入口函数 `test_pipe_write_then_read`。 Test entry function `test_pipe_write_then_read`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_pipe_write_then_read`。 Test entry function
+ * `test_pipe_write_then_read`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_pipe_write_then_read()
 {
@@ -67,9 +71,11 @@ void test_pipe_write_then_read()
 }
 
 /**
- * @brief 测试入口函数 `test_pipe_chunked_rw`。 Test entry function `test_pipe_chunked_rw`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_pipe_chunked_rw`。 Test entry function
+ * `test_pipe_chunked_rw`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_pipe_chunked_rw()
 {
@@ -104,9 +110,11 @@ void test_pipe_chunked_rw()
 }
 
 /**
- * @brief 测试入口函数 `test_pipe_stream_api`。 Test entry function `test_pipe_stream_api`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_pipe_stream_api`。 Test entry function
+ * `test_pipe_stream_api`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_pipe_stream_api()
 {
@@ -140,8 +148,11 @@ void test_pipe_stream_api()
 
 /**
  * @brief 测试项函数 `RunBasePipeBasicTests`。 Test-item function `RunBasePipeBasicTests`.
- * @details 测试内容：执行当前分组里的 `rw`/`pipe` 子场景。 Execute the grouped `rw`/`pipe` sub-scenarios for this split file.
- *          测试原理：把同类状态机场景收在一组，降低单文件体积并保留聚合入口。 Group related state-machine scenarios together to shrink file size while preserving aggregated entrypoints.
+ * @details 测试内容：执行当前分组里的 `rw`/`pipe` 子场景。 Execute the grouped
+ * `rw`/`pipe` sub-scenarios for this split file.
+ *          测试原理：把同类状态机场景收在一组，降低单文件体积并保留聚合入口。 Group
+ * related state-machine scenarios together to shrink file size while preserving
+ * aggregated entrypoints.
  */
 void RunBasePipeBasicTests()
 {

--- a/test/base/rw/test_pipe_stream.cpp
+++ b/test/base/rw/test_pipe_stream.cpp
@@ -1,13 +1,16 @@
 /**
  * @file test_pipe_stream.cpp
- * @brief base `Pipe` stream 语义场景子测试。 Split test unit for base `Pipe` stream semantics.
+ * @brief base `Pipe` stream 语义场景子测试。 Split test unit for base `Pipe` stream
+ * semantics.
  */
 #include "rw_test_common.hpp"
 
 /**
- * @brief 测试入口函数 `test_pipe_stream_block_immediate_path`。 Test entry function `test_pipe_stream_block_immediate_path`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_pipe_stream_block_immediate_path`。 Test entry function
+ * `test_pipe_stream_block_immediate_path`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_pipe_stream_block_immediate_path()
 {
@@ -40,9 +43,11 @@ void test_pipe_stream_block_immediate_path()
 }
 
 /**
- * @brief 测试入口函数 `test_pipe_stream_commit_releases_lock_for_next_stream`。 Test entry function `test_pipe_stream_commit_releases_lock_for_next_stream`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_pipe_stream_commit_releases_lock_for_next_stream`。 Test
+ * entry function `test_pipe_stream_commit_releases_lock_for_next_stream`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_pipe_stream_commit_releases_lock_for_next_stream()
 {
@@ -77,9 +82,11 @@ void test_pipe_stream_commit_releases_lock_for_next_stream()
 }
 
 /**
- * @brief 测试入口函数 `test_pipe_stream_commit_allows_persistent_and_external_streams`。 Test entry function `test_pipe_stream_commit_allows_persistent_and_external_streams`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_pipe_stream_commit_allows_persistent_and_external_streams`。
+ * Test entry function `test_pipe_stream_commit_allows_persistent_and_external_streams`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_pipe_stream_commit_allows_persistent_and_external_streams()
 {
@@ -118,9 +125,13 @@ void test_pipe_stream_commit_allows_persistent_and_external_streams()
 }
 
 /**
- * @brief 测试项函数 `RunBasePipeStreamTests`。 Test-item function `RunBasePipeStreamTests`.
- * @details 测试内容：执行当前分组里的 `rw`/`pipe` 子场景。 Execute the grouped `rw`/`pipe` sub-scenarios for this split file.
- *          测试原理：把同类状态机场景收在一组，降低单文件体积并保留聚合入口。 Group related state-machine scenarios together to shrink file size while preserving aggregated entrypoints.
+ * @brief 测试项函数 `RunBasePipeStreamTests`。 Test-item function
+ * `RunBasePipeStreamTests`.
+ * @details 测试内容：执行当前分组里的 `rw`/`pipe` 子场景。 Execute the grouped
+ * `rw`/`pipe` sub-scenarios for this split file.
+ *          测试原理：把同类状态机场景收在一组，降低单文件体积并保留聚合入口。 Group
+ * related state-machine scenarios together to shrink file size while preserving
+ * aggregated entrypoints.
  */
 void RunBasePipeStreamTests()
 {

--- a/test/base/rw/test_pipe_stress.cpp
+++ b/test/base/rw/test_pipe_stress.cpp
@@ -1,13 +1,16 @@
 /**
  * @file test_pipe_stress.cpp
- * @brief base `Pipe` 压力与模式场景子测试。 Split test unit for base `Pipe` stress and mode scenarios.
+ * @brief base `Pipe` 压力与模式场景子测试。 Split test unit for base `Pipe` stress and
+ * mode scenarios.
  */
 #include "rw_test_common.hpp"
 
 /**
- * @brief 测试入口函数 `test_pipe_mode_matrix`。 Test entry function `test_pipe_mode_matrix`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_pipe_mode_matrix`。 Test entry function
+ * `test_pipe_mode_matrix`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_pipe_mode_matrix()
 {
@@ -26,9 +29,11 @@ void test_pipe_mode_matrix()
 }
 
 /**
- * @brief 测试入口函数 `test_pipe_reuse_stress`。 Test entry function `test_pipe_reuse_stress`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_pipe_reuse_stress`。 Test entry function
+ * `test_pipe_reuse_stress`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_pipe_reuse_stress()
 {
@@ -75,9 +80,11 @@ void test_pipe_reuse_stress()
 }
 
 /**
- * @brief 测试入口函数 `test_pipe_block_reuse_stress`。 Test entry function `test_pipe_block_reuse_stress`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_pipe_block_reuse_stress`。 Test entry function
+ * `test_pipe_block_reuse_stress`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_pipe_block_reuse_stress()
 {
@@ -129,9 +136,11 @@ void test_pipe_block_reuse_stress()
 }
 
 /**
- * @brief 测试入口函数 `test_pipe_edge_cases`。 Test entry function `test_pipe_edge_cases`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_pipe_edge_cases`。 Test entry function
+ * `test_pipe_edge_cases`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_pipe_edge_cases()
 {
@@ -148,9 +157,13 @@ void test_pipe_edge_cases()
 }
 
 /**
- * @brief 测试项函数 `RunBasePipeStressTests`。 Test-item function `RunBasePipeStressTests`.
- * @details 测试内容：执行当前分组里的 `rw`/`pipe` 子场景。 Execute the grouped `rw`/`pipe` sub-scenarios for this split file.
- *          测试原理：把同类状态机场景收在一组，降低单文件体积并保留聚合入口。 Group related state-machine scenarios together to shrink file size while preserving aggregated entrypoints.
+ * @brief 测试项函数 `RunBasePipeStressTests`。 Test-item function
+ * `RunBasePipeStressTests`.
+ * @details 测试内容：执行当前分组里的 `rw`/`pipe` 子场景。 Execute the grouped
+ * `rw`/`pipe` sub-scenarios for this split file.
+ *          测试原理：把同类状态机场景收在一组，降低单文件体积并保留聚合入口。 Group
+ * related state-machine scenarios together to shrink file size while preserving
+ * aggregated entrypoints.
  */
 void RunBasePipeStressTests()
 {

--- a/test/base/rw/test_rw_block.cpp
+++ b/test/base/rw/test_rw_block.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_rw_block.cpp
- * @brief base `rw` 阻塞/超时场景聚合入口。 Aggregation entry for split base `rw` blocking/timeout scenarios.
+ * @brief base `rw` 阻塞/超时场景聚合入口。 Aggregation entry for split base `rw`
+ * blocking/timeout scenarios.
  * @details 测试项目：
  *          1. 聚合阻塞 `Stream` 子场景。
  *          2. 聚合超时与立即错误子场景。
@@ -18,8 +19,10 @@ void RunBaseRwBlockWaiterTests();
 
 /**
  * @brief 测试项函数 `RunBaseRwBlockTests`。 Test-item function `RunBaseRwBlockTests`.
- * @details 测试内容：执行拆分后的 base `rw` 阻塞/超时子场景。 Execute the split base `rw` blocking/timeout sub-scenarios.
- *          测试原理：保留原有聚合入口，同时让具体场景落到更小的主题文件里。 Preserve the original aggregation entry while moving concrete scenarios into smaller themed files.
+ * @details 测试内容：执行拆分后的 base `rw` 阻塞/超时子场景。 Execute the split base `rw`
+ * blocking/timeout sub-scenarios.
+ *          测试原理：保留原有聚合入口，同时让具体场景落到更小的主题文件里。 Preserve the
+ * original aggregation entry while moving concrete scenarios into smaller themed files.
  */
 void RunBaseRwBlockTests()
 {

--- a/test/base/rw/test_rw_block_stream.cpp
+++ b/test/base/rw/test_rw_block_stream.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_rw_block_stream.cpp
- * @brief base `rw` 阻塞 `Stream` 场景子测试。 Split test unit for base blocking `Stream` scenarios.
+ * @brief base `rw` 阻塞 `Stream` 场景子测试。 Split test unit for base blocking `Stream`
+ * scenarios.
  * @details 测试项目：
  *          1. `Stream::Commit` 在挂起完成后会回传最终失败码。
  *          2. `Stream` 超时后会解除等待者，后续完成信号不会残留。
@@ -16,39 +17,48 @@ namespace
 {
 
 /**
- * @brief 测试入口函数 `test_rw_stream_block_pending_result_propagates`。 Test entry function `test_rw_stream_block_pending_result_propagates`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_stream_block_pending_result_propagates`。 Test entry
+ * function `test_rw_stream_block_pending_result_propagates`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_stream_block_pending_result_propagates()
 {
   // 测试内容：阻塞 `Commit` 应把异步完成阶段给出的最终错误码原样返回。
-  // Test coverage: blocking `Commit` should return the exact final error produced by the asynchronous completion path.
+  // Test coverage: blocking `Commit` should return the exact final error produced by the
+  // asynchronous completion path.
   VerifyStreamBlockPendingCompletion(LibXR::ErrorCode::FAILED, LibXR::ErrorCode::FAILED,
                                      StreamSubmitMode::COMMIT);
 }
 
 /**
- * @brief 测试入口函数 `test_rw_stream_block_timeout_detaches_waiter`。 Test entry function `test_rw_stream_block_timeout_detaches_waiter`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_stream_block_timeout_detaches_waiter`。 Test entry
+ * function `test_rw_stream_block_timeout_detaches_waiter`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_stream_block_timeout_detaches_waiter()
 {
   // 测试内容：超时返回后，旧等待者不应留下额外信号或 busy 状态。
-  // Test coverage: after a timeout, the old waiter must not leave extra signals or busy state behind.
+  // Test coverage: after a timeout, the old waiter must not leave extra signals or busy
+  // state behind.
   VerifyStreamBlockTimeout();
 }
 
 /**
- * @brief 测试入口函数 `test_rw_stream_block_destructor_autocommit`。 Test entry function `test_rw_stream_block_destructor_autocommit`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_stream_block_destructor_autocommit`。 Test entry function
+ * `test_rw_stream_block_destructor_autocommit`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_stream_block_destructor_autocommit()
 {
   // 测试内容：析构自动提交也应等待挂起完成并回到空闲态。
-  // Test coverage: destructor auto-commit should also wait for pending completion and return to idle.
+  // Test coverage: destructor auto-commit should also wait for pending completion and
+  // return to idle.
   VerifyStreamBlockPendingCompletion(LibXR::ErrorCode::OK, LibXR::ErrorCode::OK,
                                      StreamSubmitMode::DESTRUCT);
 }
@@ -56,9 +66,12 @@ void test_rw_stream_block_destructor_autocommit()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunBaseRwBlockStreamTests`。 Test-item function `RunBaseRwBlockStreamTests`.
- * @details 测试内容：执行 base `rw` 阻塞 `Stream` 子场景。 Execute base blocking `Stream` sub-scenarios.
- *          测试原理：把 `Stream` 的阻塞提交路径单独成组，避免和普通端口等待者路径混排。 Group blocking `Stream` submission paths separately from ordinary port waiter paths.
+ * @brief 测试项函数 `RunBaseRwBlockStreamTests`。 Test-item function
+ * `RunBaseRwBlockStreamTests`.
+ * @details 测试内容：执行 base `rw` 阻塞 `Stream` 子场景。 Execute base blocking `Stream`
+ * sub-scenarios. 测试原理：把 `Stream`
+ * 的阻塞提交路径单独成组，避免和普通端口等待者路径混排。 Group blocking `Stream`
+ * submission paths separately from ordinary port waiter paths.
  */
 void RunBaseRwBlockStreamTests()
 {

--- a/test/base/rw/test_rw_block_timeout.cpp
+++ b/test/base/rw/test_rw_block_timeout.cpp
@@ -1,14 +1,18 @@
 /**
  * @file test_rw_block_timeout.cpp
- * @brief base `rw` 超时与立即错误场景子测试。 Split test unit for base `rw` timeout and immediate-error scenarios.
+ * @brief base `rw` 超时与立即错误场景子测试。 Split test unit for base `rw` timeout and
+ * immediate-error scenarios.
  * @details 测试项目：
  *          1. 阻塞读超时后会解除挂起关系，后续补进的数据不会污染旧缓冲区。
  *          2. 阻塞写超时后会解除等待者，后续再次提交仍按新的等待周期工作。
  *          3. 立即失败的读写回调会在各模式下直接透传错误并复位状态机。
  *          Test items:
- *          1. A blocking read timeout detaches the pending relation and later bytes do not corrupt the stale buffer.
- *          2. A blocking write timeout detaches the waiter and later submissions start a fresh wait cycle.
- *          3. Immediate read/write failures propagate the error directly and reset the state machine in every mode.
+ *          1. A blocking read timeout detaches the pending relation and later bytes do
+ * not corrupt the stale buffer.
+ *          2. A blocking write timeout detaches the waiter and later submissions start a
+ * fresh wait cycle.
+ *          3. Immediate read/write failures propagate the error directly and reset the
+ * state machine in every mode.
  */
 #include "rw_test_common.hpp"
 
@@ -16,14 +20,17 @@ namespace
 {
 
 /**
- * @brief 测试入口函数 `test_rw_block_read_timeout_detaches_pending`。 Test entry function `test_rw_block_read_timeout_detaches_pending`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_block_read_timeout_detaches_pending`。 Test entry function
+ * `test_rw_block_read_timeout_detaches_pending`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_block_read_timeout_detaches_pending()
 {
   // 测试内容：阻塞读超时后，旧缓冲区和信号量状态都不应被后续补数据污染。
-  // Test coverage: later queued bytes must not corrupt the stale buffer or semaphore state after a blocking read timeout.
+  // Test coverage: later queued bytes must not corrupt the stale buffer or semaphore
+  // state after a blocking read timeout.
   using namespace LibXR;
 
   Pipe pipe(64);
@@ -57,14 +64,17 @@ void test_rw_block_read_timeout_detaches_pending()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_block_write_timeout_detaches_waiter`。 Test entry function `test_rw_block_write_timeout_detaches_waiter`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_block_write_timeout_detaches_waiter`。 Test entry function
+ * `test_rw_block_write_timeout_detaches_waiter`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_block_write_timeout_detaches_waiter()
 {
   // 测试内容：阻塞写超时后，旧等待者不应阻止下一个等待周期重新建立。
-  // Test coverage: a timed-out blocking write waiter should not prevent the next wait cycle from being established.
+  // Test coverage: a timed-out blocking write waiter should not prevent the next wait
+  // cycle from being established.
   using namespace LibXR;
 
   WritePort w(2, 64);
@@ -96,14 +106,17 @@ void test_rw_block_write_timeout_detaches_waiter()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_immediate_error_propagates`。 Test entry function `test_rw_immediate_error_propagates`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_immediate_error_propagates`。 Test entry function
+ * `test_rw_immediate_error_propagates`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_immediate_error_propagates()
 {
   // 测试内容：立即失败路径应在每种模式下直接返回错误，且端口状态恢复为空闲。
-  // Test coverage: immediate failure paths should return errors directly in every mode and restore idle port state.
+  // Test coverage: immediate failure paths should return errors directly in every mode
+  // and restore idle port state.
   using namespace LibXR;
 
   for (auto mode : LibXRTest::ALL_MODES)
@@ -144,9 +157,12 @@ void test_rw_immediate_error_propagates()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunBaseRwBlockTimeoutTests`。 Test-item function `RunBaseRwBlockTimeoutTests`.
- * @details 测试内容：执行 base `rw` 超时与立即错误子场景。 Execute base `rw` timeout and immediate-error sub-scenarios.
- *          测试原理：把超时/立即失败路径单独成组，聚焦等待者解绑和错误透传契约。 Group timeout/immediate-failure paths around waiter-detach and error-propagation contracts.
+ * @brief 测试项函数 `RunBaseRwBlockTimeoutTests`。 Test-item function
+ * `RunBaseRwBlockTimeoutTests`.
+ * @details 测试内容：执行 base `rw` 超时与立即错误子场景。 Execute base `rw` timeout and
+ * immediate-error sub-scenarios.
+ *          测试原理：把超时/立即失败路径单独成组，聚焦等待者解绑和错误透传契约。 Group
+ * timeout/immediate-failure paths around waiter-detach and error-propagation contracts.
  */
 void RunBaseRwBlockTimeoutTests()
 {

--- a/test/base/rw/test_rw_block_waiter.cpp
+++ b/test/base/rw/test_rw_block_waiter.cpp
@@ -1,12 +1,14 @@
 /**
  * @file test_rw_block_waiter.cpp
- * @brief base `WritePort` 阻塞等待者场景子测试。 Split test unit for base `WritePort` blocking waiter scenarios.
+ * @brief base `WritePort` 阻塞等待者场景子测试。 Split test unit for base `WritePort`
+ * blocking waiter scenarios.
  * @details 测试项目：
  *          1. 阻塞写等待者在挂起完成后会收到最终失败码。
  *          2. 复用同一个阻塞信号量时，上一轮的陈旧信号不会污染下一轮等待。
  *          Test items:
  *          1. A blocking write waiter receives the final error after pending completion.
- *          2. Reusing the same blocking semaphore does not leak stale signals into the next wait cycle.
+ *          2. Reusing the same blocking semaphore does not leak stale signals into the
+ * next wait cycle.
  */
 #include "rw_test_common.hpp"
 
@@ -14,14 +16,17 @@ namespace
 {
 
 /**
- * @brief 测试入口函数 `test_rw_write_port_block_pending_result_propagates`。 Test entry function `test_rw_write_port_block_pending_result_propagates`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_write_port_block_pending_result_propagates`。 Test entry
+ * function `test_rw_write_port_block_pending_result_propagates`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_write_port_block_pending_result_propagates()
 {
   // 测试内容：阻塞写在完成线程返回失败时，应把该错误直接传给调用者。
-  // Test coverage: a blocking write should forward the exact failure returned by the completion thread.
+  // Test coverage: a blocking write should forward the exact failure returned by the
+  // completion thread.
   using namespace LibXR;
 
   WritePort w(2, 16);
@@ -41,14 +46,17 @@ void test_rw_write_port_block_pending_result_propagates()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_write_port_block_reused_waiter_discards_stale_signal`。 Test entry function `test_rw_write_port_block_reused_waiter_discards_stale_signal`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_write_port_block_reused_waiter_discards_stale_signal`。
+ * Test entry function `test_rw_write_port_block_reused_waiter_discards_stale_signal`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_write_port_block_reused_waiter_discards_stale_signal()
 {
   // 测试内容：复用同一阻塞等待者时，上一轮完成令牌必须被清干净，不能串到下一轮。
-  // Test coverage: reusing the same blocking waiter must drain the previous completion token before the next wait cycle.
+  // Test coverage: reusing the same blocking waiter must drain the previous completion
+  // token before the next wait cycle.
   using namespace LibXR;
 
   WritePort w(2, 16);
@@ -82,9 +90,13 @@ void test_rw_write_port_block_reused_waiter_discards_stale_signal()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunBaseRwBlockWaiterTests`。 Test-item function `RunBaseRwBlockWaiterTests`.
- * @details 测试内容：执行 base `WritePort` 阻塞等待者子场景。 Execute base `WritePort` blocking waiter sub-scenarios.
- *          测试原理：把阻塞等待者生命周期单独成组，集中验证最终错误透传和陈旧信号清理。 Group blocking waiter lifecycle checks around final-error propagation and stale-signal draining.
+ * @brief 测试项函数 `RunBaseRwBlockWaiterTests`。 Test-item function
+ * `RunBaseRwBlockWaiterTests`.
+ * @details 测试内容：执行 base `WritePort` 阻塞等待者子场景。 Execute base `WritePort`
+ * blocking waiter sub-scenarios.
+ *          测试原理：把阻塞等待者生命周期单独成组，集中验证最终错误透传和陈旧信号清理。
+ * Group blocking waiter lifecycle checks around final-error propagation and stale-signal
+ * draining.
  */
 void RunBaseRwBlockWaiterTests()
 {

--- a/test/base/rw/test_rw_fail_clear.cpp
+++ b/test/base/rw/test_rw_fail_clear.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_rw_fail_clear.cpp
- * @brief base `FailAndClearAll` 场景聚合入口。 Aggregation entry for split base `FailAndClearAll` scenarios.
+ * @brief base `FailAndClearAll` 场景聚合入口。 Aggregation entry for split base
+ * `FailAndClearAll` scenarios.
  * @details 测试项目：
  *          1. 聚合异步完成子场景。
  *          2. 聚合队列清理与 stream 锁保持子场景。
@@ -16,9 +17,13 @@ void RunBaseRwFailAndClearAsyncTests();
 void RunBaseRwFailAndClearStreamTests();
 
 /**
- * @brief 测试项函数 `RunBaseRwFailAndClearTests`。 Test-item function `RunBaseRwFailAndClearTests`.
- * @details 测试内容：执行拆分后的 base `FailAndClearAll` 子场景。 Execute the split base `FailAndClearAll` sub-scenarios.
- *          测试原理：保留原有聚合入口，同时把不同状态语义拆到更细的主题文件。 Preserve the original aggregation entry while moving different state semantics into smaller themed files.
+ * @brief 测试项函数 `RunBaseRwFailAndClearTests`。 Test-item function
+ * `RunBaseRwFailAndClearTests`.
+ * @details 测试内容：执行拆分后的 base `FailAndClearAll` 子场景。 Execute the split base
+ * `FailAndClearAll` sub-scenarios.
+ *          测试原理：保留原有聚合入口，同时把不同状态语义拆到更细的主题文件。 Preserve
+ * the original aggregation entry while moving different state semantics into smaller
+ * themed files.
  */
 void RunBaseRwFailAndClearTests()
 {

--- a/test/base/rw/test_rw_fail_clear_async.cpp
+++ b/test/base/rw/test_rw_fail_clear_async.cpp
@@ -1,12 +1,15 @@
 /**
  * @file test_rw_fail_clear_async.cpp
- * @brief base `FailAndClearAll` 异步完成场景子测试。 Split test unit for base `FailAndClearAll` asynchronous completion scenarios.
+ * @brief base `FailAndClearAll` 异步完成场景子测试。 Split test unit for base
+ * `FailAndClearAll` asynchronous completion scenarios.
  * @details 测试项目：
  *          1. `ReadPort::FailAndClearAll` 会完成异步挂起读并回传指定错误。
  *          2. `WritePort::FailAndClearAll` 会完成异步挂起写并回传指定错误。
  *          Test items:
- *          1. `ReadPort::FailAndClearAll` completes asynchronous pending reads with the requested error.
- *          2. `WritePort::FailAndClearAll` completes asynchronous pending writes with the requested error.
+ *          1. `ReadPort::FailAndClearAll` completes asynchronous pending reads with the
+ * requested error.
+ *          2. `WritePort::FailAndClearAll` completes asynchronous pending writes with the
+ * requested error.
  */
 #include "rw_test_common.hpp"
 
@@ -14,14 +17,17 @@ namespace
 {
 
 /**
- * @brief 测试入口函数 `test_rw_read_port_fail_and_clear_all_completes_async_pending`。 Test entry function `test_rw_read_port_fail_and_clear_all_completes_async_pending`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_read_port_fail_and_clear_all_completes_async_pending`。
+ * Test entry function `test_rw_read_port_fail_and_clear_all_completes_async_pending`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_read_port_fail_and_clear_all_completes_async_pending()
 {
   // 测试内容：所有异步模式下的挂起读都应收到 `INIT_ERR` 完成通知。
-  // Test coverage: every asynchronous mode should receive an `INIT_ERR` completion for pending reads.
+  // Test coverage: every asynchronous mode should receive an `INIT_ERR` completion for
+  // pending reads.
   for (auto mode : LibXRTest::ASYNC_MODES)
   {
     VerifyPendingReadFailAndClearMode(mode, LibXR::ErrorCode::INIT_ERR);
@@ -29,14 +35,17 @@ void test_rw_read_port_fail_and_clear_all_completes_async_pending()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_write_port_fail_and_clear_all_completes_async_pending`。 Test entry function `test_rw_write_port_fail_and_clear_all_completes_async_pending`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_write_port_fail_and_clear_all_completes_async_pending`。
+ * Test entry function `test_rw_write_port_fail_and_clear_all_completes_async_pending`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_write_port_fail_and_clear_all_completes_async_pending()
 {
   // 测试内容：所有异步模式下的挂起写都应收到 `INIT_ERR` 完成通知。
-  // Test coverage: every asynchronous mode should receive an `INIT_ERR` completion for pending writes.
+  // Test coverage: every asynchronous mode should receive an `INIT_ERR` completion for
+  // pending writes.
   for (auto mode : LibXRTest::ASYNC_MODES)
   {
     VerifyPendingWriteFailAndClearMode(mode, LibXR::ErrorCode::INIT_ERR);
@@ -46,9 +55,12 @@ void test_rw_write_port_fail_and_clear_all_completes_async_pending()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunBaseRwFailAndClearAsyncTests`。 Test-item function `RunBaseRwFailAndClearAsyncTests`.
- * @details 测试内容：执行 `FailAndClearAll` 异步完成子场景。 Execute `FailAndClearAll` asynchronous completion sub-scenarios.
- *          测试原理：把异步完成路径单独成组，减少和阻塞/stream 语义的耦合。 Group asynchronous completions separately from blocking and stream semantics.
+ * @brief 测试项函数 `RunBaseRwFailAndClearAsyncTests`。 Test-item function
+ * `RunBaseRwFailAndClearAsyncTests`.
+ * @details 测试内容：执行 `FailAndClearAll` 异步完成子场景。 Execute `FailAndClearAll`
+ * asynchronous completion sub-scenarios.
+ *          测试原理：把异步完成路径单独成组，减少和阻塞/stream 语义的耦合。 Group
+ * asynchronous completions separately from blocking and stream semantics.
  */
 void RunBaseRwFailAndClearAsyncTests()
 {

--- a/test/base/rw/test_rw_fail_clear_block.cpp
+++ b/test/base/rw/test_rw_fail_clear_block.cpp
@@ -1,12 +1,15 @@
 /**
  * @file test_rw_fail_clear_block.cpp
- * @brief base `FailAndClearAll` 阻塞等待者场景子测试。 Split test unit for base `FailAndClearAll` blocking-waiter scenarios.
+ * @brief base `FailAndClearAll` 阻塞等待者场景子测试。 Split test unit for base
+ * `FailAndClearAll` blocking-waiter scenarios.
  * @details 测试项目：
  *          1. 阻塞读等待者被 `FailAndClearAll` 唤醒后会收到失败结果，且旧缓冲区不被污染。
- *          2. 阻塞写等待者被 `FailAndClearAll` 唤醒后会收到失败结果，后续写入仍能恢复工作。
- *          Test items:
- *          1. A blocking read waiter is failed by `FailAndClearAll` without corrupting the stale buffer.
- *          2. A blocking write waiter is failed by `FailAndClearAll`, and later writes still recover normally.
+ *          2. 阻塞写等待者被 `FailAndClearAll`
+ * 唤醒后会收到失败结果，后续写入仍能恢复工作。 Test items:
+ *          1. A blocking read waiter is failed by `FailAndClearAll` without corrupting
+ * the stale buffer.
+ *          2. A blocking write waiter is failed by `FailAndClearAll`, and later writes
+ * still recover normally.
  */
 #include "rw_test_common.hpp"
 
@@ -14,14 +17,17 @@ namespace
 {
 
 /**
- * @brief 测试入口函数 `test_rw_read_port_fail_and_clear_all_fails_block_waiter`。 Test entry function `test_rw_read_port_fail_and_clear_all_fails_block_waiter`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_read_port_fail_and_clear_all_fails_block_waiter`。 Test
+ * entry function `test_rw_read_port_fail_and_clear_all_fails_block_waiter`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_read_port_fail_and_clear_all_fails_block_waiter()
 {
   // 测试内容：阻塞读被失败清理打断后，应保持旧缓冲区不变并允许后续继续读取。
-  // Test coverage: a blocking read interrupted by fail-clear should keep the stale buffer intact and allow later reads.
+  // Test coverage: a blocking read interrupted by fail-clear should keep the stale buffer
+  // intact and allow later reads.
   using namespace LibXR;
 
   ReadPort r(16);
@@ -58,14 +64,17 @@ void test_rw_read_port_fail_and_clear_all_fails_block_waiter()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_write_port_fail_and_clear_all_fails_block_waiter`。 Test entry function `test_rw_write_port_fail_and_clear_all_fails_block_waiter`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_write_port_fail_and_clear_all_fails_block_waiter`。 Test
+ * entry function `test_rw_write_port_fail_and_clear_all_fails_block_waiter`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_write_port_fail_and_clear_all_fails_block_waiter()
 {
   // 测试内容：阻塞写被失败清理打断后，应释放端口并允许新的写请求重新进入。
-  // Test coverage: a blocking write interrupted by fail-clear should release the port and allow a new write to enter.
+  // Test coverage: a blocking write interrupted by fail-clear should release the port and
+  // allow a new write to enter.
   using namespace LibXR;
 
   WritePort w(2, 16);
@@ -108,9 +117,13 @@ void test_rw_write_port_fail_and_clear_all_fails_block_waiter()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunBaseRwFailAndClearBlockTests`。 Test-item function `RunBaseRwFailAndClearBlockTests`.
- * @details 测试内容：执行 `FailAndClearAll` 阻塞等待者子场景。 Execute `FailAndClearAll` blocking-waiter sub-scenarios.
- *          测试原理：把阻塞等待者语义单独成组，避免和异步完成、stream 锁状态互相缠绕。 Group blocking-waiter semantics away from asynchronous completions and stream-lock semantics.
+ * @brief 测试项函数 `RunBaseRwFailAndClearBlockTests`。 Test-item function
+ * `RunBaseRwFailAndClearBlockTests`.
+ * @details 测试内容：执行 `FailAndClearAll` 阻塞等待者子场景。 Execute `FailAndClearAll`
+ * blocking-waiter sub-scenarios.
+ *          测试原理：把阻塞等待者语义单独成组，避免和异步完成、stream 锁状态互相缠绕。
+ * Group blocking-waiter semantics away from asynchronous completions and stream-lock
+ * semantics.
  */
 void RunBaseRwFailAndClearBlockTests()
 {

--- a/test/base/rw/test_rw_fail_clear_stream.cpp
+++ b/test/base/rw/test_rw_fail_clear_stream.cpp
@@ -1,12 +1,14 @@
 /**
  * @file test_rw_fail_clear_stream.cpp
- * @brief base `FailAndClearAll` 队列清理与 stream 锁场景子测试。 Split test unit for base `FailAndClearAll` queue-cleanup and stream-lock scenarios.
+ * @brief base `FailAndClearAll` 队列清理与 stream 锁场景子测试。 Split test unit for base
+ * `FailAndClearAll` queue-cleanup and stream-lock scenarios.
  * @details 测试项目：
  *          1. 空闲写口上的 `FailAndClearAll` 会清空残留队列数据和 info block。
- *          2. 活跃 `Stream` 持锁期间调用 `FailAndClearAll` 不会错误解锁，提交后仍能按原数据落队。
- *          Test items:
+ *          2. 活跃 `Stream` 持锁期间调用 `FailAndClearAll`
+ * 不会错误解锁，提交后仍能按原数据落队。 Test items:
  *          1. `FailAndClearAll` clears queued data and info blocks on an idle write port.
- *          2. `FailAndClearAll` does not unlock an active `Stream`; commit still flushes the original payload.
+ *          2. `FailAndClearAll` does not unlock an active `Stream`; commit still flushes
+ * the original payload.
  */
 #include "rw_test_common.hpp"
 
@@ -14,14 +16,17 @@ namespace
 {
 
 /**
- * @brief 测试入口函数 `test_rw_write_port_fail_and_clear_all_clears_idle_queue`。 Test entry function `test_rw_write_port_fail_and_clear_all_clears_idle_queue`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_write_port_fail_and_clear_all_clears_idle_queue`。 Test
+ * entry function `test_rw_write_port_fail_and_clear_all_clears_idle_queue`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_write_port_fail_and_clear_all_clears_idle_queue()
 {
   // 测试内容：空闲写口的残留队列应在失败清理后被完整清空。
-  // Test coverage: residual queued bytes on an idle write port should be fully cleared by fail-clear.
+  // Test coverage: residual queued bytes on an idle write port should be fully cleared by
+  // fail-clear.
   using namespace LibXR;
 
   WritePort w(2, 16);
@@ -42,14 +47,18 @@ void test_rw_write_port_fail_and_clear_all_clears_idle_queue()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_write_port_fail_and_clear_all_does_not_unlock_active_stream`。 Test entry function `test_rw_write_port_fail_and_clear_all_does_not_unlock_active_stream`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数
+ * `test_rw_write_port_fail_and_clear_all_does_not_unlock_active_stream`。 Test entry
+ * function `test_rw_write_port_fail_and_clear_all_does_not_unlock_active_stream`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_write_port_fail_and_clear_all_does_not_unlock_active_stream()
 {
   // 测试内容：活跃 stream 持锁期间的失败清理不能把写口提前释放给其他请求。
-  // Test coverage: fail-clear during an active stream lock must not release the write port early to other requests.
+  // Test coverage: fail-clear during an active stream lock must not release the write
+  // port early to other requests.
   using namespace LibXR;
 
   WritePort w(2, 16);
@@ -90,9 +99,13 @@ void test_rw_write_port_fail_and_clear_all_does_not_unlock_active_stream()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunBaseRwFailAndClearStreamTests`。 Test-item function `RunBaseRwFailAndClearStreamTests`.
- * @details 测试内容：执行 `FailAndClearAll` 队列清理与 stream 锁子场景。 Execute `FailAndClearAll` queue-cleanup and stream-lock sub-scenarios.
- *          测试原理：把“空闲清理”和“活跃 stream 锁保持”放在同组，聚焦写口内部状态约束。 Group idle cleanup and active stream-lock preservation around write-port state constraints.
+ * @brief 测试项函数 `RunBaseRwFailAndClearStreamTests`。 Test-item function
+ * `RunBaseRwFailAndClearStreamTests`.
+ * @details 测试内容：执行 `FailAndClearAll` 队列清理与 stream 锁子场景。 Execute
+ * `FailAndClearAll` queue-cleanup and stream-lock sub-scenarios.
+ *          测试原理：把“空闲清理”和“活跃 stream 锁保持”放在同组，聚焦写口内部状态约束。
+ * Group idle cleanup and active stream-lock preservation around write-port state
+ * constraints.
  */
 void RunBaseRwFailAndClearStreamTests()
 {

--- a/test/base/rw/test_rw_pending.cpp
+++ b/test/base/rw/test_rw_pending.cpp
@@ -1,13 +1,16 @@
 /**
  * @file test_rw_pending.cpp
- * @brief base `rw` pending mode 与边界场景子测试。 Split test unit for base `rw` pending-mode and edge scenarios.
+ * @brief base `rw` pending mode 与边界场景子测试。 Split test unit for base `rw`
+ * pending-mode and edge scenarios.
  */
 #include "rw_test_common.hpp"
 
 /**
- * @brief 测试入口函数 `test_rw_pending_mode_matrix`。 Test entry function `test_rw_pending_mode_matrix`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_pending_mode_matrix`。 Test entry function
+ * `test_rw_pending_mode_matrix`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_pending_mode_matrix()
 {
@@ -22,8 +25,9 @@ void test_rw_pending_mode_matrix()
 
 /**
  * @brief 测试入口函数 `test_rw_edge_cases`。 Test entry function `test_rw_edge_cases`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_edge_cases()
 {
@@ -56,8 +60,11 @@ void test_rw_edge_cases()
 
 /**
  * @brief 测试项函数 `RunBaseRwPendingTests`。 Test-item function `RunBaseRwPendingTests`.
- * @details 测试内容：执行当前分组里的 `rw`/`pipe` 子场景。 Execute the grouped `rw`/`pipe` sub-scenarios for this split file.
- *          测试原理：把同类状态机场景收在一组，降低单文件体积并保留聚合入口。 Group related state-machine scenarios together to shrink file size while preserving aggregated entrypoints.
+ * @details 测试内容：执行当前分组里的 `rw`/`pipe` 子场景。 Execute the grouped
+ * `rw`/`pipe` sub-scenarios for this split file.
+ *          测试原理：把同类状态机场景收在一组，降低单文件体积并保留聚合入口。 Group
+ * related state-machine scenarios together to shrink file size while preserving
+ * aggregated entrypoints.
  */
 void RunBaseRwPendingTests()
 {

--- a/test/base/rw/test_rw_pipe.cpp
+++ b/test/base/rw/test_rw_pipe.cpp
@@ -1,13 +1,17 @@
 /**
  * @file test_rw_pipe.cpp
- * @brief base `rw` / `pipe` 测试聚合入口。 Aggregation entry for split base `rw` / `pipe` tests.
+ * @brief base `rw` / `pipe` 测试聚合入口。 Aggregation entry for split base `rw` / `pipe`
+ * tests.
  */
 #include "rw_test_common.hpp"
 
 /**
  * @brief 测试入口函数 `test_rw`。 Test entry function `test_rw`.
- * @details 测试内容：聚合执行拆分后的 base `rw` 裸机可跑子测试组。 Aggregate and execute the split base `rw` subtest groups that can run on the bare-metal backend.
- *          测试原理：把纯端口状态机验证留在 base 入口，阻塞等待者和后台补齐场景交给 runtime 入口。 Keep pure port-state-machine verification in the base entry and leave blocking-waiter/background-completion scenarios to the runtime entry.
+ * @details 测试内容：聚合执行拆分后的 base `rw` 裸机可跑子测试组。 Aggregate and execute
+ * the split base `rw` subtest groups that can run on the bare-metal backend.
+ *          测试原理：把纯端口状态机验证留在 base 入口，阻塞等待者和后台补齐场景交给
+ * runtime 入口。 Keep pure port-state-machine verification in the base entry and leave
+ * blocking-waiter/background-completion scenarios to the runtime entry.
  */
 void test_rw()
 {
@@ -18,8 +22,11 @@ void test_rw()
 
 /**
  * @brief 测试入口函数 `test_pipe`。 Test entry function `test_pipe`.
- * @details 测试内容：聚合执行拆分后的 base `Pipe` 子测试组。 Aggregate and execute the split base `Pipe` subtest groups.
- *          测试原理：把基础传输、stream 语义和压力场景拆分后，继续通过单入口提供给现有 harness。 Keep the existing harness contract after splitting basic transport, stream semantics, and stress scenarios into separate files.
+ * @details 测试内容：聚合执行拆分后的 base `Pipe` 子测试组。 Aggregate and execute the
+ * split base `Pipe` subtest groups. 测试原理：把基础传输、stream
+ * 语义和压力场景拆分后，继续通过单入口提供给现有 harness。 Keep the existing harness
+ * contract after splitting basic transport, stream semantics, and stress scenarios into
+ * separate files.
  */
 void test_pipe()
 {

--- a/test/base/rw/test_rw_read_queue.cpp
+++ b/test/base/rw/test_rw_read_queue.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_rw_read_queue.cpp
- * @brief base `ReadPort` 读队列场景聚合入口。 Aggregation entry for split base `ReadPort` queue scenarios.
+ * @brief base `ReadPort` 读队列场景聚合入口。 Aggregation entry for split base `ReadPort`
+ * queue scenarios.
  * @details 测试项目：
  *          1. 聚合 `ClearQueuedData` 子场景。
  *          2. 挂起完成与零长度读子场景由 runtime `rw` 入口覆盖。
@@ -13,11 +14,11 @@
 void RunBaseRwReadQueueClearTests();
 
 /**
- * @brief 测试项函数 `RunBaseRwReadQueueTests`。 Test-item function `RunBaseRwReadQueueTests`.
- * @details 测试内容：执行拆分后的 base `ReadPort` 读队列子场景。 Execute the split base `ReadPort` queue sub-scenarios.
- *          测试原理：保留原有分组入口，同时把具体场景拆到更细的主题文件。 Preserve the original group entrypoint while moving concrete scenarios into smaller themed files.
+ * @brief 测试项函数 `RunBaseRwReadQueueTests`。 Test-item function
+ * `RunBaseRwReadQueueTests`.
+ * @details 测试内容：执行拆分后的 base `ReadPort` 读队列子场景。 Execute the split base
+ * `ReadPort` queue sub-scenarios.
+ *          测试原理：保留原有分组入口，同时把具体场景拆到更细的主题文件。 Preserve the
+ * original group entrypoint while moving concrete scenarios into smaller themed files.
  */
-void RunBaseRwReadQueueTests()
-{
-  RunBaseRwReadQueueClearTests();
-}
+void RunBaseRwReadQueueTests() { RunBaseRwReadQueueClearTests(); }

--- a/test/base/rw/test_rw_read_queue_clear.cpp
+++ b/test/base/rw/test_rw_read_queue_clear.cpp
@@ -1,14 +1,17 @@
 /**
  * @file test_rw_read_queue_clear.cpp
- * @brief base `ReadPort::ClearQueuedData` 场景子测试。 Split test unit for base `ReadPort::ClearQueuedData` scenarios.
+ * @brief base `ReadPort::ClearQueuedData` 场景子测试。 Split test unit for base
+ * `ReadPort::ClearQueuedData` scenarios.
  * @details 测试项目：
  *          1. 空闲队列上的 `ClearQueuedData` 会吃掉已有数据并复位 busy 状态。
  *          2. `EVENT` 状态下的 `ClearQueuedData` 仍会清空事件队列并记录一次 dequeue。
- *          3. 读等待挂起期间调用 `ClearQueuedData` 会返回 `BUSY`，不会偷吃尚未交付的数据。
- *          Test items:
+ *          3. 读等待挂起期间调用 `ClearQueuedData` 会返回
+ * `BUSY`，不会偷吃尚未交付的数据。 Test items:
  *          1. `ClearQueuedData` consumes queued bytes and resets busy state while idle.
- *          2. `ClearQueuedData` still drains event-mode queue contents and records one dequeue.
- *          3. `ClearQueuedData` returns `BUSY` during pending reads and leaves unread bytes intact.
+ *          2. `ClearQueuedData` still drains event-mode queue contents and records one
+ * dequeue.
+ *          3. `ClearQueuedData` returns `BUSY` during pending reads and leaves unread
+ * bytes intact.
  */
 #include "rw_test_common.hpp"
 
@@ -16,14 +19,17 @@ namespace
 {
 
 /**
- * @brief 测试入口函数 `test_rw_read_port_clear_queued_data_clears_idle_queue`。 Test entry function `test_rw_read_port_clear_queued_data_clears_idle_queue`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_read_port_clear_queued_data_clears_idle_queue`。 Test
+ * entry function `test_rw_read_port_clear_queued_data_clears_idle_queue`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_read_port_clear_queued_data_clears_idle_queue()
 {
   // 测试内容：空闲读口在清空队列后应回到 `IDLE`，并递增一次 dequeue 计数。
-  // Test coverage: an idle read port should return to `IDLE` and record one dequeue after clearing.
+  // Test coverage: an idle read port should return to `IDLE` and record one dequeue after
+  // clearing.
   using namespace LibXR;
 
   TrackingReadPort r(16);
@@ -39,14 +45,17 @@ void test_rw_read_port_clear_queued_data_clears_idle_queue()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_read_port_clear_queued_data_clears_event_queue`。 Test entry function `test_rw_read_port_clear_queued_data_clears_event_queue`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_read_port_clear_queued_data_clears_event_queue`。 Test
+ * entry function `test_rw_read_port_clear_queued_data_clears_event_queue`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_read_port_clear_queued_data_clears_event_queue()
 {
   // 测试内容：事件态下清空动作应同时吞掉待读字节并结束一次事件通知。
-  // Test coverage: clearing in event state should consume queued bytes and finish one event notification.
+  // Test coverage: clearing in event state should consume queued bytes and finish one
+  // event notification.
   using namespace LibXR;
 
   TrackingReadPort r(16);
@@ -64,14 +73,17 @@ void test_rw_read_port_clear_queued_data_clears_event_queue()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_read_port_clear_queued_data_busy_pending_read`。 Test entry function `test_rw_read_port_clear_queued_data_busy_pending_read`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_read_port_clear_queued_data_busy_pending_read`。 Test
+ * entry function `test_rw_read_port_clear_queued_data_busy_pending_read`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_read_port_clear_queued_data_busy_pending_read()
 {
   // 测试内容：挂起读请求期间清空操作必须拒绝，并保留尚未送达的数据。
-  // Test coverage: clearing during a pending read must be rejected and preserve unread bytes.
+  // Test coverage: clearing during a pending read must be rejected and preserve unread
+  // bytes.
   using namespace LibXR;
 
   TrackingReadPort r(16);
@@ -97,9 +109,12 @@ void test_rw_read_port_clear_queued_data_busy_pending_read()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunBaseRwReadQueueClearTests`。 Test-item function `RunBaseRwReadQueueClearTests`.
- * @details 测试内容：执行 `ClearQueuedData` 相关子场景。 Execute `ClearQueuedData`-focused sub-scenarios.
- *          测试原理：把清队列语义单独聚合，避免与其他读完成路径混在一起。 Group clear-queue semantics separately from other read-completion paths.
+ * @brief 测试项函数 `RunBaseRwReadQueueClearTests`。 Test-item function
+ * `RunBaseRwReadQueueClearTests`.
+ * @details 测试内容：执行 `ClearQueuedData` 相关子场景。 Execute
+ * `ClearQueuedData`-focused sub-scenarios.
+ *          测试原理：把清队列语义单独聚合，避免与其他读完成路径混在一起。 Group
+ * clear-queue semantics separately from other read-completion paths.
  */
 void RunBaseRwReadQueueClearTests()
 {

--- a/test/base/rw/test_rw_read_queue_pending.cpp
+++ b/test/base/rw/test_rw_read_queue_pending.cpp
@@ -1,12 +1,15 @@
 /**
  * @file test_rw_read_queue_pending.cpp
- * @brief base `ReadPort` 队列完成与零长度读场景子测试。 Split test unit for base `ReadPort` queue-completion and zero-length read scenarios.
+ * @brief base `ReadPort` 队列完成与零长度读场景子测试。 Split test unit for base
+ * `ReadPort` queue-completion and zero-length read scenarios.
  * @details 测试项目：
  *          1. 零长度挂起读在完成时只发通知，不会偷读队列字节。
  *          2. 阻塞读在后台补齐队列数据后会把目标字节拷贝到用户缓冲区。
  *          Test items:
- *          1. A pending zero-length read only triggers completion and does not consume queued bytes.
- *          2. A blocking read copies bytes into the user buffer after queued data arrives asynchronously.
+ *          1. A pending zero-length read only triggers completion and does not consume
+ * queued bytes.
+ *          2. A blocking read copies bytes into the user buffer after queued data arrives
+ * asynchronously.
  */
 #include "rw_test_common.hpp"
 
@@ -14,14 +17,17 @@ namespace
 {
 
 /**
- * @brief 测试入口函数 `test_rw_zero_read_pending_notifies_without_dequeue`。 Test entry function `test_rw_zero_read_pending_notifies_without_dequeue`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_zero_read_pending_notifies_without_dequeue`。 Test entry
+ * function `test_rw_zero_read_pending_notifies_without_dequeue`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_zero_read_pending_notifies_without_dequeue()
 {
   // 测试内容：零长度挂起请求完成后，队列字节仍应保留给后续真实读取。
-  // Test coverage: queued bytes should remain available for a later real read after a zero-length pending completion.
+  // Test coverage: queued bytes should remain available for a later real read after a
+  // zero-length pending completion.
   using namespace LibXR;
 
   for (auto mode : LibXRTest::ALL_MODES)
@@ -62,14 +68,17 @@ void test_rw_zero_read_pending_notifies_without_dequeue()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_read_port_block_queue_completion_copies_data`。 Test entry function `test_rw_read_port_block_queue_completion_copies_data`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_read_port_block_queue_completion_copies_data`。 Test entry
+ * function `test_rw_read_port_block_queue_completion_copies_data`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_read_port_block_queue_completion_copies_data()
 {
   // 测试内容：阻塞读在异步补齐后应写回数据且不残留旧信号量状态。
-  // Test coverage: a blocking read should copy asynchronously supplied bytes and leave no stale semaphore state.
+  // Test coverage: a blocking read should copy asynchronously supplied bytes and leave no
+  // stale semaphore state.
   using namespace LibXR;
 
   ReadPort r(16);
@@ -94,9 +103,12 @@ void test_rw_read_port_block_queue_completion_copies_data()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunBaseRwReadQueuePendingTests`。 Test-item function `RunBaseRwReadQueuePendingTests`.
- * @details 测试内容：执行读队列完成与零长度请求子场景。 Execute queued-read completion and zero-length request sub-scenarios.
- *          测试原理：把“挂起后完成”的路径单独聚合，减少和清队列语义的耦合。 Group pending-completion paths separately from clear-queue semantics.
+ * @brief 测试项函数 `RunBaseRwReadQueuePendingTests`。 Test-item function
+ * `RunBaseRwReadQueuePendingTests`.
+ * @details 测试内容：执行读队列完成与零长度请求子场景。 Execute queued-read completion
+ * and zero-length request sub-scenarios.
+ *          测试原理：把“挂起后完成”的路径单独聚合，减少和清队列语义的耦合。 Group
+ * pending-completion paths separately from clear-queue semantics.
  */
 void RunBaseRwReadQueuePendingTests()
 {

--- a/test/base/string/string_test_common.hpp
+++ b/test/base/string/string_test_common.hpp
@@ -1,12 +1,14 @@
 /**
  * @file string_test_common.hpp
- * @brief 运行时字符串测试共用编译期约束与头文件。 Shared compile-time constraints and includes for runtime-string tests.
+ * @brief 运行时字符串测试共用编译期约束与头文件。 Shared compile-time constraints and
+ * includes for runtime-string tests.
  * @details 测试项目：
  *          1. 汇总运行时字符串测试所需头文件和类型工具。
  *          2. 固化 `Reformat` / `Reprintf` 接受类型的编译期约束。
  *          Test items:
  *          1. Gather the headers and type utilities used by runtime-string tests.
- *          2. Lock in the compile-time accepted-type constraints for `Reformat` / `Reprintf`.
+ *          2. Lock in the compile-time accepted-type constraints for `Reformat` /
+ * `Reprintf`.
  */
 #pragma once
 
@@ -22,17 +24,15 @@
 
 template <typename T>
 constexpr bool accepts_uint32_reformat =
-    requires(LibXR::RuntimeStringView<"stamp_{}", std::uint32_t>& view, T value)
-{
-  view.Reformat(value);
-};
+    requires(LibXR::RuntimeStringView<"stamp_{}", std::uint32_t>& view, T value) {
+      view.Reformat(value);
+    };
 
 template <typename T>
 constexpr bool accepts_uint_reprintf =
-    requires(LibXR::RuntimeStringView<"stamp_%u", unsigned int>& view, T value)
-{
-  view.Reprintf(value);
-};
+    requires(LibXR::RuntimeStringView<"stamp_%u", unsigned int>& view, T value) {
+      view.Reprintf(value);
+    };
 
 static_assert(accepts_uint32_reformat<std::uint32_t>);
 static_assert(!accepts_uint32_reformat<std::uint64_t>);

--- a/test/base/string/test_string.cpp
+++ b/test/base/string/test_string.cpp
@@ -18,8 +18,9 @@ void RunRuntimeStringFormatTests();
 
 /**
  * @brief 测试入口函数 `test_string`。 Test entry function `test_string`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_string()
 {

--- a/test/base/string/test_string_errors.cpp
+++ b/test/base/string/test_string_errors.cpp
@@ -1,12 +1,14 @@
 /**
  * @file test_string_errors.cpp
- * @brief 运行时字符串空指针错误路径子测试。 Split test unit for runtime-string null-pointer error paths.
+ * @brief 运行时字符串空指针错误路径子测试。 Split test unit for runtime-string
+ * null-pointer error paths.
  * @details 测试项目：
  *          1. 复制构造和后缀构造遇到空指针时返回 `PTR_NULL`。
  *          2. 错误对象退化为空字符串视图并保留安全的 `CStr()` 语义。
  *          Test items:
  *          1. Copy and suffix construction return `PTR_NULL` when given null pointers.
- *          2. Error objects collapse to empty string views while keeping safe `CStr()` semantics.
+ *          2. Error objects collapse to empty string views while keeping safe `CStr()`
+ * semantics.
  */
 #include "string_test_common.hpp"
 
@@ -14,14 +16,19 @@ namespace
 {
 
 /**
- * @brief 测试项函数 `TestRuntimeStringErrors`。 Test-item function `TestRuntimeStringErrors`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestRuntimeStringErrors`。 Test-item function
+ * `TestRuntimeStringErrors`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestRuntimeStringErrors()
 {
   // 测试内容：验证空指针输入的错误码、空视图和安全存储语义。
-  // Test coverage: verify error code, empty-view, and safe-storage semantics for null-pointer inputs.
+  // Test coverage: verify error code, empty-view, and safe-storage semantics for
+  // null-pointer inputs.
   LibXR::RuntimeStringView<> null_part("camera", static_cast<const char*>(nullptr));
   ASSERT(null_part.Empty());
   ASSERT(null_part.Status() == LibXR::ErrorCode::PTR_NULL);
@@ -48,11 +55,10 @@ void TestRuntimeStringErrors()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunRuntimeStringErrorTests`。 Test-item function `RunRuntimeStringErrorTests`.
- * @details 测试内容：执行运行时字符串错误路径子场景。 Execute runtime-string error-path sub-scenarios.
- *          测试原理：把错误路径单独成组，集中验证空指针输入的退化契约。 Group error paths around the null-pointer degradation contract.
+ * @brief 测试项函数 `RunRuntimeStringErrorTests`。 Test-item function
+ * `RunRuntimeStringErrorTests`.
+ * @details 测试内容：执行运行时字符串错误路径子场景。 Execute runtime-string error-path
+ * sub-scenarios. 测试原理：把错误路径单独成组，集中验证空指针输入的退化契约。 Group error
+ * paths around the null-pointer degradation contract.
  */
-void RunRuntimeStringErrorTests()
-{
-  TestRuntimeStringErrors();
-}
+void RunRuntimeStringErrorTests() { TestRuntimeStringErrors(); }

--- a/test/base/string/test_string_format.cpp
+++ b/test/base/string/test_string_format.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_string_format.cpp
- * @brief 运行时字符串重格式化场景子测试。 Split test unit for runtime-string reformat/reprintf scenarios.
+ * @brief 运行时字符串重格式化场景子测试。 Split test unit for runtime-string
+ * reformat/reprintf scenarios.
  * @details 测试项目：
  *          1. `Reformat` / `Reprintf` 生成预期文本。
  *          2. 多次重格式化复用同一块稳定存储。
@@ -8,7 +9,8 @@
  *          Test items:
  *          1. `Reformat` / `Reprintf` produce the expected text.
  *          2. Repeated formatting reuses the same stable storage buffer.
- *          3. Floating-point and integer representative values keep producing valid output.
+ *          3. Floating-point and integer representative values keep producing valid
+ * output.
  */
 #include "string_test_common.hpp"
 
@@ -16,14 +18,19 @@ namespace
 {
 
 /**
- * @brief 测试项函数 `TestRuntimeStringFormat`。 Test-item function `TestRuntimeStringFormat`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestRuntimeStringFormat`。 Test-item function
+ * `TestRuntimeStringFormat`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestRuntimeStringFormat()
 {
   // 测试内容：验证运行时格式化输出、稳定存储和边界值路径。
-  // Test coverage: verify runtime formatting output, stable storage reuse, and boundary-value paths.
+  // Test coverage: verify runtime formatting output, stable storage reuse, and
+  // boundary-value paths.
   LibXR::RuntimeStringView<"camera_{}", unsigned int> formatted;
   ASSERT(formatted.Reformat(7U) == LibXR::ErrorCode::OK);
   ASSERT(formatted.Status() == LibXR::ErrorCode::OK);
@@ -64,11 +71,11 @@ void TestRuntimeStringFormat()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunRuntimeStringFormatTests`。 Test-item function `RunRuntimeStringFormatTests`.
- * @details 测试内容：执行运行时字符串重格式化子场景。 Execute runtime-string reformat/reprintf sub-scenarios.
- *          测试原理：把格式化路径单独成组，聚焦文本生成与稳定存储契约。 Group formatting paths around text-generation and stable-storage contracts.
+ * @brief 测试项函数 `RunRuntimeStringFormatTests`。 Test-item function
+ * `RunRuntimeStringFormatTests`.
+ * @details 测试内容：执行运行时字符串重格式化子场景。 Execute runtime-string
+ * reformat/reprintf sub-scenarios.
+ *          测试原理：把格式化路径单独成组，聚焦文本生成与稳定存储契约。 Group formatting
+ * paths around text-generation and stable-storage contracts.
  */
-void RunRuntimeStringFormatTests()
-{
-  TestRuntimeStringFormat();
-}
+void RunRuntimeStringFormatTests() { TestRuntimeStringFormat(); }

--- a/test/base/string/test_string_text.cpp
+++ b/test/base/string/test_string_text.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_string_text.cpp
- * @brief 运行时字符串文本构造场景子测试。 Split test unit for runtime-string text construction scenarios.
+ * @brief 运行时字符串文本构造场景子测试。 Split test unit for runtime-string text
+ * construction scenarios.
  * @details 测试项目：
  *          1. 普通文本、定长数组和空字符串构造。
  *          2. 嵌入 NUL 输入与带后缀拼接构造。
@@ -15,13 +16,17 @@ namespace
 
 /**
  * @brief 测试项函数 `TestRuntimeStringText`。 Test-item function `TestRuntimeStringText`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestRuntimeStringText()
 {
   // 测试内容：验证不同文本来源都能保持预期视图和稳定存储。
-  // Test coverage: verify that different text sources preserve the expected view and stable storage.
+  // Test coverage: verify that different text sources preserve the expected view and
+  // stable storage.
   LibXR::RuntimeStringView<> copied("camera");
   ASSERT(copied.Status() == LibXR::ErrorCode::OK);
   ASSERT(!copied.Empty());
@@ -104,11 +109,11 @@ void TestRuntimeStringText()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunRuntimeStringTextTests`。 Test-item function `RunRuntimeStringTextTests`.
- * @details 测试内容：执行运行时字符串文本构造子场景。 Execute runtime-string text-construction sub-scenarios.
- *          测试原理：把文本构造语义单独成组，避免与错误路径和重格式化路径缠在一起。 Group text-construction semantics away from error and reformatting paths.
+ * @brief 测试项函数 `RunRuntimeStringTextTests`。 Test-item function
+ * `RunRuntimeStringTextTests`.
+ * @details 测试内容：执行运行时字符串文本构造子场景。 Execute runtime-string
+ * text-construction sub-scenarios.
+ *          测试原理：把文本构造语义单独成组，避免与错误路径和重格式化路径缠在一起。 Group
+ * text-construction semantics away from error and reformatting paths.
  */
-void RunRuntimeStringTextTests()
-{
-  TestRuntimeStringText();
-}
+void RunRuntimeStringTextTests() { TestRuntimeStringText(); }

--- a/test/base/structure/test_double_buffer.cpp
+++ b/test/base/structure/test_double_buffer.cpp
@@ -1,16 +1,24 @@
 /**
  * @file test_double_buffer.cpp
- * @brief `DoubleBuffer` pending/active 双半区切换测试。 `DoubleBuffer` pending/active half-switch tests.
+ * @brief `DoubleBuffer` pending/active 双半区切换测试。 `DoubleBuffer` pending/active
+ * half-switch tests.
  *
  * 测试项目 / Test items:
- * 1. 初始分块与 pending 初始状态。 Initial split and pending state: verify the raw buffer is divided evenly and starts without pending data.
- * 2. `nullptr + 0` 空 backing storage。 Empty backing storage: verify an empty raw view can initialize the object without forcing a dummy pointer.
- * 3. `FillPending()` 的写入与重复写保护。 Pending fill semantics: verify `FillPending()` stores bytes and rejects a second pending fill before switch.
- * 4. `Switch()` 切换和越界长度拒绝。 Switch semantics and bounds: verify active-half toggling and oversized pending writes are rejected.
+ * 1. 初始分块与 pending 初始状态。 Initial split and pending state: verify the raw buffer
+ * is divided evenly and starts without pending data.
+ * 2. `nullptr + 0` 空 backing storage。 Empty backing storage: verify an empty raw view
+ * can initialize the object without forcing a dummy pointer.
+ * 3. `FillPending()` 的写入与重复写保护。 Pending fill semantics: verify `FillPending()`
+ * stores bytes and rejects a second pending fill before switch.
+ * 4. `Switch()` 切换和越界长度拒绝。 Switch semantics and bounds: verify active-half
+ * toggling and oversized pending writes are rejected.
  *
  * 测试原理 / Test principles:
- * 1. 使用一个具体后备缓冲区，同时检查地址和长度，因为它是纯存储布局原语。 Use one concrete backing buffer and inspect both addresses and lengths, because this utility is a pure storage-layout primitive.
- * 2. 同时覆盖成功和拒绝分支，明确状态机而不只看 happy path。 Check both accepted and rejected writes so the test documents the state machine, not just the happy path.
+ * 1. 使用一个具体后备缓冲区，同时检查地址和长度，因为它是纯存储布局原语。 Use one
+ * concrete backing buffer and inspect both addresses and lengths, because this utility is
+ * a pure storage-layout primitive.
+ * 2. 同时覆盖成功和拒绝分支，明确状态机而不只看 happy path。 Check both accepted and
+ * rejected writes so the test documents the state machine, not just the happy path.
  */
 #include "double_buffer.hpp"
 #include "libxr_def.hpp"
@@ -19,8 +27,9 @@
 
 /**
  * @brief 测试入口函数 `test_double_buffer`。 Test entry function `test_double_buffer`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_double_buffer()
 {
@@ -32,8 +41,10 @@ void test_double_buffer()
   LibXR::DoubleBuffer init_later;
   init_later.Init(raw);
   ASSERT(init_later.Size() == 64);
-  ASSERT((reinterpret_cast<uintptr_t>(init_later.ActiveBuffer()) % alignof(size_t)) == 0U);
-  ASSERT((reinterpret_cast<uintptr_t>(init_later.PendingBuffer()) % alignof(size_t)) == 0U);
+  ASSERT((reinterpret_cast<uintptr_t>(init_later.ActiveBuffer()) % alignof(size_t)) ==
+         0U);
+  ASSERT((reinterpret_cast<uintptr_t>(init_later.PendingBuffer()) % alignof(size_t)) ==
+         0U);
 
   LibXR::DoubleBuffer empty_buffer;
   LibXR::RawData empty_raw(nullptr, 0);

--- a/test/base/structure/test_list.cpp
+++ b/test/base/structure/test_list.cpp
@@ -1,14 +1,21 @@
 /**
  * @file test_list.cpp
- * @brief 普通链表与 lock-free 链表遍历测试。 Ordered list and lock-free list traversal tests.
+ * @brief 普通链表与 lock-free 链表遍历测试。 Ordered list and lock-free list traversal
+ * tests.
  *
  * 测试项目 / Test items:
- * 1. 普通 `List` 的增删遍历行为。 Ordinary `List`: verify add, foreach, delete and not-found delete behavior.
- * 2. `LockFreeList` 的基本遍历覆盖。 `LockFreeList` basic traversal: verify append count and foreach coverage on the lock-free variant.
+ * 1. 普通 `List` 的增删遍历行为。 Ordinary `List`: verify add, foreach, delete and
+ * not-found delete behavior.
+ * 2. `LockFreeList` 的基本遍历覆盖。 `LockFreeList` basic traversal: verify append count
+ * and foreach coverage on the lock-free variant.
  *
  * 测试原理 / Test principles:
- * 1. 复用同一个回调计数器，直接比较两类链表对外可见的遍历契约。 Reuse the same callback counter across both list types so the test compares the observable traversal contract directly.
- * 2. 每次删除后都检查返回值和 size，因为这是普通链表最核心的调用方语义。 Check deletion results after each mutation, because size/accounting is the key caller-visible contract of the ordinary list.
+ * 1. 复用同一个回调计数器，直接比较两类链表对外可见的遍历契约。 Reuse the same callback
+ * counter across both list types so the test compares the observable traversal contract
+ * directly.
+ * 2. 每次删除后都检查返回值和 size，因为这是普通链表最核心的调用方语义。 Check deletion
+ * results after each mutation, because size/accounting is the key caller-visible contract
+ * of the ordinary list.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -18,8 +25,9 @@ static uint32_t counter = 0;
 
 /**
  * @brief 测试入口函数 `test_list`。 Test entry function `test_list`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_list()
 {

--- a/test/base/structure/test_lockfree_list.cpp
+++ b/test/base/structure/test_lockfree_list.cpp
@@ -1,14 +1,20 @@
 /**
  * @file test_lockfree_list.cpp
- * @brief `LockFreeList` 聚焦遍历与提前终止测试。 Focused `LockFreeList` traversal and early-stop tests.
+ * @brief `LockFreeList` 聚焦遍历与提前终止测试。 Focused `LockFreeList` traversal and
+ * early-stop tests.
  *
  * 测试项目 / Test items:
- * 1. 插入后头插遍历顺序。 Insertion order observation: verify the lock-free list exposes the expected head-first traversal order after repeated `Add()` calls.
- * 2. `Foreach()` 非 `OK` 提前停止。 Early termination: verify `Foreach()` stops and returns the callback's first non-`OK` result.
+ * 1. 插入后头插遍历顺序。 Insertion order observation: verify the lock-free list exposes
+ * the expected head-first traversal order after repeated `Add()` calls.
+ * 2. `Foreach()` 非 `OK` 提前停止。 Early termination: verify `Foreach()` stops and
+ * returns the callback's first non-`OK` result.
  *
  * 测试原理 / Test principles:
- * 1. 只观察公开遍历 API，因为 lock-free list 的契约是可见迭代行为。 Observe only the public traversal API, because the lock-free list contract is about visible iteration behavior rather than internal link layout.
- * 2. 用显式非 `OK` 返回击中取消分支。 Use a non-`OK` callback return to drive the cancellation branch explicitly.
+ * 1. 只观察公开遍历 API，因为 lock-free list 的契约是可见迭代行为。 Observe only the
+ * public traversal API, because the lock-free list contract is about visible iteration
+ * behavior rather than internal link layout.
+ * 2. 用显式非 `OK` 返回击中取消分支。 Use a non-`OK` callback return to drive the
+ * cancellation branch explicitly.
  */
 #include <cstdint>
 
@@ -18,8 +24,9 @@
 
 /**
  * @brief 测试入口函数 `test_lockfree_list`。 Test entry function `test_lockfree_list`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_lockfree_list()
 {

--- a/test/base/structure/test_mpmc_queue.cpp
+++ b/test/base/structure/test_mpmc_queue.cpp
@@ -23,9 +23,9 @@ bool EqualDouble(double a, double b) { return std::abs(a - b) < 1e-9; }
  */
 struct ProducerArg
 {
-  size_t begin;                    ///< 本生产者负责的起始值 / First value owned by this producer.
-  size_t count;                    ///< 本生产者负责推送的元素数 / Number of items pushed by this producer.
-  Queue* queue;                    ///< 共享队列 / Shared queue instance.
+  size_t begin;  ///< 本生产者负责的起始值 / First value owned by this producer.
+  size_t count;  ///< 本生产者负责推送的元素数 / Number of items pushed by this producer.
+  Queue* queue;  ///< 共享队列 / Shared queue instance.
   std::atomic<size_t>* done_count;  ///< 完成计数器 / Producer completion counter.
 };
 
@@ -35,14 +35,17 @@ struct ProducerArg
  */
 struct ConsumerArg
 {
-  Queue* queue;                                 ///< 共享队列 / Shared queue instance.
-  size_t total_items;                           ///< 目标总元素数 / Expected total item count.
-  size_t producer_count;                        ///< 生产者总数 / Total number of producers.
-  std::atomic<size_t>* produced_done_count;     ///< 生产者完成计数 / Producer completion counter.
-  std::atomic<size_t>* consumed_done_count;     ///< 消费者完成计数 / Consumer completion counter.
-  std::atomic<size_t>* pop_count;               ///< 已消费元素数 / Total consumed item count.
-  std::atomic<unsigned long long>* pop_sum;     ///< 已消费元素和 / Running sum of consumed values.
-  std::atomic<uint8_t>* seen;                   ///< 去重标记表 / Deduplication mark table.
+  Queue* queue;           ///< 共享队列 / Shared queue instance.
+  size_t total_items;     ///< 目标总元素数 / Expected total item count.
+  size_t producer_count;  ///< 生产者总数 / Total number of producers.
+  std::atomic<size_t>*
+      produced_done_count;  ///< 生产者完成计数 / Producer completion counter.
+  std::atomic<size_t>*
+      consumed_done_count;         ///< 消费者完成计数 / Consumer completion counter.
+  std::atomic<size_t>* pop_count;  ///< 已消费元素数 / Total consumed item count.
+  std::atomic<unsigned long long>*
+      pop_sum;                 ///< 已消费元素和 / Running sum of consumed values.
+  std::atomic<uint8_t>* seen;  ///< 去重标记表 / Deduplication mark table.
 };
 
 /**

--- a/test/base/structure/test_queue.cpp
+++ b/test/base/structure/test_queue.cpp
@@ -1,15 +1,23 @@
 /**
  * @file test_queue.cpp
- * @brief 公开队列家族的基础字节语义与 FIFO helper 测试。 Tests for public queue-family byte semantics and FIFO helpers.
+ * @brief 公开队列家族的基础字节语义与 FIFO helper 测试。 Tests for public queue-family
+ * byte semantics and FIFO helpers.
  *
  * 测试项目 / Test items:
- * 1. `QueueBase` / `SPSCQueueBase` / `MPMCQueueBase` 的字节级 push/pop。 Byte-level push/pop on the public queue bases.
- * 2. 普通 `Queue` 的 `Overwrite()`、capacity-1 和无默认构造 payload 行为。 Ordinary `Queue` overwrite, capacity-1, and no-default-payload behavior.
- * 3. 普通 `Queue` 的批量 push/pop/peek wraparound 顺序。 FIFO wraparound ordering for ordinary `Queue` batch helpers.
+ * 1. `QueueBase` / `SPSCQueueBase` / `MPMCQueueBase` 的字节级 push/pop。 Byte-level
+ * push/pop on the public queue bases.
+ * 2. 普通 `Queue` 的 `Overwrite()`、capacity-1 和无默认构造 payload 行为。 Ordinary
+ * `Queue` overwrite, capacity-1, and no-default-payload behavior.
+ * 3. 普通 `Queue` 的批量 push/pop/peek wraparound 顺序。 FIFO wraparound ordering for
+ * ordinary `Queue` batch helpers.
  *
  * 测试原理 / Test principles:
- * 1. 主线现在公开了 queue-base 层，因此要直接验证 byte API，而不只验证 typed wrapper。 The mainline now exposes the queue-base layer, so verify the byte API directly instead of only the typed wrappers.
- * 2. 保留普通 `Queue` 的 typed FIFO 验证，因为它仍然是 object-pool 和通用测试里的基础构件。 Keep typed FIFO checks on ordinary `Queue`, because it remains a foundational building block for object-pool and general tests.
+ * 1. 主线现在公开了 queue-base 层，因此要直接验证 byte API，而不只验证 typed wrapper。
+ * The mainline now exposes the queue-base layer, so verify the byte API directly instead
+ * of only the typed wrappers.
+ * 2. 保留普通 `Queue` 的 typed FIFO 验证，因为它仍然是 object-pool
+ * 和通用测试里的基础构件。 Keep typed FIFO checks on ordinary `Queue`, because it remains
+ * a foundational building block for object-pool and general tests.
  */
 #include <cstddef>
 #include <cstdint>
@@ -35,8 +43,8 @@ static_assert(std::is_final_v<LibXR::MPMCQueue<int>>);
 static_assert(std::is_base_of_v<LibXR::QueueBase, LibXR::Queue<int>>);
 static_assert(std::is_base_of_v<LibXR::SPSCQueueBase, LibXR::SPSCQueue<int>>);
 static_assert(std::is_base_of_v<LibXR::MPMCQueueBase, LibXR::MPMCQueue<int>>);
-static_assert(std::is_base_of_v<LibXR::QueueTypedBase<LibXR::Queue<int>, int>,
-                                LibXR::Queue<int>>);
+static_assert(
+    std::is_base_of_v<LibXR::QueueTypedBase<LibXR::Queue<int>, int>, LibXR::Queue<int>>);
 static_assert(std::is_base_of_v<LibXR::QueueTypedBase<LibXR::SPSCQueue<int>, int>,
                                 LibXR::SPSCQueue<int>>);
 static_assert(std::is_base_of_v<LibXR::QueueTypedBase<LibXR::MPMCQueue<int>, int>,
@@ -87,7 +95,8 @@ void test_queue()
     ASSERT(queue.Pop(value) == LibXR::ErrorCode::EMPTY);
   }
 
-  // The ordinary FIFO queue supports capacity 1 and no-default payloads for normal byte Push/Pop.
+  // The ordinary FIFO queue supports capacity 1 and no-default payloads for normal byte
+  // Push/Pop.
   {
     LibXR::Queue<uint32_t> queue(1);
     uint32_t value = 0;

--- a/test/base/structure/test_rbt.cpp
+++ b/test/base/structure/test_rbt.cpp
@@ -1,14 +1,19 @@
 /**
  * @file test_rbt.cpp
- * @brief 红黑树插入、遍历与删除测试。 Red-black tree insertion, traversal and deletion tests.
+ * @brief 红黑树插入、遍历与删除测试。 Red-black tree insertion, traversal and deletion
+ * tests.
  *
  * 测试项目 / Test items:
- * 1. 有序遍历顺序。 Ordered traversal: verify inserted keys are returned in ascending order through discrete and callback traversal.
- * 2. 节点数量与删除收缩行为。 Node counting and deletion: verify the tree count grows to the inserted size and shrinks monotonically during deletion.
+ * 1. 有序遍历顺序。 Ordered traversal: verify inserted keys are returned in ascending
+ * order through discrete and callback traversal.
+ * 2. 节点数量与删除收缩行为。 Node counting and deletion: verify the tree count grows to
+ * the inserted size and shrinks monotonically during deletion.
  *
  * 测试原理 / Test principles:
- * 1. 用顺序整数键让排序错误立即可见。 Use sequential integer keys so ordering mistakes become obvious without additional decoding.
- * 2. 每次删除后都检查数量，确保平衡和删除路径的可见结果正确。 Check count after every delete so balancing-side regressions still surface as observable cardinality errors.
+ * 1. 用顺序整数键让排序错误立即可见。 Use sequential integer keys so ordering mistakes
+ * become obvious without additional decoding.
+ * 2. 每次删除后都检查数量，确保平衡和删除路径的可见结果正确。 Check count after every
+ * delete so balancing-side regressions still surface as observable cardinality errors.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -16,15 +21,15 @@
 
 /**
  * @brief 测试入口函数 `test_rbt`。 Test entry function `test_rbt`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rbt()
 {
   // 测试内容：按文件头列出的测试项目顺序执行当前测试入口。
   // Test coverage: execute the test items listed in this file header in sequence.
-  LibXR::RBTree<int> rbtree(
-      [](const int& a, const int& b) { return (a > b) - (a < b); });
+  LibXR::RBTree<int> rbtree([](const int& a, const int& b) { return (a > b) - (a < b); });
 
   LibXR::RBTree<int>::Node<int> nodes[100];
 
@@ -61,8 +66,8 @@ void test_rbt()
 
   ASSERT(rbtree.GetNum() == 0);
 
-  LibXR::RBTree<uint32_t> uint32_tree(
-      [](const uint32_t& a, const uint32_t& b) { return (a > b) - (a < b); });
+  LibXR::RBTree<uint32_t> uint32_tree([](const uint32_t& a, const uint32_t& b)
+                                      { return (a > b) - (a < b); });
   constexpr uint32_t keys[] = {0U, 1U, 0x7FFFFFFFU, 0x80000000U, 0xFFFFFFFFU};
   LibXR::RBTree<uint32_t>::Node<uint32_t> uint32_nodes[std::size(keys)];
 

--- a/test/base/structure/test_spsc_queue.cpp
+++ b/test/base/structure/test_spsc_queue.cpp
@@ -1,11 +1,11 @@
-#include "libxr.hpp"
-#include "libxr_def.hpp"
-#include "test.hpp"
-
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
+
+#include "libxr.hpp"
+#include "libxr_def.hpp"
+#include "test.hpp"
 
 namespace
 {
@@ -212,18 +212,17 @@ void test_spsc_queue()
 
     uint8_t write_next = 20;
     size_t write_chunks = 0;
-    ASSERT(byte_queue.PushWithWriter(
-               4,
-               [&](uint8_t* chunk, size_t count)
-               {
-                 ASSERT(count == 2);
-                 ++write_chunks;
-                 for (size_t index = 0; index < count; ++index)
-                 {
-                   chunk[index] = write_next++;
-                 }
-                 return LibXR::ErrorCode::OK;
-               }) == LibXR::ErrorCode::OK);
+    ASSERT(byte_queue.PushWithWriter(4,
+                                     [&](uint8_t* chunk, size_t count)
+                                     {
+                                       ASSERT(count == 2);
+                                       ++write_chunks;
+                                       for (size_t index = 0; index < count; ++index)
+                                       {
+                                         chunk[index] = write_next++;
+                                       }
+                                       return LibXR::ErrorCode::OK;
+                                     }) == LibXR::ErrorCode::OK);
     ASSERT(write_chunks == 2);
 
     const uint8_t expected_after_write[6] = {13, 14, 20, 21, 22, 23};
@@ -247,19 +246,19 @@ void test_spsc_queue()
     const uint8_t expected_read_chunks[5] = {5, 6, 7, 8, 9};
     size_t read_cursor = 0;
     size_t read_chunks = 0;
-    ASSERT(byte_queue.PopWithReader(
-               5,
-               [&](const uint8_t* chunk, size_t count)
-               {
-                 ASSERT((read_chunks == 0 && count == 1) ||
-                        (read_chunks == 1 && count == 4));
-                 for (size_t index = 0; index < count; ++index)
-                 {
-                   ASSERT(chunk[index] == expected_read_chunks[read_cursor++]);
-                 }
-                 ++read_chunks;
-                 return LibXR::ErrorCode::OK;
-               }) == LibXR::ErrorCode::OK);
+    ASSERT(byte_queue.PopWithReader(5,
+                                    [&](const uint8_t* chunk, size_t count)
+                                    {
+                                      ASSERT((read_chunks == 0 && count == 1) ||
+                                             (read_chunks == 1 && count == 4));
+                                      for (size_t index = 0; index < count; ++index)
+                                      {
+                                        ASSERT(chunk[index] ==
+                                               expected_read_chunks[read_cursor++]);
+                                      }
+                                      ++read_chunks;
+                                      return LibXR::ErrorCode::OK;
+                                    }) == LibXR::ErrorCode::OK);
     ASSERT(read_chunks == 2);
     ASSERT(read_cursor == 5);
     ASSERT(byte_queue.Pop(value) == LibXR::ErrorCode::OK);
@@ -274,8 +273,9 @@ void test_spsc_queue()
     std::atomic<bool> producer_done = false;
     LibXR::Thread producer;
 
-    producer.Create<ProducerArg>(ProducerArg{&queue, TOTAL_ITEMS, &producer_done}, ProducerTask,
-                                 "spsc_prod", 1024, LibXR::Thread::Priority::REALTIME);
+    producer.Create<ProducerArg>(ProducerArg{&queue, TOTAL_ITEMS, &producer_done},
+                                 ProducerTask, "spsc_prod", 1024,
+                                 LibXR::Thread::Priority::REALTIME);
 
     for (uint32_t expected = 0; expected < TOTAL_ITEMS; ++expected)
     {

--- a/test/base/structure/test_stack.cpp
+++ b/test/base/structure/test_stack.cpp
@@ -3,11 +3,15 @@
  * @brief `Stack` push/pop 与索引编辑测试。 `Stack` push/pop and indexed edit tests.
  *
  * 测试项目 / Test items:
- * 1. 容量与 LIFO 出栈行为。 Capacity behavior: verify push fills the stack, the extra push reports `FULL`, and pop returns LIFO order.
- * 2. `Insert()` / `Delete()` 索引位移行为。 In-place editing helpers: verify indexed `Insert()` and `Delete()` shift the expected elements and update size.
+ * 1. 容量与 LIFO 出栈行为。 Capacity behavior: verify push fills the stack, the extra
+ * push reports `FULL`, and pop returns LIFO order.
+ * 2. `Insert()` / `Delete()` 索引位移行为。 In-place editing helpers: verify indexed
+ * `Insert()` and `Delete()` shift the expected elements and update size.
  *
  * 测试原理 / Test principles:
- * 1. 同时验证栈顶顺序和随机位置编辑副作用，因为这个容器同时承担两类语义。 Check both top-of-stack order and indexed edit side effects, because this container combines stack semantics with random-position maintenance helpers.
+ * 1. 同时验证栈顶顺序和随机位置编辑副作用，因为这个容器同时承担两类语义。 Check both
+ * top-of-stack order and indexed edit side effects, because this container combines stack
+ * semantics with random-position maintenance helpers.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -15,8 +19,9 @@
 
 /**
  * @brief 测试入口函数 `test_stack`。 Test entry function `test_stack`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_stack()
 {

--- a/test/base/test_assert.cpp
+++ b/test/base/test_assert.cpp
@@ -1,14 +1,22 @@
 /**
  * @file test_assert.cpp
- * @brief `LibXR::Assert` fatal 回调表面测试。 `LibXR::Assert` fatal-callback surface tests.
+ * @brief `LibXR::Assert` fatal 回调表面测试。 `LibXR::Assert` fatal-callback surface
+ * tests.
  *
  * 测试项目 / Test items:
- * 1. Fatal 回调的注册与替换。 Fatal callback registration and replacement: verify the global fatal callback handle can be installed and restored cleanly.
- * 2. Fatal 回调分发参数透传。 Fatal callback dispatch argument propagation: verify `RunFatalErrorCallback()` forwards the ISR flag, file name and line number to the bound callback.
+ * 1. Fatal 回调的注册与替换。 Fatal callback registration and replacement: verify the
+ * global fatal callback handle can be installed and restored cleanly.
+ * 2. Fatal 回调分发参数透传。 Fatal callback dispatch argument propagation: verify
+ * `RunFatalErrorCallback()` forwards the ISR flag, file name and line number to the bound
+ * callback.
  *
  * 测试原理 / Test principles:
- * 1. 只通过公开的 `LibXR::Assert` 回调接口操作，避免把私有存储细节当成契约。 Operate only through the public `LibXR::Assert` callback API, so the test documents the stable contract instead of private storage details.
- * 2. 通过真实一次分发后的副作用来确认注册路径和参数透传路径都正确。 Observe the callback side effects after a real dispatch to confirm both registration and parameter forwarding paths.
+ * 1. 只通过公开的 `LibXR::Assert` 回调接口操作，避免把私有存储细节当成契约。 Operate only
+ * through the public `LibXR::Assert` callback API, so the test documents the stable
+ * contract instead of private storage details.
+ * 2. 通过真实一次分发后的副作用来确认注册路径和参数透传路径都正确。 Observe the callback
+ * side effects after a real dispatch to confirm both registration and parameter
+ * forwarding paths.
  */
 #include <cstdint>
 #include <string_view>
@@ -32,13 +40,15 @@ struct FatalProbe
 
 /**
  * @brief 测试入口函数 `test_assert`。 Test entry function `test_assert`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_assert()
 {
   // 测试项：保存当前测试框架 fatal 回调，避免本测试污染后续测试。
-  // Test item: preserve the current test-runner fatal callback so this test restores global state before returning.
+  // Test item: preserve the current test-runner fatal callback so this test restores
+  // global state before returning.
   auto old_callback = LibXR::Assert::FatalErrorCallback();
 
   // 测试项：构造探针回调，用副作用记录一次分发传入的全部参数。
@@ -55,22 +65,26 @@ void test_assert()
       &probe);
 
   // 测试项：注册探针回调，并确认公开读取接口能看到非空 fatal 回调。
-  // Test item: register the probe callback and verify the public getter reports a non-empty fatal callback.
+  // Test item: register the probe callback and verify the public getter reports a
+  // non-empty fatal callback.
   LibXR::Assert::RegisterFatalErrorCallback(callback);
   ASSERT(!LibXR::Assert::FatalErrorCallback().Empty());
 
   // 测试项：通过封装后的执行入口触发 fatal 回调，而不是直接访问全局存储。
-  // Test item: dispatch through the wrapped run entry instead of reaching into global storage.
+  // Test item: dispatch through the wrapped run entry instead of reaching into global
+  // storage.
   LibXR::Assert::RunFatalErrorCallback(false, "test_assert.cpp", 42);
 
   // 测试项：确认回调只执行一次，并且 ISR 标志、文件名、行号都原样透传。
-  // Test item: verify one callback hit and exact propagation of ISR flag, file name, and line number.
+  // Test item: verify one callback hit and exact propagation of ISR flag, file name, and
+  // line number.
   ASSERT(probe.hit_count == 1);
   ASSERT(!probe.in_isr);
   ASSERT(probe.file == "test_assert.cpp");
   ASSERT(probe.line == 42);
 
   // 测试项：恢复进入本测试前的 fatal 回调，保持测试入口的全局状态契约。
-  // Test item: restore the fatal callback that was active before this test to preserve the test runner contract.
+  // Test item: restore the fatal callback that was active before this test to preserve
+  // the test runner contract.
   LibXR::Assert::RegisterFatalErrorCallback(old_callback);
 }

--- a/test/base/test_color.cpp
+++ b/test/base/test_color.cpp
@@ -1,14 +1,22 @@
 /**
  * @file test_color.cpp
- * @brief `libxr_color.hpp` ANSI 颜色/样式/控制表测试。 ANSI color/style/control lookup-table tests for `libxr_color.hpp`.
+ * @brief `libxr_color.hpp` ANSI 颜色/样式/控制表测试。 ANSI color/style/control
+ * lookup-table tests for `libxr_color.hpp`.
  *
  * 测试项目 / Test items:
- * 1. 枚举与查表数组的数量对应关系。 Enum/table cardinality: verify every exported enum `COUNT` matches its corresponding string table length.
- * 2. 关键 ANSI 转义序列的取值。 Representative escape values: verify key style, terminal-control, foreground, background and preset entries map to the expected ANSI sequences.
+ * 1. 枚举与查表数组的数量对应关系。 Enum/table cardinality: verify every exported enum
+ * `COUNT` matches its corresponding string table length.
+ * 2. 关键 ANSI 转义序列的取值。 Representative escape values: verify key style,
+ * terminal-control, foreground, background and preset entries map to the expected ANSI
+ * sequences.
  *
  * 测试原理 / Test principles:
- * 1. 先检查编译期表长，避免枚举和字符串表静默漂移。 Check the compile-time table sizes first, because a silent enum/table drift would invalidate every runtime user of these lookup tables.
- * 2. 再检查代表性运行时字符串，确认公开文本契约而不只是数值布局。 Check representative strings at runtime to confirm the published textual contract, not just the numeric enum layout.
+ * 1. 先检查编译期表长，避免枚举和字符串表静默漂移。 Check the compile-time table sizes
+ * first, because a silent enum/table drift would invalidate every runtime user of these
+ * lookup tables.
+ * 2. 再检查代表性运行时字符串，确认公开文本契约而不只是数值布局。 Check representative
+ * strings at runtime to confirm the published textual contract, not just the numeric enum
+ * layout.
  */
 #include <cstddef>
 #include <iterator>
@@ -20,8 +28,9 @@
 
 /**
  * @brief 测试入口函数 `test_color`。 Test entry function `test_color`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_color()
 {
@@ -52,10 +61,13 @@ void test_color()
   ASSERT(std::string_view(LibXR::LIBXR_TERMINAL_CONTROL_STR[static_cast<size_t>(
              LibXR::TerminalControl::ERASE_LINE)]) == "\033[K");
 
-  ASSERT(std::string_view(LibXR::LIBXR_FOREGROUND_STR[static_cast<size_t>(
-             LibXR::Foreground::GREEN)]) == "\033[32m");
-  ASSERT(std::string_view(LibXR::LIBXR_BACKGROUND_STR[static_cast<size_t>(
-             LibXR::Background::BLUE)]) == "\033[44m");
+  ASSERT(
+      std::string_view(
+          LibXR::LIBXR_FOREGROUND_STR[static_cast<size_t>(LibXR::Foreground::GREEN)]) ==
+      "\033[32m");
+  ASSERT(std::string_view(
+             LibXR::LIBXR_BACKGROUND_STR[static_cast<size_t>(LibXR::Background::BLUE)]) ==
+         "\033[44m");
 
   ASSERT(std::string_view(
              LibXR::LIBXR_PRESET_STR[static_cast<size_t>(LibXR::Preset::YELLOW_BOLD)]) ==

--- a/test/base/test_def.cpp
+++ b/test/base/test_def.cpp
@@ -1,15 +1,24 @@
 /**
  * @file test_def.cpp
- * @brief `libxr_def.hpp` 基础宏与辅助函数测试。 Foundational helpers in `libxr_def.hpp` tests.
+ * @brief `libxr_def.hpp` 基础宏与辅助函数测试。 Foundational helpers in `libxr_def.hpp`
+ * tests.
  *
  * 测试项目 / Test items:
- * 1. 基础常量与字符串化宏。 Numeric constants and macros: verify `PI`, `TWO_PI`, gravity and `DEF2STR` behave as declared.
- * 2. `OffsetOf()` / `ContainerOf()` 布局辅助。 Layout helpers: verify `OffsetOf()` and `ContainerOf()` recover the owning object correctly for mutable and const member pointers.
- * 3. `SizeLimitCheck()` 四种模式语义。 Size-limit predicate semantics: verify `SizeLimitCheck()` matches the documented `EQUAL / LESS / MORE / NONE` rules.
+ * 1. 基础常量与字符串化宏。 Numeric constants and macros: verify `PI`, `TWO_PI`, gravity
+ * and `DEF2STR` behave as declared.
+ * 2. `OffsetOf()` / `ContainerOf()` 布局辅助。 Layout helpers: verify `OffsetOf()` and
+ * `ContainerOf()` recover the owning object correctly for mutable and const member
+ * pointers.
+ * 3. `SizeLimitCheck()` 四种模式语义。 Size-limit predicate semantics: verify
+ * `SizeLimitCheck()` matches the documented `EQUAL / LESS / MORE / NONE` rules.
  *
  * 测试原理 / Test principles:
- * 1. 使用具体对象布局和宏 token，验证这些小工具作为全库基础契约的稳定性。 Use concrete layout objects and stringized macro tokens, because these helpers are small but widely reused contract surfaces.
- * 2. 同时覆盖正反两类边界，避免只验证单一 happy path。 Check both positive and negative predicate cases so the test documents the exact boundary semantics rather than a single happy path.
+ * 1. 使用具体对象布局和宏 token，验证这些小工具作为全库基础契约的稳定性。 Use concrete
+ * layout objects and stringized macro tokens, because these helpers are small but widely
+ * reused contract surfaces.
+ * 2. 同时覆盖正反两类边界，避免只验证单一 happy path。 Check both positive and negative
+ * predicate cases so the test documents the exact boundary semantics rather than a single
+ * happy path.
  */
 #include <cstddef>
 #include <cstdint>
@@ -37,8 +46,9 @@ static_assert(LibXR::CommonOrdered<int, double>);
 
 /**
  * @brief 测试入口函数 `test_def`。 Test entry function `test_def`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_def()
 {

--- a/test/base/test_mem.cpp
+++ b/test/base/test_mem.cpp
@@ -1,15 +1,24 @@
 /**
  * @file test_mem.cpp
- * @brief `LibXR::Memory` 快速 set/copy/compare 测试。 `LibXR::Memory` fast set/copy/compare tests.
+ * @brief `LibXR::Memory` 快速 set/copy/compare 测试。 `LibXR::Memory` fast
+ * set/copy/compare tests.
  *
  * 测试项目 / Test items:
- * 1. `FastSet` 的填充与零长度空操作。 `FastSet`: verify full-buffer fill and zero-length no-op behavior.
- * 2. `FastCopy` 的普通拷贝、自拷贝、非对齐拷贝和小尺寸扫宽。 `FastCopy`: verify basic copy, self-copy, unaligned copy and a width sweep over small copy lengths.
- * 3. `FastCmp` 与 `std::memcmp` 的一致性。 `FastCmp`: verify equality, first/middle/last-byte differences and sign alignment with `std::memcmp`, including unaligned spans.
+ * 1. `FastSet` 的填充与零长度空操作。 `FastSet`: verify full-buffer fill and zero-length
+ * no-op behavior.
+ * 2. `FastCopy` 的普通拷贝、自拷贝、非对齐拷贝和小尺寸扫宽。 `FastCopy`: verify basic
+ * copy, self-copy, unaligned copy and a width sweep over small copy lengths.
+ * 3. `FastCmp` 与 `std::memcmp` 的一致性。 `FastCmp`: verify equality,
+ * first/middle/last-byte differences and sign alignment with `std::memcmp`, including
+ * unaligned spans.
  *
  * 测试原理 / Test principles:
- * 1. 把标准库语义当参照，因为这些函数本质上是在优化一个已知契约。 Compare against standard-library semantics at the byte level, because these routines are performance-focused replacements for well-known contracts.
- * 2. 显式压非对齐地址和零长度边界，因为最容易在这里偏离参考行为。 Stress unaligned addresses and zero-length cases explicitly, since those are the edge conditions most likely to diverge from the reference behavior.
+ * 1. 把标准库语义当参照，因为这些函数本质上是在优化一个已知契约。 Compare against
+ * standard-library semantics at the byte level, because these routines are
+ * performance-focused replacements for well-known contracts.
+ * 2. 显式压非对齐地址和零长度边界，因为最容易在这里偏离参考行为。 Stress unaligned
+ * addresses and zero-length cases explicitly, since those are the edge conditions most
+ * likely to diverge from the reference behavior.
  */
 #include <cstddef>
 #include <cstdint>
@@ -24,8 +33,9 @@ static int sign(int v) { return (v > 0) - (v < 0); }
 
 /**
  * @brief 测试入口函数 `test_memory`。 Test entry function `test_memory`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_memory()
 {

--- a/test/base/test_time.cpp
+++ b/test/base/test_time.cpp
@@ -1,14 +1,20 @@
 /**
  * @file test_time.cpp
- * @brief `MicrosecondTimestamp` / `MillisecondTimestamp` 算术测试。 `MicrosecondTimestamp` and `MillisecondTimestamp` arithmetic tests.
+ * @brief `MicrosecondTimestamp` / `MillisecondTimestamp` 算术测试。
+ * `MicrosecondTimestamp` and `MillisecondTimestamp` arithmetic tests.
  *
  * 测试项目 / Test items:
- * 1. 直线时间差与单位换算。 Straight-line subtraction: verify elapsed microsecond and millisecond durations and their unit-conversion helpers.
- * 2. 单次回绕后的时间差计算。 Single-wrap subtraction: verify configured wrap ranges are used when the new timestamp is numerically smaller than the old one.
+ * 1. 直线时间差与单位换算。 Straight-line subtraction: verify elapsed microsecond and
+ * millisecond durations and their unit-conversion helpers.
+ * 2. 单次回绕后的时间差计算。 Single-wrap subtraction: verify configured wrap ranges are
+ * used when the new timestamp is numerically smaller than the old one.
  *
  * 测试原理 / Test principles:
- * 1. 同时检查原始 duration 和换算辅助接口，因为调用方会同时使用两者。 Check both raw duration values and converted unit helpers, because callers use both surfaces.
- * 2. 在测试内主动改 wrap 配置，让回绕分支可确定复现。 Override the wrap configuration in-test so the wraparound branch is exercised deterministically instead of depending on platform timebase limits.
+ * 1. 同时检查原始 duration 和换算辅助接口，因为调用方会同时使用两者。 Check both raw
+ * duration values and converted unit helpers, because callers use both surfaces.
+ * 2. 在测试内主动改 wrap 配置，让回绕分支可确定复现。 Override the wrap configuration
+ * in-test so the wraparound branch is exercised deterministically instead of depending on
+ * platform timebase limits.
  */
 #include <cstdint>
 
@@ -31,8 +37,9 @@ struct TimebaseWrapGuard
 
 /**
  * @brief 测试入口函数 `test_time`。 Test entry function `test_time`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_time()
 {

--- a/test/base/test_type.cpp
+++ b/test/base/test_type.cpp
@@ -1,14 +1,22 @@
 /**
  * @file test_libxr_type.cpp
- * @brief `libxr_type.hpp` 原始数据视图构造测试。 Raw-data view construction tests for `libxr_type.hpp`.
+ * @brief `libxr_type.hpp` 原始数据视图构造测试。 Raw-data view construction tests for
+ * `libxr_type.hpp`.
  *
  * 测试项目 / Test items:
- * 1. 可写数组视图构造。 Mutable array views: verify `RawData` captures the original address and byte count for writable bounded arrays.
- * 2. 只读数组、嵌入 NUL 文本与显式 `string_view` 构造。 Const array and string views: verify `ConstRawData` preserves bounded-array length, embedded-NUL payloads and explicit `std::string_view` sizes.
+ * 1. 可写数组视图构造。 Mutable array views: verify `RawData` captures the original
+ * address and byte count for writable bounded arrays.
+ * 2. 只读数组、嵌入 NUL 文本与显式 `string_view` 构造。 Const array and string views:
+ * verify `ConstRawData` preserves bounded-array length, embedded-NUL payloads and
+ * explicit `std::string_view` sizes.
  *
  * 测试原理 / Test principles:
- * 1. 使用定长数组和嵌入 NUL 载荷，明确区分字节视图和 C 字符串终止语义。 Use bounded arrays and embedded-NUL payloads, because this API must distinguish true byte spans from ordinary C-string termination.
- * 2. 同时检查地址和值长度，因为下游契约依赖这两个量成对成立。 Check both address identity and size, since downstream code relies on the pair rather than on textual interpretation.
+ * 1. 使用定长数组和嵌入 NUL 载荷，明确区分字节视图和 C 字符串终止语义。 Use bounded
+ * arrays and embedded-NUL payloads, because this API must distinguish true byte spans
+ * from ordinary C-string termination.
+ * 2. 同时检查地址和值长度，因为下游契约依赖这两个量成对成立。 Check both address identity
+ * and size, since downstream code relies on the pair rather than on textual
+ * interpretation.
  */
 #include <string_view>
 
@@ -18,8 +26,9 @@
 
 /**
  * @brief 测试入口函数 `test_type`。 Test entry function `test_type`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_type()
 {

--- a/test/base/utils/pid_test_common.hpp
+++ b/test/base/utils/pid_test_common.hpp
@@ -13,8 +13,11 @@
 
 /**
  * @brief 辅助函数 `near`。 Helper function `near`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 static inline bool near(double a, double b, double eps = 1e-6)
 {

--- a/test/base/utils/test_crc.cpp
+++ b/test/base/utils/test_crc.cpp
@@ -1,13 +1,18 @@
 /**
  * @file test_crc.cpp
- * @brief CRC8 / CRC16 / CRC32 计算与校验测试。 CRC8 / CRC16 / CRC32 calculation and verification tests.
+ * @brief CRC8 / CRC16 / CRC32 计算与校验测试。 CRC8 / CRC16 / CRC32 calculation and
+ * verification tests.
  *
  * 测试项目 / Test items:
- * 1. 带尾校验字段的 packed 结构计算。 Packed structure checksum generation: verify each CRC helper computes the trailer field over the intended prefix bytes.
- * 2. 对应 `Verify()` 校验通过。 Checksum verification: verify the generated trailer makes the corresponding `Verify()` helper succeed.
+ * 1. 带尾校验字段的 packed 结构计算。 Packed structure checksum generation: verify each
+ * CRC helper computes the trailer field over the intended prefix bytes.
+ * 2. 对应 `Verify()` 校验通过。 Checksum verification: verify the generated trailer makes
+ * the corresponding `Verify()` helper succeed.
  *
  * 测试原理 / Test principles:
- * 1. 使用末尾 CRC 字段的 packed 载荷，贴近仓库内最主要的真实用法。 Use packed payloads with trailing checksum fields, because this matches the dominant in-repo usage pattern for CRC helpers.
+ * 1. 使用末尾 CRC 字段的 packed 载荷，贴近仓库内最主要的真实用法。 Use packed payloads
+ * with trailing checksum fields, because this matches the dominant in-repo usage pattern
+ * for CRC helpers.
  */
 #include "crc.hpp"
 #include "libxr.hpp"
@@ -16,8 +21,9 @@
 
 /**
  * @brief 测试入口函数 `test_crc`。 Test entry function `test_crc`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_crc()
 {

--- a/test/base/utils/test_cycle_value.cpp
+++ b/test/base/utils/test_cycle_value.cpp
@@ -3,11 +3,14 @@
  * @brief 循环角值归一化与算术测试。 Cyclic-angle normalization arithmetic tests.
  *
  * 测试项目 / Test items:
- * 1. 构造时超周期归一化。 Constructor normalization: verify values outside one full period are wrapped into the canonical range.
- * 2. 加减、取反与差值重建后的循环语义。 Arithmetic updates: verify `+=`, `-=`, unary negation and subtraction-based reconstruction preserve cyclic semantics.
+ * 1. 构造时超周期归一化。 Constructor normalization: verify values outside one full
+ * period are wrapped into the canonical range.
+ * 2. 加减、取反与差值重建后的循环语义。 Arithmetic updates: verify `+=`, `-=`, unary
+ * negation and subtraction-based reconstruction preserve cyclic semantics.
  *
  * 测试原理 / Test principles:
- * 1. 选用 `PI` 的整倍数组合，让期望 wrap 结果容易推导和比较。 Use multiples of `PI` so the expected wrapped values stay easy to reason about and compare numerically.
+ * 1. 选用 `PI` 的整倍数组合，让期望 wrap 结果容易推导和比较。 Use multiples of `PI` so
+ * the expected wrapped values stay easy to reason about and compare numerically.
  */
 #include "cycle_value.hpp"
 #include "libxr.hpp"
@@ -16,8 +19,9 @@
 
 /**
  * @brief 测试入口函数 `test_cycle_value`。 Test entry function `test_cycle_value`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_cycle_value()
 {

--- a/test/base/utils/test_encoder.cpp
+++ b/test/base/utils/test_encoder.cpp
@@ -1,15 +1,22 @@
 /**
  * @file test_encoder.cpp
- * @brief `FloatEncoder` 量化、夹紧与稳健性测试。 `FloatEncoder` quantization, clamp and robustness tests.
+ * @brief `FloatEncoder` 量化、夹紧与稳健性测试。 `FloatEncoder` quantization, clamp and
+ * robustness tests.
  *
  * 测试项目 / Test items:
- * 1. 标称 encode/decode 精度。 Nominal encode/decode accuracy: verify representative gyroscope, accelerometer and Euler-angle ranges decode within the expected tolerance.
- * 2. 越界输入夹紧与边界值回环。 Clamp and boundary behavior: verify out-of-range inputs clamp to min/max and exact boundary values round-trip correctly.
- * 3. 中心点、最小位宽和非有限值路径。 Special cases: verify center-point encoding, minimum bit width and non-finite inputs do not break the encoder contract.
+ * 1. 标称 encode/decode 精度。 Nominal encode/decode accuracy: verify representative
+ * gyroscope, accelerometer and Euler-angle ranges decode within the expected tolerance.
+ * 2. 越界输入夹紧与边界值回环。 Clamp and boundary behavior: verify out-of-range inputs
+ * clamp to min/max and exact boundary values round-trip correctly.
+ * 3. 中心点、最小位宽和非有限值路径。 Special cases: verify center-point encoding,
+ * minimum bit width and non-finite inputs do not break the encoder contract.
  *
  * 测试原理 / Test principles:
- * 1. 按场景误差容忍度比较 decode 误差，因为它本来就是位宽和误差的交换器。 Check decoded numeric error against scenario-specific tolerances, because this utility exists to trade bits for bounded reconstruction error.
- * 2. 显式压夹紧和特殊值分支，把稳健性和精度一起写清。 Exercise explicit clamp and special-value paths so robustness is documented alongside nominal accuracy.
+ * 1. 按场景误差容忍度比较 decode 误差，因为它本来就是位宽和误差的交换器。 Check decoded
+ * numeric error against scenario-specific tolerances, because this utility exists to
+ * trade bits for bounded reconstruction error.
+ * 2. 显式压夹紧和特殊值分支，把稳健性和精度一起写清。 Exercise explicit clamp and
+ * special-value paths so robustness is documented alongside nominal accuracy.
  */
 #include "float_encoder.hpp"
 #include "libxr_def.hpp"
@@ -17,8 +24,9 @@
 
 /**
  * @brief 测试入口函数 `test_float_encoder`。 Test entry function `test_float_encoder`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_float_encoder()
 {

--- a/test/base/utils/test_flag.cpp
+++ b/test/base/utils/test_flag.cpp
@@ -1,14 +1,20 @@
 /**
  * @file test_flag.cpp
- * @brief 普通/原子 flag 与 scoped restore 测试。 Plain/atomic flag and scoped-restore tests.
+ * @brief 普通/原子 flag 与 scoped restore 测试。 Plain/atomic flag and scoped-restore
+ * tests.
  *
  * 测试项目 / Test items:
- * 1. Plain flag 的状态迁移。 Plain flag state transitions: verify set/clear/test-and-set/test-and-clear/exchange semantics.
- * 2. Atomic flag 的同构语义。 Atomic flag state transitions: verify the atomic variant exposes the same visible contract.
- * 3. 嵌套 scoped restore 的恢复行为。 Scoped restore: verify nested scoped guards restore the previous flag value on scope exit.
+ * 1. Plain flag 的状态迁移。 Plain flag state transitions: verify
+ * set/clear/test-and-set/test-and-clear/exchange semantics.
+ * 2. Atomic flag 的同构语义。 Atomic flag state transitions: verify the atomic variant
+ * exposes the same visible contract.
+ * 3. 嵌套 scoped restore 的恢复行为。 Scoped restore: verify nested scoped guards restore
+ * the previous flag value on scope exit.
  *
  * 测试原理 / Test principles:
- * 1. 同时检查返回的旧状态和值最终状态，因为这个 API 的契约覆盖两者。 Check the returned previous-state values as well as the final flag state, because the API contract is about both.
+ * 1. 同时检查返回的旧状态和值最终状态，因为这个 API 的契约覆盖两者。 Check the returned
+ * previous-state values as well as the final flag state, because the API contract is
+ * about both.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -16,8 +22,9 @@
 
 /**
  * @brief 测试入口函数 `test_flag`。 Test entry function `test_flag`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_flag()
 {

--- a/test/base/utils/test_inertia.cpp
+++ b/test/base/utils/test_inertia.cpp
@@ -1,14 +1,20 @@
 /**
  * @file test_inertia.cpp
- * @brief 惯量构造、平移、旋转与质心组合测试。 Inertia construction, translation, rotation and center-of-mass composition tests.
+ * @brief 惯量构造、平移、旋转与质心组合测试。 Inertia construction, translation, rotation
+ * and center-of-mass composition tests.
  *
  * 测试项目 / Test items:
- * 1. 多种构造形式的一致性。 Constructor forms: verify array, matrix, symmetric and explicit-value constructors produce equivalent inertia tensors.
- * 2. 平移/旋转后的张量变换。 Translation/rotation transforms: verify translated and rotated tensors match expected coefficients and quaternion/matrix rotation paths agree.
- * 3. 组合质心后的总质量和位置。 Composite center of mass: verify adding mass properties produces the expected combined mass and centroid.
+ * 1. 多种构造形式的一致性。 Constructor forms: verify array, matrix, symmetric and
+ * explicit-value constructors produce equivalent inertia tensors.
+ * 2. 平移/旋转后的张量变换。 Translation/rotation transforms: verify translated and
+ * rotated tensors match expected coefficients and quaternion/matrix rotation paths agree.
+ * 3. 组合质心后的总质量和位置。 Composite center of mass: verify adding mass properties
+ * produces the expected combined mass and centroid.
  *
  * 测试原理 / Test principles:
- * 1. 用同一组期望张量对比多种前端，说明不同 API 的语义等价性。 Compare multiple construction and rotation frontends against the same expected tensor so the test documents semantic equivalence between APIs.
+ * 1. 用同一组期望张量对比多种前端，说明不同 API 的语义等价性。 Compare multiple
+ * construction and rotation frontends against the same expected tensor so the test
+ * documents semantic equivalence between APIs.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -16,8 +22,9 @@
 
 /**
  * @brief 测试入口函数 `test_inertia`。 Test entry function `test_inertia`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_inertia()
 {

--- a/test/base/utils/test_kinematic.cpp
+++ b/test/base/utils/test_kinematic.cpp
@@ -3,12 +3,18 @@
  * @brief 前向/反向运动链求解测试。 Forward/backward kinematic chain solve test.
  *
  * 测试项目 / Test items:
- * 1. 两关节链的前向传播。 Forward propagation: build a start-point, intermediate object and end-point chain with two joints.
- * 2. 端点目标位姿的反向求解残差。 Backward solve: verify the endpoint target position/quaternion can be reached with small residual error after backward computation.
+ * 1. 两关节链的前向传播。 Forward propagation: build a start-point, intermediate object
+ * and end-point chain with two joints.
+ * 2. 端点目标位姿的反向求解残差。 Backward solve: verify the endpoint target
+ * position/quaternion can be reached with small residual error after backward
+ * computation.
  *
  * 测试原理 / Test principles:
- * 1. 用具体两关节链而不是孤立公式，覆盖对象/关节在真实 API 上的组合行为。 Use a concrete two-joint chain instead of isolated algebra checks so the test covers object/joint composition on the real API surface.
- * 2. 以端点残差为准，而不是强行断言内部中间状态。 Assert residual error rather than exact internal state, because the public contract is geometric convergence at the endpoint.
+ * 1. 用具体两关节链而不是孤立公式，覆盖对象/关节在真实 API 上的组合行为。 Use a concrete
+ * two-joint chain instead of isolated algebra checks so the test covers object/joint
+ * composition on the real API surface.
+ * 2. 以端点残差为准，而不是强行断言内部中间状态。 Assert residual error rather than exact
+ * internal state, because the public contract is geometric convergence at the endpoint.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -16,8 +22,9 @@
 
 /**
  * @brief 测试入口函数 `test_kinematic`。 Test entry function `test_kinematic`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_kinematic()
 {

--- a/test/base/utils/test_pid.cpp
+++ b/test/base/utils/test_pid.cpp
@@ -6,8 +6,10 @@
 
 /**
  * @brief 测试入口函数 `test_pid`。 Test entry function `test_pid`.
- * @details 测试内容：聚合执行拆分后的 PID 子测试组。 Aggregate and execute the split PID subtest groups.
- *          测试原理：在保持原 runner 入口不变的前提下，把 PID 的大文件按语义拆分。 Preserve the original runner entry while splitting the oversized PID test by semantic groups.
+ * @details 测试内容：聚合执行拆分后的 PID 子测试组。 Aggregate and execute the split PID
+ * subtest groups. 测试原理：在保持原 runner 入口不变的前提下，把 PID 的大文件按语义拆分。
+ * Preserve the original runner entry while splitting the oversized PID test by semantic
+ * groups.
  */
 void test_pid()
 {

--- a/test/base/utils/test_pid_cycle.cpp
+++ b/test/base/utils/test_pid_cycle.cpp
@@ -6,8 +6,11 @@
 
 /**
  * @brief 测试项函数 `RunPidCycleTests`。 Test-item function `RunPidCycleTests`.
- * @details 测试内容：执行当前分组里的 PID 子场景。 Execute the grouped PID sub-scenarios for this split file.
- *          测试原理：把响应、防积分和状态语义拆开，避免一个测试文件继续承担过多控制器语义。 Split response, anti-windup, and state semantics so one test file does not keep carrying too many controller behaviors.
+ * @details 测试内容：执行当前分组里的 PID 子场景。 Execute the grouped PID sub-scenarios
+ * for this split file.
+ *          测试原理：把响应、防积分和状态语义拆开，避免一个测试文件继续承担过多控制器语义。
+ * Split response, anti-windup, and state semantics so one test file does not keep
+ * carrying too many controller behaviors.
  */
 void RunPidCycleTests()
 {
@@ -58,5 +61,4 @@ void RunPidCycleTests()
       ASSERT(near(pid.LastError(), EXPECT_CYCLE, 1e-6));
     }
   }
-
 }

--- a/test/base/utils/test_pid_response.cpp
+++ b/test/base/utils/test_pid_response.cpp
@@ -1,13 +1,17 @@
 /**
  * @file test_pid_response.cpp
- * @brief PID 响应与防饱和子测试。 Split test unit for PID response and anti-windup behavior.
+ * @brief PID 响应与防饱和子测试。 Split test unit for PID response and anti-windup
+ * behavior.
  */
 #include "pid_test_common.hpp"
 
 /**
  * @brief 测试项函数 `RunPidResponseTests`。 Test-item function `RunPidResponseTests`.
- * @details 测试内容：执行当前分组里的 PID 子场景。 Execute the grouped PID sub-scenarios for this split file.
- *          测试原理：把响应、防积分和状态语义拆开，避免一个测试文件继续承担过多控制器语义。 Split response, anti-windup, and state semantics so one test file does not keep carrying too many controller behaviors.
+ * @details 测试内容：执行当前分组里的 PID 子场景。 Execute the grouped PID sub-scenarios
+ * for this split file.
+ *          测试原理：把响应、防积分和状态语义拆开，避免一个测试文件继续承担过多控制器语义。
+ * Split response, anti-windup, and state semantics so one test file does not keep
+ * carrying too many controller behaviors.
  */
 void RunPidResponseTests()
 {

--- a/test/base/utils/test_pid_state.cpp
+++ b/test/base/utils/test_pid_state.cpp
@@ -1,13 +1,17 @@
 /**
  * @file test_pid_state.cpp
- * @brief PID 状态访问器与重置子测试。 Split test unit for PID state-accessor and reset behavior.
+ * @brief PID 状态访问器与重置子测试。 Split test unit for PID state-accessor and reset
+ * behavior.
  */
 #include "pid_test_common.hpp"
 
 /**
  * @brief 测试项函数 `RunPidStateTests`。 Test-item function `RunPidStateTests`.
- * @details 测试内容：执行当前分组里的 PID 子场景。 Execute the grouped PID sub-scenarios for this split file.
- *          测试原理：把响应、防积分和状态语义拆开，避免一个测试文件继续承担过多控制器语义。 Split response, anti-windup, and state semantics so one test file does not keep carrying too many controller behaviors.
+ * @details 测试内容：执行当前分组里的 PID 子场景。 Execute the grouped PID sub-scenarios
+ * for this split file.
+ *          测试原理：把响应、防积分和状态语义拆开，避免一个测试文件继续承担过多控制器语义。
+ * Split response, anti-windup, and state semantics so one test file does not keep
+ * carrying too many controller behaviors.
  */
 void RunPidStateTests()
 {

--- a/test/base/utils/test_transform.cpp
+++ b/test/base/utils/test_transform.cpp
@@ -6,8 +6,11 @@
 
 /**
  * @brief 测试入口函数 `test_transform`。 Test entry function `test_transform`.
- * @details 测试内容：聚合执行拆分后的 transform 子测试组。 Aggregate and execute the split transform subtest groups.
- *          测试原理：保留原入口名字，同时把一个大文件拆成构造、互操作和欧拉顺序三个语义组。 Preserve the original entry name while splitting one large file into construction, interoperability, and Euler-order groups.
+ * @details 测试内容：聚合执行拆分后的 transform 子测试组。 Aggregate and execute the
+ * split transform subtest groups.
+ *          测试原理：保留原入口名字，同时把一个大文件拆成构造、互操作和欧拉顺序三个语义组。
+ * Preserve the original entry name while splitting one large file into construction,
+ * interoperability, and Euler-order groups.
  */
 void test_transform()
 {

--- a/test/base/utils/test_transform_construction.cpp
+++ b/test/base/utils/test_transform_construction.cpp
@@ -1,13 +1,18 @@
 /**
  * @file test_transform_construction.cpp
- * @brief transform 构造与基础代数子测试。 Split test unit for transform construction and basic algebra.
+ * @brief transform 构造与基础代数子测试。 Split test unit for transform construction and
+ * basic algebra.
  */
 #include "transform_test_common.hpp"
 
 /**
- * @brief 测试项函数 `RunTransformConstructionTests`。 Test-item function `RunTransformConstructionTests`.
- * @details 测试内容：执行当前分组里的 transform 子场景。 Execute the grouped transform sub-scenarios for this split file.
- *          测试原理：把构造/互操作/欧拉顺序三个语义维度拆开，降低单文件阅读压力。 Split construction/interoperability/Euler-order semantics into separate files to reduce single-file reading load.
+ * @brief 测试项函数 `RunTransformConstructionTests`。 Test-item function
+ * `RunTransformConstructionTests`.
+ * @details 测试内容：执行当前分组里的 transform 子场景。 Execute the grouped transform
+ * sub-scenarios for this split file.
+ *          测试原理：把构造/互操作/欧拉顺序三个语义维度拆开，降低单文件阅读压力。 Split
+ * construction/interoperability/Euler-order semantics into separate files to reduce
+ * single-file reading load.
  */
 void RunTransformConstructionTests()
 {
@@ -80,6 +85,4 @@ void RunTransformConstructionTests()
   pos_new += pos;
   ASSERT(equal(pos_new(0), pos(0)) && equal(pos_new(1), pos(1)) &&
          equal(pos_new(2), pos(2)));
-
-
 }

--- a/test/base/utils/test_transform_euler_orders.cpp
+++ b/test/base/utils/test_transform_euler_orders.cpp
@@ -1,13 +1,18 @@
 /**
  * @file test_transform_euler_orders.cpp
- * @brief transform 欧拉顺序 round-trip 子测试。 Split test unit for transform Euler-order round trips.
+ * @brief transform 欧拉顺序 round-trip 子测试。 Split test unit for transform Euler-order
+ * round trips.
  */
 #include "transform_test_common.hpp"
 
 /**
- * @brief 测试项函数 `RunTransformEulerOrderTests`。 Test-item function `RunTransformEulerOrderTests`.
- * @details 测试内容：执行当前分组里的 transform 子场景。 Execute the grouped transform sub-scenarios for this split file.
- *          测试原理：把构造/互操作/欧拉顺序三个语义维度拆开，降低单文件阅读压力。 Split construction/interoperability/Euler-order semantics into separate files to reduce single-file reading load.
+ * @brief 测试项函数 `RunTransformEulerOrderTests`。 Test-item function
+ * `RunTransformEulerOrderTests`.
+ * @details 测试内容：执行当前分组里的 transform 子场景。 Execute the grouped transform
+ * sub-scenarios for this split file.
+ *          测试原理：把构造/互操作/欧拉顺序三个语义维度拆开，降低单文件阅读压力。 Split
+ * construction/interoperability/Euler-order semantics into separate files to reduce
+ * single-file reading load.
  */
 void RunTransformEulerOrderTests()
 {
@@ -186,5 +191,4 @@ void RunTransformEulerOrderTests()
   eulr_new = quat.ToEulerAngleYZX();
   ASSERT(equal(eulr_new(0), eulr(0)) && equal(eulr_new(1), eulr(1)) &&
          equal(eulr_new(2), eulr(2)));
-
 }

--- a/test/base/utils/test_transform_rotation.cpp
+++ b/test/base/utils/test_transform_rotation.cpp
@@ -1,13 +1,18 @@
 /**
  * @file test_transform_rotation.cpp
- * @brief transform 旋转互操作子测试。 Split test unit for transform rotation interoperability.
+ * @brief transform 旋转互操作子测试。 Split test unit for transform rotation
+ * interoperability.
  */
 #include "transform_test_common.hpp"
 
 /**
- * @brief 测试项函数 `RunTransformRotationInteropTests`。 Test-item function `RunTransformRotationInteropTests`.
- * @details 测试内容：执行当前分组里的 transform 子场景。 Execute the grouped transform sub-scenarios for this split file.
- *          测试原理：把构造/互操作/欧拉顺序三个语义维度拆开，降低单文件阅读压力。 Split construction/interoperability/Euler-order semantics into separate files to reduce single-file reading load.
+ * @brief 测试项函数 `RunTransformRotationInteropTests`。 Test-item function
+ * `RunTransformRotationInteropTests`.
+ * @details 测试内容：执行当前分组里的 transform 子场景。 Execute the grouped transform
+ * sub-scenarios for this split file.
+ *          测试原理：把构造/互操作/欧拉顺序三个语义维度拆开，降低单文件阅读压力。 Split
+ * construction/interoperability/Euler-order semantics into separate files to reduce
+ * single-file reading load.
  */
 void RunTransformRotationInteropTests()
 {
@@ -49,6 +54,4 @@ void RunTransformRotationInteropTests()
       Eigen::Quaternion<double>(quat) * eigen_quat.conjugate();
   ASSERT(equal(quat_new.w(), eigen_div.w()) && equal(quat_new.x(), eigen_div.x()) &&
          equal(quat_new.y(), eigen_div.y()) && equal(quat_new.z(), eigen_div.z()));
-
-
 }

--- a/test/common/rw/pipe_stream_test_common.hpp
+++ b/test/common/rw/pipe_stream_test_common.hpp
@@ -1,6 +1,7 @@
 /**
  * @file pipe_stream_test_common.hpp
- * @brief `Pipe::Stream` 阻塞提交语义测试 helper。 Shared blocking-stream helpers for `Pipe::Stream` tests.
+ * @brief `Pipe::Stream` 阻塞提交语义测试 helper。 Shared blocking-stream helpers for
+ * `Pipe::Stream` tests.
  * @details 测试项目：
  *          1. 提供阻塞 `Stream` 提交结果传播 helper。
  *          2. 提供析构自动提交与超时回收 helper。
@@ -55,9 +56,13 @@ void VerifyStreamBlockPendingCompletion(LibXR::ErrorCode finish_result,
 }
 
 /**
- * @brief 辅助函数 `VerifyStreamBlockTimeout`。 Helper function `VerifyStreamBlockTimeout`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @brief 辅助函数 `VerifyStreamBlockTimeout`。 Helper function
+ * `VerifyStreamBlockTimeout`.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void VerifyStreamBlockTimeout()
 {

--- a/test/common/rw/pipe_transfer_test_common.hpp
+++ b/test/common/rw/pipe_transfer_test_common.hpp
@@ -1,14 +1,18 @@
 /**
  * @file pipe_transfer_test_common.hpp
- * @brief `Pipe` 传输与模式矩阵测试 helper。 Shared transport and mode-matrix helpers for `Pipe` tests.
+ * @brief `Pipe` 传输与模式矩阵测试 helper。 Shared transport and mode-matrix helpers for
+ * `Pipe` tests.
  * @details 测试项目：
  *          1. 提供 `Pipe` 延迟写入、样本填充和调用结果断言 helper。
  *          2. 提供读先写后、写先读后与零长度读写场景验证 helper。
  *          3. 提供混合模式与阻塞模式压力场景复用的基础常量和上下文。
  *          Test items:
- *          1. Provide delayed write, sample fill, and call-result assertion helpers for `Pipe`.
- *          2. Provide helpers for read-first, write-first, and zero-length read/write scenarios.
- *          3. Provide reusable constants and contexts for mixed-mode and blocking-mode stress scenarios.
+ *          1. Provide delayed write, sample fill, and call-result assertion helpers for
+ * `Pipe`.
+ *          2. Provide helpers for read-first, write-first, and zero-length read/write
+ * scenarios.
+ *          3. Provide reusable constants and contexts for mixed-mode and blocking-mode
+ * stress scenarios.
  */
 #pragma once
 
@@ -36,8 +40,11 @@ struct DelayedPipeWriteContext
 
 /**
  * @brief 辅助函数 `DelayedPipeWrite`。 Helper function `DelayedPipeWrite`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void DelayedPipeWrite(DelayedPipeWriteContext* ctx)
 {
@@ -55,8 +62,11 @@ void StartDelayedPipeWriter(LibXR::Thread& thread, DelayedPipeWriteContext& ctx,
 
 /**
  * @brief 辅助函数 `FillPattern`。 Helper function `FillPattern`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void FillPattern(std::vector<uint8_t>& buffer, uint8_t seed)
 {

--- a/test/common/rw/pipe_zero_test_common.hpp
+++ b/test/common/rw/pipe_zero_test_common.hpp
@@ -5,8 +5,10 @@
  *          1. 提供零长度写请求的完成与后续通路验证 helper。
  *          2. 提供零长度读请求的完成与后续通路验证 helper。
  *          Test items:
- *          1. Provide helpers for zero-length write completion and follow-up transport checks.
- *          2. Provide helpers for zero-length read completion and follow-up transport checks.
+ *          1. Provide helpers for zero-length write completion and follow-up transport
+ * checks.
+ *          2. Provide helpers for zero-length read completion and follow-up transport
+ * checks.
  */
 #pragma once
 

--- a/test/common/rw/rw_mode_test_common.hpp
+++ b/test/common/rw/rw_mode_test_common.hpp
@@ -1,12 +1,14 @@
 /**
  * @file rw_mode_test_common.hpp
- * @brief `rw` / `pipe` 模式与等待器测试 helper。 Shared mode and waiter helpers for `rw` / `pipe` tests.
+ * @brief `rw` / `pipe` 模式与等待器测试 helper。 Shared mode and waiter helpers for `rw`
+ * / `pipe` tests.
  * @details 测试项目：
  *          1. 统一封装 `NONE` / `POLLING` / `CALLBACK` / `BLOCK` 四类操作模式。
  *          2. 统一维护异步回调计数、最终错误码和等待信号量。
  *          3. 统一提供等待断言，避免各测试文件重复展开样板代码。
  *          Test items:
- *          1. Provide one shared wrapper for `NONE` / `POLLING` / `CALLBACK` / `BLOCK` modes.
+ *          1. Provide one shared wrapper for `NONE` / `POLLING` / `CALLBACK` / `BLOCK`
+ * modes.
  *          2. Keep callback counts, final status, and semaphores in one reusable probe.
  *          3. Centralize wait assertions so scenario files stay focused.
  */
@@ -49,8 +51,11 @@ struct CompletionProbe
 
   /**
    * @brief 辅助函数 `Reset`。 Helper function `Reset`.
-   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
-   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+   * measure, or validate shared state for later test steps.
+   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+   * repeated helper logic locally so the main test body stays focused on the test item
+   * itself.
    */
   void Reset()
   {
@@ -77,8 +82,11 @@ struct ModeHarness
 
   /**
    * @brief 辅助函数 `Reset`。 Helper function `Reset`.
-   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
-   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+   * measure, or validate shared state for later test steps.
+   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+   * repeated helper logic locally so the main test body stays focused on the test item
+   * itself.
    */
   void Reset()
   {
@@ -87,9 +95,12 @@ struct ModeHarness
   }
 
   /**
-   * @brief 断言辅助函数 `ExpectPendingSubmitted`。 Assertion helper function `ExpectPendingSubmitted`.
-   * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check to the current result.
-   *          测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。 Concentrate repeated validation logic so test items do not drift to inconsistent checks.
+   * @brief 断言辅助函数 `ExpectPendingSubmitted`。 Assertion helper function
+   * `ExpectPendingSubmitted`.
+   * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check
+   * to the current result.
+   *          测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。 Concentrate
+   * repeated validation logic so test items do not drift to inconsistent checks.
    */
   void ExpectPendingSubmitted() const
   {
@@ -107,8 +118,10 @@ struct ModeHarness
 
   /**
    * @brief 断言辅助函数 `ExpectFinal`。 Assertion helper function `ExpectFinal`.
-   * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check to the current result.
-   *          测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。 Concentrate repeated validation logic so test items do not drift to inconsistent checks.
+   * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check
+   * to the current result.
+   *          测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。 Concentrate
+   * repeated validation logic so test items do not drift to inconsistent checks.
    */
   void ExpectFinal(LibXR::ErrorCode expected)
   {
@@ -136,8 +149,11 @@ struct ModeHarness
 
   /**
    * @brief 辅助函数 `OnCallback`。 Helper function `OnCallback`.
-   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
-   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+   * measure, or validate shared state for later test steps.
+   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+   * repeated helper logic locally so the main test body stays focused on the test item
+   * itself.
    */
   static void OnCallback(bool in_isr, ModeHarness* self, LibXR::ErrorCode status)
   {
@@ -148,8 +164,11 @@ struct ModeHarness
 
   /**
    * @brief 辅助函数 `Bind`。 Helper function `Bind`.
-   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
-   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+   * measure, or validate shared state for later test steps.
+   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+   * repeated helper logic locally so the main test body stays focused on the test item
+   * itself.
    */
   void Bind(uint32_t timeout)
   {

--- a/test/common/rw/rw_port_test_common.hpp
+++ b/test/common/rw/rw_port_test_common.hpp
@@ -1,6 +1,7 @@
 /**
  * @file rw_port_test_common.hpp
- * @brief `ReadPort` / `WritePort` 状态机测试 helper。 Shared state-machine helpers for `ReadPort` / `WritePort` tests.
+ * @brief `ReadPort` / `WritePort` 状态机测试 helper。 Shared state-machine helpers for
+ * `ReadPort` / `WritePort` tests.
  * @details 测试项目：
  *          1. 提供 `PENDING` / 失败回调桩和阻塞调用线程封装。
  *          2. 提供 `ReadPort` / `WritePort` 队列完成、失败清理与阻塞唤醒验证 helper。
@@ -14,6 +15,7 @@
 
 #include <cstring>
 #include <vector>
+
 #include "rw_thread_test_common.hpp"
 
 namespace
@@ -59,8 +61,11 @@ struct TrackingReadPort : LibXR::ReadPort
 
 /**
  * @brief 辅助函数 `VerifyPendingReadMode`。 Helper function `VerifyPendingReadMode`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void VerifyPendingReadMode(TestMode mode)
 {
@@ -105,8 +110,11 @@ void VerifyPendingReadMode(TestMode mode)
 
 /**
  * @brief 辅助函数 `VerifyPendingWriteMode`。 Helper function `VerifyPendingWriteMode`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void VerifyPendingWriteMode(TestMode mode, LibXR::ErrorCode result)
 {
@@ -148,9 +156,13 @@ void VerifyPendingWriteMode(TestMode mode, LibXR::ErrorCode result)
 }
 
 /**
- * @brief 辅助函数 `VerifyPendingReadFailAndClearMode`。 Helper function `VerifyPendingReadFailAndClearMode`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @brief 辅助函数 `VerifyPendingReadFailAndClearMode`。 Helper function
+ * `VerifyPendingReadFailAndClearMode`.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void VerifyPendingReadFailAndClearMode(TestMode mode, LibXR::ErrorCode reason)
 {
@@ -179,9 +191,13 @@ void VerifyPendingReadFailAndClearMode(TestMode mode, LibXR::ErrorCode reason)
 }
 
 /**
- * @brief 辅助函数 `VerifyPendingWriteFailAndClearMode`。 Helper function `VerifyPendingWriteFailAndClearMode`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @brief 辅助函数 `VerifyPendingWriteFailAndClearMode`。 Helper function
+ * `VerifyPendingWriteFailAndClearMode`.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void VerifyPendingWriteFailAndClearMode(TestMode mode, LibXR::ErrorCode reason)
 {

--- a/test/common/rw/rw_thread_test_common.hpp
+++ b/test/common/rw/rw_thread_test_common.hpp
@@ -1,13 +1,15 @@
 /**
  * @file rw_thread_test_common.hpp
- * @brief `rw` / `pipe` 线程与等待同步测试 helper。 Shared thread and waiter helpers for `rw` / `pipe` tests.
+ * @brief `rw` / `pipe` 线程与等待同步测试 helper。 Shared thread and waiter helpers for
+ * `rw` / `pipe` tests.
  * @details 测试项目：
  *          1. 提供线程收尾与等待断言 helper。
  *          2. 提供挂起读写完成、阻塞读写调用的上下文与线程启动封装。
  *          3. 提供把后台补数据/补完成的动作统一包装成可复用 helper。
  *          Test items:
  *          1. Provide thread-settle and wait assertion helpers.
- *          2. Provide contexts and starters for pending completion and blocking read/write calls.
+ *          2. Provide contexts and starters for pending completion and blocking
+ * read/write calls.
  *          3. Wrap background completion actions into reusable helpers.
  */
 #pragma once
@@ -26,8 +28,11 @@ using LibXRTest::WriteHarness;
 
 /**
  * @brief 辅助函数 `JoinThreadIfNeeded`。 Helper function `JoinThreadIfNeeded`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 inline void JoinThreadIfNeeded(LibXR::Thread& thread)
 {
@@ -38,8 +43,10 @@ inline void JoinThreadIfNeeded(LibXR::Thread& thread)
 
 /**
  * @brief 断言辅助函数 `ExpectWaitOk`。 Assertion helper function `ExpectWaitOk`.
- * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check to the current result.
- *          测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。 Concentrate repeated validation logic so test items do not drift to inconsistent checks.
+ * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check
+ * to the current result. 测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。
+ * Concentrate repeated validation logic so test items do not drift to inconsistent
+ * checks.
  */
 inline void ExpectWaitOk(LibXR::Semaphore& sem, uint32_t timeout = ASYNC_TIMEOUT_MS)
 {
@@ -57,9 +64,13 @@ struct ReadQueueCompletionContext
 };
 
 /**
- * @brief 辅助函数 `CompletePendingReadFromQueue`。 Helper function `CompletePendingReadFromQueue`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @brief 辅助函数 `CompletePendingReadFromQueue`。 Helper function
+ * `CompletePendingReadFromQueue`.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void CompletePendingReadFromQueue(ReadQueueCompletionContext ctx)
 {
@@ -85,8 +96,11 @@ struct WriteFinishContext
 
 /**
  * @brief 辅助函数 `FinishPendingWrite`。 Helper function `FinishPendingWrite`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void FinishPendingWrite(WriteFinishContext ctx)
 {
@@ -112,8 +126,11 @@ struct BlockingReadCallContext
 
 /**
  * @brief 辅助函数 `BlockingReadCall`。 Helper function `BlockingReadCall`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void BlockingReadCall(BlockingReadCallContext* ctx)
 {
@@ -134,8 +151,11 @@ struct BlockingWriteCallContext
 
 /**
  * @brief 辅助函数 `BlockingWriteCall`。 Helper function `BlockingWriteCall`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void BlockingWriteCall(BlockingWriteCallContext* ctx)
 {

--- a/test/framework/main.cpp
+++ b/test/framework/main.cpp
@@ -1,22 +1,27 @@
 /**
  * @file main.cpp
- * @brief base/runtime 测试主执行器聚合入口。 Aggregation entry for the base/runtime main test runner.
+ * @brief base/runtime 测试主执行器聚合入口。 Aggregation entry for the base/runtime main
+ * test runner.
  * @details 职责：
  *          1. 安装把断言失败转换成进程失败的 fatal 测试回调。
  *          2. 调用拆分后的测试分组注册表。
  *          Responsibilities:
- *          1. Register the fatal test callback that converts assertion failures into process failure.
+ *          1. Register the fatal test callback that converts assertion failures into
+ * process failure.
  *          2. Invoke the split test-group registry.
  */
-#include "test_main_sets.hpp"
-
 #include <cmath>
 #include <cstdio>
 
+#include "test_main_sets.hpp"
+
 /**
  * @brief 辅助函数 `main`。 Helper function `main`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 bool equal(double a, double b) { return std::abs(a - b) < 1e-6; }
 
@@ -32,8 +37,7 @@ int main()
         UNUSED(file);
         UNUSED(line);
 
-        std::fprintf(stderr, "Error: Union test failed at step [%s].\r\n",
-                     test_name);
+        std::fprintf(stderr, "Error: Union test failed at step [%s].\r\n", test_name);
         std::fflush(stderr);
         // NOLINTNEXTLINE
         *(volatile long long*)(nullptr) = 0;

--- a/test/framework/test_base.hpp
+++ b/test/framework/test_base.hpp
@@ -3,8 +3,11 @@
  * @brief base/runtime 测试入口声明。 Base/runtime test entrypoint declarations.
  *
  * 作用 / Purpose:
- * 1. 收集主测试执行器要调用的入口符号。 Collect the callable entry symbols used by the main test runner.
- * 2. 把执行矩阵保持在一个显式声明边界上，避免文件搬动后悄悄脱离 runner。 Keep the execution matrix explicit at the declaration boundary so moved files do not silently disappear from the runner.
+ * 1. 收集主测试执行器要调用的入口符号。 Collect the callable entry symbols used by the
+ * main test runner.
+ * 2. 把执行矩阵保持在一个显式声明边界上，避免文件搬动后悄悄脱离 runner。 Keep the
+ * execution matrix explicit at the declaration boundary so moved files do not silently
+ * disappear from the runner.
  */
 void test_async();
 void test_assert();

--- a/test/framework/test_case_runner.hpp
+++ b/test/framework/test_case_runner.hpp
@@ -1,12 +1,15 @@
 /**
  * @file test_case_runner.hpp
- * @brief base/runtime 测试 case 运行 helper。 Case-running helpers for the base/runtime test harness.
+ * @brief base/runtime 测试 case 运行 helper。 Case-running helpers for the base/runtime
+ * test harness.
  * @details 作用：
  *          1. 定义 `TestCase`、`TEST_STEP` 和单 case 隔离执行 helper。
  *          2. 集中 `fork()` 隔离逻辑，避免主 runner 反复展开样板代码。
  *          Purpose:
- *          1. Define `TestCase`, `TEST_STEP`, and the single-case isolated execution helper.
- *          2. Centralize the `fork()` isolation logic so the main runner avoids repeated boilerplate.
+ *          1. Define `TestCase`, `TEST_STEP`, and the single-case isolated execution
+ * helper.
+ *          2. Centralize the `fork()` isolation logic so the main runner avoids repeated
+ * boilerplate.
  */
 #pragma once
 
@@ -22,15 +25,15 @@
 
 inline const char* test_name = nullptr;
 
-#define TEST_STEP(_arg)                                           \
-  do                                                              \
-  {                                                               \
-    test_name = _arg;                                             \
-    if (test_name)                                                \
-    {                                                             \
-      std::fprintf(stderr, "\tTest [%s] Passed.\n", test_name);   \
-      std::fflush(stderr);                                        \
-    }                                                             \
+#define TEST_STEP(_arg)                                         \
+  do                                                            \
+  {                                                             \
+    test_name = _arg;                                           \
+    if (test_name)                                              \
+    {                                                           \
+      std::fprintf(stderr, "\tTest [%s] Passed.\n", test_name); \
+      std::fflush(stderr);                                      \
+    }                                                           \
   } while (0)
 
 bool equal(double a, double b);
@@ -51,8 +54,11 @@ int RunVoidEntry()
 
 /**
  * @brief 辅助函数 `run_test_case`。 Helper function `run_test_case`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 inline void run_test_case(const TestCase& test_case)
 {

--- a/test/framework/test_main_sets.hpp
+++ b/test/framework/test_main_sets.hpp
@@ -1,12 +1,14 @@
 /**
  * @file test_main_sets.hpp
- * @brief Linux 主测试二进制固定执行顺序定义。 Fixed execution order for the Linux main `test` binary.
+ * @brief Linux 主测试二进制固定执行顺序定义。 Fixed execution order for the Linux main
+ * `test` binary.
  * @details 作用：
  *          1. 显式列出 Linux 主测试二进制要执行的 case。
- *          2. 保持主 runner 的执行顺序清晰，不再按 `bare_metal` / `rtos` / `full_os` 切分运行集合。
- *          Purpose:
+ *          2. 保持主 runner 的执行顺序清晰，不再按 `bare_metal` / `rtos` / `full_os`
+ * 切分运行集合。 Purpose:
  *          1. Explicitly list the cases executed by the Linux main `test` binary.
- *          2. Keep the execution order clear without splitting runtime sets into `bare_metal`, `rtos`, and `full_os`.
+ *          2. Keep the execution order clear without splitting runtime sets into
+ * `bare_metal`, `rtos`, and `full_os`.
  */
 #pragma once
 
@@ -102,8 +104,10 @@ inline constexpr GroupedTestCase kMainTestCases[] = {
     {"control_tests", {"pid", &RunVoidEntry<test_pid>, false}},
 
     {"system_tests", {"ramfs", &RunVoidEntry<test_ramfs>, false}},
-    {"system_tests", {"app_framework_application", &RunVoidEntry<test_app_framework_application>, false}},
-    {"system_tests", {"app_framework_hardware", &RunVoidEntry<test_app_framework_hardware>, false}},
+    {"system_tests",
+     {"app_framework_application", &RunVoidEntry<test_app_framework_application>, false}},
+    {"system_tests",
+     {"app_framework_hardware", &RunVoidEntry<test_app_framework_hardware>, false}},
     {"system_tests", {"event", &RunVoidEntry<test_event>, false}},
     {"system_tests", {"message_topic", &RunVoidEntry<test_message_topic>, false}},
     {"system_tests", {"message_packet", &RunVoidEntry<test_message_packet>, false}},

--- a/test/linux_bench/bench_latency.cpp
+++ b/test/linux_bench/bench_latency.cpp
@@ -1,19 +1,18 @@
 /**
  * @file bench_latency.cpp
- * @brief `LinuxSharedTopic` one-way latency 基准聚合入口。 Aggregation entry for `LinuxSharedTopic` one-way latency benchmarks.
+ * @brief `LinuxSharedTopic` one-way latency 基准聚合入口。 Aggregation entry for
+ * `LinuxSharedTopic` one-way latency benchmarks.
  * @details 测试项目：
  *          1. 聚合不同 payload 大小与 payload touch 模式的 one-way latency case。
  *          Test items:
- *          1. Aggregate one-way latency cases across payload sizes and payload-touch modes.
+ *          1. Aggregate one-way latency cases across payload sizes and payload-touch
+ * modes.
  */
 #include "linux_shared_topic_latency_bench_runner.hpp"
 
 namespace LinuxSharedTopicBench
 {
-int RunLatencyBenchmarksSmoke()
-{
-  return RunLatencyCase<64, false>(128);
-}
+int RunLatencyBenchmarksSmoke() { return RunLatencyCase<64, false>(128); }
 
 int RunLatencyBenchmarks()
 {

--- a/test/linux_bench/bench_modes.cpp
+++ b/test/linux_bench/bench_modes.cpp
@@ -1,6 +1,7 @@
 /**
  * @file bench_modes.cpp
- * @brief `LinuxSharedTopic` subscriber mode 基准聚合入口。 Aggregation entry for `LinuxSharedTopic` subscriber-mode benchmarks.
+ * @brief `LinuxSharedTopic` subscriber mode 基准聚合入口。 Aggregation entry for
+ * `LinuxSharedTopic` subscriber-mode benchmarks.
  * @details 测试项目：
  *          1. 聚合 64 KiB 与 1 MiB payload 的 subscriber mode 对比 case。
  *          Test items:
@@ -25,21 +26,21 @@ int RunModeBenchmarks()
   const uint64_t count_64k = ScaleBenchCount(4000, 32);
   const uint64_t count_1m = ScaleBenchCount(256, 8);
 
-  status |= RunModeCase<65536>(
-      "broadcast_full_64k",
-      {{LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 0, "sub_a"},
-       {LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 0, "sub_b"}},
-      count_64k, 512, 32);
+  status |=
+      RunModeCase<65536>("broadcast_full_64k",
+                         {{LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 0, "sub_a"},
+                          {LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 0, "sub_b"}},
+                         count_64k, 512, 32);
   status |= RunModeCase<65536>(
       "broadcast_drop_old_64k",
       {{LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD, 50, "sub_slow"},
        {LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD, 0, "sub_fast"}},
       count_64k, 512, 8);
-  status |= RunModeCase<65536>(
-      "balance_rr_64k",
-      {{LibXR::LinuxSharedSubscriberMode::BALANCE_RR, 0, "worker_a"},
-       {LibXR::LinuxSharedSubscriberMode::BALANCE_RR, 0, "worker_b"}},
-      count_64k, 512, 32);
+  status |=
+      RunModeCase<65536>("balance_rr_64k",
+                         {{LibXR::LinuxSharedSubscriberMode::BALANCE_RR, 0, "worker_a"},
+                          {LibXR::LinuxSharedSubscriberMode::BALANCE_RR, 0, "worker_b"}},
+                         count_64k, 512, 32);
   status |= RunModeCase<1048576>(
       "broadcast_full_1m",
       {{LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 0, "sub_a"},

--- a/test/linux_bench/bench_overload.cpp
+++ b/test/linux_bench/bench_overload.cpp
@@ -1,6 +1,7 @@
 /**
  * @file bench_overload.cpp
- * @brief `LinuxSharedTopic` overload 基准聚合入口。 Aggregation entry for `LinuxSharedTopic` overload benchmarks.
+ * @brief `LinuxSharedTopic` overload 基准聚合入口。 Aggregation entry for
+ * `LinuxSharedTopic` overload benchmarks.
  * @details 测试项目：
  *          1. 聚合不同 payload 与广播策略的 overload case。
  *          Test items:
@@ -12,16 +13,20 @@ namespace LinuxSharedTopicBench
 {
 int RunOverloadBenchmarksSmoke()
 {
-  return RunOverloadCase<65536>(LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 50, 256);
+  return RunOverloadCase<65536>(LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 50,
+                                256);
 }
 
 int RunOverloadBenchmarks()
 {
   int status = 0;
   status |= RunOverloadCase<65536>(LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 50);
-  status |= RunOverloadCase<65536>(LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD, 50);
-  status |= RunOverloadCase<1048576>(LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 50);
-  status |= RunOverloadCase<1048576>(LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD, 50);
+  status |=
+      RunOverloadCase<65536>(LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD, 50);
+  status |=
+      RunOverloadCase<1048576>(LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL, 50);
+  status |=
+      RunOverloadCase<1048576>(LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD, 50);
   return status;
 }
 }  // namespace LinuxSharedTopicBench

--- a/test/linux_bench/bench_standard.cpp
+++ b/test/linux_bench/bench_standard.cpp
@@ -1,6 +1,7 @@
 /**
  * @file bench_standard.cpp
- * @brief `LinuxSharedTopic` standard 基准聚合入口。 Aggregation entry for `LinuxSharedTopic` standard benchmarks.
+ * @brief `LinuxSharedTopic` standard 基准聚合入口。 Aggregation entry for
+ * `LinuxSharedTopic` standard benchmarks.
  * @details 测试项目：
  *          1. 聚合不同 payload 大小与 payload touch 模式的 standard case。
  *          Test items:
@@ -10,10 +11,7 @@
 
 namespace LinuxSharedTopicBench
 {
-int RunStandardBenchmarksSmoke()
-{
-  return RunBenchCase<64, false>(256);
-}
+int RunStandardBenchmarksSmoke() { return RunBenchCase<64, false>(256); }
 
 int RunStandardBenchmarks()
 {

--- a/test/linux_bench/linux_shared_topic_bench_common.hpp
+++ b/test/linux_bench/linux_shared_topic_bench_common.hpp
@@ -1,6 +1,7 @@
 /**
  * @file linux_shared_topic_bench_common.hpp
- * @brief `LinuxSharedTopic` 基准聚合 helper 入口。 Aggregation helper entry for `LinuxSharedTopic` benchmarks.
+ * @brief `LinuxSharedTopic` 基准聚合 helper 入口。 Aggregation helper entry for
+ * `LinuxSharedTopic` benchmarks.
  * @details 作用：
  *          1. 聚合统计/frame helper 与 I/O/attach helper。
  *          2. 对外只保留 benchmark 组运行入口声明。

--- a/test/linux_bench/linux_shared_topic_bench_io_common.hpp
+++ b/test/linux_bench/linux_shared_topic_bench_io_common.hpp
@@ -1,6 +1,7 @@
 /**
  * @file linux_shared_topic_bench_io_common.hpp
- * @brief `LinuxSharedTopic` 基准共用 I/O 与 attach helper。 Shared I/O and attach helpers for `LinuxSharedTopic` benchmarks.
+ * @brief `LinuxSharedTopic` 基准共用 I/O 与 attach helper。 Shared I/O and attach helpers
+ * for `LinuxSharedTopic` benchmarks.
  * @details 作用：
  *          1. 提供 pipe 完整读写 helper。
  *          2. 提供等待 subscriber attach 的共用 helper。
@@ -10,12 +11,13 @@
  */
 #pragma once
 
-#include <csignal>
-#include <cerrno>
-#include <cstdio>
-#include <cstdint>
 #include <sys/wait.h>
 #include <unistd.h>
+
+#include <cerrno>
+#include <csignal>
+#include <cstdint>
+#include <cstdio>
 #include <type_traits>
 #include <utility>
 
@@ -33,7 +35,8 @@ class ScopeExit
   ScopeExit(const ScopeExit&) = delete;
   ScopeExit& operator=(const ScopeExit&) = delete;
 
-  ScopeExit(ScopeExit&& other) noexcept : fn_(std::move(other.fn_)), active_(other.active_)
+  ScopeExit(ScopeExit&& other) noexcept
+      : fn_(std::move(other.fn_)), active_(other.active_)
   {
     other.active_ = false;
   }
@@ -128,7 +131,8 @@ inline bool ReadAll(int fd, void* buffer, size_t size)
 }
 
 template <typename TopicType>
-bool WaitForSubscriberAttach(TopicType& topic, uint32_t expected_num, const char* case_label)
+bool WaitForSubscriberAttach(TopicType& topic, uint32_t expected_num,
+                             const char* case_label)
 {
   // 辅助内容：为后续测试准备或校验共享状态。
   // Helper coverage: prepare or validate shared state for later tests.
@@ -138,8 +142,8 @@ bool WaitForSubscriberAttach(TopicType& topic, uint32_t expected_num, const char
   }
   if (topic.GetSubscriberNum() < expected_num)
   {
-    std::fprintf(stderr, "%s subscriber attach timeout: expected=%u actual=%u\n", case_label,
-                 expected_num, topic.GetSubscriberNum());
+    std::fprintf(stderr, "%s subscriber attach timeout: expected=%u actual=%u\n",
+                 case_label, expected_num, topic.GetSubscriberNum());
     return false;
   }
   return true;

--- a/test/linux_bench/linux_shared_topic_bench_stats_common.hpp
+++ b/test/linux_bench/linux_shared_topic_bench_stats_common.hpp
@@ -1,12 +1,15 @@
 /**
  * @file linux_shared_topic_bench_stats_common.hpp
- * @brief `LinuxSharedTopic` 基准共用统计与 frame helper。 Shared stats and frame helpers for `LinuxSharedTopic` benchmarks.
+ * @brief `LinuxSharedTopic` 基准共用统计与 frame helper。 Shared stats and frame helpers
+ * for `LinuxSharedTopic` benchmarks.
  * @details 作用：
  *          1. 集中复用的时钟、统计结构和 payload frame 模板。
  *          2. 提供 payload 规模相关的计数、配置和延迟统计 helper。
  *          Purpose:
- *          1. Centralize reusable clock, statistics structures, and payload frame templates.
- *          2. Provide payload-dependent count/configuration and latency-statistics helpers.
+ *          1. Centralize reusable clock, statistics structures, and payload frame
+ * templates.
+ *          2. Provide payload-dependent count/configuration and latency-statistics
+ * helpers.
  */
 #pragma once
 
@@ -14,8 +17,8 @@
 #include <array>
 #include <chrono>
 #include <cmath>
-#include <cstdlib>
 #include <cstdint>
+#include <cstdlib>
 #include <vector>
 
 #include "libxr.hpp"
@@ -58,9 +61,9 @@ inline uint64_t NowNs()
 {
   // 辅助内容：为后续测试准备或校验共享状态。
   // Helper coverage: prepare or validate shared state for later tests.
-  return static_cast<uint64_t>(
-      std::chrono::duration_cast<std::chrono::nanoseconds>(Clock::now().time_since_epoch())
-          .count());
+  return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                   Clock::now().time_since_epoch())
+                                   .count());
 }
 
 struct BenchStats
@@ -85,7 +88,8 @@ struct OverloadStats
 
 struct ModeSubConfig
 {
-  LibXR::LinuxSharedSubscriberMode mode = LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL;
+  LibXR::LinuxSharedSubscriberMode mode =
+      LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL;
   uint32_t delay_us = 0;
   const char* label = "";
 };
@@ -213,7 +217,8 @@ BenchStats BuildStats(const std::vector<double>& lat_us, uint64_t sequence_error
 
   std::vector<double> sorted = lat_us;
   std::sort(sorted.begin(), sorted.end());
-  auto percentile = [&](double p) {
+  auto percentile = [&](double p)
+  {
     const size_t index = static_cast<size_t>(
         std::floor((static_cast<double>(sorted.size() - 1U)) * p + 0.5));
     return sorted[index];

--- a/test/linux_bench/linux_shared_topic_latency_bench_runner.hpp
+++ b/test/linux_bench/linux_shared_topic_latency_bench_runner.hpp
@@ -1,6 +1,7 @@
 /**
  * @file linux_shared_topic_latency_bench_runner.hpp
- * @brief `LinuxSharedTopic` one-way latency 基准执行 helper。 Shared execution helper for `LinuxSharedTopic` one-way latency benchmarks.
+ * @brief `LinuxSharedTopic` one-way latency 基准执行 helper。 Shared execution helper for
+ * `LinuxSharedTopic` one-way latency benchmarks.
  * @details 作用：
  *          1. 封装单 outstanding message 的延迟测量流程。
  *          2. 让 `bench_latency.cpp` 只保留 payload case 组合。
@@ -27,8 +28,8 @@ int RunLatencyCase(uint64_t count_override = 0)
   using Data = typename Topic::Data;
   using Subscriber = typename Topic::SyncSubscriber;
 
-  const uint64_t count = (count_override == 0) ? LatencyCountForPayload<PayloadBytes>()
-                                                : count_override;
+  const uint64_t count =
+      (count_override == 0) ? LatencyCountForPayload<PayloadBytes>() : count_override;
 
   LibXR::LinuxSharedTopicConfig config = {};
   config.slot_num = 4;
@@ -36,22 +37,23 @@ int RunLatencyCase(uint64_t count_override = 0)
   config.queue_num = 4;
 
   char topic_name[96] = {};
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shared_latency_%zu_%d", PayloadBytes,
-                static_cast<int>(getpid()));
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shared_latency_%zu_%d",
+                PayloadBytes, static_cast<int>(getpid()));
   (void)Topic::Remove(topic_name);
 
   int ready_pipe[2] = {-1, -1};
   int ack_pipe[2] = {-1, -1};
   pid_t child = -1;
-  auto cleanup = MakeScopeExit([&]()
-  {
-    CloseFd(ready_pipe[0]);
-    CloseFd(ready_pipe[1]);
-    CloseFd(ack_pipe[0]);
-    CloseFd(ack_pipe[1]);
-    KillAndReapChild(child);
-    (void)Topic::Remove(topic_name);
-  });
+  auto cleanup = MakeScopeExit(
+      [&]()
+      {
+        CloseFd(ready_pipe[0]);
+        CloseFd(ready_pipe[1]);
+        CloseFd(ack_pipe[0]);
+        CloseFd(ack_pipe[1]);
+        KillAndReapChild(child);
+        (void)Topic::Remove(topic_name);
+      });
 
   if (pipe(ready_pipe) != 0 || pipe(ack_pipe) != 0)
   {
@@ -150,7 +152,8 @@ int RunLatencyCase(uint64_t count_override = 0)
     frame->pub_ns = NowNs();
     if constexpr (TouchPayload)
     {
-      std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU), frame->payload.size());
+      std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU),
+                  frame->payload.size());
     }
     else if constexpr (PayloadBytes > 0)
     {
@@ -191,13 +194,12 @@ int RunLatencyCase(uint64_t count_override = 0)
   const BenchStats stats = BuildStats<PayloadBytes>(lat_us, 0, 0);
   const double total_s = static_cast<double>(end_ns - start_ns) / 1e9;
   const double exchange_rate = static_cast<double>(count) / total_s;
-  std::printf(
-      "[BENCH] shared_latency mode=%s payload=%zuB count=%" PRIu64
-      " exchange_rate=%.0f msg/s create_retry=%" PRIu64 " publish_retry=%" PRIu64
-      " one_way_avg=%.3f us p50=%.3f us p95=%.3f us p99=%.3f us max=%.3f us\n",
-      TouchPayload ? "full-touch" : "transport", sizeof(BenchFrame<PayloadBytes>), count,
-      exchange_rate, create_retries, publish_retries, stats.avg_us, stats.p50_us, stats.p95_us,
-      stats.p99_us, stats.max_us);
+  std::printf("[BENCH] shared_latency mode=%s payload=%zuB count=%" PRIu64
+              " exchange_rate=%.0f msg/s create_retry=%" PRIu64 " publish_retry=%" PRIu64
+              " one_way_avg=%.3f us p50=%.3f us p95=%.3f us p99=%.3f us max=%.3f us\n",
+              TouchPayload ? "full-touch" : "transport", sizeof(BenchFrame<PayloadBytes>),
+              count, exchange_rate, create_retries, publish_retries, stats.avg_us,
+              stats.p50_us, stats.p95_us, stats.p99_us, stats.max_us);
   std::fflush(stdout);
 
   return 0;

--- a/test/linux_bench/linux_shared_topic_mode_bench_runner.hpp
+++ b/test/linux_bench/linux_shared_topic_mode_bench_runner.hpp
@@ -1,11 +1,13 @@
 /**
  * @file linux_shared_topic_mode_bench_runner.hpp
- * @brief `LinuxSharedTopic` subscriber mode 基准执行 helper。 Shared execution helper for `LinuxSharedTopic` subscriber-mode benchmarks.
+ * @brief `LinuxSharedTopic` subscriber mode 基准执行 helper。 Shared execution helper for
+ * `LinuxSharedTopic` subscriber-mode benchmarks.
  * @details 作用：
  *          1. 封装 mode benchmark 的 parent 侧发布与结果聚合流程。
  *          2. 让 `bench_modes.cpp` 只保留模式组合。
  *          Purpose:
- *          1. Encapsulate the publisher-side flow and result aggregation of mode benchmarks.
+ *          1. Encapsulate the publisher-side flow and result aggregation of mode
+ * benchmarks.
  *          2. Keep `bench_modes.cpp` focused on mode combinations only.
  */
 #pragma once
@@ -55,20 +57,21 @@ int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscr
   };
 
   std::vector<ChildRuntime> runtimes(subscribers.size());
-  auto cleanup = MakeScopeExit([&]()
-  {
-    for (auto& runtime : runtimes)
-    {
-      CloseFd(runtime.ready_pipe[0]);
-      CloseFd(runtime.ready_pipe[1]);
-      CloseFd(runtime.done_pipe[0]);
-      CloseFd(runtime.done_pipe[1]);
-      CloseFd(runtime.stats_pipe[0]);
-      CloseFd(runtime.stats_pipe[1]);
-      KillAndReapChild(runtime.pid);
-    }
-    (void)Topic::Remove(topic_name);
-  });
+  auto cleanup = MakeScopeExit(
+      [&]()
+      {
+        for (auto& runtime : runtimes)
+        {
+          CloseFd(runtime.ready_pipe[0]);
+          CloseFd(runtime.ready_pipe[1]);
+          CloseFd(runtime.done_pipe[0]);
+          CloseFd(runtime.done_pipe[1]);
+          CloseFd(runtime.stats_pipe[0]);
+          CloseFd(runtime.stats_pipe[1]);
+          KillAndReapChild(runtime.pid);
+        }
+        (void)Topic::Remove(topic_name);
+      });
 
   for (size_t i = 0; i < subscribers.size(); ++i)
   {
@@ -94,8 +97,8 @@ int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscr
       CloseFd(runtimes[i].done_pipe[1]);
       CloseFd(runtimes[i].stats_pipe[0]);
       const int child_status = RunModeSubscriberChild<PayloadBytes, Subscriber, Data>(
-          topic_name, subscribers[i], count, runtimes[i].done_pipe[0], runtimes[i].stats_pipe[1],
-          runtimes[i].ready_pipe[1]);
+          topic_name, subscribers[i], count, runtimes[i].done_pipe[0],
+          runtimes[i].stats_pipe[1], runtimes[i].ready_pipe[1]);
       CloseFd(runtimes[i].done_pipe[0]);
       CloseFd(runtimes[i].stats_pipe[1]);
       CloseFd(runtimes[i].ready_pipe[1]);
@@ -119,7 +122,8 @@ int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscr
     CloseFd(runtimes[i].ready_pipe[0]);
   }
 
-  if (!WaitForSubscriberAttach(publisher, static_cast<uint32_t>(subscribers.size()), case_label))
+  if (!WaitForSubscriberAttach(publisher, static_cast<uint32_t>(subscribers.size()),
+                               case_label))
   {
     return 1;
   }
@@ -141,7 +145,8 @@ int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscr
     auto* frame = data.GetData();
     frame->seq = seq;
     frame->pub_ns = NowNs();
-    std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU), frame->payload.size());
+    std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU),
+                frame->payload.size());
     frame->checksum = ComputeChecksum(*frame);
 
     if (publisher.Publish(data) != LibXR::ErrorCode::OK)
@@ -161,7 +166,8 @@ int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscr
   std::vector<ModeSubResult> results(subscribers.size());
   for (size_t i = 0; i < subscribers.size(); ++i)
   {
-    const bool read_ok = ReadAll(runtimes[i].stats_pipe[0], &results[i], sizeof(results[i]));
+    const bool read_ok =
+        ReadAll(runtimes[i].stats_pipe[0], &results[i], sizeof(results[i]));
     CloseFd(runtimes[i].stats_pipe[0]);
     int status = 0;
     while (waitpid(runtimes[i].pid, &status, 0) == -1 && errno == EINTR)
@@ -187,9 +193,10 @@ int RunModeCase(const char* case_label, const std::vector<ModeSubConfig>& subscr
     std::printf("[BENCH] shared_mode_subscriber case=%s sub=%s mode=%u recv=%" PRIu64
                 " drop=%" PRIu64 " first=%" PRIu64 " last=%" PRIu64
                 " lat_avg=%.3f us p95=%.3f us\n",
-                case_label, subscribers[i].label, static_cast<unsigned>(subscribers[i].mode),
-                results[i].recv_count, results[i].drop_count, results[i].first_seq,
-                results[i].last_seq, results[i].latency.avg_us, results[i].latency.p95_us);
+                case_label, subscribers[i].label,
+                static_cast<unsigned>(subscribers[i].mode), results[i].recv_count,
+                results[i].drop_count, results[i].first_seq, results[i].last_seq,
+                results[i].latency.avg_us, results[i].latency.p95_us);
   }
   std::fflush(stdout);
 

--- a/test/linux_bench/linux_shared_topic_mode_child_common.hpp
+++ b/test/linux_bench/linux_shared_topic_mode_child_common.hpp
@@ -1,18 +1,21 @@
 /**
  * @file linux_shared_topic_mode_child_common.hpp
- * @brief `LinuxSharedTopic` subscriber mode 子进程 helper。 Shared subscriber-child helper for `LinuxSharedTopic` mode benchmarks.
+ * @brief `LinuxSharedTopic` subscriber mode 子进程 helper。 Shared subscriber-child
+ * helper for `LinuxSharedTopic` mode benchmarks.
  * @details 作用：
  *          1. 封装 mode benchmark 中 subscriber 子进程的接收与统计逻辑。
  *          2. 减小 mode runner 主执行函数的体积。
  *          Purpose:
- *          1. Encapsulate receive/statistics logic for subscriber children in mode benchmarks.
+ *          1. Encapsulate receive/statistics logic for subscriber children in mode
+ * benchmarks.
  *          2. Reduce the size of the main mode runner function.
  */
 #pragma once
 
-#include <cerrno>
 #include <fcntl.h>
 #include <unistd.h>
+
+#include <cerrno>
 
 #include "linux_shared_topic_bench_common.hpp"
 

--- a/test/linux_bench/linux_shared_topic_overload_bench_runner.hpp
+++ b/test/linux_bench/linux_shared_topic_overload_bench_runner.hpp
@@ -1,6 +1,7 @@
 /**
  * @file linux_shared_topic_overload_bench_runner.hpp
- * @brief `LinuxSharedTopic` overload 基准执行 helper。 Shared execution helper for `LinuxSharedTopic` overload benchmarks.
+ * @brief `LinuxSharedTopic` overload 基准执行 helper。 Shared execution helper for
+ * `LinuxSharedTopic` overload benchmarks.
  * @details 作用：
  *          1. 封装 overload benchmark 的 parent 侧发布与统计流程。
  *          2. 让 `bench_overload.cpp` 只保留策略/载荷组合。
@@ -28,10 +29,10 @@ int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
   using Data = typename Topic::Data;
   using Subscriber = typename Topic::SyncSubscriber;
 
-  const uint64_t count =
-      (count_override != 0)
-          ? count_override
-          : ((PayloadBytes >= 1048576U) ? ScaleBenchCount(256U, 8U) : ScaleBenchCount(4000U, 32U));
+  const uint64_t count = (count_override != 0)
+                             ? count_override
+                             : ((PayloadBytes >= 1048576U) ? ScaleBenchCount(256U, 8U)
+                                                           : ScaleBenchCount(4000U, 32U));
 
   LibXR::LinuxSharedTopicConfig config = {};
   config.subscriber_num = 1;
@@ -47,25 +48,27 @@ int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
   }
 
   char topic_name[96] = {};
-  std::snprintf(topic_name, sizeof(topic_name), "linux_shared_overload_%zu_%u_%d", PayloadBytes,
-                static_cast<unsigned>(subscriber_mode), static_cast<int>(getpid()));
+  std::snprintf(topic_name, sizeof(topic_name), "linux_shared_overload_%zu_%u_%d",
+                PayloadBytes, static_cast<unsigned>(subscriber_mode),
+                static_cast<int>(getpid()));
   (void)Topic::Remove(topic_name);
 
   int done_pipe[2] = {-1, -1};
   int stats_pipe[2] = {-1, -1};
   int ready_pipe[2] = {-1, -1};
   pid_t child = -1;
-  auto cleanup = MakeScopeExit([&]()
-  {
-    CloseFd(done_pipe[0]);
-    CloseFd(done_pipe[1]);
-    CloseFd(stats_pipe[0]);
-    CloseFd(stats_pipe[1]);
-    CloseFd(ready_pipe[0]);
-    CloseFd(ready_pipe[1]);
-    KillAndReapChild(child);
-    (void)Topic::Remove(topic_name);
-  });
+  auto cleanup = MakeScopeExit(
+      [&]()
+      {
+        CloseFd(done_pipe[0]);
+        CloseFd(done_pipe[1]);
+        CloseFd(stats_pipe[0]);
+        CloseFd(stats_pipe[1]);
+        CloseFd(ready_pipe[0]);
+        CloseFd(ready_pipe[1]);
+        KillAndReapChild(child);
+        (void)Topic::Remove(topic_name);
+      });
 
   if (pipe(done_pipe) != 0 || pipe(stats_pipe) != 0 || pipe(ready_pipe) != 0)
   {
@@ -76,7 +79,8 @@ int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
   Topic publisher(topic_name, config);
   if (!publisher.Valid())
   {
-    std::fprintf(stderr, "overload publisher open failed for payload=%zu\n", PayloadBytes);
+    std::fprintf(stderr, "overload publisher open failed for payload=%zu\n",
+                 PayloadBytes);
     return 1;
   }
 
@@ -93,8 +97,8 @@ int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
     CloseFd(stats_pipe[0]);
     CloseFd(ready_pipe[0]);
     const int child_status = RunOverloadSubscriberChild<PayloadBytes, Subscriber, Data>(
-        topic_name, subscriber_mode, subscriber_delay_us, count, done_pipe[0], stats_pipe[1],
-        ready_pipe[1]);
+        topic_name, subscriber_mode, subscriber_delay_us, count, done_pipe[0],
+        stats_pipe[1], ready_pipe[1]);
     CloseFd(done_pipe[0]);
     CloseFd(stats_pipe[1]);
     CloseFd(ready_pipe[1]);
@@ -130,7 +134,8 @@ int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
     auto* frame = data.GetData();
     frame->seq = seq;
     frame->pub_ns = NowNs();
-    std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU), frame->payload.size());
+    std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU),
+                frame->payload.size());
     frame->checksum = ComputeChecksum(*frame);
 
     if (publisher.Publish(data) != LibXR::ErrorCode::OK)
@@ -165,13 +170,14 @@ int RunOverloadCase(LibXR::LinuxSharedSubscriberMode subscriber_mode,
   std::printf(
       "[BENCH] shared_overload policy=%s payload=%zuB count=%" PRIu64
       " delay=%u us attempt_rate=%.0f msg/s ok_rate=%.0f msg/s create_fail=%" PRIu64
-      " publish_fail=%" PRIu64 " recv=%" PRIu64 " sub_drop=%" PRIu64
-      " seq_gap=%" PRIu64 " lat_avg=%.3f us p50=%.3f us p95=%.3f us p99=%.3f us max=%.3f us\n",
-      subscriber_mode == LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL ? "FULL" : "DROP_OLD",
+      " publish_fail=%" PRIu64 " recv=%" PRIu64 " sub_drop=%" PRIu64 " seq_gap=%" PRIu64
+      " lat_avg=%.3f us p50=%.3f us p95=%.3f us p99=%.3f us max=%.3f us\n",
+      subscriber_mode == LibXR::LinuxSharedSubscriberMode::BROADCAST_FULL ? "FULL"
+                                                                          : "DROP_OLD",
       sizeof(BenchFrame<PayloadBytes>), count, subscriber_delay_us, attempt_rate, ok_rate,
       create_fail, publish_fail, stats.latency.count, stats.subscriber_drop_num,
-      stats.sequence_gap, stats.latency.avg_us, stats.latency.p50_us, stats.latency.p95_us,
-      stats.latency.p99_us, stats.latency.max_us);
+      stats.sequence_gap, stats.latency.avg_us, stats.latency.p50_us,
+      stats.latency.p95_us, stats.latency.p99_us, stats.latency.max_us);
   std::fflush(stdout);
 
   return 0;

--- a/test/linux_bench/linux_shared_topic_overload_child_common.hpp
+++ b/test/linux_bench/linux_shared_topic_overload_child_common.hpp
@@ -1,18 +1,21 @@
 /**
  * @file linux_shared_topic_overload_child_common.hpp
- * @brief `LinuxSharedTopic` overload subscriber 子进程 helper。 Shared subscriber-child helper for `LinuxSharedTopic` overload benchmarks.
+ * @brief `LinuxSharedTopic` overload subscriber 子进程 helper。 Shared subscriber-child
+ * helper for `LinuxSharedTopic` overload benchmarks.
  * @details 作用：
  *          1. 封装 overload 场景下 subscriber 侧的接收、延迟和 drop 统计。
  *          2. 减小 overload runner 主执行函数的体积。
  *          Purpose:
- *          1. Encapsulate receive/latency/drop collection on the subscriber side of overload cases.
+ *          1. Encapsulate receive/latency/drop collection on the subscriber side of
+ * overload cases.
  *          2. Reduce the size of the main overload runner function.
  */
 #pragma once
 
-#include <cerrno>
 #include <fcntl.h>
 #include <unistd.h>
+
+#include <cerrno>
 
 #include "linux_shared_topic_bench_common.hpp"
 

--- a/test/linux_bench/linux_shared_topic_standard_bench_runner.hpp
+++ b/test/linux_bench/linux_shared_topic_standard_bench_runner.hpp
@@ -1,11 +1,13 @@
 /**
  * @file linux_shared_topic_standard_bench_runner.hpp
- * @brief `LinuxSharedTopic` standard 基准执行 helper。 Shared execution helper for `LinuxSharedTopic` standard benchmarks.
+ * @brief `LinuxSharedTopic` standard 基准执行 helper。 Shared execution helper for
+ * `LinuxSharedTopic` standard benchmarks.
  * @details 作用：
  *          1. 封装 standard throughput/latency 子场景的通用执行流程。
  *          2. 让 `bench_standard.cpp` 只保留 payload case 组合。
  *          Purpose:
- *          1. Encapsulate the common execution flow for standard throughput/latency cases.
+ *          1. Encapsulate the common execution flow for standard throughput/latency
+ * cases.
  *          2. Keep `bench_standard.cpp` focused on payload-case composition only.
  */
 #pragma once
@@ -27,7 +29,8 @@ int RunBenchCase(uint64_t count_override = 0)
   using Data = typename Topic::Data;
   using Subscriber = typename Topic::SyncSubscriber;
 
-  const uint64_t count = (count_override == 0) ? CountForPayload<PayloadBytes>() : count_override;
+  const uint64_t count =
+      (count_override == 0) ? CountForPayload<PayloadBytes>() : count_override;
   const LibXR::LinuxSharedTopicConfig config = ConfigForPayload<PayloadBytes>();
 
   char topic_name[96] = {};
@@ -38,15 +41,16 @@ int RunBenchCase(uint64_t count_override = 0)
   int stats_pipe[2] = {-1, -1};
   int ready_pipe[2] = {-1, -1};
   pid_t child = -1;
-  auto cleanup = MakeScopeExit([&]()
-  {
-    CloseFd(stats_pipe[0]);
-    CloseFd(stats_pipe[1]);
-    CloseFd(ready_pipe[0]);
-    CloseFd(ready_pipe[1]);
-    KillAndReapChild(child);
-    (void)Topic::Remove(topic_name);
-  });
+  auto cleanup = MakeScopeExit(
+      [&]()
+      {
+        CloseFd(stats_pipe[0]);
+        CloseFd(stats_pipe[1]);
+        CloseFd(ready_pipe[0]);
+        CloseFd(ready_pipe[1]);
+        KillAndReapChild(child);
+        (void)Topic::Remove(topic_name);
+      });
 
   if (pipe(stats_pipe) != 0 || pipe(ready_pipe) != 0)
   {
@@ -151,7 +155,8 @@ int RunBenchCase(uint64_t count_override = 0)
     frame->pub_ns = NowNs();
     if constexpr (TouchPayload)
     {
-      std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU), frame->payload.size());
+      std::memset(frame->payload.data(), static_cast<int>(seq & 0xFFU),
+                  frame->payload.size());
     }
     else if constexpr (PayloadBytes > 0)
     {
@@ -186,22 +191,21 @@ int RunBenchCase(uint64_t count_override = 0)
   const double total_s = static_cast<double>(end_ns - start_ns) / 1e9;
   const double msg_per_s = static_cast<double>(count) / total_s;
   const double mib_per_s =
-      (static_cast<double>(count) * static_cast<double>(sizeof(BenchFrame<PayloadBytes>)) /
-       (1024.0 * 1024.0)) /
+      (static_cast<double>(count) *
+       static_cast<double>(sizeof(BenchFrame<PayloadBytes>)) / (1024.0 * 1024.0)) /
       total_s;
   const double publish_avg_us =
       static_cast<double>(end_ns - start_ns) / 1000.0 / static_cast<double>(count);
 
-  std::printf(
-      "[BENCH] shared_standard mode=%s payload=%zuB count=%" PRIu64
-      " publish_avg=%.3f us throughput=%.0f msg/s bandwidth=%.2f MiB/s "
-      "create_retry=%" PRIu64 " publish_retry=%" PRIu64
-      " latency_avg=%.3f us p50=%.3f us p95=%.3f us p99=%.3f us max=%.3f us "
-      "seq_err=%" PRIu64 " timeout_err=%" PRIu64 "\n",
-      TouchPayload ? "full-touch" : "transport", sizeof(BenchFrame<PayloadBytes>), count,
-      publish_avg_us, msg_per_s, mib_per_s, create_retries, publish_retries, stats.avg_us,
-      stats.p50_us, stats.p95_us, stats.p99_us, stats.max_us, stats.sequence_errors,
-      stats.timeout_errors);
+  std::printf("[BENCH] shared_standard mode=%s payload=%zuB count=%" PRIu64
+              " publish_avg=%.3f us throughput=%.0f msg/s bandwidth=%.2f MiB/s "
+              "create_retry=%" PRIu64 " publish_retry=%" PRIu64
+              " latency_avg=%.3f us p50=%.3f us p95=%.3f us p99=%.3f us max=%.3f us "
+              "seq_err=%" PRIu64 " timeout_err=%" PRIu64 "\n",
+              TouchPayload ? "full-touch" : "transport", sizeof(BenchFrame<PayloadBytes>),
+              count, publish_avg_us, msg_per_s, mib_per_s, create_retries,
+              publish_retries, stats.avg_us, stats.p50_us, stats.p95_us, stats.p99_us,
+              stats.max_us, stats.sequence_errors, stats.timeout_errors);
   std::fflush(stdout);
 
   return 0;

--- a/test/linux_database/linux_database_flash_test_common.hpp
+++ b/test/linux_database/linux_database_flash_test_common.hpp
@@ -1,6 +1,7 @@
 /**
  * @file linux_database_flash_test_common.hpp
- * @brief linux database 测试共用 flash/fatal helper。 Shared flash and fatal-path helpers for linux database tests.
+ * @brief linux database 测试共用 flash/fatal helper。 Shared flash and fatal-path helpers
+ * for linux database tests.
  * @details 共享职责：
  *          1. 定义 flash 布局常量和 main/backup 校验元数据常量。
  *          2. 提供可注入读写擦失败的 `FailingFlash`。
@@ -118,9 +119,13 @@ class FailingFlash : public Flash
 
  private:
   /**
-   * @brief 辅助函数 `SeedValidSequentialBlocks`。 Helper function `SeedValidSequentialBlocks`.
-   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
-   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+   * @brief 辅助函数 `SeedValidSequentialBlocks`。 Helper function
+   * `SeedValidSequentialBlocks`.
+   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+   * measure, or validate shared state for later test steps.
+   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+   * repeated helper logic locally so the main test body stays focused on the test item
+   * itself.
    */
   void SeedValidSequentialBlocks()
   {

--- a/test/linux_database/linux_database_image_test_common.hpp
+++ b/test/linux_database/linux_database_image_test_common.hpp
@@ -1,6 +1,7 @@
 /**
  * @file linux_database_image_test_common.hpp
- * @brief linux database 测试共用 flash 映像注入 helper。 Shared flash-image mutation helpers for linux database tests.
+ * @brief linux database 测试共用 flash 映像注入 helper。 Shared flash-image mutation
+ * helpers for linux database tests.
  * @details 共享职责：
  *          1. 读取/写回原始 flash 映像并注入 main/backup 损坏。
  *          2. 生成 seed 数据库与双 key 数据库。
@@ -30,8 +31,11 @@ namespace LinuxDatabaseTestCommon
 
 /**
  * @brief 辅助函数 `WriteLe32`。 Helper function `WriteLe32`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 inline void WriteLe32(std::vector<uint8_t>& bytes, size_t offset, uint32_t value)
 {
@@ -57,8 +61,11 @@ inline void WriteLe32(std::vector<uint8_t>& bytes, size_t offset, uint32_t value
 
 /**
  * @brief 辅助函数 `WriteAllBytes`。 Helper function `WriteAllBytes`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 inline void WriteAllBytes(const char* path, const std::vector<uint8_t>& bytes)
 {

--- a/test/linux_database/linux_database_reopen_test_common.hpp
+++ b/test/linux_database/linux_database_reopen_test_common.hpp
@@ -1,6 +1,7 @@
 /**
  * @file linux_database_reopen_test_common.hpp
- * @brief linux database 测试共用 reopen/断言 helper。 Shared reopen/assertion helpers for linux database tests.
+ * @brief linux database 测试共用 reopen/断言 helper。 Shared reopen/assertion helpers for
+ * linux database tests.
  * @details 共享职责：
  *          1. 通过公开 database API reopen 后读取持久化值。
  *          2. 校验 main 有效/backup 无效的持久化状态。
@@ -17,7 +18,8 @@
 namespace LinuxDatabaseTestCommon
 {
 
-[[nodiscard]] inline uint32_t ReopenDatabaseValue(const char* path, uint32_t default_value)
+[[nodiscard]] inline uint32_t ReopenDatabaseValue(const char* path,
+                                                  uint32_t default_value)
 {
   LinuxBinaryFileFlash<XR_DB_FLASH_SIZE> flash(path, XR_DB_MIN_ERASE_SIZE,
                                                XR_DB_MIN_WRITE_SIZE, false, true);
@@ -26,7 +28,8 @@ namespace LinuxDatabaseTestCommon
   return key.data_;
 }
 
-[[nodiscard]] inline uint32_t ReopenDatabaseValue(const char* path, uint32_t default_value,
+[[nodiscard]] inline uint32_t ReopenDatabaseValue(const char* path,
+                                                  uint32_t default_value,
                                                   const char* key_name)
 {
   LinuxBinaryFileFlash<XR_DB_FLASH_SIZE> flash(path, XR_DB_MIN_ERASE_SIZE,

--- a/test/linux_database/linux_database_test_common.hpp
+++ b/test/linux_database/linux_database_test_common.hpp
@@ -1,6 +1,7 @@
 /**
  * @file linux_database_test_common.hpp
- * @brief linux database 测试聚合 helper 入口。 Aggregation helper entry for linux database tests.
+ * @brief linux database 测试聚合 helper 入口。 Aggregation helper entry for linux
+ * database tests.
  * @details 共享职责：
  *          1. 聚合 flash/fatal helper 与 flash-image/reopen helper。
  *          2. 让 sequential/raw 子测试只依赖一个薄包装头。

--- a/test/linux_database/raw_database_test_groups.hpp
+++ b/test/linux_database/raw_database_test_groups.hpp
@@ -1,6 +1,7 @@
 /**
  * @file raw_database_test_groups.hpp
- * @brief `DatabaseRaw` linux database 测试分组声明。 Group declarations for split `DatabaseRaw` linux database tests.
+ * @brief `DatabaseRaw` linux database 测试分组声明。 Group declarations for split
+ * `DatabaseRaw` linux database tests.
  */
 #pragma once
 

--- a/test/linux_database/test_database_raw_failures.cpp
+++ b/test/linux_database/test_database_raw_failures.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_raw_failures.cpp
- * @brief linux file-backed `DatabaseRaw` failure 场景子测试。 Split test unit for linux file-backed `DatabaseRaw` failure scenarios.
+ * @brief linux file-backed `DatabaseRaw` failure 场景子测试。 Split test unit for linux
+ * file-backed `DatabaseRaw` failure scenarios.
  */
 #include "linux_database_test_common.hpp"
 #include "raw_database_test_groups.hpp"
@@ -11,108 +12,123 @@ namespace
 using namespace LinuxDatabaseTestCommon;
 
 /**
- * @brief 测试项函数 `TestDatabaseKeyAddFailureRequires`。 Test-item function `TestDatabaseKeyAddFailureRequires`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabaseKeyAddFailureRequires`。 Test-item function
+ * `TestDatabaseKeyAddFailureRequires`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabaseKeyAddFailureRequires()
 {
   // 测试内容：执行当前辅助测试项，对应文件头中的一个具体项目。
   // Test coverage: execute the current helper-scoped test item from this file.
 #if defined(LIBXR_SYSTEM_Linux)
-  ExpectFatalExit(
-      XR_DB_FATAL_KEY_ADD,
-      []
-      {
-        class MemoryDatabase : public Database
-        {
-         public:
-          ErrorCode get_result = ErrorCode::NOT_FOUND;
-          ErrorCode add_result = ErrorCode::FAILED;
+  ExpectFatalExit(XR_DB_FATAL_KEY_ADD,
+                  []
+                  {
+                    class MemoryDatabase : public Database
+                    {
+                     public:
+                      ErrorCode get_result = ErrorCode::NOT_FOUND;
+                      ErrorCode add_result = ErrorCode::FAILED;
 
-          ErrorCode Get(KeyBase&) override { return get_result; }
-          ErrorCode Set(KeyBase&, RawData) override { return ErrorCode::OK; }
-          ErrorCode Add(KeyBase&) override { return add_result; }
-        } db;
+                      ErrorCode Get(KeyBase&) override { return get_result; }
+                      ErrorCode Set(KeyBase&, RawData) override { return ErrorCode::OK; }
+                      ErrorCode Add(KeyBase&) override { return add_result; }
+                    } db;
 
-        Database::Key<uint32_t> key(db, "mock", 123);
-        UNUSED(key);
-      });
+                    Database::Key<uint32_t> key(db, "mock", 123);
+                    UNUSED(key);
+                  });
 #endif
 }
 
 /**
- * @brief 测试项函数 `TestDatabaseRawReadFailureRequires`。 Test-item function `TestDatabaseRawReadFailureRequires`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabaseRawReadFailureRequires`。 Test-item function
+ * `TestDatabaseRawReadFailureRequires`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabaseRawReadFailureRequires()
 {
   // 测试内容：执行当前辅助测试项，对应文件头中的一个具体项目。
   // Test coverage: execute the current helper-scoped test item from this file.
 #if defined(LIBXR_SYSTEM_Linux)
-  ExpectFatalExit(
-      XR_DB_FATAL_RAW_READ,
-      []
-      {
-        FailingFlash flash(XR_DB_MIN_ERASE_SIZE, XR_DB_MIN_WRITE_SIZE);
-        flash.SetFailOp(FailingFlash::FailOp::READ);
-        DatabaseRaw<XR_DB_MIN_WRITE_SIZE> db(flash, 5);
-        UNUSED(db);
-      });
+  ExpectFatalExit(XR_DB_FATAL_RAW_READ,
+                  []
+                  {
+                    FailingFlash flash(XR_DB_MIN_ERASE_SIZE, XR_DB_MIN_WRITE_SIZE);
+                    flash.SetFailOp(FailingFlash::FailOp::READ);
+                    DatabaseRaw<XR_DB_MIN_WRITE_SIZE> db(flash, 5);
+                    UNUSED(db);
+                  });
 #endif
 }
 
 /**
- * @brief 测试项函数 `TestDatabaseRawWriteFailureRequires`。 Test-item function `TestDatabaseRawWriteFailureRequires`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabaseRawWriteFailureRequires`。 Test-item function
+ * `TestDatabaseRawWriteFailureRequires`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabaseRawWriteFailureRequires()
 {
   // 测试内容：执行当前辅助测试项，对应文件头中的一个具体项目。
   // Test coverage: execute the current helper-scoped test item from this file.
 #if defined(LIBXR_SYSTEM_Linux)
-  ExpectFatalExit(
-      XR_DB_FATAL_RAW_WRITE,
-      []
-      {
-        FailingFlash flash(XR_DB_MIN_ERASE_SIZE, XR_DB_MIN_WRITE_SIZE);
-        flash.SetFailOp(FailingFlash::FailOp::WRITE);
-        DatabaseRaw<XR_DB_MIN_WRITE_SIZE> db(flash, 5);
-        UNUSED(db);
-      });
+  ExpectFatalExit(XR_DB_FATAL_RAW_WRITE,
+                  []
+                  {
+                    FailingFlash flash(XR_DB_MIN_ERASE_SIZE, XR_DB_MIN_WRITE_SIZE);
+                    flash.SetFailOp(FailingFlash::FailOp::WRITE);
+                    DatabaseRaw<XR_DB_MIN_WRITE_SIZE> db(flash, 5);
+                    UNUSED(db);
+                  });
 #endif
 }
 
 /**
- * @brief 测试项函数 `TestDatabaseRawEraseFailureRequires`。 Test-item function `TestDatabaseRawEraseFailureRequires`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabaseRawEraseFailureRequires`。 Test-item function
+ * `TestDatabaseRawEraseFailureRequires`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabaseRawEraseFailureRequires()
 {
   // 测试内容：执行当前辅助测试项，对应文件头中的一个具体项目。
   // Test coverage: execute the current helper-scoped test item from this file.
 #if defined(LIBXR_SYSTEM_Linux)
-  ExpectFatalExit(
-      XR_DB_FATAL_RAW_ERASE,
-      []
-      {
-        FailingFlash flash(XR_DB_MIN_ERASE_SIZE, XR_DB_MIN_WRITE_SIZE);
-        flash.SetFailOp(FailingFlash::FailOp::ERASE);
-        DatabaseRaw<XR_DB_MIN_WRITE_SIZE> db(flash, 5);
-        UNUSED(db);
-      });
+  ExpectFatalExit(XR_DB_FATAL_RAW_ERASE,
+                  []
+                  {
+                    FailingFlash flash(XR_DB_MIN_ERASE_SIZE, XR_DB_MIN_WRITE_SIZE);
+                    flash.SetFailOp(FailingFlash::FailOp::ERASE);
+                    DatabaseRaw<XR_DB_MIN_WRITE_SIZE> db(flash, 5);
+                    UNUSED(db);
+                  });
 #endif
 }
 
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunLinuxDatabaseRawFailureTests`。 Test-item function `RunLinuxDatabaseRawFailureTests`.
- * @details 测试内容：执行当前分组里的 `DatabaseRaw` linux database 子场景。 Execute the grouped `DatabaseRaw` linux database sub-scenarios.
- *          测试原理：把 smoke / failure / recovery 三类路径拆开，避免一个原始大文件持续膨胀。 Split smoke, failure, and recovery paths so one raw monolithic file does not keep growing.
+ * @brief 测试项函数 `RunLinuxDatabaseRawFailureTests`。 Test-item function
+ * `RunLinuxDatabaseRawFailureTests`.
+ * @details 测试内容：执行当前分组里的 `DatabaseRaw` linux database 子场景。 Execute the
+ * grouped `DatabaseRaw` linux database sub-scenarios. 测试原理：把 smoke / failure /
+ * recovery 三类路径拆开，避免一个原始大文件持续膨胀。 Split smoke, failure, and recovery
+ * paths so one raw monolithic file does not keep growing.
  */
 void RunLinuxDatabaseRawFailureTests()
 {

--- a/test/linux_database/test_database_raw_recovery.cpp
+++ b/test/linux_database/test_database_raw_recovery.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_raw_recovery.cpp
- * @brief linux file-backed `DatabaseRaw` recovery 场景子测试。 Split test unit for linux file-backed `DatabaseRaw` recovery scenarios.
+ * @brief linux file-backed `DatabaseRaw` recovery 场景子测试。 Split test unit for linux
+ * file-backed `DatabaseRaw` recovery scenarios.
  */
 #include "linux_database_test_common.hpp"
 #include "raw_database_test_groups.hpp"
@@ -11,9 +12,13 @@ namespace
 using namespace LinuxDatabaseTestCommon;
 
 /**
- * @brief 测试项函数 `TestDatabaseRawInvalidMainKeyMetadataReinitializes`。 Test-item function `TestDatabaseRawInvalidMainKeyMetadataReinitializes`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabaseRawInvalidMainKeyMetadataReinitializes`。 Test-item
+ * function `TestDatabaseRawInvalidMainKeyMetadataReinitializes`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabaseRawInvalidMainKeyMetadataReinitializes()
 {
@@ -33,9 +38,13 @@ void TestDatabaseRawInvalidMainKeyMetadataReinitializes()
 }
 
 /**
- * @brief 测试项函数 `TestDatabaseRawInvalidBackupMetadataDoesNotRestore`。 Test-item function `TestDatabaseRawInvalidBackupMetadataDoesNotRestore`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabaseRawInvalidBackupMetadataDoesNotRestore`。 Test-item
+ * function `TestDatabaseRawInvalidBackupMetadataDoesNotRestore`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabaseRawInvalidBackupMetadataDoesNotRestore()
 {
@@ -55,9 +64,13 @@ void TestDatabaseRawInvalidBackupMetadataDoesNotRestore()
 }
 
 /**
- * @brief 测试项函数 `TestDatabaseRawRestoresFromValidBackup`。 Test-item function `TestDatabaseRawRestoresFromValidBackup`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabaseRawRestoresFromValidBackup`。 Test-item function
+ * `TestDatabaseRawRestoresFromValidBackup`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabaseRawRestoresFromValidBackup()
 {
@@ -76,9 +89,13 @@ void TestDatabaseRawRestoresFromValidBackup()
 }
 
 /**
- * @brief 测试项函数 `TestDatabaseRawCorruptFirstKeySizeInMultiKeyDatabaseReinitializes`。 Test-item function `TestDatabaseRawCorruptFirstKeySizeInMultiKeyDatabaseReinitializes`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabaseRawCorruptFirstKeySizeInMultiKeyDatabaseReinitializes`。
+ * Test-item function `TestDatabaseRawCorruptFirstKeySizeInMultiKeyDatabaseReinitializes`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabaseRawCorruptFirstKeySizeInMultiKeyDatabaseReinitializes()
 {
@@ -101,9 +118,12 @@ void TestDatabaseRawCorruptFirstKeySizeInMultiKeyDatabaseReinitializes()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunLinuxDatabaseRawRecoveryTests`。 Test-item function `RunLinuxDatabaseRawRecoveryTests`.
- * @details 测试内容：执行当前分组里的 `DatabaseRaw` linux database 子场景。 Execute the grouped `DatabaseRaw` linux database sub-scenarios.
- *          测试原理：把 smoke / failure / recovery 三类路径拆开，避免一个原始大文件持续膨胀。 Split smoke, failure, and recovery paths so one raw monolithic file does not keep growing.
+ * @brief 测试项函数 `RunLinuxDatabaseRawRecoveryTests`。 Test-item function
+ * `RunLinuxDatabaseRawRecoveryTests`.
+ * @details 测试内容：执行当前分组里的 `DatabaseRaw` linux database 子场景。 Execute the
+ * grouped `DatabaseRaw` linux database sub-scenarios. 测试原理：把 smoke / failure /
+ * recovery 三类路径拆开，避免一个原始大文件持续膨胀。 Split smoke, failure, and recovery
+ * paths so one raw monolithic file does not keep growing.
  */
 void RunLinuxDatabaseRawRecoveryTests()
 {

--- a/test/linux_database/test_database_raw_smoke.cpp
+++ b/test/linux_database/test_database_raw_smoke.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_raw_smoke.cpp
- * @brief linux file-backed `DatabaseRaw` smoke/save 场景子测试。 Split test unit for linux file-backed `DatabaseRaw` smoke/save scenarios.
+ * @brief linux file-backed `DatabaseRaw` smoke/save 场景子测试。 Split test unit for
+ * linux file-backed `DatabaseRaw` smoke/save scenarios.
  */
 #include "linux_database_test_common.hpp"
 #include "raw_database_test_groups.hpp"
@@ -11,9 +12,13 @@ namespace
 using namespace LinuxDatabaseTestCommon;
 
 /**
- * @brief 测试项函数 `TestLinuxDatabaseRawSmoke`。 Test-item function `TestLinuxDatabaseRawSmoke`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestLinuxDatabaseRawSmoke`。 Test-item function
+ * `TestLinuxDatabaseRawSmoke`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestLinuxDatabaseRawSmoke()
 {
@@ -26,8 +31,7 @@ void TestLinuxDatabaseRawSmoke()
   std::array<uint32_t, 3> data_k3 = {111, 222, 333};
   std::array<uint32_t, 4> data_k4 = {1111, 2222, 3333, 4444};
 
-  LinuxBinaryFileFlash<FLASH_SIZE> flash_2("/tmp/flash_test_2.bin", 512, 16, false,
-                                           true);
+  LinuxBinaryFileFlash<FLASH_SIZE> flash_2("/tmp/flash_test_2.bin", 512, 16, false, true);
   DatabaseRaw<16> test_db_2(flash_2, 5);
 
   DatabaseRaw<16>::Key k1_2(test_db_2, "key1", data_k1);
@@ -87,9 +91,13 @@ void TestLinuxDatabaseRawSmoke()
 }
 
 /**
- * @brief 测试项函数 `TestDatabasePartialBackupRecovery`。 Test-item function `TestDatabasePartialBackupRecovery`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabasePartialBackupRecovery`。 Test-item function
+ * `TestDatabasePartialBackupRecovery`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabasePartialBackupRecovery()
 {
@@ -102,9 +110,13 @@ void TestDatabasePartialBackupRecovery()
 }
 
 /**
- * @brief 测试项函数 `TestDatabaseRawSaveCurrentValue`。 Test-item function `TestDatabaseRawSaveCurrentValue`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabaseRawSaveCurrentValue`。 Test-item function
+ * `TestDatabaseRawSaveCurrentValue`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabaseRawSaveCurrentValue()
 {
@@ -123,9 +135,13 @@ void TestDatabaseRawSaveCurrentValue()
 }
 
 /**
- * @brief 测试项函数 `TestDatabaseRawRequiresExactStoredSize`。 Test-item function `TestDatabaseRawRequiresExactStoredSize`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestDatabaseRawRequiresExactStoredSize`。 Test-item function
+ * `TestDatabaseRawRequiresExactStoredSize`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestDatabaseRawRequiresExactStoredSize()
 {
@@ -156,9 +172,12 @@ void TestDatabaseRawRequiresExactStoredSize()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunLinuxDatabaseRawSmokeTests`。 Test-item function `RunLinuxDatabaseRawSmokeTests`.
- * @details 测试内容：执行当前分组里的 `DatabaseRaw` linux database 子场景。 Execute the grouped `DatabaseRaw` linux database sub-scenarios.
- *          测试原理：把 smoke / failure / recovery 三类路径拆开，避免一个原始大文件持续膨胀。 Split smoke, failure, and recovery paths so one raw monolithic file does not keep growing.
+ * @brief 测试项函数 `RunLinuxDatabaseRawSmokeTests`。 Test-item function
+ * `RunLinuxDatabaseRawSmokeTests`.
+ * @details 测试内容：执行当前分组里的 `DatabaseRaw` linux database 子场景。 Execute the
+ * grouped `DatabaseRaw` linux database sub-scenarios. 测试原理：把 smoke / failure /
+ * recovery 三类路径拆开，避免一个原始大文件持续膨胀。 Split smoke, failure, and recovery
+ * paths so one raw monolithic file does not keep growing.
  */
 void RunLinuxDatabaseRawSmokeTests()
 {

--- a/test/linux_database/test_database_sequential_failures.cpp
+++ b/test/linux_database/test_database_sequential_failures.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_sequential_failures.cpp
- * @brief linux file-backed `DatabaseRawSequential` fatal 失败路径子测试。 Split test unit for linux file-backed `DatabaseRawSequential` fatal failure paths.
+ * @brief linux file-backed `DatabaseRawSequential` fatal 失败路径子测试。 Split test unit
+ * for linux file-backed `DatabaseRawSequential` fatal failure paths.
  * @details 测试项目：
  *          1. backend 读失败触发预期 fatal exit。
  *          2. backend 写失败触发预期 fatal exit。
@@ -20,51 +21,51 @@ using namespace LinuxDatabaseTestCommon;
 void TestDatabaseSequentialReadFailureRequires()
 {
   // 测试内容：验证 sequential backend 读失败时走到规定的 fatal 退出路径。
-  // Test coverage: verify that sequential backend read failures take the specified fatal-exit path.
+  // Test coverage: verify that sequential backend read failures take the specified
+  // fatal-exit path.
 #if defined(LIBXR_SYSTEM_Linux)
-  ExpectFatalExit(
-      XR_DB_FATAL_SEQ_READ,
-      []
-      {
-        FailingFlash flash;
-        DatabaseRawSequential db(flash);
-        flash.SetFailOp(FailingFlash::FailOp::READ);
-        db.Load();
-      });
+  ExpectFatalExit(XR_DB_FATAL_SEQ_READ,
+                  []
+                  {
+                    FailingFlash flash;
+                    DatabaseRawSequential db(flash);
+                    flash.SetFailOp(FailingFlash::FailOp::READ);
+                    db.Load();
+                  });
 #endif
 }
 
 void TestDatabaseSequentialWriteFailureRequires()
 {
   // 测试内容：验证 sequential backend 写失败时走到规定的 fatal 退出路径。
-  // Test coverage: verify that sequential backend write failures take the specified fatal-exit path.
+  // Test coverage: verify that sequential backend write failures take the specified
+  // fatal-exit path.
 #if defined(LIBXR_SYSTEM_Linux)
-  ExpectFatalExit(
-      XR_DB_FATAL_SEQ_WRITE,
-      []
-      {
-        FailingFlash flash;
-        DatabaseRawSequential db(flash);
-        flash.SetFailOp(FailingFlash::FailOp::WRITE);
-        db.Restore();
-      });
+  ExpectFatalExit(XR_DB_FATAL_SEQ_WRITE,
+                  []
+                  {
+                    FailingFlash flash;
+                    DatabaseRawSequential db(flash);
+                    flash.SetFailOp(FailingFlash::FailOp::WRITE);
+                    db.Restore();
+                  });
 #endif
 }
 
 void TestDatabaseSequentialEraseFailureRequires()
 {
   // 测试内容：验证 sequential backend 擦除失败时走到规定的 fatal 退出路径。
-  // Test coverage: verify that sequential backend erase failures take the specified fatal-exit path.
+  // Test coverage: verify that sequential backend erase failures take the specified
+  // fatal-exit path.
 #if defined(LIBXR_SYSTEM_Linux)
-  ExpectFatalExit(
-      XR_DB_FATAL_SEQ_ERASE,
-      []
-      {
-        FailingFlash flash;
-        DatabaseRawSequential db(flash);
-        flash.SetFailOp(FailingFlash::FailOp::ERASE);
-        db.Save();
-      });
+  ExpectFatalExit(XR_DB_FATAL_SEQ_ERASE,
+                  []
+                  {
+                    FailingFlash flash;
+                    DatabaseRawSequential db(flash);
+                    flash.SetFailOp(FailingFlash::FailOp::ERASE);
+                    db.Save();
+                  });
 #endif
 }
 

--- a/test/linux_database/test_database_sequential_smoke.cpp
+++ b/test/linux_database/test_database_sequential_smoke.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_sequential_smoke.cpp
- * @brief linux file-backed `DatabaseRawSequential` smoke/save 场景子测试。 Split test unit for linux file-backed `DatabaseRawSequential` smoke/save scenarios.
+ * @brief linux file-backed `DatabaseRawSequential` smoke/save 场景子测试。 Split test
+ * unit for linux file-backed `DatabaseRawSequential` smoke/save scenarios.
  * @details 测试项目：
  *          1. 多 key sequential 数据库烟雾流量与重复 load/store。
  *          2. `Save()` 保存当前值语义。
@@ -18,7 +19,8 @@ using namespace LinuxDatabaseTestCommon;
 void TestLinuxDatabaseSequentialSmoke()
 {
   // 测试内容：验证 linux database sequential 在长时间多 key 读写流量下保持持久化一致性。
-  // Test coverage: verify that the linux database sequential keeps persistence consistency under long-running multi-key traffic.
+  // Test coverage: verify that the linux database sequential keeps persistence
+  // consistency under long-running multi-key traffic.
   constexpr size_t FLASH_SIZE = XR_DB_FLASH_SIZE;
 
   LinuxBinaryFileFlash<FLASH_SIZE> test_flash("/tmp/flash_test.bin", 512, 8, true, true);
@@ -98,7 +100,8 @@ void TestLinuxDatabaseSequentialSmoke()
 void TestDatabaseSequentialSaveCurrentValue()
 {
   // 测试内容：验证 `Save()` 会把 key 对象当前缓冲区中的值持久化到 sequential backend。
-  // Test coverage: verify that `Save()` persists the key object's current in-memory value to the sequential backend.
+  // Test coverage: verify that `Save()` persists the key object's current in-memory value
+  // to the sequential backend.
   const char* path = "/tmp/flash_test_seq_save_current.bin";
   LinuxBinaryFileFlash<XR_DB_FLASH_SIZE> flash(path, 512, 8, true, true);
   DatabaseRawSequential db(flash);

--- a/test/linux_database/test_linux_database_raw.cpp
+++ b/test/linux_database/test_linux_database_raw.cpp
@@ -1,13 +1,18 @@
 /**
  * @file test_raw.cpp
- * @brief linux file-backed `DatabaseRaw` 测试聚合入口。 Aggregation entry for split linux file-backed `DatabaseRaw` tests.
+ * @brief linux file-backed `DatabaseRaw` 测试聚合入口。 Aggregation entry for split linux
+ * file-backed `DatabaseRaw` tests.
  */
 #include "raw_database_test_groups.hpp"
 
 /**
- * @brief 测试入口函数 `test_linux_database_raw`。 Test entry function `test_linux_database_raw`.
- * @details 测试内容：聚合执行拆分后的 linux file-backed `DatabaseRaw` 子测试组。 Aggregate and execute the split linux file-backed `DatabaseRaw` subtest groups.
- *          测试原理：在拆开 smoke / failure / recovery 之后，继续保留原 runner 使用的单入口名称。 Preserve the original runner-visible entry name after splitting smoke, failure, and recovery paths.
+ * @brief 测试入口函数 `test_linux_database_raw`。 Test entry function
+ * `test_linux_database_raw`.
+ * @details 测试内容：聚合执行拆分后的 linux file-backed `DatabaseRaw` 子测试组。
+ * Aggregate and execute the split linux file-backed `DatabaseRaw` subtest groups.
+ *          测试原理：在拆开 smoke / failure / recovery 之后，继续保留原 runner
+ * 使用的单入口名称。 Preserve the original runner-visible entry name after splitting
+ * smoke, failure, and recovery paths.
  */
 void test_linux_database_raw()
 {

--- a/test/linux_database/test_linux_database_sequential.cpp
+++ b/test/linux_database/test_linux_database_sequential.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_sequential.cpp
- * @brief linux file-backed `DatabaseRawSequential` 测试聚合入口。 Aggregation entry for split linux file-backed `DatabaseRawSequential` tests.
+ * @brief linux file-backed `DatabaseRawSequential` 测试聚合入口。 Aggregation entry for
+ * split linux file-backed `DatabaseRawSequential` tests.
  * @details 测试项目：
  *          1. 聚合 smoke/save 子场景。
  *          2. 聚合 fatal 失败路径子场景。
@@ -14,9 +15,11 @@ void RunLinuxDatabaseSequentialSmokeTests();
 void RunLinuxDatabaseSequentialFailureTests();
 
 /**
- * @brief 测试入口函数 `test_linux_database_sequential`。 Test entry function `test_linux_database_sequential`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_linux_database_sequential`。 Test entry function
+ * `test_linux_database_sequential`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_linux_database_sequential()
 {

--- a/test/linux_shm/linux_shm_topic_test_common.hpp
+++ b/test/linux_shm/linux_shm_topic_test_common.hpp
@@ -1,21 +1,23 @@
 /**
  * @file linux_shm_topic_test_common.hpp
- * @brief `LinuxSharedTopic` 环境验证共用 helper。 Shared helpers for `LinuxSharedTopic` environment verification.
+ * @brief `LinuxSharedTopic` 环境验证共用 helper。 Shared helpers for `LinuxSharedTopic`
+ * environment verification.
  *
  * 作用 / Purpose:
  * 1. 集中跨进程验证共用的 payload、别名、命名和断言 helper。
- *    Centralize shared payload, aliases, naming helpers, and assertions used by cross-process verification.
+ *    Centralize shared payload, aliases, naming helpers, and assertions used by
+ * cross-process verification.
  * 2. 让拆分后的各个场景文件只保留自己的验证语义。
  *    Keep each split scenario file focused on its own verification semantics.
  */
 #pragma once
 
+#include <sys/wait.h>
+#include <unistd.h>
+
 #include <array>
 #include <cstdio>
 #include <cstdlib>
-
-#include <sys/wait.h>
-#include <unistd.h>
 
 #include "libxr.hpp"
 #include "test.hpp"
@@ -38,8 +40,11 @@ using SharedSubscriber = SharedTopic::SyncSubscriber;
 
 /**
  * @brief 辅助函数 `ComputeChecksum`。 Helper function `ComputeChecksum`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 inline uint32_t ComputeChecksum(const IPCFrame& frame)
 {
@@ -53,8 +58,11 @@ inline uint32_t ComputeChecksum(const IPCFrame& frame)
 
 /**
  * @brief 辅助函数 `FillFrame`。 Helper function `FillFrame`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 inline void FillFrame(IPCFrame& frame, uint32_t seq)
 {
@@ -70,8 +78,10 @@ inline void FillFrame(IPCFrame& frame, uint32_t seq)
 
 /**
  * @brief 断言辅助函数 `AssertFrame`。 Assertion helper function `AssertFrame`.
- * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check to the current result.
- *          测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。 Concentrate repeated validation logic so test items do not drift to inconsistent checks.
+ * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check
+ * to the current result. 测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。
+ * Concentrate repeated validation logic so test items do not drift to inconsistent
+ * checks.
  */
 inline void AssertFrame(const IPCFrame& frame, uint32_t expected_seq)
 {
@@ -83,8 +93,11 @@ inline void AssertFrame(const IPCFrame& frame, uint32_t expected_seq)
 
 /**
  * @brief 辅助函数 `MakeTopicName`。 Helper function `MakeTopicName`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 inline void MakeTopicName(char* topic_name, size_t topic_name_size, const char* prefix)
 {
@@ -95,8 +108,11 @@ inline void MakeTopicName(char* topic_name, size_t topic_name_size, const char* 
 
 /**
  * @brief 辅助函数 `WaitForSubscriberNum`。 Helper function `WaitForSubscriberNum`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 inline void WaitForSubscriberNum(SharedTopic& topic, uint32_t expected_num)
 {
@@ -111,8 +127,10 @@ inline void WaitForSubscriberNum(SharedTopic& topic, uint32_t expected_num)
 
 /**
  * @brief 断言辅助函数 `ExpectChildExit`。 Assertion helper function `ExpectChildExit`.
- * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check to the current result.
- *          测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。 Concentrate repeated validation logic so test items do not drift to inconsistent checks.
+ * @details 测试内容：对当前结果施加统一的期望检查。 Apply one unified expectation check
+ * to the current result. 测试原理：把重复判定逻辑收口，避免各测试项使用不一致的检查标准。
+ * Concentrate repeated validation logic so test items do not drift to inconsistent
+ * checks.
  */
 inline void ExpectChildExit(pid_t child, int expected_code = 0)
 {

--- a/test/linux_shm/test_attach_queue.cpp
+++ b/test/linux_shm/test_attach_queue.cpp
@@ -1,15 +1,20 @@
 /**
  * @file test_attach_queue.cpp
- * @brief `LinuxSharedTopic` attach/queue 语义子验证。 Split verification unit for `LinuxSharedTopic` attach and queue semantics.
+ * @brief `LinuxSharedTopic` attach/queue 语义子验证。 Split verification unit for
+ * `LinuxSharedTopic` attach and queue semantics.
  */
 #include "linux_shm_topic_test_common.hpp"
 
 namespace LinuxShmTopicTest
 {
 /**
- * @brief 测试项函数 `RunAttachQueueScenarios`。 Test-item function `RunAttachQueueScenarios`.
- * @details 测试内容：验证本地 attach/backpressure 以及 broadcast 队列模式的基本行为。 Execute the local attach/backpressure and broadcast queue-mode scenarios.
- *          测试原理：把无需跨进程协调的基础共享内存 topic 语义集中到同一场景文件里。 Group the foundational shared-memory topic semantics that do not require complex cross-process coordination into one scenario file.
+ * @brief 测试项函数 `RunAttachQueueScenarios`。 Test-item function
+ * `RunAttachQueueScenarios`.
+ * @details 测试内容：验证本地 attach/backpressure 以及 broadcast 队列模式的基本行为。
+ * Execute the local attach/backpressure and broadcast queue-mode scenarios.
+ *          测试原理：把无需跨进程协调的基础共享内存 topic 语义集中到同一场景文件里。
+ * Group the foundational shared-memory topic semantics that do not require complex
+ * cross-process coordination into one scenario file.
  */
 void RunAttachQueueScenarios()
 {
@@ -139,7 +144,8 @@ void RunAttachQueueScenarios()
     SharedTopic publisher(topic_name, config);
     ASSERT(publisher.Valid());
 
-    SharedSubscriber subscriber(topic_name, LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD);
+    SharedSubscriber subscriber(topic_name,
+                                LibXR::LinuxSharedSubscriberMode::BROADCAST_DROP_OLD);
     ASSERT(subscriber.Valid());
 
     IPCFrame frame = {};

--- a/test/linux_shm/test_balance_rr.cpp
+++ b/test/linux_shm/test_balance_rr.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_balance_rr.cpp
- * @brief `LinuxSharedTopic` BALANCE_RR 策略聚合入口。 Aggregation entry for split `LinuxSharedTopic` BALANCE_RR semantics.
+ * @brief `LinuxSharedTopic` BALANCE_RR 策略聚合入口。 Aggregation entry for split
+ * `LinuxSharedTopic` BALANCE_RR semantics.
  * @details 测试项目：
  *          1. 聚合轮转分发子场景。
  *          2. 聚合死亡成员回收子场景。

--- a/test/linux_shm/test_balance_rr_dead.cpp
+++ b/test/linux_shm/test_balance_rr_dead.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_balance_rr_dead.cpp
- * @brief `LinuxSharedTopic` BALANCE_RR 死亡成员回收子验证。 Split verification unit for BALANCE_RR dead-member reclamation semantics.
+ * @brief `LinuxSharedTopic` BALANCE_RR 死亡成员回收子验证。 Split verification unit for
+ * BALANCE_RR dead-member reclamation semantics.
  * @details 测试项目：
  *          1. 死亡 balanced subscriber 被回收后组仍能继续工作。
  *          Test items:
@@ -40,7 +41,8 @@ void RunBalanceRoundRobinDeadMemberScenario()
       close(ack_pipe[0]);
       close(cmd_pipe[1]);
 
-      SharedSubscriber subscriber(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+      SharedSubscriber subscriber(topic_name,
+                                  LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
       if (!subscriber.Valid())
       {
         _exit(40);
@@ -81,7 +83,8 @@ void RunBalanceRoundRobinDeadMemberScenario()
            static_cast<ssize_t>(sizeof(first_seq)));
     ASSERT(first_seq == 361);
 
-    SharedSubscriber subscriber_alive(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    SharedSubscriber subscriber_alive(topic_name,
+                                      LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
     ASSERT(subscriber_alive.Valid());
     WaitForSubscriberNum(publisher, 2);
 

--- a/test/linux_shm/test_balance_rr_rotate.cpp
+++ b/test/linux_shm/test_balance_rr_rotate.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_balance_rr_rotate.cpp
- * @brief `LinuxSharedTopic` BALANCE_RR 轮转分发子验证。 Split verification unit for BALANCE_RR rotation semantics.
+ * @brief `LinuxSharedTopic` BALANCE_RR 轮转分发子验证。 Split verification unit for
+ * BALANCE_RR rotation semantics.
  * @details 测试项目：
  *          1. 活跃 balanced subscriber 之间按轮转顺序交付。
  *          Test items:
@@ -27,8 +28,10 @@ void RunBalanceRoundRobinRotateScenario()
     SharedTopic publisher(topic_name, config);
     ASSERT(publisher.Valid());
 
-    SharedSubscriber subscriber_a(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
-    SharedSubscriber subscriber_b(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    SharedSubscriber subscriber_a(topic_name,
+                                  LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    SharedSubscriber subscriber_b(topic_name,
+                                  LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
     ASSERT(subscriber_a.Valid());
     ASSERT(subscriber_b.Valid());
 

--- a/test/linux_shm/test_balance_rr_skip.cpp
+++ b/test/linux_shm/test_balance_rr_skip.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_balance_rr_skip.cpp
- * @brief `LinuxSharedTopic` BALANCE_RR 跳过满队列成员子验证。 Split verification unit for BALANCE_RR full-member skipping semantics.
+ * @brief `LinuxSharedTopic` BALANCE_RR 跳过满队列成员子验证。 Split verification unit for
+ * BALANCE_RR full-member skipping semantics.
  * @details 测试项目：
  *          1. 某个 balanced subscriber 满时会跳过它并投递给其他成员。
  *          Test items:
@@ -27,9 +28,12 @@ void RunBalanceRoundRobinSkipFullScenario()
     SharedTopic publisher(topic_name, config);
     ASSERT(publisher.Valid());
 
-    SharedSubscriber subscriber_a(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
-    SharedSubscriber subscriber_b(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
-    SharedSubscriber subscriber_c(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    SharedSubscriber subscriber_a(topic_name,
+                                  LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    SharedSubscriber subscriber_b(topic_name,
+                                  LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    SharedSubscriber subscriber_c(topic_name,
+                                  LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
     ASSERT(subscriber_a.Valid());
     ASSERT(subscriber_b.Valid());
     ASSERT(subscriber_c.Valid());

--- a/test/linux_shm/test_cross_process.cpp
+++ b/test/linux_shm/test_cross_process.cpp
@@ -1,15 +1,20 @@
 /**
  * @file test_cross_process.cpp
- * @brief `LinuxSharedTopic` 纯跨进程顺序子验证。 Split verification unit for pure cross-process ordering semantics.
+ * @brief `LinuxSharedTopic` 纯跨进程顺序子验证。 Split verification unit for pure
+ * cross-process ordering semantics.
  */
 #include "linux_shm_topic_test_common.hpp"
 
 namespace LinuxShmTopicTest
 {
 /**
- * @brief 测试项函数 `RunCrossProcessScenarios`。 Test-item function `RunCrossProcessScenarios`.
- * @details 测试内容：验证独立 publisher/subscriber 进程之间的顺序和 payload 完整性。 Execute the cross-process publish/subscribe ordering and payload-integrity scenario.
- *          测试原理：单独把纯跨进程序列完整性拉出来，避免它被其他资源管理场景噪声掩盖。 Isolate the pure cross-process ordering/integrity check so it is not obscured by unrelated resource-management scenarios.
+ * @brief 测试项函数 `RunCrossProcessScenarios`。 Test-item function
+ * `RunCrossProcessScenarios`.
+ * @details 测试内容：验证独立 publisher/subscriber 进程之间的顺序和 payload 完整性。
+ * Execute the cross-process publish/subscribe ordering and payload-integrity scenario.
+ *          测试原理：单独把纯跨进程序列完整性拉出来，避免它被其他资源管理场景噪声掩盖。
+ * Isolate the pure cross-process ordering/integrity check so it is not obscured by
+ * unrelated resource-management scenarios.
  */
 void RunCrossProcessScenarios()
 {

--- a/test/linux_shm/test_lifecycle.cpp
+++ b/test/linux_shm/test_lifecycle.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_lifecycle.cpp
- * @brief `LinuxSharedTopic` 生命周期语义聚合入口。 Aggregation entry for split `LinuxSharedTopic` lifecycle semantics.
+ * @brief `LinuxSharedTopic` 生命周期语义聚合入口。 Aggregation entry for split
+ * `LinuxSharedTopic` lifecycle semantics.
  * @details 测试项目：
  *          1. 聚合 stale publisher takeover 子场景。
  *          2. 聚合 slot 引用钉住子场景。

--- a/test/linux_shm/test_lifecycle_dead_sub.cpp
+++ b/test/linux_shm/test_lifecycle_dead_sub.cpp
@@ -1,12 +1,14 @@
 /**
  * @file test_lifecycle_dead_sub.cpp
- * @brief `LinuxSharedTopic` 死亡 subscriber 回收子验证。 Split verification unit for dead-subscriber reclamation semantics.
+ * @brief `LinuxSharedTopic` 死亡 subscriber 回收子验证。 Split verification unit for
+ * dead-subscriber reclamation semantics.
  * @details 测试项目：
  *          1. 死亡 subscriber 与其持有的 slot 状态会被回收。
  *          2. 回收后 publisher 的 subscriber 计数和 slot 可用性恢复。
  *          Test items:
  *          1. A dead subscriber and its held slot state are reclaimed.
- *          2. After reclamation, publisher subscriber count and slot availability recover.
+ *          2. After reclamation, publisher subscriber count and slot availability
+ * recover.
  */
 #include "linux_shm_topic_test_common.hpp"
 

--- a/test/linux_shm/test_lifecycle_slot_ref.cpp
+++ b/test/linux_shm/test_lifecycle_slot_ref.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_lifecycle_slot_ref.cpp
- * @brief `LinuxSharedTopic` slot 引用钉住子验证。 Split verification unit for slot-reference pinning semantics.
+ * @brief `LinuxSharedTopic` slot 引用钉住子验证。 Split verification unit for
+ * slot-reference pinning semantics.
  * @details 测试项目：
  *          1. slot 在所有 subscriber 释放前保持占用。
  *          2. 最后一个 subscriber 释放后 publisher 能再次创建新数据。

--- a/test/linux_shm/test_lifecycle_takeover.cpp
+++ b/test/linux_shm/test_lifecycle_takeover.cpp
@@ -1,10 +1,12 @@
 /**
  * @file test_lifecycle_takeover.cpp
- * @brief `LinuxSharedTopic` stale publisher takeover 子验证。 Split verification unit for stale-publisher takeover semantics.
+ * @brief `LinuxSharedTopic` stale publisher takeover 子验证。 Split verification unit for
+ * stale-publisher takeover semantics.
  * @details 测试项目：
  *          1. 旧 publisher 退出后新的 creator 能重新接管共享段。
  *          Test items:
- *          1. A fresh creator can take over the shared segment after the old publisher exits.
+ *          1. A fresh creator can take over the shared segment after the old publisher
+ * exits.
  */
 #include "linux_shm_topic_test_common.hpp"
 

--- a/test/linux_shm/test_linux_shm_topic.cpp
+++ b/test/linux_shm/test_linux_shm_topic.cpp
@@ -1,13 +1,18 @@
 /**
  * @file test_linux_shm_topic.cpp
- * @brief `LinuxSharedTopic` 环境验证聚合入口。 Aggregation entry for split `LinuxSharedTopic` environment verification.
+ * @brief `LinuxSharedTopic` 环境验证聚合入口。 Aggregation entry for split
+ * `LinuxSharedTopic` environment verification.
  */
 #include "linux_shm_topic_test_common.hpp"
 
 /**
- * @brief 测试入口函数 `test_linux_shm_topic`。 Test entry function `test_linux_shm_topic`.
- * @details 测试内容：按分组顺序执行拆分后的 `LinuxSharedTopic` 环境验证场景。 Execute the split `LinuxSharedTopic` environment verification scenarios in grouped order.
- *          测试原理：把大而杂的环境验证文件收成多个语义子场景，再由单一入口统一调度。 Replace one oversized environment-verification file with multiple semantic sub-scenarios and dispatch them from one entry.
+ * @brief 测试入口函数 `test_linux_shm_topic`。 Test entry function
+ * `test_linux_shm_topic`.
+ * @details 测试内容：按分组顺序执行拆分后的 `LinuxSharedTopic` 环境验证场景。 Execute the
+ * split `LinuxSharedTopic` environment verification scenarios in grouped order.
+ *          测试原理：把大而杂的环境验证文件收成多个语义子场景，再由单一入口统一调度。
+ * Replace one oversized environment-verification file with multiple semantic
+ * sub-scenarios and dispatch them from one entry.
  */
 void test_linux_shm_topic()
 {

--- a/test/linux_shm/test_mixed_modes.cpp
+++ b/test/linux_shm/test_mixed_modes.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_mixed_modes.cpp
- * @brief `LinuxSharedTopic` domain/mixed-mode 子验证。 Split verification unit for `LinuxSharedTopic` domain and mixed-mode semantics.
+ * @brief `LinuxSharedTopic` domain/mixed-mode 子验证。 Split verification unit for
+ * `LinuxSharedTopic` domain and mixed-mode semantics.
  */
 #include "linux_shm_topic_test_common.hpp"
 
@@ -8,8 +9,12 @@ namespace LinuxShmTopicTest
 {
 /**
  * @brief 测试项函数 `RunMixedModeScenarios`。 Test-item function `RunMixedModeScenarios`.
- * @details 测试内容：验证 domain 隔离、broadcast 与 balanced 混合共存，以及 balanced group 不可服务时的整体失败语义。 Execute domain-isolation, mixed broadcast/balanced coexistence, and balanced-group-required failure scenarios.
- *          测试原理：这些场景关注的是 topic 分组与模式混搭后的策略边界，而不是单一模式内部行为。 These scenarios focus on policy boundaries created by topic grouping and mixed subscriber modes rather than one mode in isolation.
+ * @details 测试内容：验证 domain 隔离、broadcast 与 balanced 混合共存，以及 balanced
+ * group 不可服务时的整体失败语义。 Execute domain-isolation, mixed broadcast/balanced
+ * coexistence, and balanced-group-required failure scenarios. 测试原理：这些场景关注的是
+ * topic 分组与模式混搭后的策略边界，而不是单一模式内部行为。 These scenarios focus on
+ * policy boundaries created by topic grouping and mixed subscriber modes rather than one
+ * mode in isolation.
  */
 void RunMixedModeScenarios()
 {
@@ -71,8 +76,10 @@ void RunMixedModeScenarios()
     ASSERT(publisher.Valid());
 
     SharedSubscriber subscriber_broadcast(topic_name);
-    SharedSubscriber subscriber_rr_a(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
-    SharedSubscriber subscriber_rr_b(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    SharedSubscriber subscriber_rr_a(topic_name,
+                                     LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    SharedSubscriber subscriber_rr_b(topic_name,
+                                     LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
     ASSERT(subscriber_broadcast.Valid());
     ASSERT(subscriber_rr_a.Valid());
     ASSERT(subscriber_rr_b.Valid());
@@ -122,7 +129,8 @@ void RunMixedModeScenarios()
     ASSERT(publisher.Valid());
 
     SharedSubscriber subscriber_broadcast(topic_name);
-    SharedSubscriber subscriber_rr(topic_name, LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
+    SharedSubscriber subscriber_rr(topic_name,
+                                   LibXR::LinuxSharedSubscriberMode::BALANCE_RR);
     ASSERT(subscriber_broadcast.Valid());
     ASSERT(subscriber_rr.Valid());
 

--- a/test/runtime/middleware/message/test_runtime.cpp
+++ b/test/runtime/middleware/message/test_runtime.cpp
@@ -1,14 +1,23 @@
 /**
  * @file test_runtime.cpp
- * @brief runtime 平面 `Topic` 订阅等待测试。 Runtime-plane subscriber waiting tests for `Topic`.
+ * @brief runtime 平面 `Topic` 订阅等待测试。 Runtime-plane subscriber waiting tests for
+ * `Topic`.
  *
  * 测试项目 / Test items:
- * 1. ASyncSubscriber 的 fresh wait 语义。 Async subscriber wait semantics: verify `StartWaiting()` only arms fresh notifications and preserves timestamp/data for the next publish.
- * 2. SyncSubscriber 的阻塞等待、忙重入和 callback-context 唤醒。 Sync subscriber wait semantics: verify blocking waits, busy reentry rejection, timeout behavior and callback-context publish wakeups.
+ * 1. ASyncSubscriber 的 fresh wait 语义。 Async subscriber wait semantics: verify
+ * `StartWaiting()` only arms fresh notifications and preserves timestamp/data for the
+ * next publish.
+ * 2. SyncSubscriber 的阻塞等待、忙重入和 callback-context 唤醒。 Sync subscriber wait
+ * semantics: verify blocking waits, busy reentry rejection, timeout behavior and
+ * callback-context publish wakeups.
  *
  * 测试原理 / Test principles:
- * 1. 使用真实 runtime 线程驱动阻塞等待，因为这些语义在 base 平面不存在。 Use real runtime threads for the blocking wait path, because these semantics do not exist on the base plane alone.
- * 2. 同时检查 wait 返回码和收到的数据/时间戳，保证同步和数据传递一起被验证。 Check both wait return codes and received payload/timestamp values so synchronization and data delivery are validated together.
+ * 1. 使用真实 runtime 线程驱动阻塞等待，因为这些语义在 base 平面不存在。 Use real runtime
+ * threads for the blocking wait path, because these semantics do not exist on the base
+ * plane alone.
+ * 2. 同时检查 wait 返回码和收到的数据/时间戳，保证同步和数据传递一起被验证。 Check both
+ * wait return codes and received payload/timestamp values so synchronization and data
+ * delivery are validated together.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -24,18 +33,21 @@ struct WaitContext
 
 /**
  * @brief 辅助函数 `WaitForSyncSubscriber`。 Helper function `WaitForSyncSubscriber`.
- * @details 测试内容：在 LibXR 线程中执行同步订阅等待。 Execute sync-subscriber waiting inside a LibXR thread.
- *          测试原理：只通过 LibXR thread API 构造等待者，避免测试体依赖宿主线程库。 Use only LibXR's thread API to construct the waiter, avoiding host-thread-library dependencies in the test body.
+ * @details 测试内容：在 LibXR 线程中执行同步订阅等待。 Execute sync-subscriber waiting
+ * inside a LibXR thread. 测试原理：只通过 LibXR thread API
+ * 构造等待者，避免测试体依赖宿主线程库。 Use only LibXR's thread API to construct the
+ * waiter, avoiding host-thread-library dependencies in the test body.
  */
-void WaitForSyncSubscriber(WaitContext* ctx)
-{
-  ctx->result = ctx->subscriber->Wait(200);
-}
+void WaitForSyncSubscriber(WaitContext* ctx) { ctx->result = ctx->subscriber->Wait(200); }
 
 /**
- * @brief 测试项函数 `TestASyncSubscriberFreshWait`。 Test-item function `TestASyncSubscriberFreshWait`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestASyncSubscriberFreshWait`。 Test-item function
+ * `TestASyncSubscriberFreshWait`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestASyncSubscriberFreshWait()
 {
@@ -70,9 +82,13 @@ void TestASyncSubscriberFreshWait()
 }
 
 /**
- * @brief 测试项函数 `TestSyncSubscriberFreshWait`。 Test-item function `TestSyncSubscriberFreshWait`.
- * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete scenario and assertions for the current helper-scoped test item.
- *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。 Split one explainable test item into an independent function so failures and reused scenarios stay easy to locate.
+ * @brief 测试项函数 `TestSyncSubscriberFreshWait`。 Test-item function
+ * `TestSyncSubscriberFreshWait`.
+ * @details 测试内容：执行当前辅助测试项对应的具体场景与断言。 Execute the concrete
+ * scenario and assertions for the current helper-scoped test item.
+ *          测试原理：把一个可单独说明的测试项目拆成独立函数，便于定位失败点并复用场景。
+ * Split one explainable test item into an independent function so failures and reused
+ * scenarios stay easy to locate.
  */
 void TestSyncSubscriberFreshWait()
 {
@@ -96,13 +112,12 @@ void TestSyncSubscriberFreshWait()
   {
     WaitContext ctx{&suber, LibXR::ErrorCode::FAILED};
     LibXR::Thread wait_thread;
-    wait_thread.Create<WaitContext*>(&ctx, WaitForSyncSubscriber, "msg_sync_wait",
-                                     1024, LibXR::Thread::Priority::MEDIUM);
+    wait_thread.Create<WaitContext*>(&ctx, WaitForSyncSubscriber, "msg_sync_wait", 1024,
+                                     LibXR::Thread::Priority::MEDIUM);
 
     for (uint32_t i = 0;
-         i < 1000000 &&
-         suber.block_->data_.wait_state.load(std::memory_order_acquire) !=
-             LibXR::Topic::SyncBlock::WAITING;
+         i < 1000000 && suber.block_->data_.wait_state.load(std::memory_order_acquire) !=
+                            LibXR::Topic::SyncBlock::WAITING;
          i++)
     {
       LibXR::Thread::Yield();
@@ -141,9 +156,11 @@ void TestSyncSubscriberFreshWait()
 }  // namespace
 
 /**
- * @brief 测试入口函数 `test_message_runtime`。 Test entry function `test_message_runtime`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_message_runtime`。 Test entry function
+ * `test_message_runtime`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_message_runtime()
 {

--- a/test/runtime/rw/rw_runtime_test_common.hpp
+++ b/test/runtime/rw/rw_runtime_test_common.hpp
@@ -1,6 +1,7 @@
 /**
  * @file rw_runtime_test_common.hpp
- * @brief runtime `rw` / `pipe` 测试聚合 helper 入口。 Aggregation helper entry for runtime `rw` / `pipe` tests.
+ * @brief runtime `rw` / `pipe` 测试聚合 helper 入口。 Aggregation helper entry for
+ * runtime `rw` / `pipe` tests.
  * @details 测试项目：
  *          1. 聚合共享的模式、端口状态机和 `Pipe` helper。
  *          2. 对外仅保留 runtime `rw` / `pipe` 分组运行入口声明。
@@ -13,7 +14,6 @@
 #pragma once
 
 #include "../../common/rw/pipe_test_common.hpp"
-
 
 void RunRuntimeRwBlockTests();
 void RunRuntimePipeTests();

--- a/test/runtime/rw/test_pipe_runtime_cases.cpp
+++ b/test/runtime/rw/test_pipe_runtime_cases.cpp
@@ -8,9 +8,11 @@ namespace
 {
 
 /**
- * @brief 测试入口函数 `test_pipe_stream_block_immediate_path`。 Test entry function `test_pipe_stream_block_immediate_path`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_pipe_stream_block_immediate_path`。 Test entry function
+ * `test_pipe_stream_block_immediate_path`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_pipe_stream_block_immediate_path()
 {
@@ -43,9 +45,11 @@ void test_pipe_stream_block_immediate_path()
 }
 
 /**
- * @brief 测试入口函数 `test_pipe_block_reuse_stress`。 Test entry function `test_pipe_block_reuse_stress`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_pipe_block_reuse_stress`。 Test entry function
+ * `test_pipe_block_reuse_stress`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_pipe_block_reuse_stress()
 {
@@ -103,8 +107,10 @@ void test_pipe_block_reuse_stress()
 
 /**
  * @brief 测试项函数 `RunRuntimePipeTests`。 Test-item function `RunRuntimePipeTests`.
- * @details 测试内容：执行当前分组里的 runtime `rw`/`Pipe` 子场景。 Execute the grouped runtime `rw`/`Pipe` sub-scenarios.
- *          测试原理：把 runtime 平面的阻塞和 pipe 场景拆分开，减小单文件复杂度。 Separate runtime blocking and pipe scenarios to reduce single-file complexity.
+ * @details 测试内容：执行当前分组里的 runtime `rw`/`Pipe` 子场景。 Execute the grouped
+ * runtime `rw`/`Pipe` sub-scenarios. 测试原理：把 runtime 平面的阻塞和 pipe
+ * 场景拆分开，减小单文件复杂度。 Separate runtime blocking and pipe scenarios to reduce
+ * single-file complexity.
  */
 void RunRuntimePipeTests()
 {

--- a/test/runtime/rw/test_rw_block.cpp
+++ b/test/runtime/rw/test_rw_block.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_rw_block.cpp
- * @brief runtime `rw` 阻塞/超时场景聚合入口。 Aggregation entry for split runtime `rw` blocking/timeout scenarios.
+ * @brief runtime `rw` 阻塞/超时场景聚合入口。 Aggregation entry for split runtime `rw`
+ * blocking/timeout scenarios.
  * @details 测试项目：
  *          1. 聚合阻塞 `Stream` 子场景。
  *          2. 聚合超时、零长度与队列补齐子场景。
@@ -20,9 +21,13 @@ void RunRuntimeRwBlockFailClearTests();
 void RunRuntimeRwBlockWaiterTests();
 
 /**
- * @brief 测试项函数 `RunRuntimeRwBlockTests`。 Test-item function `RunRuntimeRwBlockTests`.
- * @details 测试内容：执行拆分后的 runtime `rw` 阻塞/超时子场景。 Execute the split runtime `rw` blocking/timeout sub-scenarios.
- *          测试原理：保留原有聚合入口，同时让不同状态语义落到更小的主题文件里。 Preserve the original aggregation entry while moving different state semantics into smaller themed files.
+ * @brief 测试项函数 `RunRuntimeRwBlockTests`。 Test-item function
+ * `RunRuntimeRwBlockTests`.
+ * @details 测试内容：执行拆分后的 runtime `rw` 阻塞/超时子场景。 Execute the split
+ * runtime `rw` blocking/timeout sub-scenarios.
+ *          测试原理：保留原有聚合入口，同时让不同状态语义落到更小的主题文件里。 Preserve
+ * the original aggregation entry while moving different state semantics into smaller
+ * themed files.
  */
 void RunRuntimeRwBlockTests()
 {

--- a/test/runtime/rw/test_rw_block_fail_clear_cases.cpp
+++ b/test/runtime/rw/test_rw_block_fail_clear_cases.cpp
@@ -1,12 +1,15 @@
 /**
  * @file test_rw_block_fail_clear_cases.cpp
- * @brief runtime `FailAndClearAll` 阻塞等待者场景子测试。 Split test unit for runtime `FailAndClearAll` blocking-waiter scenarios.
+ * @brief runtime `FailAndClearAll` 阻塞等待者场景子测试。 Split test unit for runtime
+ * `FailAndClearAll` blocking-waiter scenarios.
  * @details 测试项目：
  *          1. 阻塞读等待者被 `FailAndClearAll` 唤醒后会收到失败结果，且旧缓冲区不被污染。
- *          2. 阻塞写等待者被 `FailAndClearAll` 唤醒后会收到失败结果，后续写入仍能恢复工作。
- *          Test items:
- *          1. A blocking read waiter is failed by `FailAndClearAll` without corrupting the stale buffer.
- *          2. A blocking write waiter is failed by `FailAndClearAll`, and later writes still recover normally.
+ *          2. 阻塞写等待者被 `FailAndClearAll`
+ * 唤醒后会收到失败结果，后续写入仍能恢复工作。 Test items:
+ *          1. A blocking read waiter is failed by `FailAndClearAll` without corrupting
+ * the stale buffer.
+ *          2. A blocking write waiter is failed by `FailAndClearAll`, and later writes
+ * still recover normally.
  */
 #include "rw_runtime_test_common.hpp"
 
@@ -14,14 +17,17 @@ namespace
 {
 
 /**
- * @brief 测试入口函数 `test_rw_read_port_fail_and_clear_all_fails_block_waiter`。 Test entry function `test_rw_read_port_fail_and_clear_all_fails_block_waiter`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_read_port_fail_and_clear_all_fails_block_waiter`。 Test
+ * entry function `test_rw_read_port_fail_and_clear_all_fails_block_waiter`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_read_port_fail_and_clear_all_fails_block_waiter()
 {
   // 测试内容：阻塞读被失败清理打断后，应保持旧缓冲区不变并允许后续继续读取。
-  // Test coverage: a blocking read interrupted by fail-clear should keep the stale buffer intact and allow later reads.
+  // Test coverage: a blocking read interrupted by fail-clear should keep the stale buffer
+  // intact and allow later reads.
   using namespace LibXR;
 
   ReadPort r(16);
@@ -58,14 +64,17 @@ void test_rw_read_port_fail_and_clear_all_fails_block_waiter()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_write_port_fail_and_clear_all_fails_block_waiter`。 Test entry function `test_rw_write_port_fail_and_clear_all_fails_block_waiter`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_write_port_fail_and_clear_all_fails_block_waiter`。 Test
+ * entry function `test_rw_write_port_fail_and_clear_all_fails_block_waiter`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_write_port_fail_and_clear_all_fails_block_waiter()
 {
   // 测试内容：阻塞写被失败清理打断后，应释放端口并允许新的写请求重新进入。
-  // Test coverage: a blocking write interrupted by fail-clear should release the port and allow a new write to enter.
+  // Test coverage: a blocking write interrupted by fail-clear should release the port and
+  // allow a new write to enter.
   using namespace LibXR;
 
   WritePort w(2, 16);
@@ -108,9 +117,12 @@ void test_rw_write_port_fail_and_clear_all_fails_block_waiter()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunRuntimeRwBlockFailClearTests`。 Test-item function `RunRuntimeRwBlockFailClearTests`.
- * @details 测试内容：执行 runtime `FailAndClearAll` 阻塞等待者子场景。 Execute runtime `FailAndClearAll` blocking-waiter sub-scenarios.
- *          测试原理：把阻塞等待者语义单独成组，避免和超时/stream 语义互相缠绕。 Group blocking-waiter semantics away from timeout and stream semantics.
+ * @brief 测试项函数 `RunRuntimeRwBlockFailClearTests`。 Test-item function
+ * `RunRuntimeRwBlockFailClearTests`.
+ * @details 测试内容：执行 runtime `FailAndClearAll` 阻塞等待者子场景。 Execute runtime
+ * `FailAndClearAll` blocking-waiter sub-scenarios.
+ *          测试原理：把阻塞等待者语义单独成组，避免和超时/stream 语义互相缠绕。 Group
+ * blocking-waiter semantics away from timeout and stream semantics.
  */
 void RunRuntimeRwBlockFailClearTests()
 {

--- a/test/runtime/rw/test_rw_block_stream_cases.cpp
+++ b/test/runtime/rw/test_rw_block_stream_cases.cpp
@@ -1,6 +1,7 @@
 /**
  * @file test_rw_block_stream_cases.cpp
- * @brief runtime `rw` 阻塞 `Stream` 场景子测试。 Split test unit for runtime blocking `Stream` scenarios.
+ * @brief runtime `rw` 阻塞 `Stream` 场景子测试。 Split test unit for runtime blocking
+ * `Stream` scenarios.
  * @details 测试项目：
  *          1. `Stream::Commit` 在挂起完成后会回传最终失败码。
  *          2. `Stream` 超时后会解除等待者，后续完成信号不会残留。
@@ -16,39 +17,48 @@ namespace
 {
 
 /**
- * @brief 测试入口函数 `test_rw_stream_block_pending_result_propagates`。 Test entry function `test_rw_stream_block_pending_result_propagates`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_stream_block_pending_result_propagates`。 Test entry
+ * function `test_rw_stream_block_pending_result_propagates`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_stream_block_pending_result_propagates()
 {
   // 测试内容：阻塞 `Commit` 应把异步完成阶段给出的最终错误码原样返回。
-  // Test coverage: blocking `Commit` should return the exact final error produced by the asynchronous completion path.
+  // Test coverage: blocking `Commit` should return the exact final error produced by the
+  // asynchronous completion path.
   VerifyStreamBlockPendingCompletion(LibXR::ErrorCode::FAILED, LibXR::ErrorCode::FAILED,
                                      StreamSubmitMode::COMMIT);
 }
 
 /**
- * @brief 测试入口函数 `test_rw_stream_block_timeout_detaches_waiter`。 Test entry function `test_rw_stream_block_timeout_detaches_waiter`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_stream_block_timeout_detaches_waiter`。 Test entry
+ * function `test_rw_stream_block_timeout_detaches_waiter`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_stream_block_timeout_detaches_waiter()
 {
   // 测试内容：超时返回后，旧等待者不应留下额外信号或 busy 状态。
-  // Test coverage: after a timeout, the old waiter must not leave extra signals or busy state behind.
+  // Test coverage: after a timeout, the old waiter must not leave extra signals or busy
+  // state behind.
   VerifyStreamBlockTimeout();
 }
 
 /**
- * @brief 测试入口函数 `test_rw_stream_block_destructor_autocommit`。 Test entry function `test_rw_stream_block_destructor_autocommit`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_stream_block_destructor_autocommit`。 Test entry function
+ * `test_rw_stream_block_destructor_autocommit`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_stream_block_destructor_autocommit()
 {
   // 测试内容：析构自动提交也应等待挂起完成并回到空闲态。
-  // Test coverage: destructor auto-commit should also wait for pending completion and return to idle.
+  // Test coverage: destructor auto-commit should also wait for pending completion and
+  // return to idle.
   VerifyStreamBlockPendingCompletion(LibXR::ErrorCode::OK, LibXR::ErrorCode::OK,
                                      StreamSubmitMode::DESTRUCT);
 }
@@ -56,9 +66,12 @@ void test_rw_stream_block_destructor_autocommit()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunRuntimeRwBlockStreamTests`。 Test-item function `RunRuntimeRwBlockStreamTests`.
- * @details 测试内容：执行 runtime `rw` 阻塞 `Stream` 子场景。 Execute runtime blocking `Stream` sub-scenarios.
- *          测试原理：把 `Stream` 的阻塞提交路径单独成组，避免和普通端口等待者路径混排。 Group blocking `Stream` submission paths separately from ordinary port waiter paths.
+ * @brief 测试项函数 `RunRuntimeRwBlockStreamTests`。 Test-item function
+ * `RunRuntimeRwBlockStreamTests`.
+ * @details 测试内容：执行 runtime `rw` 阻塞 `Stream` 子场景。 Execute runtime blocking
+ * `Stream` sub-scenarios. 测试原理：把 `Stream`
+ * 的阻塞提交路径单独成组，避免和普通端口等待者路径混排。 Group blocking `Stream`
+ * submission paths separately from ordinary port waiter paths.
  */
 void RunRuntimeRwBlockStreamTests()
 {

--- a/test/runtime/rw/test_rw_block_timeout_cases.cpp
+++ b/test/runtime/rw/test_rw_block_timeout_cases.cpp
@@ -1,16 +1,21 @@
 /**
  * @file test_rw_block_timeout_cases.cpp
- * @brief runtime `rw` 超时、零长度与队列补齐场景子测试。 Split test unit for runtime `rw` timeout, zero-length, and queue-completion scenarios.
+ * @brief runtime `rw` 超时、零长度与队列补齐场景子测试。 Split test unit for runtime `rw`
+ * timeout, zero-length, and queue-completion scenarios.
  * @details 测试项目：
  *          1. 阻塞读超时后会解除挂起关系，后续补进的数据不会污染旧缓冲区。
  *          2. 零长度挂起读在完成时只发通知，不会偷读队列字节。
  *          3. 阻塞写超时后会解除等待者，后续再次提交仍按新的等待周期工作。
  *          4. 阻塞读在后台补齐队列数据后会把目标字节拷贝到用户缓冲区。
  *          Test items:
- *          1. A blocking read timeout detaches the pending relation and later bytes do not corrupt the stale buffer.
- *          2. A pending zero-length read only triggers completion and does not consume queued bytes.
- *          3. A blocking write timeout detaches the waiter and later submissions start a fresh wait cycle.
- *          4. A blocking read copies bytes into the user buffer after queued data arrives asynchronously.
+ *          1. A blocking read timeout detaches the pending relation and later bytes do
+ * not corrupt the stale buffer.
+ *          2. A pending zero-length read only triggers completion and does not consume
+ * queued bytes.
+ *          3. A blocking write timeout detaches the waiter and later submissions start a
+ * fresh wait cycle.
+ *          4. A blocking read copies bytes into the user buffer after queued data arrives
+ * asynchronously.
  */
 #include "rw_runtime_test_common.hpp"
 
@@ -18,14 +23,17 @@ namespace
 {
 
 /**
- * @brief 测试入口函数 `test_rw_block_read_timeout_detaches_pending`。 Test entry function `test_rw_block_read_timeout_detaches_pending`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_block_read_timeout_detaches_pending`。 Test entry function
+ * `test_rw_block_read_timeout_detaches_pending`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_block_read_timeout_detaches_pending()
 {
   // 测试内容：阻塞读超时后，旧缓冲区和信号量状态都不应被后续补数据污染。
-  // Test coverage: later queued bytes must not corrupt the stale buffer or semaphore state after a blocking read timeout.
+  // Test coverage: later queued bytes must not corrupt the stale buffer or semaphore
+  // state after a blocking read timeout.
   using namespace LibXR;
 
   Pipe pipe(64);
@@ -59,14 +67,17 @@ void test_rw_block_read_timeout_detaches_pending()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_zero_read_pending_notifies_without_dequeue`。 Test entry function `test_rw_zero_read_pending_notifies_without_dequeue`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_zero_read_pending_notifies_without_dequeue`。 Test entry
+ * function `test_rw_zero_read_pending_notifies_without_dequeue`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_zero_read_pending_notifies_without_dequeue()
 {
   // 测试内容：零长度挂起请求完成后，队列字节仍应保留给后续真实读取。
-  // Test coverage: queued bytes should remain available for a later real read after a zero-length pending completion.
+  // Test coverage: queued bytes should remain available for a later real read after a
+  // zero-length pending completion.
   using namespace LibXR;
 
   for (auto mode : ALL_MODES)
@@ -107,14 +118,17 @@ void test_rw_zero_read_pending_notifies_without_dequeue()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_block_write_timeout_detaches_waiter`。 Test entry function `test_rw_block_write_timeout_detaches_waiter`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_block_write_timeout_detaches_waiter`。 Test entry function
+ * `test_rw_block_write_timeout_detaches_waiter`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_block_write_timeout_detaches_waiter()
 {
   // 测试内容：阻塞写超时后，旧等待者不应阻止下一个等待周期重新建立。
-  // Test coverage: a timed-out blocking write waiter should not prevent the next wait cycle from being established.
+  // Test coverage: a timed-out blocking write waiter should not prevent the next wait
+  // cycle from being established.
   using namespace LibXR;
 
   WritePort w(2, 64);
@@ -146,14 +160,17 @@ void test_rw_block_write_timeout_detaches_waiter()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_read_port_block_queue_completion_copies_data`。 Test entry function `test_rw_read_port_block_queue_completion_copies_data`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_read_port_block_queue_completion_copies_data`。 Test entry
+ * function `test_rw_read_port_block_queue_completion_copies_data`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_read_port_block_queue_completion_copies_data()
 {
   // 测试内容：阻塞读在异步补齐后应写回数据且不残留旧信号量状态。
-  // Test coverage: a blocking read should copy asynchronously supplied bytes and leave no stale semaphore state.
+  // Test coverage: a blocking read should copy asynchronously supplied bytes and leave no
+  // stale semaphore state.
   using namespace LibXR;
 
   ReadPort r(16);
@@ -178,9 +195,12 @@ void test_rw_read_port_block_queue_completion_copies_data()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunRuntimeRwBlockTimeoutTests`。 Test-item function `RunRuntimeRwBlockTimeoutTests`.
- * @details 测试内容：执行 runtime `rw` 超时、零长度与队列补齐子场景。 Execute runtime `rw` timeout, zero-length, and queue-completion sub-scenarios.
- *          测试原理：把等待者解绑与补齐路径单独成组，降低单文件复杂度。 Group waiter-detach and completion paths together to reduce single-file complexity.
+ * @brief 测试项函数 `RunRuntimeRwBlockTimeoutTests`。 Test-item function
+ * `RunRuntimeRwBlockTimeoutTests`.
+ * @details 测试内容：执行 runtime `rw` 超时、零长度与队列补齐子场景。 Execute runtime
+ * `rw` timeout, zero-length, and queue-completion sub-scenarios.
+ *          测试原理：把等待者解绑与补齐路径单独成组，降低单文件复杂度。 Group
+ * waiter-detach and completion paths together to reduce single-file complexity.
  */
 void RunRuntimeRwBlockTimeoutTests()
 {

--- a/test/runtime/rw/test_rw_block_waiter_cases.cpp
+++ b/test/runtime/rw/test_rw_block_waiter_cases.cpp
@@ -1,12 +1,14 @@
 /**
  * @file test_rw_block_waiter_cases.cpp
- * @brief runtime `WritePort` 阻塞等待者场景子测试。 Split test unit for runtime `WritePort` blocking waiter scenarios.
+ * @brief runtime `WritePort` 阻塞等待者场景子测试。 Split test unit for runtime
+ * `WritePort` blocking waiter scenarios.
  * @details 测试项目：
  *          1. 阻塞写等待者在挂起完成后会收到最终失败码。
  *          2. 复用同一个阻塞信号量时，上一轮的陈旧信号不会污染下一轮等待。
  *          Test items:
  *          1. A blocking write waiter receives the final error after pending completion.
- *          2. Reusing the same blocking semaphore does not leak stale signals into the next wait cycle.
+ *          2. Reusing the same blocking semaphore does not leak stale signals into the
+ * next wait cycle.
  */
 #include "rw_runtime_test_common.hpp"
 
@@ -14,14 +16,17 @@ namespace
 {
 
 /**
- * @brief 测试入口函数 `test_rw_write_port_block_pending_result_propagates`。 Test entry function `test_rw_write_port_block_pending_result_propagates`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_write_port_block_pending_result_propagates`。 Test entry
+ * function `test_rw_write_port_block_pending_result_propagates`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_write_port_block_pending_result_propagates()
 {
   // 测试内容：阻塞写在完成线程返回失败时，应把该错误直接传给调用者。
-  // Test coverage: a blocking write should forward the exact failure returned by the completion thread.
+  // Test coverage: a blocking write should forward the exact failure returned by the
+  // completion thread.
   using namespace LibXR;
 
   WritePort w(2, 16);
@@ -41,14 +46,17 @@ void test_rw_write_port_block_pending_result_propagates()
 }
 
 /**
- * @brief 测试入口函数 `test_rw_write_port_block_reused_waiter_discards_stale_signal`。 Test entry function `test_rw_write_port_block_reused_waiter_discards_stale_signal`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @brief 测试入口函数 `test_rw_write_port_block_reused_waiter_discards_stale_signal`。
+ * Test entry function `test_rw_write_port_block_reused_waiter_discards_stale_signal`.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_rw_write_port_block_reused_waiter_discards_stale_signal()
 {
   // 测试内容：复用同一阻塞等待者时，上一轮完成令牌必须被清干净，不能串到下一轮。
-  // Test coverage: reusing the same blocking waiter must drain the previous completion token before the next wait cycle.
+  // Test coverage: reusing the same blocking waiter must drain the previous completion
+  // token before the next wait cycle.
   using namespace LibXR;
 
   WritePort w(2, 16);
@@ -82,9 +90,13 @@ void test_rw_write_port_block_reused_waiter_discards_stale_signal()
 }  // namespace
 
 /**
- * @brief 测试项函数 `RunRuntimeRwBlockWaiterTests`。 Test-item function `RunRuntimeRwBlockWaiterTests`.
- * @details 测试内容：执行 runtime `WritePort` 阻塞等待者子场景。 Execute runtime `WritePort` blocking waiter sub-scenarios.
- *          测试原理：把阻塞等待者生命周期单独成组，集中验证最终错误透传和陈旧信号清理。 Group blocking waiter lifecycle checks around final-error propagation and stale-signal draining.
+ * @brief 测试项函数 `RunRuntimeRwBlockWaiterTests`。 Test-item function
+ * `RunRuntimeRwBlockWaiterTests`.
+ * @details 测试内容：执行 runtime `WritePort` 阻塞等待者子场景。 Execute runtime
+ * `WritePort` blocking waiter sub-scenarios.
+ *          测试原理：把阻塞等待者生命周期单独成组，集中验证最终错误透传和陈旧信号清理。
+ * Group blocking waiter lifecycle checks around final-error propagation and stale-signal
+ * draining.
  */
 void RunRuntimeRwBlockWaiterTests()
 {

--- a/test/runtime/rw/test_rw_pipe_runtime.cpp
+++ b/test/runtime/rw/test_rw_pipe_runtime.cpp
@@ -1,25 +1,24 @@
 /**
  * @file test_rw_pipe_runtime.cpp
- * @brief runtime `rw` / `pipe` 测试聚合入口。 Aggregation entry for split runtime `rw` / `pipe` tests.
+ * @brief runtime `rw` / `pipe` 测试聚合入口。 Aggregation entry for split runtime `rw` /
+ * `pipe` tests.
  */
 #include "rw_runtime_test_common.hpp"
 
 /**
  * @brief 测试入口函数 `test_rw_runtime`。 Test entry function `test_rw_runtime`.
- * @details 测试内容：聚合执行拆分后的 runtime `rw` 子测试组。 Aggregate and execute the split runtime `rw` subtest groups.
- *          测试原理：在拆分 runtime 大文件后，继续保留原 runner 使用的单入口名称。 Preserve the original single-entry name used by the runner after splitting the oversized runtime file.
+ * @details 测试内容：聚合执行拆分后的 runtime `rw` 子测试组。 Aggregate and execute the
+ * split runtime `rw` subtest groups. 测试原理：在拆分 runtime 大文件后，继续保留原 runner
+ * 使用的单入口名称。 Preserve the original single-entry name used by the runner after
+ * splitting the oversized runtime file.
  */
-void test_rw_runtime()
-{
-  RunRuntimeRwBlockTests();
-}
+void test_rw_runtime() { RunRuntimeRwBlockTests(); }
 
 /**
  * @brief 测试入口函数 `test_pipe_runtime`。 Test entry function `test_pipe_runtime`.
- * @details 测试内容：聚合执行拆分后的 runtime `Pipe` 子测试组。 Aggregate and execute the split runtime `Pipe` subtest groups.
- *          测试原理：把 runtime pipe 场景拆分后，继续通过单入口提供给现有 harness。 Keep the existing harness contract after splitting runtime pipe scenarios into separate files.
+ * @details 测试内容：聚合执行拆分后的 runtime `Pipe` 子测试组。 Aggregate and execute the
+ * split runtime `Pipe` subtest groups. 测试原理：把 runtime pipe
+ * 场景拆分后，继续通过单入口提供给现有 harness。 Keep the existing harness contract after
+ * splitting runtime pipe scenarios into separate files.
  */
-void test_pipe_runtime()
-{
-  RunRuntimePipeTests();
-}
+void test_pipe_runtime() { RunRuntimePipeTests(); }

--- a/test/runtime/system/test_async.cpp
+++ b/test/runtime/system/test_async.cpp
@@ -3,11 +3,15 @@
  * @brief runtime `ASync` worker 生命周期测试。 Runtime `ASync` worker lifecycle tests.
  *
  * 测试项目 / Test items:
- * 1. job 分配的状态机。 Job assignment lifecycle: verify the worker transitions through `READY -> BUSY -> DONE -> READY` on repeated assignments.
- * 2. job 执行后的副作用。 Job execution side effect: verify the bound job actually runs and mutates the target state once per assignment.
+ * 1. job 分配的状态机。 Job assignment lifecycle: verify the worker transitions through
+ * `READY -> BUSY -> DONE -> READY` on repeated assignments.
+ * 2. job 执行后的副作用。 Job execution side effect: verify the bound job actually runs
+ * and mutates the target state once per assignment.
  *
  * 测试原理 / Test principles:
- * 1. 围绕真实 worker thread 观察公开状态机，因为这里的正确性首先是调度和生命周期语义。 Observe the public status machine around a real worker thread, because runtime correctness here is primarily scheduling/lifecycle semantics.
+ * 1. 围绕真实 worker thread 观察公开状态机，因为这里的正确性首先是调度和生命周期语义。
+ * Observe the public status machine around a real worker thread, because runtime
+ * correctness here is primarily scheduling/lifecycle semantics.
  */
 #include <cstddef>
 #include <new>
@@ -18,8 +22,9 @@
 
 /**
  * @brief 测试入口函数 `test_async`。 Test entry function `test_async`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_async()
 {
@@ -36,7 +41,8 @@ void test_async()
       },
       &async_arg);
 
-  // ASync has a permanent worker, so the test instance must not register an exit-time destructor.
+  // ASync has a permanent worker, so the test instance must not register an exit-time
+  // destructor.
   alignas(LibXR::ASync) static std::byte async_storage[sizeof(LibXR::ASync)];
   static LibXR::ASync* async =
       new (async_storage) LibXR::ASync(512, LibXR::Thread::Priority::REALTIME);

--- a/test/runtime/system/test_mutex.cpp
+++ b/test/runtime/system/test_mutex.cpp
@@ -1,14 +1,20 @@
 /**
  * @file test_mutex.cpp
- * @brief runtime mutex 加锁、try-lock 与 waiter handoff 测试。 Runtime mutex lock, try-lock and waiter handoff tests.
+ * @brief runtime mutex 加锁、try-lock 与 waiter handoff 测试。 Runtime mutex lock,
+ * try-lock and waiter handoff tests.
  *
  * 测试项目 / Test items:
- * 1. 立即加锁与 `TryLock()` busy 返回。 Immediate lock semantics: verify `Lock()` succeeds and `TryLock()` reports `BUSY` while held.
- * 2. 阻塞 waiter 的所有权交接。 Waiter handoff: verify a blocked runtime thread acquires the mutex only after the owner unlocks it.
- * 3. 交接后的再次复用。 Post-handoff reuse: verify `TryLock()` succeeds again after the waiter completes.
+ * 1. 立即加锁与 `TryLock()` busy 返回。 Immediate lock semantics: verify `Lock()`
+ * succeeds and `TryLock()` reports `BUSY` while held.
+ * 2. 阻塞 waiter 的所有权交接。 Waiter handoff: verify a blocked runtime thread acquires
+ * the mutex only after the owner unlocks it.
+ * 3. 交接后的再次复用。 Post-handoff reuse: verify `TryLock()` succeeds again after the
+ * waiter completes.
  *
  * 测试原理 / Test principles:
- * 1. 使用真实 waiter 线程和完成信号量，让所有权交接在 runtime 同步路径上被验证。 Use a real waiter thread and a completion semaphore so ownership transfer is checked on the runtime synchronization path itself.
+ * 1. 使用真实 waiter 线程和完成信号量，让所有权交接在 runtime 同步路径上被验证。 Use a
+ * real waiter thread and a completion semaphore so ownership transfer is checked on the
+ * runtime synchronization path itself.
  */
 #include <atomic>
 
@@ -27,8 +33,11 @@ struct MutexAcquireContext
 
 /**
  * @brief 辅助函数 `AcquireMutex`。 Helper function `AcquireMutex`.
- * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
- *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+ * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+ * measure, or validate shared state for later test steps.
+ *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+ * repeated helper logic locally so the main test body stays focused on the test item
+ * itself.
  */
 void AcquireMutex(MutexAcquireContext* ctx)
 {
@@ -42,8 +51,9 @@ void AcquireMutex(MutexAcquireContext* ctx)
 
 /**
  * @brief 测试入口函数 `test_mutex`。 Test entry function `test_mutex`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_mutex()
 {
@@ -59,7 +69,7 @@ void test_mutex()
 
   MutexAcquireContext ctx = {&mutex, &acquired, &done};
   waiter.Create<MutexAcquireContext*>(&ctx, AcquireMutex, "mutex_waiter", 1024,
-                                     LibXR::Thread::Priority::MEDIUM);
+                                      LibXR::Thread::Priority::MEDIUM);
 
   LibXR::Thread::Sleep(20);
   ASSERT(!acquired.load(std::memory_order_acquire));

--- a/test/runtime/system/test_semaphore.cpp
+++ b/test/runtime/system/test_semaphore.cpp
@@ -3,11 +3,15 @@
  * @brief runtime semaphore post/wait 测试。 Runtime semaphore post/wait tests.
  *
  * 测试项目 / Test items:
- * 1. 空信号量立即超时与预先 post 的缓存令牌。 Immediate timeout and queued posts: verify zero-time waits time out on empty state and consume pre-posted counts correctly.
- * 2. 延迟 post 对阻塞 wait 的唤醒。 Delayed post wakeup: verify a runtime thread can wake a blocking wait by posting later.
+ * 1. 空信号量立即超时与预先 post 的缓存令牌。 Immediate timeout and queued posts: verify
+ * zero-time waits time out on empty state and consume pre-posted counts correctly.
+ * 2. 延迟 post 对阻塞 wait 的唤醒。 Delayed post wakeup: verify a runtime thread can wake
+ * a blocking wait by posting later.
  *
  * 测试原理 / Test principles:
- * 1. 同时检查缓存计数和运行时唤醒，因为 semaphore 契约同时覆盖两种模式。 Check both preloaded counts and delayed runtime wakeup, because the semaphore contract spans cached tokens and blocking synchronization.
+ * 1. 同时检查缓存计数和运行时唤醒，因为 semaphore 契约同时覆盖两种模式。 Check both
+ * preloaded counts and delayed runtime wakeup, because the semaphore contract spans
+ * cached tokens and blocking synchronization.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -15,8 +19,9 @@
 
 /**
  * @brief 测试入口函数 `test_semaphore`。 Test entry function `test_semaphore`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_semaphore()
 {

--- a/test/runtime/system/test_thread.cpp
+++ b/test/runtime/system/test_thread.cpp
@@ -1,14 +1,20 @@
 /**
  * @file test_thread.cpp
- * @brief runtime thread 创建与 sleep 原语测试。 Runtime thread creation and sleep primitive tests.
+ * @brief runtime thread 创建与 sleep 原语测试。 Runtime thread creation and sleep
+ * primitive tests.
  *
  * 测试项目 / Test items:
- * 1. 线程创建后的信号唤醒。 Thread creation/wakeup: verify a created runtime thread can signal completion through a semaphore.
- * 2. 相对睡眠 `Sleep()`。 Relative sleep: verify `Thread::Sleep()` waits for approximately the requested duration.
- * 3. 周期性 `SleepUntil()`。 Periodic sleep-until: verify `SleepUntil()` advances wakeups monotonically across successive periods.
+ * 1. 线程创建后的信号唤醒。 Thread creation/wakeup: verify a created runtime thread can
+ * signal completion through a semaphore.
+ * 2. 相对睡眠 `Sleep()`。 Relative sleep: verify `Thread::Sleep()` waits for
+ * approximately the requested duration.
+ * 3. 周期性 `SleepUntil()`。 Periodic sleep-until: verify `SleepUntil()` advances wakeups
+ * monotonically across successive periods.
  *
  * 测试原理 / Test principles:
- * 1. 只通过 LibXR 时间 API 观察线程睡眠与周期唤醒语义，避免测试体依赖宿主平台调用。 Observe sleep and periodic wakeup semantics only through LibXR time APIs, so the test body does not depend on host platform calls.
+ * 1. 只通过 LibXR 时间 API 观察线程睡眠与周期唤醒语义，避免测试体依赖宿主平台调用。
+ * Observe sleep and periodic wakeup semantics only through LibXR time APIs, so the test
+ * body does not depend on host platform calls.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -16,8 +22,9 @@
 
 /**
  * @brief 测试入口函数 `test_thread`。 Test entry function `test_thread`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_thread()
 {

--- a/test/runtime/system/test_timebase.cpp
+++ b/test/runtime/system/test_timebase.cpp
@@ -1,13 +1,18 @@
 /**
  * @file test_timebase.cpp
- * @brief runtime timebase 递进与 wrap-range 配置测试。 Runtime timebase progression and wrap-range configuration tests.
+ * @brief runtime timebase 递进与 wrap-range 配置测试。 Runtime timebase progression and
+ * wrap-range configuration tests.
  *
  * 测试项目 / Test items:
- * 1. live 时钟递进。 Live progression: verify runtime microsecond and millisecond clocks advance by roughly the expected amount across a sleep interval.
- * 2. 自定义 wrap range 下的时间差语义。 Configured wrap semantics: verify custom wrap ranges are applied to timestamp subtraction on both millisecond and microsecond scales.
+ * 1. live 时钟递进。 Live progression: verify runtime microsecond and millisecond clocks
+ * advance by roughly the expected amount across a sleep interval.
+ * 2. 自定义 wrap range 下的时间差语义。 Configured wrap semantics: verify custom wrap
+ * ranges are applied to timestamp subtraction on both millisecond and microsecond scales.
  *
  * 测试原理 / Test principles:
- * 1. 把 live progression 和显式 wrap 覆盖放在同一文件，兼顾后端取时和静态算术策略。 Pair live time progression with explicit wrap-range overrides so the test covers both backend clock sourcing and static arithmetic policy.
+ * 1. 把 live progression 和显式 wrap 覆盖放在同一文件，兼顾后端取时和静态算术策略。 Pair
+ * live time progression with explicit wrap-range overrides so the test covers both
+ * backend clock sourcing and static arithmetic policy.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -19,8 +24,11 @@ struct TimebaseWrapProbe : LibXR::Timebase
 {
   /**
    * @brief 辅助函数 `Set`。 Helper function `Set`.
-   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform, measure, or validate shared state for later test steps.
-   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate repeated helper logic locally so the main test body stays focused on the test item itself.
+   * @details 测试内容：为后续测试准备、转换、统计或校验共享状态。 Prepare, transform,
+   * measure, or validate shared state for later test steps.
+   *          测试原理：把重复辅助逻辑局部封装，保持测试主体聚焦在测试项本身。 Encapsulate
+   * repeated helper logic locally so the main test body stays focused on the test item
+   * itself.
    */
   static void Set(uint64_t max_valid_us, uint32_t max_valid_ms)
   {
@@ -34,8 +42,9 @@ struct TimebaseWrapProbe : LibXR::Timebase
 
 /**
  * @brief 测试入口函数 `test_timebase`。 Test entry function `test_timebase`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_timebase()
 {

--- a/test/runtime/system/test_timer.cpp
+++ b/test/runtime/system/test_timer.cpp
@@ -1,13 +1,18 @@
 /**
  * @file test_timer.cpp
- * @brief runtime 周期 timer start/stop 测试。 Runtime periodic timer start/stop behavior test.
+ * @brief runtime 周期 timer start/stop 测试。 Runtime periodic timer start/stop behavior
+ * test.
  *
  * 测试项目 / Test items:
- * 1. timer 周期回调执行。 Timer periodic execution: verify a started timer repeatedly invokes its callback.
- * 2. stop/restart 后的重复可用性。 Stop/restart behavior: verify stopping and restarting the same timer handle still yields the expected periodic count.
+ * 1. timer 周期回调执行。 Timer periodic execution: verify a started timer repeatedly
+ * invokes its callback.
+ * 2. stop/restart 后的重复可用性。 Stop/restart behavior: verify stopping and restarting
+ * the same timer handle still yields the expected periodic count.
  *
  * 测试原理 / Test principles:
- * 1. 使用真实 timer 推进路径和重复 restart 尝试，验证 runtime 调度而不是模拟回调循环。 Use the real timer progression path and repeated restart attempts so the test checks runtime scheduling rather than a simulated callback loop.
+ * 1. 使用真实 timer 推进路径和重复 restart 尝试，验证 runtime 调度而不是模拟回调循环。
+ * Use the real timer progression path and repeated restart attempts so the test checks
+ * runtime scheduling rather than a simulated callback loop.
  */
 #include "libxr.hpp"
 #include "libxr_def.hpp"
@@ -16,8 +21,9 @@
 
 /**
  * @brief 测试入口函数 `test_timer`。 Test entry function `test_timer`.
- * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared in this file in order.
- *          测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。 Validate the module contract through the scenarios assembled in this file.
+ * @details 测试内容：按本文件声明的测试项目顺序执行验证。 Execute the test items declared
+ * in this file in order. 测试原理：通过当前文件组织的测试场景组合，对外验证该模块契约。
+ * Validate the module contract through the scenarios assembled in this file.
  */
 void test_timer()
 {

--- a/tools/format_cpp_files.sh
+++ b/tools/format_cpp_files.sh
@@ -8,10 +8,11 @@ cd "${REPO_ROOT}"
 usage() {
   cat <<'EOF'
 Usage:
-  tools/format_driver_src.sh [--check]
+  tools/format_cpp_files.sh [--check]
 
 Description:
-  Format all C/C++ source files under driver/ and src/ using clang-format.
+  Format all C/C++ files under driver/, src/, system/, and test/ using
+  clang-format.
   Requires clang-format version 21.1.8 by default.
 
 Options:
@@ -76,15 +77,16 @@ EOF
 fi
 
 list_source_files() {
-  find driver src -type f \( \
+  find driver src system test -type f \( \
+    -name '*.h' -o -name '*.hpp' -o \
     -name '*.c' -o -name '*.cc' -o -name '*.cpp' -o -name '*.cxx' \
   \) -print0
 }
 
 if [[ "${MODE}" == "check" ]]; then
   list_source_files | xargs -0 -r "${CLANG_FORMAT_BIN}" --dry-run --Werror --style=file
-  echo "clang-format check passed for driver/ and src/."
+  echo "clang-format check passed for C/C++ files under driver/, src/, system/, and test/."
 else
   list_source_files | xargs -0 -r "${CLANG_FORMAT_BIN}" -i --style=file
-  echo "Formatted C/C++ sources under driver/ and src/."
+  echo "Formatted C/C++ files under driver/, src/, system/, and test/."
 fi


### PR DESCRIPTION
## Summary
- establish a clang-format 21.1.8 baseline for C/C++ headers and sources under `driver/`, `src/`, `system/`, and `test/`
- retain global include sorting while locally protecting six implementation include chains whose order is semantically significant
- rename the format script and expand CI enforcement to all 564 matching files

## Validation
- `tools/format_cpp_files.sh --check` with clang-format 21.1.8
- Linux Docker configure and full build
- complete host test runner: `All tests completed.`
- `git diff --check`