### PR TITLE
feat(mspm0): add MSPM0 flash driver

### DIFF
--- a/driver/mspm0/CMakeLists.txt
+++ b/driver/mspm0/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(_xr_mspm0_driver_sources
     ${CMAKE_CURRENT_LIST_DIR}/mspm0_group1_shared.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/mspm0_flash.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mspm0_gpio.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mspm0_pwm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mspm0_timebase.cpp

--- a/driver/mspm0/mspm0_flash.cpp
+++ b/driver/mspm0/mspm0_flash.cpp
@@ -99,10 +99,10 @@ ErrorCode MSPM0Flash::Erase(std::size_t offset, std::size_t size)
   const std::size_t erase_begin = AlignDown(offset, MIN_ERASE_SIZE_BYTES);
   const std::size_t erase_end = AlignUp(offset + size, MIN_ERASE_SIZE_BYTES);
 
-  IrqGuard guard;
   for (std::size_t sector_offset = erase_begin; sector_offset < erase_end;
        sector_offset += MIN_ERASE_SIZE_BYTES)
   {
+    IrqGuard guard;
     const std::uint32_t address =
         base_address_ + static_cast<std::uint32_t>(sector_offset);
     DL_FlashCTL_executeClearStatus(FLASHCTL);
@@ -133,7 +133,6 @@ ErrorCode MSPM0Flash::Write(std::size_t offset, ConstRawData data)
   }
 
   const auto* source = static_cast<const std::uint8_t*>(data.addr_);
-  IrqGuard guard;
   std::size_t written = 0U;
   while (written < data.size_)
   {
@@ -151,11 +150,16 @@ ErrorCode MSPM0Flash::Write(std::size_t offset, ConstRawData data)
       continue;
     }
 
-    DL_FlashCTL_executeClearStatus(FLASHCTL);
-    DL_FlashCTL_unprotectSector(FLASHCTL, address, DL_FLASHCTL_REGION_SELECT_MAIN);
-    const auto status =
-        DL_FlashCTL_programMemoryFromRAM64WithECCGenerated(FLASHCTL, address, words);
-    DL_FlashCTL_protectMainMemory(FLASHCTL);
+    DL_FLASHCTL_COMMAND_STATUS status;
+    {
+      IrqGuard guard;
+      DL_FlashCTL_executeClearStatus(FLASHCTL);
+      DL_FlashCTL_disableOverrideHardwareGeneratedECC(FLASHCTL);
+      DL_FlashCTL_unprotectSector(FLASHCTL, address, DL_FLASHCTL_REGION_SELECT_MAIN);
+      status =
+          DL_FlashCTL_programMemoryFromRAM64WithECCGenerated(FLASHCTL, address, words);
+      DL_FlashCTL_protectMainMemory(FLASHCTL);
+    }
     if (!FlashCommandPassed(status))
     {
       return ErrorCode::FAILED;

--- a/driver/mspm0/mspm0_flash.cpp
+++ b/driver/mspm0/mspm0_flash.cpp
@@ -1,0 +1,178 @@
+#include "mspm0_flash.hpp"
+
+#include <algorithm>
+#include <cstring>
+
+#include "core_cm0plus.h"
+#include "libxr_mem.hpp"
+
+using namespace LibXR;
+
+namespace
+{
+
+class IrqGuard
+{
+ public:
+  IrqGuard() : primask_(__get_PRIMASK()) { __disable_irq(); }
+
+  ~IrqGuard()
+  {
+    if ((primask_ & 1U) == 0U)
+    {
+      __enable_irq();
+    }
+  }
+
+ private:
+  std::uint32_t primask_;
+};
+
+bool FlashCommandPassed(DL_FLASHCTL_COMMAND_STATUS status)
+{
+  return status == DL_FLASHCTL_COMMAND_STATUS_PASSED;
+}
+
+std::size_t AlignDown(std::size_t value, std::size_t alignment)
+{
+  return value - (value % alignment);
+}
+
+std::size_t AlignUp(std::size_t value, std::size_t alignment)
+{
+  return AlignDown(value + alignment - 1U, alignment);
+}
+
+const FlashSector& CheckedStartSector(const FlashSector* sectors,
+                                      std::size_t sector_count, std::size_t start_sector)
+{
+  ASSERT(sectors != nullptr);
+  ASSERT(sector_count > 0U);
+  ASSERT(start_sector > 0U);
+  ASSERT(start_sector <= sector_count);
+  return sectors[start_sector - 1U];
+}
+
+std::size_t CheckedFlashWindowSize(const FlashSector* sectors, std::size_t sector_count,
+                                   std::size_t start_sector)
+{
+  const auto& start = CheckedStartSector(sectors, sector_count, start_sector);
+  const auto& end = sectors[sector_count - 1U];
+  ASSERT(end.address >= start.address);
+  ASSERT(end.size > 0U);
+  return static_cast<std::size_t>(end.address - start.address) + end.size;
+}
+
+}  // namespace
+
+MSPM0Flash::MSPM0Flash(std::uint32_t base_address, std::size_t size)
+    : Flash(MIN_ERASE_SIZE_BYTES, MIN_WRITE_SIZE_BYTES,
+            RawData(reinterpret_cast<void*>(base_address), size)),
+      base_address_(base_address),
+      size_(size)
+{
+  ASSERT(IsAligned(base_address_, MIN_ERASE_SIZE_BYTES));
+  ASSERT(IsAligned(size_, MIN_ERASE_SIZE_BYTES));
+}
+
+MSPM0Flash::MSPM0Flash(const FlashSector* sectors, std::size_t sector_count,
+                       std::size_t start_sector)
+    : MSPM0Flash(CheckedStartSector(sectors, sector_count, start_sector).address,
+                 CheckedFlashWindowSize(sectors, sector_count, start_sector))
+{
+  ASSERT(CheckedStartSector(sectors, sector_count, start_sector).size ==
+         MIN_ERASE_SIZE_BYTES);
+}
+
+ErrorCode MSPM0Flash::Erase(std::size_t offset, std::size_t size)
+{
+  if (size == 0U)
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  if (!IsRangeValid(offset, size))
+  {
+    return ErrorCode::OUT_OF_RANGE;
+  }
+
+  const std::size_t erase_begin = AlignDown(offset, MIN_ERASE_SIZE_BYTES);
+  const std::size_t erase_end = AlignUp(offset + size, MIN_ERASE_SIZE_BYTES);
+
+  IrqGuard guard;
+  for (std::size_t sector_offset = erase_begin; sector_offset < erase_end;
+       sector_offset += MIN_ERASE_SIZE_BYTES)
+  {
+    const std::uint32_t address =
+        base_address_ + static_cast<std::uint32_t>(sector_offset);
+    DL_FlashCTL_executeClearStatus(FLASHCTL);
+    DL_FlashCTL_unprotectSector(FLASHCTL, address, DL_FLASHCTL_REGION_SELECT_MAIN);
+    const auto status = DL_FlashCTL_eraseMemoryFromRAM(FLASHCTL, address,
+                                                       DL_FLASHCTL_COMMAND_SIZE_SECTOR);
+    DL_FlashCTL_protectMainMemory(FLASHCTL);
+    if (!FlashCommandPassed(status))
+    {
+      return ErrorCode::FAILED;
+    }
+  }
+
+  return ErrorCode::OK;
+}
+
+ErrorCode MSPM0Flash::Write(std::size_t offset, ConstRawData data)
+{
+  if (data.addr_ == nullptr || data.size_ == 0U ||
+      !IsAligned(offset, MIN_WRITE_SIZE_BYTES))
+  {
+    return ErrorCode::ARG_ERR;
+  }
+
+  if (!IsRangeValid(offset, data.size_))
+  {
+    return ErrorCode::OUT_OF_RANGE;
+  }
+
+  const auto* source = static_cast<const std::uint8_t*>(data.addr_);
+  IrqGuard guard;
+  std::size_t written = 0U;
+  while (written < data.size_)
+  {
+    const std::size_t chunk_size =
+        std::min<std::size_t>(MIN_WRITE_SIZE_BYTES, data.size_ - written);
+    std::uint32_t words[2] = {0xFFFFFFFFU, 0xFFFFFFFFU};
+    std::memcpy(words, source + written, chunk_size);
+
+    const std::uint32_t address =
+        base_address_ + static_cast<std::uint32_t>(offset + written);
+    if (Memory::FastCmp(reinterpret_cast<const std::uint8_t*>(address), source + written,
+                        chunk_size) == 0)
+    {
+      written += chunk_size;
+      continue;
+    }
+
+    DL_FlashCTL_executeClearStatus(FLASHCTL);
+    DL_FlashCTL_unprotectSector(FLASHCTL, address, DL_FLASHCTL_REGION_SELECT_MAIN);
+    const auto status =
+        DL_FlashCTL_programMemoryFromRAM64WithECCGenerated(FLASHCTL, address, words);
+    DL_FlashCTL_protectMainMemory(FLASHCTL);
+    if (!FlashCommandPassed(status))
+    {
+      return ErrorCode::FAILED;
+    }
+
+    written += chunk_size;
+  }
+
+  return ErrorCode::OK;
+}
+
+bool MSPM0Flash::IsRangeValid(std::size_t offset, std::size_t size) const
+{
+  return offset <= size_ && size <= (size_ - offset);
+}
+
+bool MSPM0Flash::IsAligned(std::size_t value, std::size_t alignment)
+{
+  return alignment != 0U && (value % alignment) == 0U;
+}

--- a/driver/mspm0/mspm0_flash.hpp
+++ b/driver/mspm0/mspm0_flash.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <ti/driverlib/dl_flashctl.h>
+
+#include <cstddef>
+#include <cstdint>
+
+#include "flash.hpp"
+
+namespace LibXR
+{
+
+/**
+ * @brief Flash sector descriptor.
+ */
+struct FlashSector
+{
+  std::uint32_t address;
+  std::uint32_t size;
+};
+
+class MSPM0Flash : public Flash
+{
+ public:
+  static constexpr std::size_t MIN_ERASE_SIZE_BYTES = DL_FLASHCTL_SECTOR_SIZE;
+  static constexpr std::size_t MIN_WRITE_SIZE_BYTES = 8U;
+
+  MSPM0Flash(std::uint32_t base_address, std::size_t size);
+  MSPM0Flash(const FlashSector* sectors, std::size_t sector_count,
+             std::size_t start_sector);
+
+  MSPM0Flash(const FlashSector* sectors, std::size_t sector_count)
+      : MSPM0Flash(sectors, sector_count, sector_count - 1)
+  {
+  }
+
+  ErrorCode Erase(std::size_t offset, std::size_t size) override;
+  ErrorCode Write(std::size_t offset, ConstRawData data) override;
+
+ private:
+  bool IsRangeValid(std::size_t offset, std::size_t size) const;
+  static bool IsAligned(std::size_t value, std::size_t alignment);
+
+  std::uint32_t base_address_ = 0;
+  std::size_t size_ = 0;
+};
+
+}  // namespace LibXR


### PR DESCRIPTION
## What
- Add `MSPM0Flash` driver implementing the `Flash` base class for TI MSPM0:
  - sector erase via `DL_FlashCTL_eraseMemoryFromRAM` (SECTOR size)
  - 8-byte aligned program via `DL_FlashCTL_programMemoryFromRAM64WithECCGenerated`
  - each erase/program wrapped in IRQ-guarded
    unprotect → command → protect sequence (`DL_FlashCTL_unprotectSector` /
    `DL_FlashCTL_protectMainMemory`)
  - offset/alignment/size validation (`IsRangeValid`, 8-byte write alignment,
    sector-aligned erase window rounding)
  - two constructors: contiguous `(base_address, size)` range and
    `(sectors[], count, start_sector)` sector-table form (tail-window use for OTA)
- Wire `mspm0_flash.cpp` into `driver/mspm0/CMakeLists.txt`.

## Why
- The framework exposes a `Flash` base interface (ST/CH32/Linux all implement it),
  but MSPM0 had no driver — firmware storage / OTA use cases on MSPM0 were
  unsupported. This closes the gap with the same contract as other platforms.

## Verify
- `cmake -DLIBXR_TEST_BUILD=True .. && make` (linux host) — passes
- `./test/test` — full regression suite passes (All tests completed)
- change is MSPM0-platform-only; linux build does not compile `driver/mspm0`

## Not Verified
- no board-side verification on MSPM0 (no hardware available in this
  environment) — erase/program command paths and ECC-generated program
  sequence are untested on silicon

## 由 Sourcery 提供的摘要

引入一个针对 MSPM0 的专用 Flash 驱动，实现用于擦除和写入操作的通用 Flash 接口。

新特性：
- 新增 MSPM0Flash 驱动，在 MSPM0 设备上提供基于扇区的擦除以及 8 字节对齐写入支持。

增强内容：
- 为 MSPM0 flash 窗口提供连续地址范围和基于扇区表这两种构造方式的支持。

构建：
- 在 MSPM0 驱动的 CMake 目标中包含新的 MSPM0 flash 驱动源码。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an MSPM0-specific flash driver implementing the shared Flash interface for erase and write operations.

New Features:
- Add MSPM0Flash driver providing sector-based erase and 8-byte aligned write support on MSPM0 devices.

Enhancements:
- Support both contiguous address-range and sector-table based construction for MSPM0 flash windows.

Build:
- Include the new MSPM0 flash driver source in the MSPM0 driver CMake target.

</details>